### PR TITLE
Exception regions fix

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
@@ -27,51 +27,79 @@ package java.lang.reflect.code.bytecode;
 import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeTransform;
+import java.lang.classfile.Opcode;
 import java.lang.classfile.PseudoInstruction;
 import java.lang.classfile.instruction.BranchInstruction;
 import java.lang.classfile.instruction.LabelTarget;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * BranchCompactor is a CodeTransform working as a state machine.
+ * It identifies and compacts redundant sequences of branches in a single pass.
+ */
 final class BranchCompactor implements CodeTransform {
 
-    private BranchInstruction firstBranch;
-    private final List<PseudoInstruction> pseudoBuffer = new ArrayList<>();
+    private BranchInstruction firstBranch, secondBranch;
+    private final List<PseudoInstruction> pseudoBuffer1 = new ArrayList<>(),
+                                          pseudoBuffer2 = new ArrayList<>();
 
+    //BranchCompactor is in INIT_STATE until a branch instruction appears
     private final CodeTransform INIT_STATE = new CodeTransform() {
         @Override
         public void accept(CodeBuilder cob, CodeElement coe) {
             if (coe instanceof BranchInstruction bi) {
                 firstBranch = bi;
-                activeState = LOOKING_FOR_TARGET;
+                activeState = LOOKING_FOR_SHORT_JUMP;
             } else {
+                //all other instructions and pseudo instrutions are passed
                 cob.with(coe);
             }
         }
     };
 
-    private final CodeTransform LOOKING_FOR_TARGET = new CodeTransform() {
+    //In this state we are looking for immediate target of the firstBranch
+    //or also for a second (unconditional) branch when the firstBranch is conditional
+    //all pseudo instructions are buffered as they do not represent a real bytecode
+    private final CodeTransform LOOKING_FOR_SHORT_JUMP = new CodeTransform() {
         @Override
         public void accept(CodeBuilder cob, CodeElement coe) {
             switch (coe) {
                 case LabelTarget lt -> {
                     if (firstBranch.target() == lt.label()) {
-                        pseudoBuffer.forEach(cob::with);
-                        pseudoBuffer.clear();
+                        //here we have immediate target, so the first branch is skipped
+                        //all pseudo instructions are passed (including the actual target)
+                        //and BranchCompactor returns to INIT_STATE
+                        pseudoBuffer1.forEach(cob::with);
+                        pseudoBuffer1.clear();
                         activeState = INIT_STATE;
                         cob.with(coe);
                     } else {
-                        pseudoBuffer.add(lt);
+                        //here we buffer the label as a pseudo instructions
+                        pseudoBuffer1.add(lt);
                     }
                 }
                 case PseudoInstruction pi -> {
-                    pseudoBuffer.add(pi);
+                    //here we buffer pseudo instructions
+                    pseudoBuffer1.add(pi);
                 }
                 case BranchInstruction bi -> {
-                    atEnd(cob);
-                    firstBranch = bi;
+                    if (!firstBranch.opcode().isUnconditionalBranch() && bi.opcode().isUnconditionalBranch()) {
+                        //second (unconditional) branch appears and the firstBranch is conditional
+                        //so the BranchCompactor moves to LOOKING_FOR_DOUBLE_JUMP state
+                        secondBranch = bi;
+                        activeState = LOOKING_FOR_DOUBLE_JUMP;
+                    } else {
+                        //branches do not meet criteria to look for double jumps
+                        //so we flush the firstBranch and all buffered pseudo instructions
+                        //and continue in this state with a new firstBranch
+                        atEnd(cob);
+                        firstBranch = bi;
+                    }
                 }
                 default -> {
+                    //any other instruction flushes the firstBranch and pseudo instructions
+                    //and returns BranchCompactor to INIT_STATE
                     atEnd(cob);
                     activeState = INIT_STATE;
                     cob.with(coe);
@@ -80,9 +108,73 @@ final class BranchCompactor implements CodeTransform {
         }
         @Override
         public void atEnd(CodeBuilder cob) {
+            //here we flush the firstBranch and pseudo instructions
             cob.accept(firstBranch);
-            pseudoBuffer.forEach(cob::with);
-            pseudoBuffer.clear();
+            pseudoBuffer1.forEach(cob::with);
+            pseudoBuffer1.clear();
+        }
+    };
+
+    //This state assumes we have a sequence of one conditional and one unconditional branch
+    //and we are trying to merge them with reversed condition
+    private final CodeTransform LOOKING_FOR_DOUBLE_JUMP = new CodeTransform() {
+        @Override
+        public void accept(CodeBuilder cob, CodeElement coe) {
+            switch (coe) {
+                case LabelTarget lt -> {
+                    if (secondBranch.target() == lt.label()) {
+                        //second branch has been identified as short-circuit
+                        //so we move to LOOKING_FOR_SHORT_JUMP state
+                        //and replay all pseudo instructions from the second buffer
+                        //as there might be another short target
+                        activeState = LOOKING_FOR_SHORT_JUMP;
+                        pseudoBuffer2.forEach(pi -> activeState.accept(cob, pi));
+                        pseudoBuffer2.clear();
+                        activeState.accept(cob, lt);
+                    } else if (firstBranch.target() == lt.label()) {
+                        //double branch has been detected
+                        //we replace firstBranch instruction with reverted condition and secondBranch target
+                        //move to LOOKING_FOR_SHORT_JUMP state and replay pseudoBuffer2
+                        firstBranch = BranchInstruction.of(reverseBranchOpcode(firstBranch.opcode()), secondBranch.target());
+                        activeState = LOOKING_FOR_SHORT_JUMP;
+                        pseudoBuffer2.forEach(pi -> activeState.accept(cob, pi));
+                        pseudoBuffer2.clear();
+                        activeState.accept(cob, lt);
+                    } else {
+                        //here we buffer the label as a pseudo instruction following the secondBranch
+                        pseudoBuffer2.add(lt);
+                    }
+                }
+                case PseudoInstruction pi -> {
+                    //here we buffer pseudo instructions following the secondBranch
+                    pseudoBuffer2.add(pi);
+                }
+                case BranchInstruction bi -> {
+                    //third branch has been detected, so we flush the firstBranch and its pseudo instructions
+                    //move to LOOKING_FOR_SHORT_JUMP state, shift secondBranch to the firstBranch
+                    //replay the seconBranch pseudo instructions and this actual branch
+                    LOOKING_FOR_SHORT_JUMP.atEnd(cob);
+                    activeState = LOOKING_FOR_SHORT_JUMP;
+                    firstBranch = secondBranch;
+                    pseudoBuffer2.forEach(pi -> activeState.accept(cob, pi));
+                    pseudoBuffer2.clear();
+                    activeState.accept(cob, bi);
+                }
+                default -> {
+                    //any other instruction flushes all the branches and buffered pseudo instructions
+                    atEnd(cob);
+                    activeState = INIT_STATE;
+                    cob.with(coe);
+                }
+            }
+        }
+        @Override
+        public void atEnd(CodeBuilder cob) {
+            //here we flush everything
+            LOOKING_FOR_SHORT_JUMP.atEnd(cob);
+            cob.accept(secondBranch);
+            pseudoBuffer2.forEach(cob::with);
+            pseudoBuffer2.clear();
         }
     };
 
@@ -96,5 +188,27 @@ final class BranchCompactor implements CodeTransform {
     @Override
     public void atEnd(CodeBuilder cob) {
         activeState.atEnd(cob);
+    }
+
+    static Opcode reverseBranchOpcode(Opcode op) {
+        return switch (op) {
+            case IFEQ -> Opcode.IFNE;
+            case IFNE -> Opcode.IFEQ;
+            case IFLT -> Opcode.IFGE;
+            case IFGE -> Opcode.IFLT;
+            case IFGT -> Opcode.IFLE;
+            case IFLE -> Opcode.IFGT;
+            case IF_ICMPEQ -> Opcode.IF_ICMPNE;
+            case IF_ICMPNE -> Opcode.IF_ICMPEQ;
+            case IF_ICMPLT -> Opcode.IF_ICMPGE;
+            case IF_ICMPGE -> Opcode.IF_ICMPLT;
+            case IF_ICMPGT -> Opcode.IF_ICMPLE;
+            case IF_ICMPLE -> Opcode.IF_ICMPGT;
+            case IF_ACMPEQ -> Opcode.IF_ACMPNE;
+            case IF_ACMPNE -> Opcode.IF_ACMPEQ;
+            case IFNULL -> Opcode.IFNONNULL;
+            case IFNONNULL -> Opcode.IFNULL;
+            default -> throw new IllegalArgumentException("Unknown branch instruction: " + op);
+        };
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
@@ -38,7 +38,10 @@ import java.util.List;
  * BranchCompactor is a CodeTransform working as a state machine.
  * It identifies and compacts redundant sequences of branches in a single pass.
  */
-final class BranchCompactor implements CodeTransform {
+public final class BranchCompactor implements CodeTransform {
+
+    public BranchCompactor() {
+    }
 
     private BranchInstruction firstBranch, secondBranch;
     private final List<PseudoInstruction> pseudoBuffer1 = new ArrayList<>(),

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
@@ -56,18 +56,13 @@ public final class BranchCompactor implements CodeTransform {
             }
         } else {
             switch (coe) {
-                case LabelTarget lt -> {
-                    if (branch.target() == lt.label()) {
-                        //skip branch to immediate target
-                        branch = null;
-                        //flush the buffer
-                        atEnd(cob);
-                        //pass the target
-                        cob.with(lt);
-                    } else {
-                        //buffer other targets
-                        buffer.add(lt);
-                    }
+                case LabelTarget lt when branch.target() == lt.label() -> {
+                    //skip branch to immediate target
+                    branch = null;
+                    //flush the buffer
+                    atEnd(cob);
+                    //pass the target
+                    cob.with(lt);
                 }
                 case PseudoInstruction pi -> {
                     //buffer pseudo instructions

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
@@ -55,7 +55,7 @@ public final class BranchCompactor implements CodeTransform {
                 firstBranch = bi;
                 activeState = LOOKING_FOR_SHORT_JUMP;
             } else {
-                //all other instructions and pseudo instrutions are passed
+                //all other instructions and pseudo instructions are passed
                 cob.with(coe);
             }
         }
@@ -155,7 +155,7 @@ public final class BranchCompactor implements CodeTransform {
                 case BranchInstruction bi -> {
                     //third branch has been detected, so we flush the firstBranch and its pseudo instructions
                     //move to LOOKING_FOR_SHORT_JUMP state, shift secondBranch to the firstBranch
-                    //replay the seconBranch pseudo instructions and this actual branch
+                    //replay the secondBranch pseudo instructions and this actual branch
                     LOOKING_FOR_SHORT_JUMP.atEnd(cob);
                     activeState = LOOKING_FOR_SHORT_JUMP;
                     firstBranch = secondBranch;

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang.reflect.code.bytecode;
+
+import java.lang.classfile.CodeBuilder;
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.CodeTransform;
+import java.lang.classfile.PseudoInstruction;
+import java.lang.classfile.instruction.BranchInstruction;
+import java.lang.classfile.instruction.LabelTarget;
+import java.util.ArrayList;
+import java.util.List;
+
+final class BranchCompactor implements CodeTransform {
+
+    private BranchInstruction firstBranch;
+    private final List<PseudoInstruction> pseudoBuffer = new ArrayList<>();
+
+    private final CodeTransform INIT_STATE = new CodeTransform() {
+        @Override
+        public void accept(CodeBuilder cob, CodeElement coe) {
+            if (coe instanceof BranchInstruction bi) {
+                firstBranch = bi;
+                activeState = LOOKING_FOR_TARGET;
+            } else {
+                cob.with(coe);
+            }
+        }
+    };
+
+    private final CodeTransform LOOKING_FOR_TARGET = new CodeTransform() {
+        @Override
+        public void accept(CodeBuilder cob, CodeElement coe) {
+            switch (coe) {
+                case LabelTarget lt -> {
+                    if (firstBranch.target() == lt.label()) {
+                        pseudoBuffer.forEach(cob::with);
+                        pseudoBuffer.clear();
+                        activeState = INIT_STATE;
+                        cob.with(coe);
+                    } else {
+                        pseudoBuffer.add(lt);
+                    }
+                }
+                case PseudoInstruction pi -> {
+                    pseudoBuffer.add(pi);
+                }
+                case BranchInstruction bi -> {
+                    atEnd(cob);
+                    firstBranch = bi;
+                }
+                default -> {
+                    atEnd(cob);
+                    activeState = INIT_STATE;
+                    cob.with(coe);
+                }
+            }
+        }
+        @Override
+        public void atEnd(CodeBuilder cob) {
+            cob.accept(firstBranch);
+            pseudoBuffer.forEach(cob::with);
+            pseudoBuffer.clear();
+        }
+    };
+
+    private CodeTransform activeState = INIT_STATE;
+
+    @Override
+    public void accept(CodeBuilder cob, CodeElement coe) {
+        activeState.accept(cob, coe);
+    }
+
+    @Override
+    public void atEnd(CodeBuilder cob) {
+        activeState.atEnd(cob);
+    }
+}

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BranchCompactor.java
@@ -27,7 +27,6 @@ package java.lang.reflect.code.bytecode;
 import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeTransform;
-import java.lang.classfile.Opcode;
 import java.lang.classfile.PseudoInstruction;
 import java.lang.classfile.instruction.BranchInstruction;
 import java.lang.classfile.instruction.LabelTarget;
@@ -35,183 +34,59 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * BranchCompactor is a CodeTransform working as a state machine.
- * It identifies and compacts redundant sequences of branches in a single pass.
+ * BranchCompactor is a CodeTransform skipping redundant branches to immediate targets.
  */
 public final class BranchCompactor implements CodeTransform {
 
     public BranchCompactor() {
     }
 
-    private BranchInstruction firstBranch, secondBranch;
-    private final List<PseudoInstruction> pseudoBuffer1 = new ArrayList<>(),
-                                          pseudoBuffer2 = new ArrayList<>();
+    private BranchInstruction branch;
+    private final List<PseudoInstruction> buffer = new ArrayList<>();
 
-    //BranchCompactor is in INIT_STATE until a branch instruction appears
-    private final CodeTransform INIT_STATE = new CodeTransform() {
-        @Override
-        public void accept(CodeBuilder cob, CodeElement coe) {
-            if (coe instanceof BranchInstruction bi) {
-                firstBranch = bi;
-                activeState = LOOKING_FOR_SHORT_JUMP;
+    @Override
+    public void accept(CodeBuilder cob, CodeElement coe) {
+        if (branch == null) {
+            if (coe instanceof BranchInstruction bi && bi.opcode().isUnconditionalBranch()) {
+                //unconditional branch is stored
+                branch = bi;
             } else {
                 //all other instructions and pseudo instructions are passed
                 cob.with(coe);
             }
-        }
-    };
-
-    //In this state we are looking for immediate target of the firstBranch
-    //or also for a second (unconditional) branch when the firstBranch is conditional
-    //all pseudo instructions are buffered as they do not represent a real bytecode
-    private final CodeTransform LOOKING_FOR_SHORT_JUMP = new CodeTransform() {
-        @Override
-        public void accept(CodeBuilder cob, CodeElement coe) {
-            switch (coe) {
-                case LabelTarget lt -> {
-                    if (firstBranch.target() == lt.label()) {
-                        //here we have immediate target, so the first branch is skipped
-                        //all pseudo instructions are passed (including the actual target)
-                        //and BranchCompactor returns to INIT_STATE
-                        pseudoBuffer1.forEach(cob::with);
-                        pseudoBuffer1.clear();
-                        activeState = INIT_STATE;
-                        cob.with(coe);
-                    } else {
-                        //here we buffer the label as a pseudo instructions
-                        pseudoBuffer1.add(lt);
-                    }
-                }
-                case PseudoInstruction pi -> {
-                    //here we buffer pseudo instructions
-                    pseudoBuffer1.add(pi);
-                }
-                case BranchInstruction bi -> {
-                    if (!firstBranch.opcode().isUnconditionalBranch() && bi.opcode().isUnconditionalBranch()) {
-                        //second (unconditional) branch appears and the firstBranch is conditional
-                        //so the BranchCompactor moves to LOOKING_FOR_DOUBLE_JUMP state
-                        secondBranch = bi;
-                        activeState = LOOKING_FOR_DOUBLE_JUMP;
-                    } else {
-                        //branches do not meet criteria to look for double jumps
-                        //so we flush the firstBranch and all buffered pseudo instructions
-                        //and continue in this state with a new firstBranch
-                        atEnd(cob);
-                        firstBranch = bi;
-                    }
-                }
-                default -> {
-                    //any other instruction flushes the firstBranch and pseudo instructions
-                    //and returns BranchCompactor to INIT_STATE
-                    atEnd(cob);
-                    activeState = INIT_STATE;
+        } else switch (coe) {
+            case LabelTarget lt -> {
+                if (branch.target() == lt.label()) {
+                    //skip branch to immediate target
+                    branch = null;
+                    //flush buffer
+                    buffer.forEach(cob::with);
+                    buffer.clear();
                     cob.with(coe);
+                } else {
+                    //buffer other targets
+                    buffer.add(lt);
                 }
             }
-        }
-        @Override
-        public void atEnd(CodeBuilder cob) {
-            //here we flush the firstBranch and pseudo instructions
-            cob.accept(firstBranch);
-            pseudoBuffer1.forEach(cob::with);
-            pseudoBuffer1.clear();
-        }
-    };
-
-    //This state assumes we have a sequence of one conditional and one unconditional branch
-    //and we are trying to merge them with reversed condition
-    private final CodeTransform LOOKING_FOR_DOUBLE_JUMP = new CodeTransform() {
-        @Override
-        public void accept(CodeBuilder cob, CodeElement coe) {
-            switch (coe) {
-                case LabelTarget lt -> {
-                    if (secondBranch.target() == lt.label()) {
-                        //second branch has been identified as short-circuit
-                        //so we move to LOOKING_FOR_SHORT_JUMP state
-                        //and replay all pseudo instructions from the second buffer
-                        //as there might be another short target
-                        activeState = LOOKING_FOR_SHORT_JUMP;
-                        pseudoBuffer2.forEach(pi -> activeState.accept(cob, pi));
-                        pseudoBuffer2.clear();
-                        activeState.accept(cob, lt);
-                    } else if (firstBranch.target() == lt.label()) {
-                        //double branch has been detected
-                        //we replace firstBranch instruction with reverted condition and secondBranch target
-                        //move to LOOKING_FOR_SHORT_JUMP state and replay pseudoBuffer2
-                        firstBranch = BranchInstruction.of(reverseBranchOpcode(firstBranch.opcode()), secondBranch.target());
-                        activeState = LOOKING_FOR_SHORT_JUMP;
-                        pseudoBuffer2.forEach(pi -> activeState.accept(cob, pi));
-                        pseudoBuffer2.clear();
-                        activeState.accept(cob, lt);
-                    } else {
-                        //here we buffer the label as a pseudo instruction following the secondBranch
-                        pseudoBuffer2.add(lt);
-                    }
-                }
-                case PseudoInstruction pi -> {
-                    //here we buffer pseudo instructions following the secondBranch
-                    pseudoBuffer2.add(pi);
-                }
-                case BranchInstruction bi -> {
-                    //third branch has been detected, so we flush the firstBranch and its pseudo instructions
-                    //move to LOOKING_FOR_SHORT_JUMP state, shift secondBranch to the firstBranch
-                    //replay the secondBranch pseudo instructions and this actual branch
-                    LOOKING_FOR_SHORT_JUMP.atEnd(cob);
-                    activeState = LOOKING_FOR_SHORT_JUMP;
-                    firstBranch = secondBranch;
-                    pseudoBuffer2.forEach(pi -> activeState.accept(cob, pi));
-                    pseudoBuffer2.clear();
-                    activeState.accept(cob, bi);
-                }
-                default -> {
-                    //any other instruction flushes all the branches and buffered pseudo instructions
-                    atEnd(cob);
-                    activeState = INIT_STATE;
-                    cob.with(coe);
-                }
+            case PseudoInstruction pi -> {
+                //buffer pseudo instructions
+                buffer.add(pi);
+            }
+            default -> {
+                //any other instruction flushes the branch and buffer
+                atEnd(cob);
+                //the code element is replayed
+                accept(cob, coe);
             }
         }
-        @Override
-        public void atEnd(CodeBuilder cob) {
-            //here we flush everything
-            LOOKING_FOR_SHORT_JUMP.atEnd(cob);
-            cob.accept(secondBranch);
-            pseudoBuffer2.forEach(cob::with);
-            pseudoBuffer2.clear();
-        }
-    };
-
-    private CodeTransform activeState = INIT_STATE;
-
-    @Override
-    public void accept(CodeBuilder cob, CodeElement coe) {
-        activeState.accept(cob, coe);
     }
-
     @Override
     public void atEnd(CodeBuilder cob) {
-        activeState.atEnd(cob);
-    }
-
-    static Opcode reverseBranchOpcode(Opcode op) {
-        return switch (op) {
-            case IFEQ -> Opcode.IFNE;
-            case IFNE -> Opcode.IFEQ;
-            case IFLT -> Opcode.IFGE;
-            case IFGE -> Opcode.IFLT;
-            case IFGT -> Opcode.IFLE;
-            case IFLE -> Opcode.IFGT;
-            case IF_ICMPEQ -> Opcode.IF_ICMPNE;
-            case IF_ICMPNE -> Opcode.IF_ICMPEQ;
-            case IF_ICMPLT -> Opcode.IF_ICMPGE;
-            case IF_ICMPGE -> Opcode.IF_ICMPLT;
-            case IF_ICMPGT -> Opcode.IF_ICMPLE;
-            case IF_ICMPLE -> Opcode.IF_ICMPGT;
-            case IF_ACMPEQ -> Opcode.IF_ACMPNE;
-            case IF_ACMPNE -> Opcode.IF_ACMPEQ;
-            case IFNULL -> Opcode.IFNONNULL;
-            case IFNONNULL -> Opcode.IFNULL;
-            default -> throw new IllegalArgumentException("Unknown branch instruction: " + op);
-        };
+        //flush the branch
+        cob.with(branch);
+        branch = null;
+        //flush the buffer
+        buffer.forEach(cob::with);
+        buffer.clear();
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -317,7 +317,6 @@ public final class BytecodeGenerator {
 
 
     private static void computeExceptionRegionMembership(Body body, CodeBuilder cob, ConversionContext c) {
-        final List<Block> blocks = body.blocks();
         record ExceptionRegionWithBlocks(CoreOps.ExceptionRegionEnter ere, BitSet blocks) {
         }
         // List of all regions
@@ -328,8 +327,7 @@ public final class BytecodeGenerator {
             BlockWithActiveExceptionRegions(Block block, BitSet activeRegionStack) {
                 this.block = block;
                 this.activeRegionStack = activeRegionStack;
-                int index = blocks.indexOf(block);
-                activeRegionStack.stream().forEach(r -> allRegions.get(r).blocks.set(index));
+                activeRegionStack.stream().forEach(r -> allRegions.get(r).blocks.set(block.index()));
             }
         }
         final Set<Block> visited = new HashSet<>();
@@ -365,6 +363,7 @@ public final class BytecodeGenerator {
             }
         }
         // Declare the exception regions
+        final List<Block> blocks = body.blocks();
         for (ExceptionRegionWithBlocks erNode : allRegions.reversed()) {
             int start  = erNode.blocks.nextSetBit(0);
             while (start >= 0) {

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -378,7 +378,7 @@ public final class BytecodeGenerator {
                 stack.push(new BlockWithActiveExceptionRegions(cop.trueBranch().targetBlock(), bm.activeRegions));
             } else if (top instanceof CoreOps.ExceptionRegionEnter er) {
                 ArrayList<Block.Reference> catchBlocks = new ArrayList<>(er.catchBlocks());
-                for (Block.Reference catchBlock : catchBlocks.reversed()) {
+                for (Block.Reference catchBlock : er.catchBlocks().reversed()) {
                     c.catchingBlocks.add(catchBlock.targetBlock());
                     stack.push(new BlockWithActiveExceptionRegions(catchBlock.targetBlock(), bm.activeRegions));
                 }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -348,7 +348,7 @@ public final class BytecodeGenerator {
         final List<Block> blocks = r.blocks();
         record ExceptionRegionWithBlocks(CoreOps.ExceptionRegionEnter ere, BitSet blocks) {
         }
-        // Queue of all activeRegions
+        // List of all activeRegions
         final List<ExceptionRegionWithBlocks> allRegions = new ArrayList<>();
         class BlockWithActiveExceptionRegions {
             final Block block;

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBranchCompactor.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBranchCompactor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.components.ClassPrinter;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.reflect.code.bytecode.BranchCompactor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @enablePreview
+ * @run testng TestBranchCompactor
+ */
+public class TestBranchCompactor {
+
+    @Test
+    public void testBranchCompactor() {
+        var cc = ClassFile.of();
+        var clm = cc.parse(cc.build(ClassDesc.of("c"), clb -> clb.withMethodBody("m", ConstantDescs.MTD_void, 0,
+                cb -> cb.transforming(new BranchCompactor(), cob -> {
+                    var l1 = cob.newLabel();
+                    cob.goto_(l1);
+                    cob.labelBinding(l1);
+                    l1 = cob.newLabel();
+                    cob.goto_(l1);
+                    cob.labelBinding(l1);
+                    cob.iconst_0();
+                    cob.ifThenElse(tb -> {
+                        var l2 = tb.newLabel();
+                        tb.goto_(l2);
+                        tb.labelBinding(l2);
+                        l2 = tb.newLabel();
+                        tb.goto_(l2);
+                        tb.labelBinding(l2);
+                    }, eb -> {
+                        var l2 = eb.newLabel();
+                        eb.goto_(l2);
+                        eb.labelBinding(l2);
+                        l2 = eb.newLabel();
+                        eb.goto_(l2);
+                        eb.labelBinding(l2);
+                    });
+                    l1 = cob.newLabel();
+                    cob.goto_(l1);
+                    cob.labelBinding(l1);
+                    l1 = cob.newLabel();
+                    cob.goto_(l1);
+                    cob.labelBinding(l1);
+                    cob.return_();
+                }))));
+
+        ClassPrinter.toYaml(clm, ClassPrinter.Verbosity.TRACE_ALL, System.out::print);
+        //only iconst_0 and return_ should remain
+        Assert.assertEquals(clm.methods().get(0).code().get().elementList().size(), 2);
+    }
+}

--- a/test/jdk/java/lang/reflect/code/bytecode/TestNew.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestNew.java
@@ -28,7 +28,6 @@ import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.bytecode.BytecodeGenerator;
-import java.lang.reflect.code.bytecode.BytecodeLower;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSimple.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSimple.java
@@ -28,7 +28,6 @@ import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.bytecode.BytecodeGenerator;
-import java.lang.reflect.code.bytecode.BytecodeLower;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTry.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTry.java
@@ -28,7 +28,6 @@ import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.bytecode.BytecodeGenerator;
-import java.lang.reflect.code.bytecode.BytecodeLower;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
@@ -128,8 +128,7 @@ public class TestTryFinally {
         c.accept(-1);
     }
 
-    @Test(enabled = false)
-    //finalizer in exception handler is invalid (missing exception.region.exit)
+    @Test
     public void testCatchThrow() {
         CoreOps.FuncOp f = getFuncOp("catchThrow");
 

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
@@ -28,7 +28,6 @@ import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.bytecode.BytecodeGenerator;
-import java.lang.reflect.code.bytecode.BytecodeLower;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTryFinallyNested.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTryFinallyNested.java
@@ -84,8 +84,7 @@ public class TestTryFinallyNested {
         c.accept(6);
     }
 
-    @Test(enabled = false)
-    //finalizer in exception handler is invalid (missing exception.region.exit)
+    @Test
     public void testCatchFinally() {
         CoreOps.FuncOp f = getFuncOp("tryCatchFinally");
 

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTryFinallyNested.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTryFinallyNested.java
@@ -28,7 +28,6 @@ import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.bytecode.BytecodeGenerator;
-import java.lang.reflect.code.bytecode.BytecodeLower;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;


### PR DESCRIPTION
BytecodeGenerator::computeExceptionRegionMembership now collects all necessary info into BitSets and directly declares the regions with CodeBuilder.
All tests are now passing.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [a94c0177](https://git.openjdk.org/babylon/pull/12/files/a94c0177dfc1a48d9dbe53000779f58a47aa3f03)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/babylon.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/12.diff">https://git.openjdk.org/babylon/pull/12.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/12#issuecomment-1919403693)