### PR TITLE
Move OpWriter from java.lang.reflect.code.impl to java.lang.reflect.code.writer and export from module. 

### DIFF
--- a/cr-util/copy-to-compiler.sh
+++ b/cr-util/copy-to-compiler.sh
@@ -31,7 +31,8 @@ packages="
   $base \
   $base/descriptor \
   $base/descriptor/impl \
-  $base/impl \
+  $base/writer \
+  $base/writer/impl \
   $base/op \
   "
 

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -32,7 +32,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.lang.reflect.code.impl.OpWriter;
+import java.lang.reflect.code.writer.OpWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.BiFunction;

--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/Liveness.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/Liveness.java
@@ -27,8 +27,8 @@ package java.lang.reflect.code.analysis;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.code.*;
-import java.lang.reflect.code.impl.GlobalValueBlockNaming;
-import java.lang.reflect.code.impl.OpWriter;
+import java.lang.reflect.code.writer.impl.GlobalValueBlockNaming;
+import java.lang.reflect.code.writer.OpWriter;
 import java.util.*;
 
 /**

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package java.lang.reflect.code.impl;
+package java.lang.reflect.code.writer;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -33,6 +33,7 @@ import java.lang.reflect.code.Body;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.Value;
 import java.lang.reflect.code.descriptor.TypeDesc;
+import java.lang.reflect.code.writer.impl.GlobalValueBlockNaming;
 import java.util.function.Consumer;
 
 public final class OpWriter {
@@ -147,11 +148,11 @@ public final class OpWriter {
         }
     }
 
-    final java.lang.reflect.code.impl.GlobalValueBlockNaming gn;
+    final GlobalValueBlockNaming gn;
     final IndentWriter w;
 
     public OpWriter(Writer w) {
-        this(w, new java.lang.reflect.code.impl.GlobalValueBlockNaming());
+        this(w, new GlobalValueBlockNaming());
     }
 
     public OpWriter(Writer w, GlobalValueBlockNaming gn) {

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/impl/GlobalValueBlockNaming.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/impl/GlobalValueBlockNaming.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package java.lang.reflect.code.impl;
+package java.lang.reflect.code.writer.impl;
 
 import java.lang.reflect.code.Block;
 import java.lang.reflect.code.Value;

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/package-info.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * Functionality for writing text description of code models.
+ */
+package java.lang.reflect.code.writer;

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -97,6 +97,8 @@ module java.base {
     exports java.lang.reflect.code.interpreter;
     exports java.lang.reflect.code.op;
     exports java.lang.reflect.code.parser;
+    exports java.lang.reflect.code.writer;
+    exports java.lang.reflect.code.writer.impl;
     exports java.lang.runtime;
     exports java.math;
     exports java.net;

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -651,3 +651,8 @@ jdk_containers_extended = \
 jdk_core_no_security = \
    :jdk_core \
    -:jdk_security
+
+
+jdk_lang_reflect_code = \
+   java/lang/reflect/code
+


### PR DESCRIPTION
OpWriter (and referenced GlobaValueBlockNaming class) should be exported 

Following the pattern used by OpParser I created a writer package and moved OpWrite and GlobaValueBlockNaming into that package and added this package to module-info