### PR TITLE
Replace use of MethodTypeDesc with FunctionType

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
@@ -26,8 +26,8 @@
 package oracle.code.triton;
 
 import java.lang.reflect.code.*;
-import java.lang.reflect.code.descriptor.MethodTypeDesc;
 import java.lang.reflect.code.op.*;
+import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.type.TupleType;
 import java.util.ArrayList;
@@ -42,9 +42,9 @@ public class SCFOps {
         public static class Builder {
             final Body.Builder ancestorBody;
             final List<Value> range;
-            final MethodTypeDesc loopDescriptor;
+            final FunctionType loopDescriptor;
 
-            Builder(Body.Builder ancestorBody, List<Value> range, MethodTypeDesc loopDescriptor) {
+            Builder(Body.Builder ancestorBody, List<Value> range, FunctionType loopDescriptor) {
                 this.ancestorBody = ancestorBody;
                 this.range = range;
                 this.loopDescriptor = loopDescriptor;
@@ -151,7 +151,7 @@ public class SCFOps {
         List<TypeElement> bodyParameterTypes = new ArrayList<>();
         bodyParameterTypes.add(start.type());
         bodyParameterTypes.addAll(iterValues.stream().map(Value::type).toList());
-        MethodTypeDesc bodyType = MethodTypeDesc.methodType(yieldType, bodyParameterTypes);
+        FunctionType bodyType = FunctionType.functionType(yieldType, bodyParameterTypes);
 
         List<Value> operands = new ArrayList<>();
         operands.addAll(List.of(start, end, step));

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -27,7 +27,6 @@ package oracle.code.triton;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.*;
-import java.lang.reflect.code.descriptor.MethodTypeDesc;
 import java.lang.reflect.code.op.*;
 import java.lang.reflect.code.type.*;
 import java.util.*;
@@ -110,7 +109,7 @@ public class TritonOps {
             super(NAME, JavaType.VOID,
                     List.of());
 
-            Body.Builder bodyC = Body.Builder.of(null, MethodTypeDesc.VOID);
+            Body.Builder bodyC = Body.Builder.of(null, FunctionType.VOID);
             Block.Builder entryBlock = bodyC.entryBlock();
             Map<String, FuncOp> table = new HashMap<>();
             for (FuncOp f : functions) {
@@ -138,9 +137,9 @@ public class TritonOps {
         public static class Builder {
             final Body.Builder ancestorBody;
             final String funcName;
-            final MethodTypeDesc funcDescriptor;
+            final FunctionType funcDescriptor;
 
-            Builder(Body.Builder ancestorBody, String funcName, MethodTypeDesc funcDescriptor) {
+            Builder(Body.Builder ancestorBody, String funcName, FunctionType funcDescriptor) {
                 this.ancestorBody = ancestorBody;
                 this.funcName = funcName;
                 this.funcDescriptor = funcDescriptor;
@@ -224,8 +223,8 @@ public class TritonOps {
         }
 
         @Override
-        public MethodTypeDesc funcDescriptor() {
-            return body.descriptor();
+        public FunctionType invokableType() {
+            return body.bodyType();
         }
 
         public String funcName() {
@@ -307,9 +306,9 @@ public class TritonOps {
             final Body.Builder ancestorBody;
             final int axis;
             final Value v;
-            final MethodTypeDesc reduceDescriptor;
+            final FunctionType reduceDescriptor;
 
-            Builder(Body.Builder ancestorBody, int axis, Value v, MethodTypeDesc reduceDescriptor) {
+            Builder(Body.Builder ancestorBody, int axis, Value v, FunctionType reduceDescriptor) {
                 this.ancestorBody = ancestorBody;
                 this.axis = axis;
                 this.v = v;
@@ -359,7 +358,7 @@ public class TritonOps {
         }
 
         ReduceOp(int axis, Value tensor, Body.Builder reducerBuilder) {
-            super(NAME, reducerBuilder.descriptor().returnType(), List.of(tensor));
+            super(NAME, reducerBuilder.bodyType().returnType(), List.of(tensor));
 
             this.axis = axis;
             this.reducer = reducerBuilder.build(this);
@@ -743,7 +742,7 @@ public class TritonOps {
         return new ModuleOp(List.copyOf(functions));
     }
 
-    public static FuncOp.Builder func(String funcName, MethodTypeDesc funcDescriptor) {
+    public static FuncOp.Builder func(String funcName, FunctionType funcDescriptor) {
         return new FuncOp.Builder(null, funcName, funcDescriptor);
     }
 
@@ -756,11 +755,11 @@ public class TritonOps {
     }
 
     public static CallOp call(FuncOp func, List<Value> args) {
-        return new CallOp(func.funcName(), func.funcDescriptor().returnType(), args);
+        return new CallOp(func.funcName(), func.invokableType().returnType(), args);
     }
 
     public static ReduceOp.Builder reduce(Body.Builder ancestorBody, int axis, Value tensor,
-                                          MethodTypeDesc reduceDescriptor) {
+                                          FunctionType reduceDescriptor) {
         return new ReduceOp.Builder(ancestorBody, axis, tensor, reduceDescriptor);
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
@@ -32,7 +32,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.code.*;
 import java.lang.reflect.code.analysis.SSA;
-import java.lang.reflect.code.descriptor.MethodTypeDesc;
 import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.op.ExtendedOps;
 import java.lang.reflect.code.type.JavaType;
@@ -41,8 +40,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
 import static java.lang.reflect.code.op.CoreOps.*;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 
 public final class TritonTransformer {
     private TritonTransformer() {}
@@ -557,7 +556,7 @@ public final class TritonTransformer {
             Type rType,
             Map<Value, Type> valueTypeMap, Map<Op, Object> opData,
             Map<String, TritonOps.FuncOp> fsymTable) {
-        TritonOps.FuncOp ttKernel = TritonOps.func(signature, MethodTypeDesc.methodType(TritonType.fromType(rType)))
+        TritonOps.FuncOp ttKernel = TritonOps.func(signature, functionType(TritonType.fromType(rType)))
                 .body(fblock -> {
                     // Process kernel parameters
                     List<Value> args = new ArrayList<>();
@@ -1145,11 +1144,11 @@ public final class TritonTransformer {
                                        int axisConstant,
                                        String name, TritonOps.FuncOp scalarFunc) {
             return TritonOps.func(name,
-                            methodType(elementType, tensorType))
+                            functionType(elementType, tensorType))
                     .body(fblock -> {
                         TritonOps.ReduceOp reduceOp = TritonOps.reduce(fblock.parentBody(),
                                         axisConstant, fblock.parameters().get(0),
-                                        methodType(elementType, elementType, elementType))
+                                        functionType(elementType, elementType, elementType))
                                 .body(rblock -> {
                                     Block.Parameter a = rblock.parameters().get(0);
                                     Block.Parameter b = rblock.parameters().get(1);

--- a/src/java.base/share/classes/java/lang/reflect/code/Block.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Block.java
@@ -590,7 +590,7 @@ public final class Block implements CodeElement<Block, Op> {
                         Value r;
                         if (rop.ancestorBody().blocks().size() != 1) {
                             List<TypeElement> param = rop.returnValue() != null
-                                    ? List.of(invokableOp.funcDescriptor().returnType())
+                                    ? List.of(invokableOp.invokableType().returnType())
                                     : List.of();
                             rb = block.block(param);
                             r = !param.isEmpty()

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -29,7 +29,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.lang.reflect.code.descriptor.MethodTypeDesc;
+import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.writer.OpWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -38,8 +38,8 @@ import java.util.function.BiFunction;
 /**
  * An operation modelling a unit of functionality.
  * <p>
- * An operation might model the addition of two 32-integers, or a Java method call.
- * Alternatively an operation may model something more complex like a method bodies, lambda bodies, or
+ * An operation might model the addition of two 32-bit integers, or a Java method call.
+ * Alternatively an operation may model something more complex like method bodies, lambda bodies, or
  * try/catch/finally statements. In this case such an operation will contain one or more bodies modelling
  * the nested structure.
  */
@@ -83,10 +83,9 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         Body body();
 
         /**
-         * @return the function descriptor describing the input parameter types and return type.
+         * @return the function type describing the invokable operation's parameter types and return type.
          */
-        // @@@ Replace with FunctionType
-        MethodTypeDesc funcDescriptor();
+        FunctionType invokableType();
     }
 
     /**
@@ -317,17 +316,16 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     public abstract TypeElement resultType();
 
     /**
-     * Returns the operation's descriptor.
+     * Returns the operation's function type.
      * <p>
-     * The descriptor's result type is the operation's return type and the descriptor's parameter types are the
+     * The function type's result type is the operation's result type and the function type's parameter types are the
      * operation's operand types, in order.
      *
-     * @return the descriptor
+     * @return the function type
      */
-    // @@@ Replace with FunctionType
-    public MethodTypeDesc descriptor() {
+    public FunctionType opType() {
         List<TypeElement> operandTypes = operands.stream().map(Value::type).toList();
-        return MethodTypeDesc.methodType(resultType(), operandTypes);
+        return FunctionType.functionType(resultType(), operandTypes);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -53,6 +53,8 @@ import java.lang.reflect.code.Value;
 import java.lang.reflect.code.analysis.Liveness;
 import java.lang.reflect.code.descriptor.FieldDesc;
 import java.lang.reflect.code.descriptor.MethodDesc;
+import java.lang.reflect.code.descriptor.MethodTypeDesc;
+import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.TypeElement;
 import java.util.ArrayDeque;
@@ -95,7 +97,8 @@ public final class BytecodeGenerator {
         }
 
         try {
-            MethodType mt = fop.funcDescriptor().resolve(hcl);
+            FunctionType ft = fop.invokableType();
+            MethodType mt = MethodTypeDesc.ofFunctionType(ft).resolve(hcl);
             return hcl.findStatic(hcl.lookupClass(), fop.funcName(), mt);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
@@ -113,10 +116,11 @@ public final class BytecodeGenerator {
                 ? fop.funcName()
                 : packageName + "." + fop.funcName();
         Liveness liveness = new Liveness(fop);
+        MethodTypeDesc mtd = MethodTypeDesc.ofFunctionType(fop.invokableType());
         byte[] classBytes = ClassFile.of().build(ClassDesc.of(className), clb ->
                 clb.withMethodBody(
                         fop.funcName(),
-                        fop.funcDescriptor().toNominalDescriptor(),
+                        mtd.toNominalDescriptor(),
                         ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC,
                         cb -> cb.transforming(new BranchCompactor(), cob -> {
                             ConversionContext c = new ConversionContext(lookup, liveness, cob);
@@ -611,7 +615,7 @@ public final class BytecodeGenerator {
                                     case INTERFACE_VIRTUAL          -> Opcode.INVOKEINTERFACE;
                                     case SPECIAL, INTERFACE_SPECIAL -> Opcode.INVOKESPECIAL;
                                     default ->
-                                        throw new IllegalStateException("Bad method descriptor resolution: " + op.descriptor() + " > " + op.invokeDescriptor());
+                                        throw new IllegalStateException("Bad method descriptor resolution: " + op.opType() + " > " + op.invokeDescriptor());
                                 },
                                 ((JavaType) md.refType()).toNominalDescriptor(),
                                 md.name(),

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
@@ -72,9 +72,10 @@ public final class BytecodeLift {
     }
 
     public static CoreOps.FuncOp lift(MethodModel methodModel) {
+        MethodTypeDesc mtd = MethodTypeDesc.ofNominalDescriptor(methodModel.methodTypeSymbol());
         return CoreOps.func(
                 methodModel.methodName().stringValue(),
-                MethodTypeDesc.ofNominalDescriptor(methodModel.methodTypeSymbol())).body(entryBlock -> {
+                mtd.toFunctionType()).body(entryBlock -> {
 
             final CodeModel codeModel = methodModel.code().orElseThrow();
             final HashMap<Label, Block.Builder> blockMap = new HashMap<>();

--- a/src/java.base/share/classes/java/lang/reflect/code/descriptor/MethodTypeDesc.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/descriptor/MethodTypeDesc.java
@@ -28,6 +28,7 @@ package java.lang.reflect.code.descriptor;
 import java.lang.reflect.code.descriptor.impl.MethodTypeDescImpl;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.TypeElement;
 import java.util.List;
@@ -35,7 +36,9 @@ import java.util.List;
 /**
  * The symbolic description of a method type, comprising descriptions of zero or more parameter types and a return type.
  */
+// @@@ Duplicates much of FunctionType
 public sealed interface MethodTypeDesc permits MethodTypeDescImpl {
+
     MethodTypeDesc VOID = methodType(JavaType.VOID);
 
     //
@@ -49,6 +52,11 @@ public sealed interface MethodTypeDesc permits MethodTypeDescImpl {
     MethodTypeDesc erase();
 
     String toNominalDescriptorString();
+
+    // @@@ required?
+    default FunctionType toFunctionType() {
+        return FunctionType.functionType(returnType(), parameters());
+    }
 
     default java.lang.constant.MethodTypeDesc toNominalDescriptor() {
         return java.lang.constant.MethodTypeDesc.ofDescriptor(toNominalDescriptorString());
@@ -71,6 +79,11 @@ public sealed interface MethodTypeDesc permits MethodTypeDescImpl {
 
     static MethodTypeDesc methodType(Class<?> ret, List<Class<?>> params) {
         return new MethodTypeDescImpl(JavaType.type(ret), params.stream().map(JavaType::type).toList());
+    }
+
+    // @@@ required?
+    static MethodTypeDesc ofFunctionType(FunctionType ft) {
+        return methodType(ft.returnType(), ft.parameterTypes());
     }
 
     static MethodTypeDesc ofNominalDescriptor(java.lang.constant.MethodTypeDesc d) {

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -2792,10 +2792,10 @@ public final class CoreOps {
      * Creates a function call operation
      * @param funcName the name of the function operation
      * @param funcDescriptor the function descriptor
-     * @param args the function argments
+     * @param args the function arguments
      * @return the function call operation
      */
-    public static FuncCallOp funcCall(String funcName, MethodTypeDesc funcDescriptor, Value... args) {
+    public static FuncCallOp funcCall(String funcName, FunctionType funcDescriptor, Value... args) {
         return funcCall(funcName, funcDescriptor, List.of(args));
     }
 
@@ -2803,10 +2803,10 @@ public final class CoreOps {
      * Creates a function call operation
      * @param funcName the name of the function operation
      * @param funcDescriptor the function descriptor
-     * @param args the function argments
+     * @param args the function arguments
      * @return the function call operation
      */
-    public static FuncCallOp funcCall(String funcName, MethodTypeDesc funcDescriptor, List<Value> args) {
+    public static FuncCallOp funcCall(String funcName, FunctionType funcDescriptor, List<Value> args) {
         return new FuncCallOp(funcName, funcDescriptor.returnType(), args);
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -27,8 +27,8 @@ package java.lang.reflect.code.op;
 
 import java.lang.reflect.code.*;
 import java.lang.reflect.code.descriptor.MethodDesc;
-import java.lang.reflect.code.descriptor.MethodTypeDesc;
 import java.lang.reflect.code.descriptor.RecordTypeDesc;
+import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.type.TupleType;
 import java.lang.reflect.code.TypeElement;
@@ -319,11 +319,11 @@ public class ExtendedOps {
             super(NAME, List.of());
 
             this.body = bodyC.build(this);
-            if (!body.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + body.descriptor());
+            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
-            if (!body.descriptor().parameters().isEmpty()) {
-                throw new IllegalArgumentException("Body should have zero parameters: " + body.descriptor());
+            if (!body.bodyType().parameterTypes().isEmpty()) {
+                throw new IllegalArgumentException("Body should have zero parameters: " + body.bodyType());
             }
         }
 
@@ -399,11 +399,11 @@ public class ExtendedOps {
             super(NAME, List.of());
 
             this.body = bodyC.build(this);
-            if (!body.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + body.descriptor());
+            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
-            if (!body.descriptor().parameters().isEmpty()) {
-                throw new IllegalArgumentException("Body should have zero parameters: " + body.descriptor());
+            if (!body.bodyType().parameterTypes().isEmpty()) {
+                throw new IllegalArgumentException("Body should have zero parameters: " + body.bodyType());
             }
         }
 
@@ -461,9 +461,9 @@ public class ExtendedOps {
     @OpDeclaration(JavaIfOp.NAME)
     public static final class JavaIfOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
 
-        static final MethodTypeDesc PREDICATE_TYPE = MethodTypeDesc.methodType(JavaType.BOOLEAN);
+        static final FunctionType PREDICATE_TYPE = FunctionType.functionType(JavaType.BOOLEAN);
 
-        static final MethodTypeDesc ACTION_TYPE = MethodTypeDesc.VOID;
+        static final FunctionType ACTION_TYPE = FunctionType.VOID;
 
         public static class IfBuilder {
             final Body.Builder ancestorBody;
@@ -580,7 +580,7 @@ public class ExtendedOps {
             if (bodyCs.size() % 2 == 0) {
                 bodyCs = new ArrayList<>(bodyCs);
                 Body.Builder end = Body.Builder.of(bodyCs.get(0).ancestorBody(),
-                        MethodTypeDesc.VOID);
+                        FunctionType.VOID);
                 end.entryBlock().op(_yield());
                 bodyCs.add(end);
             }
@@ -597,12 +597,12 @@ public class ExtendedOps {
                 } else {
                     action = bodies.get(i + 1);
                     Body fromPred = bodies.get(i);
-                    if (!fromPred.descriptor().equals(MethodTypeDesc.methodType(JavaType.BOOLEAN))) {
-                        throw new IllegalArgumentException("Illegal predicate body descriptor: " + fromPred.descriptor());
+                    if (!fromPred.bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+                        throw new IllegalArgumentException("Illegal predicate body descriptor: " + fromPred.bodyType());
                     }
                 }
-                if (!action.descriptor().equals(MethodTypeDesc.VOID)) {
-                    throw new IllegalArgumentException("Illegal action body descriptor: " + action.descriptor());
+                if (!action.bodyType().equals(FunctionType.VOID)) {
+                    throw new IllegalArgumentException("Illegal action body descriptor: " + action.bodyType());
                 }
             }
         }
@@ -795,7 +795,7 @@ public class ExtendedOps {
 
             public JavaForOp.CondBuilder init(Consumer<Block.Builder> c) {
                 Body.Builder init = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(TupleType.tupleType(initTypes)));
+                        FunctionType.functionType(TupleType.tupleType(initTypes)));
                 c.accept(init.entryBlock());
 
                 return new CondBuilder(ancestorBody, initTypes, init);
@@ -817,7 +817,7 @@ public class ExtendedOps {
 
             public JavaForOp.UpdateBuilder cond(Consumer<Block.Builder> c) {
                 Body.Builder cond = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(JavaType.BOOLEAN, initTypes));
+                        FunctionType.functionType(JavaType.BOOLEAN, initTypes));
                 c.accept(cond.entryBlock());
 
                 return new UpdateBuilder(ancestorBody, initTypes, init, cond);
@@ -841,7 +841,7 @@ public class ExtendedOps {
 
             public JavaForOp.BodyBuilder cond(Consumer<Block.Builder> c) {
                 Body.Builder update = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(JavaType.VOID, initTypes));
+                        FunctionType.functionType(JavaType.VOID, initTypes));
                 c.accept(update.entryBlock());
 
                 return new BodyBuilder(ancestorBody, initTypes, init, cond, update);
@@ -868,7 +868,7 @@ public class ExtendedOps {
 
             public JavaForOp body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(JavaType.VOID, initTypes));
+                        FunctionType.functionType(JavaType.VOID, initTypes));
                 c.accept(body.entryBlock());
 
                 return new JavaForOp(init, cond, update, body);
@@ -920,13 +920,13 @@ public class ExtendedOps {
             this.cond = condC.build(this);
 
             this.update = updateC.build(this);
-            if (!update.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Update should return void: " + update.descriptor());
+            if (!update.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Update should return void: " + update.bodyType());
             }
 
             this.body = bodyC.build(this);
-            if (!body.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + body.descriptor());
+            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
         }
 
@@ -1056,7 +1056,7 @@ public class ExtendedOps {
 
             public DefinitionBuilder expression(Consumer<Block.Builder> c) {
                 Body.Builder expression = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(iterableType));
+                        FunctionType.functionType(iterableType));
                 c.accept(expression.entryBlock());
 
                 return new DefinitionBuilder(ancestorBody, elementType, expression);
@@ -1081,7 +1081,7 @@ public class ExtendedOps {
 
             public BodyBuilder definition(TypeElement bodyElementType, Consumer<Block.Builder> c) {
                 Body.Builder definition = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(bodyElementType, elementType));
+                        FunctionType.functionType(bodyElementType, elementType));
                 c.accept(definition.entryBlock());
 
                 return new BodyBuilder(ancestorBody, elementType, expression, definition);
@@ -1104,7 +1104,7 @@ public class ExtendedOps {
 
             public JavaEnhancedForOp body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(JavaType.VOID, elementType));
+                        FunctionType.functionType(JavaType.VOID, elementType));
                 c.accept(body.entryBlock());
 
                 return new JavaEnhancedForOp(expression, definition, body);
@@ -1146,27 +1146,27 @@ public class ExtendedOps {
             super(NAME, List.of());
 
             this.expression = expressionC.build(this);
-            if (expression.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Expression should return non-void value: " + expression.descriptor());
+            if (expression.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Expression should return non-void value: " + expression.bodyType());
             }
-            if (!expression.descriptor().parameters().isEmpty()) {
-                throw new IllegalArgumentException("Expression should have zero parameters: " + expression.descriptor());
+            if (!expression.bodyType().parameterTypes().isEmpty()) {
+                throw new IllegalArgumentException("Expression should have zero parameters: " + expression.bodyType());
             }
 
             this.init = initC.build(this);
-            if (init.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Initialization should return non-void value: " + init.descriptor());
+            if (init.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Initialization should return non-void value: " + init.bodyType());
             }
-            if (init.descriptor().parameters().size() != 1) {
-                throw new IllegalArgumentException("Initialization should have one parameter: " + init.descriptor());
+            if (init.bodyType().parameterTypes().size() != 1) {
+                throw new IllegalArgumentException("Initialization should have one parameter: " + init.bodyType());
             }
 
             this.body = bodyC.build(this);
-            if (!body.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + body.descriptor());
+            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
-            if (body.descriptor().parameters().size() != 1) {
-                throw new IllegalArgumentException("Body should have one parameter: " + body.descriptor());
+            if (body.bodyType().parameterTypes().size() != 1) {
+                throw new IllegalArgumentException("Body should have one parameter: " + body.bodyType());
             }
         }
 
@@ -1195,9 +1195,9 @@ public class ExtendedOps {
         @Override
         public Block.Builder lower(Block.Builder b, OpTransformer opT) {
             JavaType elementType = (JavaType) init.entryBlock().parameters().get(0).type();
-            boolean isArray = ((JavaType) expression.descriptor().returnType()).isArray();
+            boolean isArray = ((JavaType) expression.bodyType().returnType()).isArray();
 
-            Block.Builder preHeader = b.block(expression.descriptor().returnType());
+            Block.Builder preHeader = b.block(expression.bodyType().returnType());
             Block.Builder header = b.block(isArray ? List.of(JavaType.INT) : List.of());
             Block.Builder init = b.block();
             Block.Builder body = b.block();
@@ -1310,7 +1310,7 @@ public class ExtendedOps {
             }
 
             public JavaWhileOp.BodyBuilder predicate(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, MethodTypeDesc.methodType(JavaType.BOOLEAN));
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
                 c.accept(body.entryBlock());
 
                 return new JavaWhileOp.BodyBuilder(ancestorBody, body);
@@ -1327,7 +1327,7 @@ public class ExtendedOps {
             }
 
             public JavaWhileOp body(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, MethodTypeDesc.VOID);
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.VOID);
                 c.accept(body.entryBlock());
 
                 return new JavaWhileOp(List.of(predicate, body));
@@ -1360,15 +1360,15 @@ public class ExtendedOps {
                     .map(bc -> bc.build(this)).toList();
 
             // @@@ This will change with pattern bindings
-            if (!bodies.get(0).descriptor().equals(MethodTypeDesc.methodType(JavaType.BOOLEAN))) {
+            if (!bodies.get(0).bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
                 throw new IllegalArgumentException(
-                        "Predicate body descriptor should be " + MethodTypeDesc.methodType(JavaType.BOOLEAN) +
-                                " but is " + bodies.get(0).descriptor());
+                        "Predicate body descriptor should be " + FunctionType.functionType(JavaType.BOOLEAN) +
+                                " but is " + bodies.get(0).bodyType());
             }
-            if (!bodies.get(1).descriptor().equals(MethodTypeDesc.VOID)) {
+            if (!bodies.get(1).bodyType().equals(FunctionType.VOID)) {
                 throw new IllegalArgumentException(
-                        "Body descriptor should be " + MethodTypeDesc.methodType(JavaType.VOID) +
-                                " but is " + bodies.get(1).descriptor());
+                        "Body descriptor should be " + FunctionType.functionType(JavaType.VOID) +
+                                " but is " + bodies.get(1).bodyType());
             }
         }
 
@@ -1457,7 +1457,7 @@ public class ExtendedOps {
             }
 
             public JavaDoWhileOp predicate(Consumer<Block.Builder> c) {
-                Body.Builder predicate = Body.Builder.of(ancestorBody, MethodTypeDesc.methodType(JavaType.BOOLEAN));
+                Body.Builder predicate = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
                 c.accept(predicate.entryBlock());
 
                 return new JavaDoWhileOp(List.of(body, predicate));
@@ -1472,7 +1472,7 @@ public class ExtendedOps {
             }
 
             public JavaDoWhileOp.PredicateBuilder body(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, MethodTypeDesc.VOID);
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.VOID);
                 c.accept(body.entryBlock());
 
                 return new JavaDoWhileOp.PredicateBuilder(ancestorBody, body);
@@ -1504,15 +1504,15 @@ public class ExtendedOps {
             this.bodies = Stream.of(body, predicate).filter(Objects::nonNull)
                     .map(bc -> bc.build(this)).toList();
 
-            if (!bodies.get(0).descriptor().equals(MethodTypeDesc.VOID)) {
+            if (!bodies.get(0).bodyType().equals(FunctionType.VOID)) {
                 throw new IllegalArgumentException(
-                        "Body descriptor should be " + MethodTypeDesc.methodType(JavaType.VOID) +
-                                " but is " + bodies.get(1).descriptor());
+                        "Body descriptor should be " + FunctionType.functionType(JavaType.VOID) +
+                                " but is " + bodies.get(1).bodyType());
             }
-            if (!bodies.get(1).descriptor().equals(MethodTypeDesc.methodType(JavaType.BOOLEAN))) {
+            if (!bodies.get(1).bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
                 throw new IllegalArgumentException(
-                        "Predicate body descriptor should be " + MethodTypeDesc.methodType(JavaType.BOOLEAN) +
-                                " but is " + bodies.get(0).descriptor());
+                        "Predicate body descriptor should be " + FunctionType.functionType(JavaType.BOOLEAN) +
+                                " but is " + bodies.get(0).bodyType());
             }
         }
 
@@ -1618,8 +1618,8 @@ public class ExtendedOps {
 
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
             for (Body b : bodies) {
-                if (!b.descriptor().equals(MethodTypeDesc.methodType(JavaType.BOOLEAN))) {
-                    throw new IllegalArgumentException("Body conditional body descriptor: " + b.descriptor());
+                if (!b.bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+                    throw new IllegalArgumentException("Body conditional body descriptor: " + b.bodyType());
                 }
             }
         }
@@ -1682,7 +1682,7 @@ public class ExtendedOps {
                 if (i == 0) {
                     startBlock.transformBody(fromPred, List.of(), opt);
                 } else {
-                    pred = startBlock.block(fromPred.descriptor().parameters());
+                    pred = startBlock.block(fromPred.bodyType().parameterTypes());
                     pred.transformBody(fromPred, pred.parameters(), opT.andThen(opt));
                 }
             }
@@ -1714,7 +1714,7 @@ public class ExtendedOps {
             }
 
             public Builder and(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, MethodTypeDesc.methodType(JavaType.BOOLEAN));
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -1769,7 +1769,7 @@ public class ExtendedOps {
             }
 
             public Builder or(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, MethodTypeDesc.methodType(JavaType.BOOLEAN));
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -1857,8 +1857,8 @@ public class ExtendedOps {
             }
 
             Body cond = bodies.get(0);
-            if (!cond.descriptor().equals(MethodTypeDesc.methodType(JavaType.BOOLEAN))) {
-                throw new IllegalArgumentException("Illegal cond body descriptor: " + cond.descriptor());
+            if (!cond.bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+                throw new IllegalArgumentException("Illegal cond body descriptor: " + cond.bodyType());
             }
         }
 
@@ -1930,7 +1930,7 @@ public class ExtendedOps {
 
             public CatchBuilder body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(JavaType.VOID, resourceTypes));
+                        FunctionType.functionType(JavaType.VOID, resourceTypes));
                 c.accept(body.entryBlock());
 
                 return new CatchBuilder(ancestorBody, resources, body);
@@ -1953,7 +1953,7 @@ public class ExtendedOps {
             // @@@ multi-catch
             public CatchBuilder _catch(TypeElement exceptionType, Consumer<Block.Builder> c) {
                 Body.Builder _catch = Body.Builder.of(ancestorBody,
-                        MethodTypeDesc.methodType(JavaType.VOID, exceptionType));
+                        FunctionType.functionType(JavaType.VOID, exceptionType));
                 c.accept(_catch.entryBlock());
                 catchers.add(_catch);
 
@@ -1961,7 +1961,7 @@ public class ExtendedOps {
             }
 
             public JavaTryOp _finally(Consumer<Block.Builder> c) {
-                Body.Builder _finally = Body.Builder.of(ancestorBody, MethodTypeDesc.VOID);
+                Body.Builder _finally = Body.Builder.of(ancestorBody, FunctionType.VOID);
                 c.accept(_finally.entryBlock());
 
                 return new JavaTryOp(resources, body, catchers, _finally);
@@ -1988,7 +1988,7 @@ public class ExtendedOps {
 
             List<Body> bodies = def.bodyDefinitions().stream().map(b -> b.build(this)).toList();
             Body first = bodies.get(0);
-            if (first.descriptor().returnType().equals(JavaType.VOID)) {
+            if (first.bodyType().returnType().equals(JavaType.VOID)) {
                 this.resources = null;
                 this.body = first;
             } else {
@@ -1997,7 +1997,7 @@ public class ExtendedOps {
             }
 
             Body last = bodies.get(bodies.size() - 1);
-            if (last.descriptor().parameters().isEmpty()) {
+            if (last.bodyType().parameterTypes().isEmpty()) {
                 this.finalizer = last;
             } else {
                 this.finalizer = null;
@@ -2039,38 +2039,38 @@ public class ExtendedOps {
 
             if (resourcesC != null) {
                 this.resources = resourcesC.build(this);
-                if (resources.descriptor().returnType().equals(JavaType.VOID)) {
-                    throw new IllegalArgumentException("Resources should not return void: " + resources.descriptor());
+                if (resources.bodyType().returnType().equals(JavaType.VOID)) {
+                    throw new IllegalArgumentException("Resources should not return void: " + resources.bodyType());
                 }
-                if (!resources.descriptor().parameters().isEmpty()) {
-                    throw new IllegalArgumentException("Resources should have zero parameters: " + resources.descriptor());
+                if (!resources.bodyType().parameterTypes().isEmpty()) {
+                    throw new IllegalArgumentException("Resources should have zero parameters: " + resources.bodyType());
                 }
             } else {
                 this.resources = null;
             }
 
             this.body = bodyC.build(this);
-            if (!body.descriptor().returnType().equals(JavaType.VOID)) {
-                throw new IllegalArgumentException("Try should return void: " + body.descriptor());
+            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+                throw new IllegalArgumentException("Try should return void: " + body.bodyType());
             }
 
             this.catchers = catchersC.stream().map(c -> c.build(this)).toList();
             for (Body _catch : catchers) {
-                if (!_catch.descriptor().returnType().equals(JavaType.VOID)) {
-                    throw new IllegalArgumentException("Catch should return void: " + _catch.descriptor());
+                if (!_catch.bodyType().returnType().equals(JavaType.VOID)) {
+                    throw new IllegalArgumentException("Catch should return void: " + _catch.bodyType());
                 }
-                if (_catch.descriptor().parameters().size() != 1) {
-                    throw new IllegalArgumentException("Catch should have zero parameters: " + _catch.descriptor());
+                if (_catch.bodyType().parameterTypes().size() != 1) {
+                    throw new IllegalArgumentException("Catch should have zero parameters: " + _catch.bodyType());
                 }
             }
 
             if (finalizerC != null) {
                 this.finalizer = finalizerC.build(this);
-                if (!finalizer.descriptor().returnType().equals(JavaType.VOID)) {
-                    throw new IllegalArgumentException("Finally should return void: " + finalizer.descriptor());
+                if (!finalizer.bodyType().returnType().equals(JavaType.VOID)) {
+                    throw new IllegalArgumentException("Finally should return void: " + finalizer.bodyType());
                 }
-                if (!finalizer.descriptor().parameters().isEmpty()) {
-                    throw new IllegalArgumentException("Finally should have zero parameters: " + finalizer.descriptor());
+                if (!finalizer.bodyType().parameterTypes().isEmpty()) {
+                    throw new IllegalArgumentException("Finally should have zero parameters: " + finalizer.bodyType());
                 }
             } else {
                 this.finalizer = null;
@@ -2211,7 +2211,7 @@ public class ExtendedOps {
                 Block.Builder catcher = catchers.get(i);
                 Body catcherBody = this.catchers.get(i);
                 // Create the throwable argument
-                Block.Parameter t = catcher.parameter(catcherBody.descriptor().parameters().get(0));
+                Block.Parameter t = catcher.parameter(catcherBody.bodyType().parameterTypes().get(0));
 
                 if (finalizer != null) {
                     Block.Builder catchRegionEnter = b.block();
@@ -3056,7 +3056,7 @@ public class ExtendedOps {
      * @return the try operation builder
      */
     public static JavaTryOp.CatchBuilder _try(Body.Builder ancestorBody, Consumer<Block.Builder> c) {
-        Body.Builder _try = Body.Builder.of(ancestorBody, MethodTypeDesc.VOID);
+        Body.Builder _try = Body.Builder.of(ancestorBody, FunctionType.VOID);
         c.accept(_try.entryBlock());
         return new JavaTryOp.CatchBuilder(ancestorBody, null, _try);
     }
@@ -3073,7 +3073,7 @@ public class ExtendedOps {
                                                          Consumer<Block.Builder> c) {
         resourceTypes = resourceTypes.stream().map(VarType::varType).toList();
         Body.Builder resources = Body.Builder.of(ancestorBody,
-                MethodTypeDesc.methodType(TupleType.tupleType(resourceTypes)));
+                FunctionType.functionType(TupleType.tupleType(resourceTypes)));
         c.accept(resources.entryBlock());
         return new JavaTryOp.BodyBuilder(ancestorBody, resourceTypes, resources);
     }

--- a/src/java.base/share/classes/java/lang/reflect/code/parser/OpParser.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/parser/OpParser.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.code.Block;
 import java.lang.reflect.code.Body;
-import java.lang.reflect.code.descriptor.MethodTypeDesc;
+import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.TypeDefinition;
 import java.lang.reflect.code.op.*;
 import java.lang.reflect.code.Op;
@@ -261,7 +261,7 @@ public final class OpParser {
     static Body.Builder nodeToBody(BodyNode n, Context c, Body.Builder ancestorBody) {
         Body.Builder body = Body.Builder.of(ancestorBody,
                 // Create descriptor with just the return type and add parameters afterward
-                MethodTypeDesc.methodType(c.typeFactory.constructType(n.rtype)));
+                FunctionType.functionType(c.typeFactory.constructType(n.rtype)));
         Block.Builder eb = body.entryBlock();
 
         // Create blocks upfront for forward referencing successors

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -55,6 +55,25 @@ public final class CoreTypeFactory {
                         }
                         yield TupleType.tupleType(cs);
                     }
+                    case FunctionType.NAME -> {
+                        if (tree.typeArguments().isEmpty()) {
+                            throw new IllegalArgumentException();
+                        }
+
+                        TypeElement rt = thisThenF.constructType(tree.typeArguments().getFirst());
+                        if (rt == null) {
+                            throw new IllegalArgumentException();
+                        }
+                        List<TypeElement> pts = new ArrayList<>(tree.typeArguments().size() - 1);
+                        for (TypeDefinition child : tree.typeArguments().subList(1, tree.typeArguments().size())) {
+                            TypeElement c = thisThenF.constructType(child);
+                            if (c == null) {
+                                throw new IllegalArgumentException();
+                            }
+                            pts.add(c);
+                        }
+                        yield FunctionType.functionType(rt, pts);
+                    }
                     default -> null;
                 };
             }

--- a/src/java.base/share/classes/java/lang/reflect/code/type/FunctionType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/FunctionType.java
@@ -10,7 +10,14 @@ import java.util.stream.Stream;
  * A function type.
  */
 public final class FunctionType implements TypeElement {
-    static final String NAME = "->";
+    // @@@ Change to "->" when the textual form supports it
+    static final String NAME = "func";
+
+    /**
+     * The function type with no parameters, returning void.
+     */
+    // @@@ Uses JavaType
+    public static final FunctionType VOID = functionType(JavaType.VOID);
 
     final TypeElement returnType;
     final List<TypeElement> parameterTypes;

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -326,7 +326,7 @@ public final class OpWriter {
         write("(");
         writeCommaSeparatedList(eb.parameters(), this::writeValueDeclaration);
         write(")");
-        write(body.descriptor().returnType().toString());
+        write(body.bodyType().returnType().toString());
         write(" -> {\n");
         w.in();
         for (Block b : body.blocks()) {

--- a/src/jdk.code.tools/share/classes/jdk/code/tools/renderer/SRRenderer.java
+++ b/src/jdk.code.tools/share/classes/jdk/code/tools/renderer/SRRenderer.java
@@ -219,7 +219,7 @@ public final class SRRenderer extends CommonRenderer<SRRenderer> {
             commaSpaceSeparator();
             writeValueDecl(gn, v);
         }
-        cparen().type(body.descriptor().returnType().toString()).space().rarrow().space().obrace().nl();
+        cparen().type(body.bodyType().returnType().toString()).space().rarrow().space().obrace().nl();
         in();
         boolean isEntryBlock = true;
         for (Block b : body.blocks()) {

--- a/test/jdk/java/lang/reflect/code/TestBuild.java
+++ b/test/jdk/java/lang/reflect/code/TestBuild.java
@@ -29,8 +29,8 @@ import java.lang.reflect.code.analysis.SSA;
 import java.util.function.IntBinaryOperator;
 
 import static java.lang.reflect.code.op.CoreOps.*;
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.VOID;
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
+import static java.lang.reflect.code.type.FunctionType.functionType;
+import static java.lang.reflect.code.type.FunctionType.VOID;
 import static java.lang.reflect.code.type.JavaType.INT;
 import static java.lang.reflect.code.type.JavaType.type;
 
@@ -51,7 +51,7 @@ public class TestBuild {
     public void testBoundValueAsOperand() {
         LambdaOp f = f();
 
-        var body = Body.Builder.of(null, f.funcDescriptor());
+        var body = Body.Builder.of(null, f.invokableType());
         var block = body.entryBlock();
 
         var a = f.body().entryBlock().parameters().get(0);
@@ -66,7 +66,7 @@ public class TestBuild {
     public void testBoundValueAsHeaderArgument() {
         LambdaOp f = f();
 
-        var body = Body.Builder.of(null, f.funcDescriptor());
+        var body = Body.Builder.of(null, f.invokableType());
         var block = body.entryBlock();
         var anotherBlock = block.block(INT, INT);
 
@@ -83,7 +83,7 @@ public class TestBuild {
     public void testUnmappedBoundValue() {
         LambdaOp f = f();
 
-        var body = Body.Builder.of(null, f.funcDescriptor());
+        var body = Body.Builder.of(null, f.invokableType());
         var block = body.entryBlock();
 
         var freturnOp = f.body().entryBlock().terminatingOp();
@@ -95,7 +95,7 @@ public class TestBuild {
     public void testMappingToBoundValue() {
         LambdaOp f = f();
 
-        var body = Body.Builder.of(null, f.funcDescriptor());
+        var body = Body.Builder.of(null, f.invokableType());
         var block = body.entryBlock();
 
         var result = f.body().entryBlock().firstOp().result();
@@ -107,7 +107,7 @@ public class TestBuild {
     public void testMappedBoundValue() {
         LambdaOp f = f();
 
-        var body = Body.Builder.of(null, f.funcDescriptor());
+        var body = Body.Builder.of(null, f.invokableType());
         var block = body.entryBlock();
 
         var a = block.parameters().get(0);
@@ -124,7 +124,7 @@ public class TestBuild {
 
     @Test
     public void testPartiallyConstructedValueAccess() {
-        var body = Body.Builder.of(null, methodType(int.class, int.class, int.class));
+        var body = Body.Builder.of(null, functionType(INT, INT, INT));
         var block = body.entryBlock();
 
         Block.Parameter a = block.parameters().get(0);
@@ -154,7 +154,7 @@ public class TestBuild {
 
     @Test
     public void testPartiallyConstructedHeaderAccess() {
-        var body = Body.Builder.of(null, methodType(int.class, int.class, int.class));
+        var body = Body.Builder.of(null, functionType(INT, INT, INT));
         var block = body.entryBlock();
         var anotherBlock = block.block(INT, INT);
 
@@ -177,12 +177,12 @@ public class TestBuild {
 
     @Test
     public void testValueUseFromOtherModel() {
-        var abody = Body.Builder.of(null, methodType(int.class, int.class, int.class));
+        var abody = Body.Builder.of(null, functionType(INT, INT, INT));
         var ablock = abody.entryBlock();
         var aa = ablock.parameters().get(0);
         var ab = ablock.parameters().get(1);
 
-        var bbody = Body.Builder.of(null, abody.descriptor());
+        var bbody = Body.Builder.of(null, abody.bodyType());
         var bblock = bbody.entryBlock();
 
         // Operation uses values from another model

--- a/test/jdk/java/lang/reflect/code/TestClosureOps.java
+++ b/test/jdk/java/lang/reflect/code/TestClosureOps.java
@@ -45,7 +45,7 @@ import static java.lang.reflect.code.op.CoreOps.closureCall;
 import static java.lang.reflect.code.op.CoreOps.constant;
 import static java.lang.reflect.code.op.CoreOps.func;
 import static java.lang.reflect.code.op.CoreOps.quoted;
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 import static java.lang.reflect.code.type.JavaType.INT;
 import static java.lang.reflect.code.type.JavaType.type;
 
@@ -68,14 +68,14 @@ public class TestClosureOps {
     @Test
     public void testQuotedWithCapture() {
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(block -> {
                     Block.Parameter i = block.parameters().get(0);
 
                     // functional descriptor = (int)int
                     // op descriptor = ()Quoted<ClosureOp>
                     CoreOps.QuotedOp qop = quoted(block.parentBody(), qblock -> {
-                        return closure(qblock.parentBody(), methodType(int.class, int.class))
+                        return closure(qblock.parentBody(), functionType(INT, INT))
                                 .body(cblock -> {
                                     Block.Parameter ci = cblock.parameters().get(0);
 
@@ -100,14 +100,14 @@ public class TestClosureOps {
     @Test
     public void testWithCapture() {
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(block -> {
                     Block.Parameter i = block.parameters().get(0);
 
                     // functional descriptor = (int)int
                     //   captures i
                     CoreOps.ClosureOp closure = CoreOps.closure(block.parentBody(),
-                            methodType(int.class, int.class))
+                                    functionType(INT, INT))
                             .body(cblock -> {
                                 Block.Parameter ci = cblock.parameters().get(0);
 
@@ -135,6 +135,6 @@ public class TestClosureOps {
         Assert.assertTrue(top instanceof CoreOps.FuncOp);
 
         CoreOps.FuncOp fop = (CoreOps.FuncOp) top;
-        Assert.assertEquals(JavaType.type(Quoted.class, CoreOps.ClosureOp.class), fop.funcDescriptor().returnType());
+        Assert.assertEquals(JavaType.type(Quoted.class, CoreOps.ClosureOp.class), fop.invokableType().returnType());
     }
 }

--- a/test/jdk/java/lang/reflect/code/TestDominate.java
+++ b/test/jdk/java/lang/reflect/code/TestDominate.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 import java.lang.reflect.code.Block;
 import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.Op;
-import java.lang.reflect.code.descriptor.MethodTypeDesc;
+import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.JavaType;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,7 +51,7 @@ public class TestDominate {
 
     @Test
     public void testIfElse() {
-        CoreOps.FuncOp f = func("f", MethodTypeDesc.VOID).body(entry -> {
+        CoreOps.FuncOp f = func("f", FunctionType.VOID).body(entry -> {
             Block.Builder ifBlock = entry.block();
             Block.Builder elseBlock = entry.block();
             Block.Builder end = entry.block();
@@ -78,7 +78,7 @@ public class TestDominate {
 
     @Test
     public void testForwardSuccessors() {
-        CoreOps.FuncOp f = func("f", MethodTypeDesc.VOID).body(entry -> {
+        CoreOps.FuncOp f = func("f", FunctionType.VOID).body(entry -> {
             Block.Builder b1 = entry.block();
             Block.Builder b2 = entry.block();
             Block.Builder b3 = entry.block();
@@ -114,7 +114,7 @@ public class TestDominate {
 
     @Test
     public void testBackbranch() {
-        CoreOps.FuncOp f = func("f", MethodTypeDesc.VOID).body(entry -> {
+        CoreOps.FuncOp f = func("f", FunctionType.VOID).body(entry -> {
             Block.Builder cond = entry.block();
             Block.Builder body = entry.block();
             Block.Builder update = entry.block();
@@ -157,7 +157,7 @@ public class TestDominate {
 
     @Test
     public void testImmediateDominators() {
-        CoreOps.FuncOp f = func("f", MethodTypeDesc.VOID).body(entry -> {
+        CoreOps.FuncOp f = func("f", FunctionType.VOID).body(entry -> {
             Block.Builder b6 = entry.block();
             Block.Builder b5 = entry.block();
             Block.Builder b4 = entry.block();
@@ -198,7 +198,7 @@ public class TestDominate {
 
     @Test
     public void testCytronExample() {
-        CoreOps.FuncOp f = func("f", MethodTypeDesc.VOID).body(entry -> {
+        CoreOps.FuncOp f = func("f", FunctionType.VOID).body(entry -> {
             Block.Builder exit = entry.block();
             Block.Builder b12 = entry.block();
             Block.Builder b11 = entry.block();

--- a/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
+++ b/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
@@ -67,7 +67,7 @@ public class TestExceptionRegionOps {
 
     @Test
     public void test() {
-        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class))
+        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class).toFunctionType())
                 .body(fbody -> {
                     var fblock = fbody.entryBlock();
                     var catchER1ISE = fblock.block(type(IllegalStateException.class));
@@ -158,7 +158,7 @@ public class TestExceptionRegionOps {
 
     @Test
     public void testCatchThrowable() {
-        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class))
+        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class).toFunctionType())
                 .body(fbody -> {
                     var fblock = fbody.entryBlock();
                     var catchER1ISE = fblock.block(type(IllegalStateException.class));
@@ -252,7 +252,7 @@ public class TestExceptionRegionOps {
 
     @Test
     public void testNested() {
-        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class))
+        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class).toFunctionType())
                 .body(fbody -> {
                     var fblock = fbody.entryBlock();
                     var catchER1 = fblock.block(type(IllegalArgumentException.class));
@@ -373,7 +373,7 @@ public class TestExceptionRegionOps {
 
     @Test
     public void testCatchFinally() {
-        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class))
+        CoreOps.FuncOp f = func("f", methodType(void.class, IntConsumer.class).toFunctionType())
                 .body(fbody -> {
                     var fblock = fbody.entryBlock();
                     var catchRE = fblock.block(type(IllegalStateException.class));

--- a/test/jdk/java/lang/reflect/code/TestInline.java
+++ b/test/jdk/java/lang/reflect/code/TestInline.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import static java.lang.reflect.code.op.CoreOps.*;
 import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 import static java.lang.reflect.code.type.JavaType.INT;
 
 /*
@@ -50,7 +51,7 @@ public class TestInline {
         CoreOps.ClosureOp cop = (CoreOps.ClosureOp) q.op();
 
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
@@ -72,7 +73,7 @@ public class TestInline {
         CoreOps.ClosureOp cop = (CoreOps.ClosureOp) q.op();
 
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
@@ -116,7 +117,7 @@ public class TestInline {
         lcop.writeTo(System.out);
 
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
@@ -152,7 +153,7 @@ public class TestInline {
         lcop.writeTo(System.out);
 
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
@@ -184,7 +185,7 @@ public class TestInline {
         CoreOps.ClosureOp cop = (CoreOps.ClosureOp) q.op();
         cop.writeTo(System.out);
 
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
@@ -218,7 +219,7 @@ public class TestInline {
         CoreOps.ClosureOp cop = (CoreOps.ClosureOp) q.op();
 
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(void.class, int[].class))
+        CoreOps.FuncOp f = func("f", methodType(void.class, int[].class).toFunctionType())
                 .body(fblock -> {
                     Block.Parameter a = fblock.parameters().get(0);
 

--- a/test/jdk/java/lang/reflect/code/TestLambdaOps.java
+++ b/test/jdk/java/lang/reflect/code/TestLambdaOps.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 
 import static java.lang.reflect.code.op.CoreOps.*;
 import static java.lang.reflect.code.op.CoreOps.constant;
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 import static java.lang.reflect.code.type.JavaType.INT;
 import static java.lang.reflect.code.type.JavaType.type;
 
@@ -70,7 +70,7 @@ public class TestLambdaOps {
     @Test
     public void testQuotedWithCapture() {
         // functional descriptor = (int)int
-        FuncOp f = func("f", methodType(int.class, int.class))
+        FuncOp f = func("f", functionType(INT, INT))
                 .body(block -> {
                     Block.Parameter i = block.parameters().get(0);
 
@@ -78,7 +78,7 @@ public class TestLambdaOps {
                     // op descriptor = ()Quoted<LambdaOp>
                     QuotedOp qop = quoted(block.parentBody(), qblock -> {
                         return lambda(qblock.parentBody(),
-                                methodType(int.class, int.class), type(IntUnaryOperator.class))
+                                functionType(INT, INT), type(IntUnaryOperator.class))
                                 .body(lblock -> {
                                     Block.Parameter li = lblock.parameters().get(0);
 
@@ -107,7 +107,7 @@ public class TestLambdaOps {
     @Test
     public void testWithCapture() {
         // functional descriptor = (int)int
-        FuncOp f = func("f", methodType(int.class, int.class))
+        FuncOp f = func("f", functionType(INT, INT))
                 .body(block -> {
                     Block.Parameter i = block.parameters().get(0);
 
@@ -115,7 +115,7 @@ public class TestLambdaOps {
                     // op descriptor = ()IntUnaryOperator
                     //   captures i
                     LambdaOp lambda = lambda(block.parentBody(),
-                            methodType(int.class, int.class), type(IntUnaryOperator.class))
+                            functionType(INT, INT), type(IntUnaryOperator.class))
                             .body(lblock -> {
                                 Block.Parameter li = lblock.parameters().get(0);
 
@@ -153,7 +153,7 @@ public class TestLambdaOps {
         Assert.assertTrue(top instanceof CoreOps.FuncOp);
 
         CoreOps.FuncOp fop = (CoreOps.FuncOp) top;
-        Assert.assertEquals(type(Quoted.class, LambdaOp.class), fop.funcDescriptor().returnType());
+        Assert.assertEquals(type(Quoted.class, LambdaOp.class), fop.invokableType().returnType());
     }
 
     @FunctionalInterface

--- a/test/jdk/java/lang/reflect/code/TestLinqUsingQuoted.java
+++ b/test/jdk/java/lang/reflect/code/TestLinqUsingQuoted.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import static java.lang.reflect.code.descriptor.MethodDesc.method;
 import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
 import static java.lang.reflect.code.op.CoreOps.*;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 
 /*
  * @test
@@ -68,7 +69,7 @@ public class TestLinqUsingQuoted {
         default Queryable select(Quoted f) {
             // @@@@ validate
             ClosureOp c = (ClosureOp) f.op();
-            return insertQuery(c.funcDescriptor().returnType(), "select", c);
+            return insertQuery(c.invokableType().returnType(), "select", c);
         }
 
         private Queryable insertQuery(TypeElement et, String name, ClosureOp c) {
@@ -114,7 +115,7 @@ public class TestLinqUsingQuoted {
             // Copy function expression, replacing return type
             FuncOp currentQueryExpression = expression();
             FuncOp nextQueryExpression = func("queryresult",
-                    methodType(qp.queryResultType(), currentQueryExpression.funcDescriptor().parameters()))
+                    functionType(qp.queryResultType(), currentQueryExpression.invokableType().parameterTypes()))
                     .body(b -> b.inline(currentQueryExpression, b.parameters(), (block, query) -> {
                         MethodDesc md = method(qp.queryableType(), name, methodType(qp.queryResultType()));
                         Op.Result queryResult = block.op(invoke(md, query));
@@ -159,7 +160,7 @@ public class TestLinqUsingQuoted {
             this.provider = provider;
 
             // Initial expression is an identity function
-            var funDescriptor = methodType(provider().queryableType(), provider().queryableType());
+            var funDescriptor = functionType(provider().queryableType(), provider().queryableType());
             this.expression = func("query", funDescriptor)
                     .body(b -> b.op(_return(b.parameters().get(0))));
         }

--- a/test/jdk/java/lang/reflect/code/TestOpResultTypeNotCopiedBlindly.java
+++ b/test/jdk/java/lang/reflect/code/TestOpResultTypeNotCopiedBlindly.java
@@ -5,8 +5,8 @@ import java.lang.reflect.code.Op;
 import java.lang.runtime.CodeReflection;
 import java.util.Arrays;
 
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
 import static java.lang.reflect.code.op.CoreOps.*;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 import static java.lang.reflect.code.type.JavaType.DOUBLE;
 
 /*
@@ -25,7 +25,7 @@ public class TestOpResultTypeNotCopiedBlindly {
     void test() {
         FuncOp f = getCodeModel(this.getClass(), "f");
 
-        FuncOp g = func("g", methodType(DOUBLE, DOUBLE, DOUBLE))
+        FuncOp g = func("g", functionType(DOUBLE, DOUBLE, DOUBLE))
                 .body(b -> b.inline(f, b.parameters(), (block, v) -> {
                     block.op(_return(v));
                 }));

--- a/test/jdk/java/lang/reflect/code/linq/Queryable.java
+++ b/test/jdk/java/lang/reflect/code/linq/Queryable.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import static java.lang.reflect.code.descriptor.MethodDesc.method;
 import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
 import static java.lang.reflect.code.op.CoreOps.*;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 import static java.lang.reflect.code.type.JavaType.type;
 
 public interface Queryable<T> {
@@ -51,7 +52,7 @@ public interface Queryable<T> {
     @SuppressWarnings("unchecked")
     default <R> Queryable<R> select(QuotableFunction<T, R> f) {
         LambdaOp l = (LambdaOp) f.quoted().op();
-        return (Queryable<R>) insertQuery((JavaType) l.funcDescriptor().returnType(), "select", l);
+        return (Queryable<R>) insertQuery((JavaType) l.invokableType().returnType(), "select", l);
     }
 
     private Queryable<?> insertQuery(JavaType elementType, String methodName, LambdaOp lambdaOp) {
@@ -59,7 +60,7 @@ public interface Queryable<T> {
         FuncOp queryExpression = expression();
         JavaType queryableType = type(Queryable.TYPE, elementType);
         FuncOp nextQueryExpression = func("query",
-                methodType(queryableType, queryExpression.funcDescriptor().parameters()))
+                functionType(queryableType, queryExpression.invokableType().parameterTypes()))
                 .body(b -> b.inline(queryExpression, b.parameters(), (block, query) -> {
                     Op.Result fi = block.op(lambdaOp);
 
@@ -90,7 +91,7 @@ public interface Queryable<T> {
         FuncOp queryExpression = expression();
         JavaType queryResultType = JavaType.type(QueryResult.TYPE, resultType);
         FuncOp queryResultExpression = func("queryResult",
-                methodType(queryResultType, queryExpression.funcDescriptor().parameters()))
+                functionType(queryResultType, queryExpression.invokableType().parameterTypes()))
                 .body(b -> b.inline(queryExpression, b.parameters(), (block, query) -> {
                     MethodDesc md = method(Queryable.TYPE, methodName,
                             methodType(QueryResult.TYPE));

--- a/test/jdk/java/lang/reflect/code/linq/TestQueryProvider.java
+++ b/test/jdk/java/lang/reflect/code/linq/TestQueryProvider.java
@@ -24,9 +24,9 @@
 import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.type.JavaType;
 
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
 import static java.lang.reflect.code.op.CoreOps._return;
 import static java.lang.reflect.code.op.CoreOps.func;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 import static java.lang.reflect.code.type.JavaType.type;
 
 public final class TestQueryProvider extends QueryProvider {
@@ -59,7 +59,7 @@ public final class TestQueryProvider extends QueryProvider {
 
             JavaType queryableType = type(Queryable.TYPE, elementType);
             // Initial expression is an identity function
-            var funDescriptor = methodType(queryableType, queryableType);
+            var funDescriptor = functionType(queryableType, queryableType);
             this.expression = func("query", funDescriptor)
                     .body(b -> b.op(_return(b.parameters().get(0))));
         }

--- a/test/jdk/java/lang/reflect/code/parser/TestParse.java
+++ b/test/jdk/java/lang/reflect/code/parser/TestParse.java
@@ -40,11 +40,10 @@ import java.util.function.IntUnaryOperator;
 
 import static java.lang.reflect.code.op.CoreOps._return;
 import static java.lang.reflect.code.op.CoreOps.add;
-import static java.lang.reflect.code.op.CoreOps.invoke;
 import static java.lang.reflect.code.op.CoreOps.constant;
 import static java.lang.reflect.code.op.CoreOps.func;
 import static java.lang.reflect.code.op.CoreOps.lambda;
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.methodType;
+import static java.lang.reflect.code.type.FunctionType.functionType;
 import static java.lang.reflect.code.type.JavaType.INT;
 import static java.lang.reflect.code.type.JavaType.type;
 
@@ -57,7 +56,7 @@ public class TestParse {
     @Test
     public void testParseLambdaOp() {
         // functional descriptor = (int)int
-        CoreOps.FuncOp f = func("f", methodType(int.class, int.class))
+        CoreOps.FuncOp f = func("f", functionType(INT, INT))
                 .body(block -> {
                     Block.Parameter i = block.parameters().get(0);
 
@@ -65,7 +64,7 @@ public class TestParse {
                     // op descriptor = ()IntUnaryOperator
                     //   captures i
                     CoreOps.LambdaOp lambda = lambda(block.parentBody(),
-                            methodType(int.class, int.class), type(IntUnaryOperator.class))
+                            functionType(INT, INT), type(IntUnaryOperator.class))
                             .body(lbody -> {
                                 Block.Builder lblock = lbody.entryBlock();
                                 Block.Parameter li = lblock.parameters().get(0);

--- a/test/jdk/java/lang/reflect/code/stream/StreamFuser.java
+++ b/test/jdk/java/lang/reflect/code/stream/StreamFuser.java
@@ -182,7 +182,7 @@ public final class StreamFuser {
                 throw new IllegalArgumentException("Quoted consumer is not closure operation");
             }
 
-            return func("fused.forEach", MethodTypeDesc.methodType(JavaType.VOID, sourceType))
+            return func("fused.forEach", MethodTypeDesc.methodType(JavaType.VOID, sourceType).toFunctionType())
                     .body(b -> {
                         Value source = b.parameters().get(0);
 
@@ -210,8 +210,8 @@ public final class StreamFuser {
                 throw new IllegalArgumentException("Quoted accumulator is not closure operation");
             }
 
-            JavaType collectType = (JavaType) supplier.funcDescriptor().returnType();
-            return func("fused.collect", MethodTypeDesc.methodType(collectType, sourceType))
+            JavaType collectType = (JavaType) supplier.invokableType().returnType();
+            return func("fused.collect", MethodTypeDesc.methodType(collectType, sourceType).toFunctionType())
                     .body(b -> {
                         Value source = b.parameters().get(0);
 

--- a/test/jdk/java/lang/reflect/code/stream/StreamFuserUsingQuotable.java
+++ b/test/jdk/java/lang/reflect/code/stream/StreamFuserUsingQuotable.java
@@ -202,7 +202,7 @@ public final class StreamFuserUsingQuotable {
                 throw new IllegalArgumentException("Quotable consumer captures values");
             }
 
-            return func("fused.forEach", MethodTypeDesc.methodType(JavaType.VOID, sourceType))
+            return func("fused.forEach", MethodTypeDesc.methodType(JavaType.VOID, sourceType).toFunctionType())
                     .body(b -> {
                         Value source = b.parameters().get(0);
 
@@ -235,8 +235,8 @@ public final class StreamFuserUsingQuotable {
                 throw new IllegalArgumentException("Quotable accumulator captures values");
             }
 
-            JavaType collectType = (JavaType) supplier.funcDescriptor().returnType();
-            return func("fused.collect", MethodTypeDesc.methodType(collectType, sourceType))
+            JavaType collectType = (JavaType) supplier.invokableType().returnType();
+            return func("fused.collect", MethodTypeDesc.methodType(collectType, sourceType).toFunctionType())
                     .body(b -> {
                         Value source = b.parameters().get(0);
 

--- a/test/langtools/tools/javac/reflect/CodeReflectionTester.java
+++ b/test/langtools/tools/javac/reflect/CodeReflectionTester.java
@@ -29,9 +29,9 @@ import java.lang.reflect.code.op.ExtendedOps;
 import java.lang.reflect.code.parser.OpParser;
 import java.lang.runtime.CodeReflection;
 
-import static java.lang.reflect.code.descriptor.MethodTypeDesc.VOID;
 import static java.lang.reflect.code.op.CoreOps._return;
 import static java.lang.reflect.code.op.CoreOps.func;
+import static java.lang.reflect.code.type.FunctionType.VOID;
 
 public class CodeReflectionTester {
 


### PR DESCRIPTION
Replace use of `MethodTypeDesc` with `FunctionType` in the core API.

This pushes `MethodTypeDesc` more towards the reflective operation usages. There are convenience methods added to `MethodTypeDesc` for conversion/resolution between `FunctionType`. However, it may that the right approach here is convenience methods for conversion/resolution between `java.lang.invoke.MethodType` (or sequences of `Class<?>`) and `FunctionType`, which means we can likely remove `MethodTypeDesc`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/babylon.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/22.diff">https://git.openjdk.org/babylon/pull/22.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/22#issuecomment-1942942059)