### PR TITLE
Make sure method parameters keep their slots when lowering

### DIFF
--- a/test/jdk/java/lang/reflect/code/bytecode/TestSlots.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSlots.java
@@ -99,6 +99,66 @@ public class TestSlots {
         }
     }
 
+    @CodeReflection
+    static int f4(/* Unused */ int a, int b) {
+        return b;
+    }
+
+    @Test
+    public void testF4() throws Throwable {
+        CoreOps.FuncOp f = getFuncOp("f4");
+
+        MethodHandle mh;
+        try {
+            mh = generate(f);
+        } catch (VerifyError e) {
+            Assert.fail("invalid class file generated", e);
+            return;
+        }
+
+        Assert.assertEquals(f4(1, 2), (int) mh.invoke(1, 2));
+    }
+
+    @CodeReflection
+    static int f5(/* Unused */ Object a, int b) {
+        return b;
+    }
+
+    @Test
+    public void testF5() throws Throwable {
+        CoreOps.FuncOp f = getFuncOp("f5");
+
+        MethodHandle mh;
+        try {
+            mh = generate(f);
+        } catch (VerifyError e) {
+            Assert.fail("invalid class file generated", e);
+            return;
+        }
+
+        Assert.assertEquals(f5(null, 2), (int) mh.invoke(null, 2));
+    }
+
+    @CodeReflection
+    int f6(/* Unused receiver parameter */ TestSlots this, int b) {
+        return b;
+    }
+
+    @Test
+    public void testF6() throws Throwable {
+        CoreOps.FuncOp f = getFuncOp("f6");
+
+        MethodHandle mh;
+        try {
+            mh = generate(f);
+        } catch (VerifyError e) {
+            Assert.fail("invalid class file generated", e);
+            return;
+        }
+
+        Assert.assertEquals(f6(2), (int) mh.invoke(/* receiver parameter */ this, 2));
+    }
+
     static MethodHandle generate(CoreOps.FuncOp f) {
         f.writeTo(System.out);
 

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSlots.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSlots.java
@@ -120,7 +120,7 @@ public class TestSlots {
     }
 
     @CodeReflection
-    static int f5(/* Unused */ Object a, int b) {
+    static double f5(/* Unused */ double a, double b) {
         return b;
     }
 
@@ -136,27 +136,7 @@ public class TestSlots {
             return;
         }
 
-        Assert.assertEquals(f5(null, 2), (int) mh.invoke(null, 2));
-    }
-
-    @CodeReflection
-    int f6(/* Unused receiver parameter */ TestSlots this, int b) {
-        return b;
-    }
-
-    @Test
-    public void testF6() throws Throwable {
-        CoreOps.FuncOp f = getFuncOp("f6");
-
-        MethodHandle mh;
-        try {
-            mh = generate(f);
-        } catch (VerifyError e) {
-            Assert.fail("invalid class file generated", e);
-            return;
-        }
-
-        Assert.assertEquals(f6(2), (int) mh.invoke(/* receiver parameter */ this, 2));
+        Assert.assertEquals(f5(1.0, 2.0), (double) mh.invoke(1.0, 2.0));
     }
 
     static MethodHandle generate(CoreOps.FuncOp f) {


### PR DESCRIPTION
Previously, unused method parameters didn't get a slot, resulting in either wrong results or bad classfiles.

I propose a simple fix: Make sure that all parameters of the entry block get a slot, in the order they are defined.
I didn't want to change too much code here, so I decided to add a boolean flag to indicate that even values without uses get a slot.
If you have a better idea or more plans on this, please let me know.

I also added multiple test cases showcasing the issue: One that results in the wrong value returned, one with a type mismatch resulting in a VerifyError, and one with a type mismatch due to being non-static, also causing a VerifyError (this is the case that made me discover this issue).

I ran the tests in `langtools/tools/javac/reflect/` and `java/lang/reflect/code/` to make sure they all (still) pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/babylon.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/8.diff">https://git.openjdk.org/babylon/pull/8.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/8#issuecomment-1911689983)