### PR TITLE
Support array type constants in code model

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -1066,21 +1066,7 @@ public final class CoreOps {
                 return value == NULL_ATTRIBUTE_VALUE ? null :
                         value.toString();
             } else if (t.equals(TypeDesc.J_L_CLASS)) {
-                if (value == NULL_ATTRIBUTE_VALUE) {
-                    return null;
-                }
-                String asString = value.toString();
-                int bracketOpen = asString.indexOf('[');
-                int dimensions = 0;
-                if (bracketOpen != -1) {
-                    dimensions = (asString.length() - bracketOpen) / 2;
-                    asString = asString.substring(0, bracketOpen);
-                }
-                ClassDesc desc = ClassDesc.of(asString);
-                if (dimensions > 0) {
-                    desc = desc.arrayType(dimensions);
-                }
-                return TypeDesc.ofNominalDescriptor(desc);
+                return value == NULL_ATTRIBUTE_VALUE ? null : TypeDesc.ofString(value.toString());
             } else if (value == NULL_ATTRIBUTE_VALUE) {
                 return null; // null constant
             }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -1066,8 +1066,21 @@ public final class CoreOps {
                 return value == NULL_ATTRIBUTE_VALUE ? null :
                         value.toString();
             } else if (t.equals(TypeDesc.J_L_CLASS)) {
-                return value == NULL_ATTRIBUTE_VALUE ? null :
-                        TypeDesc.ofNominalDescriptor(ClassDesc.of(value.toString()));
+                if (value == NULL_ATTRIBUTE_VALUE) {
+                    return null;
+                }
+                String asString = value.toString();
+                int bracketOpen = asString.indexOf('[');
+                int dimensions = 0;
+                if (bracketOpen != -1) {
+                    dimensions = (asString.length() - bracketOpen) / 2;
+                    asString = asString.substring(0, bracketOpen);
+                }
+                ClassDesc desc = ClassDesc.of(asString);
+                if (dimensions > 0) {
+                    desc = desc.arrayType(dimensions);
+                }
+                return TypeDesc.ofNominalDescriptor(desc);
             } else if (value == NULL_ATTRIBUTE_VALUE) {
                 return null; // null constant
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -442,7 +442,8 @@ public class ReflectMethods extends TreeTranslator {
                         Tag.SWITCH_EXPRESSION, Tag.YIELD,
                         Tag.CONDEXPR,
                         Tag.LABELLED,
-                        Tag.SKIP);
+                        Tag.SKIP,
+                        Tag.TYPEARRAY);
 
         BodyScanner(JCMethodDecl tree) {
             this(tree, tree.body);
@@ -899,6 +900,11 @@ public class ReflectMethods extends TreeTranslator {
         @Override
         public void visitTypeIdent(JCTree.JCPrimitiveTypeTree tree) {
             result = null;
+        }
+
+        @Override
+        public void visitTypeArray(JCTree.JCArrayTypeTree tree) {
+            result = null; // MyType[].class is handled in visitSelect just as MyType.class
         }
 
         @Override

--- a/test/jdk/java/lang/reflect/code/TestArrayTypes.java
+++ b/test/jdk/java/lang/reflect/code/TestArrayTypes.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.code.op.CoreOps;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.Method;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/*
+ * @test
+ * @run testng TestArrayTypes
+ */
+
+public class TestArrayTypes {
+    @CodeReflection
+    public static Class<?> f() {
+        return String[].class;
+    }
+
+    @Test
+    public void testf() {
+        CoreOps.FuncOp f = getFuncOp("f");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f), f());
+    }
+
+    @CodeReflection
+    public static Class<?> f2() {
+        return int[][].class;
+    }
+
+    @Test
+    public void testf2() {
+        CoreOps.FuncOp f = getFuncOp("f2");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f), f2());
+    }
+
+    @CodeReflection
+    public static Class<?> f3() {
+        return CoreOps.ArrayLengthOp[][][][][][][].class;
+    }
+
+    @Test
+    public void testf3() {
+        CoreOps.FuncOp f = getFuncOp("f3");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f), f3());
+    }
+
+    static CoreOps.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestArrayTypes.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}

--- a/test/langtools/tools/javac/reflect/ConstantsTest.java
+++ b/test/langtools/tools/javac/reflect/ConstantsTest.java
@@ -227,4 +227,52 @@ public class ConstantsTest {
     void test14() {
         Class<?> s = String[].class;
     }
+
+    @IR("""
+            func @"test15" (%0 : ConstantsTest)void -> {
+                %1 : java.lang.Class = constant @"java.lang.String[][]";
+                %2 : Var<java.lang.Class> = var %1 @"s";
+                return;
+            };
+            """)
+    @CodeReflection
+    void test15() {
+        Class<?> s = String[][].class;
+    }
+
+    @IR("""
+            func @"test16" (%0 : ConstantsTest)void -> {
+                %1 : java.lang.Class = constant @"java.lang.String[][][]";
+                %2 : Var<java.lang.Class> = var %1 @"s";
+                return;
+            };
+            """)
+    @CodeReflection
+    void test16() {
+        Class<?> s = String[][][].class;
+    }
+
+    @IR("""
+            func @"test17" (%0 : ConstantsTest)void -> {
+                %1 : java.lang.Class = constant @"boolean[]";
+                %2 : Var<java.lang.Class> = var %1 @"s";
+                return;
+            };
+            """)
+    @CodeReflection
+    void test17() {
+        Class<?> s = boolean[].class;
+    }
+
+    @IR("""
+            func @"test18" (%0 : ConstantsTest)void -> {
+                %1 : java.lang.Class = constant @"boolean[][][]";
+                %2 : Var<java.lang.Class> = var %1 @"s";
+                return;
+            };
+            """)
+    @CodeReflection
+    void test18() {
+        Class<?> s = boolean[][][].class;
+    }
 }

--- a/test/langtools/tools/javac/reflect/ConstantsTest.java
+++ b/test/langtools/tools/javac/reflect/ConstantsTest.java
@@ -215,4 +215,16 @@ public class ConstantsTest {
     void test13() {
         Class<?> s = float.class;
     }
+
+    @IR("""
+            func @"test14" (%0 : ConstantsTest)void -> {
+                %1 : java.lang.Class = constant @"java.lang.String[]";
+                %2 : Var<java.lang.Class> = var %1 @"s";
+                return;
+            };
+            """)
+    @CodeReflection
+    void test14() {
+        Class<?> s = String[].class;
+    }
 }


### PR DESCRIPTION
Previously, expressions like `String[].class` weren't supported in the code model.

As types are embedded by their fully qualified names (e.g. `java.lang.String[]`), we also have to parse that representation again. I didn't find an existing method to do so, so I wrote it myself. Please let me know if there's a better approach.

I also adapted the test from `TestArrayCreation.java`, using different kinds of array types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/babylon.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/5.diff">https://git.openjdk.org/babylon/pull/5.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/5#issuecomment-1900009704)