### PR TITLE
Add and/or/xor operations to code model

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -529,6 +529,30 @@ public final class BytecodeGenerator {
                             default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
                         }
                     }
+                    case AndOp op -> {
+                        processOperands(cob, c, op, isLastOpResultOnStack);
+                        switch (rvt) { //this can be moved to CodeBuilder::and(TypeKind)
+                            case IntType, BooleanType -> cob.iand();
+                            case LongType -> cob.land();
+                            default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
+                        }
+                    }
+                    case OrOp op -> {
+                        processOperands(cob, c, op, isLastOpResultOnStack);
+                        switch (rvt) { //this can be moved to CodeBuilder::or(TypeKind)
+                            case IntType, BooleanType -> cob.ior();
+                            case LongType -> cob.lor();
+                            default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
+                        }
+                    }
+                    case XorOp op -> {
+                        processOperands(cob, c, op, isLastOpResultOnStack);
+                        switch (rvt) { //this can be moved to CodeBuilder::xor(TypeKind)
+                            case IntType, BooleanType -> cob.ixor();
+                            case LongType -> cob.lxor();
+                            default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
+                        }
+                    }
                     case ArrayAccessOp.ArrayLoadOp op -> {
                         processOperands(cob, c, op, isLastOpResultOnStack);
                         cob.arrayLoadInstruction(rvt);

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
@@ -75,6 +75,14 @@ final class InvokableLeafOps {
         return l | r;
     }
 
+    public static int and(int l, int r) {
+        return l & r;
+    }
+
+    public static int xor(int l, int r) {
+        return l ^ r;
+    }
+
     public static boolean eq(int l, int r) {
         return l == r;
     }
@@ -129,6 +137,15 @@ final class InvokableLeafOps {
         return l | r;
     }
 
+    public static long and(long l, long r) {
+        return l & r;
+    }
+
+    public static long xor(long l, long r) {
+        return l ^ r;
+    }
+
+
     public static boolean eq(long l, long r) {
         return l == r;
     }
@@ -177,6 +194,10 @@ final class InvokableLeafOps {
         return l / r;
     }
 
+    static float mod(float l, float r) {
+        return l % r;
+    }
+
     public static boolean eq(float l, float r) {
         return l == r;
     }
@@ -223,6 +244,34 @@ final class InvokableLeafOps {
 
     static double div(double l, double r) {
         return l / r;
+    }
+
+    static double mod(double l, double r) {
+        return l % r;
+    }
+
+
+
+    // boolean
+
+    static boolean eq(boolean l, boolean r) {
+        return l == r;
+    }
+
+    static boolean neq(boolean l, boolean r) {
+        return l != r;
+    }
+
+    static boolean and(boolean l, boolean r) {
+        return l & r;
+    }
+
+    static boolean or(boolean l, boolean r) {
+        return l | r;
+    }
+
+    static boolean xor(boolean l, boolean r) {
+        return l ^ r;
     }
 
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -31,7 +31,6 @@ import java.lang.reflect.code.descriptor.MethodDesc;
 import java.lang.reflect.code.descriptor.MethodTypeDesc;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.type.TupleType;
-import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.type.VarType;
 import java.lang.reflect.code.type.impl.JavaTypeImpl;
 import java.util.*;
@@ -2551,7 +2550,7 @@ public final class CoreOps {
     }
 
     /**
-     * The dic operation, that can model the Java language binary {@code /} operator for numeric types
+     * The div operation, that can model the Java language binary {@code /} operator for numeric types
      */
     @OpDeclaration(DivOp.NAME)
     public static final class DivOp extends BinaryOp {
@@ -2576,7 +2575,7 @@ public final class CoreOps {
     }
 
     /**
-     * The div operation, that can model the Java language binary {@code %} operator for numeric types
+     * The mod operation, that can model the Java language binary {@code %} operator for numeric types
      */
     @OpDeclaration(ModOp.NAME)
     public static final class ModOp extends BinaryOp {
@@ -2596,6 +2595,84 @@ public final class CoreOps {
         }
 
         ModOp(Value lhs, Value rhs) {
+            super(NAME, lhs, rhs);
+        }
+    }
+
+    /**
+     * The bitwise/logical or operation, that can model the Java language binary {@code |} operator for integral types
+     * and booleans
+     */
+    @OpDeclaration(OrOp.NAME)
+    public static final class OrOp extends BinaryOp {
+        public static final String NAME = "or";
+
+        public OrOp(OpDefinition opdef) {
+            super(opdef);
+        }
+
+        OrOp(OrOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public OrOp transform(CopyContext cc, OpTransformer ot) {
+            return new OrOp(this, cc);
+        }
+
+        OrOp(Value lhs, Value rhs) {
+            super(NAME, lhs, rhs);
+        }
+    }
+
+    /**
+     * The bitwise/logical and operation, that can model the Java language binary {@code &} operator for integral types
+     * and booleans
+     */
+    @OpDeclaration(AndOp.NAME)
+    public static final class AndOp extends BinaryOp {
+        public static final String NAME = "and";
+
+        public AndOp(OpDefinition opdef) {
+            super(opdef);
+        }
+
+        AndOp(AndOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public AndOp transform(CopyContext cc, OpTransformer ot) {
+            return new AndOp(this, cc);
+        }
+
+        AndOp(Value lhs, Value rhs) {
+            super(NAME, lhs, rhs);
+        }
+    }
+
+    /**
+     * The xor operation, that can model the Java language binary {@code ^} operator for integral types
+     * and booleans
+     */
+    @OpDeclaration(XorOp.NAME)
+    public static final class XorOp extends BinaryOp {
+        public static final String NAME = "xor";
+
+        public XorOp(OpDefinition opdef) {
+            super(opdef);
+        }
+
+        XorOp(XorOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public XorOp transform(CopyContext cc, OpTransformer ot) {
+            return new XorOp(this, cc);
+        }
+
+        XorOp(Value lhs, Value rhs) {
             super(NAME, lhs, rhs);
         }
     }
@@ -3462,6 +3539,39 @@ public final class CoreOps {
      */
     public static BinaryOp mod(Value lhs, Value rhs) {
         return new ModOp(lhs, rhs);
+    }
+
+    /**
+     * Creates a bitwise/logical or operation.
+     *
+     * @param lhs the first operand
+     * @param rhs the second operand
+     * @return the or operation
+     */
+    public static BinaryOp or(Value lhs, Value rhs) {
+        return new OrOp(lhs, rhs);
+    }
+
+    /**
+     * Creates a bitwise/logical and operation.
+     *
+     * @param lhs the first operand
+     * @param rhs the second operand
+     * @return the and operation
+     */
+    public static BinaryOp and(Value lhs, Value rhs) {
+        return new AndOp(lhs, rhs);
+    }
+
+    /**
+     * Creates a bitwise/logical xor operation.
+     *
+     * @param lhs the first operand
+     * @param rhs the second operand
+     * @return the xor operation
+     */
+    public static BinaryOp xor(Value lhs, Value rhs) {
+        return new XorOp(lhs, rhs);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -427,6 +427,7 @@ public class ReflectMethods extends TreeTranslator {
                         Tag.RETURN, Tag.THROW, Tag.BREAK, Tag.CONTINUE,
                         Tag.PLUS, Tag.MINUS, Tag.MUL, Tag.DIV, Tag.MOD,
                         Tag.NEG, Tag.NOT,
+                        Tag.BITOR, Tag.BITAND, Tag.BITXOR,
                         Tag.PLUS_ASG, Tag.MINUS_ASG, Tag.MUL_ASG, Tag.DIV_ASG, Tag.MOD_ASG,
                         Tag.POSTINC, Tag.PREINC, Tag.POSTDEC, Tag.PREDEC,
                         Tag.EQ, Tag.NE, Tag.LT, Tag.LE, Tag.GT, Tag.GE,
@@ -2035,6 +2036,11 @@ public class ReflectMethods extends TreeTranslator {
                     case LE -> append(CoreOps.le(lhs, rhs));
                     case GT -> append(CoreOps.gt(lhs, rhs));
                     case GE -> append(CoreOps.ge(lhs, rhs));
+
+                    // Bitwise operations (including their boolean variants)
+                    case BITOR -> append(CoreOps.or(lhs, rhs));
+                    case BITAND -> append(CoreOps.and(lhs, rhs));
+                    case BITXOR -> append(CoreOps.xor(lhs, rhs));
 
                     default -> throw unsupported(tree);
                 };

--- a/test/jdk/java/lang/reflect/code/TestBinops.java
+++ b/test/jdk/java/lang/reflect/code/TestBinops.java
@@ -67,6 +67,104 @@ public class TestBinops {
         Assert.assertEquals(Interpreter.invoke(f, 10, 3), mod(10, 3));
     }
 
+    @CodeReflection
+    public static int bitand(int a, int b) {
+        return a & b;
+    }
+
+    @Test
+    public void testBitand() {
+        CoreOps.FuncOp f = getFuncOp("bitand");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, 10, 3), bitand(10, 3));
+    }
+
+    @CodeReflection
+    public static int bitor(int a, int b) {
+        return a | b;
+    }
+
+    @Test
+    public void testBitor() {
+        CoreOps.FuncOp f = getFuncOp("bitor");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, 10, 3), bitor(10, 3));
+    }
+
+    @CodeReflection
+    public static int bitxor(int a, int b) {
+        return a ^ b;
+    }
+
+    @Test
+    public void testBitxor() {
+        CoreOps.FuncOp f = getFuncOp("bitxor");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, 10, 3), bitxor(10, 3));
+    }
+
+    @CodeReflection
+    public static boolean booland(boolean a, boolean b) {
+        return a & b;
+    }
+
+    @Test
+    public void testBooland() {
+        CoreOps.FuncOp f = getFuncOp("booland");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, true, false), booland(true, false));
+    }
+
+    @CodeReflection
+    public static boolean boolor(boolean a, boolean b) {
+        return a | b;
+    }
+
+    @Test
+    public void testBoolor() {
+        CoreOps.FuncOp f = getFuncOp("boolor");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, false, true), boolor(false, true));
+    }
+
+    @CodeReflection
+    public static boolean boolxor(boolean a, boolean b) {
+        return a ^ b;
+    }
+
+    @Test
+    public void testBoolxor() {
+        CoreOps.FuncOp f = getFuncOp("boolxor");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, true, true), boolxor(true, true));
+    }
+
+    @CodeReflection
+    public static double doublemod(double a, double b) {
+        return a % b;
+    }
+
+    @Test
+    public void testDoublemod() {
+        CoreOps.FuncOp f = getFuncOp("doublemod");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, 15.6, 2.1), doublemod(15.6, 2.1));
+    }
+
     static CoreOps.FuncOp getFuncOp(String name) {
         Optional<Method> om = Stream.of(TestBinops.class.getDeclaredMethods())
                 .filter(m -> m.getName().equals(name))

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSimple.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSimple.java
@@ -228,6 +228,19 @@ public class TestSimple {
         Assert.assertEquals((int) mh.invoke(10, 3), mod(10, 3));
     }
 
+    @CodeReflection
+    public static boolean xor(boolean a, boolean b) {
+        return a ^ b;
+    }
+
+    @Test
+    public void testXor() throws Throwable {
+        CoreOps.FuncOp f = getFuncOp("xor");
+
+        MethodHandle mh = generate(f);
+
+        Assert.assertEquals((boolean) mh.invoke(true, false), xor(true, false));
+    }
 
     static MethodHandle generate(CoreOps.FuncOp f) {
         f.writeTo(System.out);


### PR DESCRIPTION
Adds Ops for `&`, `|`, an `^`. I added some very basic tests for the interpreter and the bytecode.

I also added other missing methds to `InvokableLeafOps`, namely `mod` for floating point types and eq/neq for boolean.

I also noticed that `AddOp` currently models String concatenation, and the Interpreter also has a method for it, but that doesn't work because the method type is erased to Object, so that might require some more work in future.

There are also shifts and some unary operations missing for now, I can work on them in future if you want.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/babylon.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/21.diff">https://git.openjdk.org/babylon/pull/21.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/21#issuecomment-1941978589)