### PR TITLE
Correct computation of block indexes

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Block.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Block.java
@@ -156,7 +156,16 @@ public final class Block implements CodeElement<Block, Op> {
     }
 
     /**
-     * Returns this block's index within the parent bodies list of blocks.
+     * Returns this block's index within the parent body's blocks.
+     * <p>
+     * The following identity holds true:
+     * {@snippet lang = "java"
+     *     this.parentBody().blocks().indexOf(this) == this.index();
+     * }
+     *
+     * @apiNote
+     * The block's index may be used to efficiently track blocks using
+     * bits sets or boolean arrays.
      *
      * @return the block index.
      */

--- a/src/java.base/share/classes/java/lang/reflect/code/Body.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Body.java
@@ -423,6 +423,8 @@ public final class Body implements CodeElement<Body, Block> {
                 }
 
                 // Remove any non-entry blocks with no operations and no predecessors
+                // @@@ Remove non-empty blocks with no predecessors?
+                //     Retaining such blocks may be useful for debugging, or perhaps it's intentional?
                 if (empty &&
                         !block.isEntryBlock() &&
                         block.predecessors.isEmpty()) {
@@ -534,6 +536,9 @@ public final class Body implements CodeElement<Body, Block> {
         return body;
     }
 
+    // Sort blocks in reverse post order
+    // After sorting the following holds for a block
+    //   block.parentBody().blocks().indexOf(block) == block.index()
     private void sortReversePostorder() {
         if (blocks.size() < 2) {
             for (int i = 0; i < blocks.size(); i++) {
@@ -543,7 +548,7 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         // Reset block indexes
-        // Ensure unreferenced blocks occur last
+        // Also ensuring blocks with no predecessors occur last
         for (Block b : blocks) {
             b.index = Integer.MAX_VALUE;
         }
@@ -576,6 +581,13 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         blocks.sort(Comparator.comparingInt(b -> b.index));
+        if (blocks.get(0).index > 0) {
+            // There are blocks with no predecessors
+            // Reassign indexes to their natural indexes, sort order is preserved
+            for (int i = 0; i < blocks.size(); i++) {
+                blocks.get(i).index = i;
+            }
+        }
     }
 
     // Modifying methods

--- a/test/jdk/java/lang/reflect/code/TestBlockIndexes.java
+++ b/test/jdk/java/lang/reflect/code/TestBlockIndexes.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.code.Block;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.op.CoreOps;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+/*
+ * @test
+ * @run testng TestBlockIndexes
+ */
+
+public class TestBlockIndexes {
+
+    @CodeReflection
+    static int f(int[] a) {
+        int sum = 0;
+        for (int i = 0; i < a.length; i++) {
+            sum += a[i];
+        }
+        return sum;
+    }
+
+    @Test
+    public void testBlockIndexes() {
+        CoreOps.FuncOp f = getFuncOp("f");
+        f = f.transform((block, op) -> {
+            if (op instanceof Op.Lowerable lop) {
+                return lop.lower(block);
+            } else {
+                block.op(op);
+                return block;
+            }
+        });
+        assertBlockIndexes(f);
+
+        AtomicBoolean first = new AtomicBoolean(true);
+        f = f.transform((block, op) -> {
+            if (first.getAndSet(false)) {
+                // Create some blocks without predecessors
+                for (int i = 0; i < 5; i++) {
+                    Block.Builder redundant = block.block();
+                    redundant.op(CoreOps._return());
+                }
+            }
+            block.op(op);
+            return block;
+        });
+        assertBlockIndexes(f);
+    }
+
+    static void assertBlockIndexes(CoreOps.FuncOp f) {
+        for (Block b : f.body().blocks()) {
+            Assert.assertEquals(b.index(), b.parentBody().blocks().indexOf(b));
+        }
+    }
+
+    static CoreOps.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestBlockIndexes.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}


### PR DESCRIPTION
If there are blocks present in a body that have no predecessors then all the blocks in the body will report incorrect indexes.

The following should hold for any block:
```java
b.parentBody().blocks().indexOf(b) == b.index();
```

Thereby it is possible to use a block's index efficiently with bit sets or boolean arrays.

Note, blocks without predecessors are currently retained since they may have been intentionally added. Sometimes they can also be added by a transformation, which expects subsequent transformations to ignore or remove such blocks (such as a the bytecode generator, which ignores such blocks).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/babylon.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/14.diff">https://git.openjdk.org/babylon/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/14#issuecomment-1922239454)