### PR TITLE
throw instead returning when erasing checked to unchecked exception

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
@@ -345,7 +345,8 @@ public final class Interpreter {
         Block cb = oc.exception(l, t);
         if (cb == null) {
             // If there is no matching catch bock then rethrow back to the caller
-            throw erase(t);
+            eraseAndThrow(t);
+            throw new InternalError("should not reach here");
         }
 
         // Add a new block context to the catch block with the exception as the argument
@@ -360,8 +361,8 @@ public final class Interpreter {
     }
 
     @SuppressWarnings("unchecked")
-    public static <E extends Throwable> E erase(Throwable e) throws E {
-        return (E) e;
+    public static <E extends Throwable> void eraseAndThrow(Throwable e) throws E {
+        throw (E) e;
     }
 
     static Object exec(MethodHandles.Lookup l, OpContext oc, Op o) {
@@ -640,7 +641,8 @@ public final class Interpreter {
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Throwable e) {
-            throw erase(e);
+            eraseAndThrow(e);
+            throw new InternalError("should not reach here");
         }
     }
 }

--- a/test/jdk/java/lang/reflect/code/interpreter/TestThrowing.java
+++ b/test/jdk/java/lang/reflect/code/interpreter/TestThrowing.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.runtime.CodeReflection;
+import java.util.List;
+
+/*
+ * @test
+ * @run testng TestThrowing
+ */
+
+public class TestThrowing {
+
+    @Test(dataProvider = "methods-exceptions")
+    public void testThrowsCorrectException(String methodName, Class<?> expectedExceptionType) throws NoSuchMethodException {
+        Method method = TestThrowing.class.getDeclaredMethod(methodName);
+        try {
+            Interpreter.invoke(method.getCodeModel().orElseThrow(), List.of());
+            Assert.fail("invoke should throw");
+        } catch (Throwable throwable) {
+            Assert.assertEquals(throwable.getClass(), expectedExceptionType);
+        }
+    }
+
+    @DataProvider(name = "methods-exceptions")
+    static Object[][] testData() throws NoSuchMethodException {
+        return new Object[][]{
+                {"throwsError", Error.class},
+                {"throwsRuntimeException", RuntimeException.class},
+                {"throwsCheckedException", IOException.class},
+        };
+    }
+
+    @CodeReflection
+    static void throwsError() {
+        throw new Error();
+    }
+
+    @CodeReflection
+    static void throwsRuntimeException() {
+        throw new RuntimeException();
+    }
+
+    @CodeReflection
+    static void throwsCheckedException() throws IOException {
+        throw new IOException();
+    }
+}


### PR DESCRIPTION
As discussed in https://mail.openjdk.org/pipermail/babylon-dev/2024-January/000006.html, I change the `erase` method to `eraseAndThrow` and added a test as suggested. I ensured that the test fails without my change and does not fail with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/babylon.git pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/2.diff">https://git.openjdk.org/babylon/pull/2.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/2#issuecomment-1895514758)