### PR TITLE
Test break statements within try statements

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -2248,7 +2248,7 @@ public class ExtendedOps {
 
         boolean ifExitFromTry(JavaLabelOp lop) {
             Op target = lop.target();
-            return ifAncestorOp(target, this);
+            return target == this || ifAncestorOp(target, this);
         }
 
         static boolean ifAncestorOp(Op ancestor, Op op) {


### PR DESCRIPTION
Small issue fixed when determining an exit from a try statement.

--

More generally we should probably add a new kind of test that compares the lowered code model, similarly to how we test the code models produced by the compiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/babylon.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/10.diff">https://git.openjdk.org/babylon/pull/10.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/10#issuecomment-1917783173)