### PR TITLE
Invokable block parameters

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Block.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Block.java
@@ -64,7 +64,7 @@ public final class Block implements CodeElement<Block, Op> {
          * <p>
          * If this block parameter is declared in an entry block and that
          * block's ancestor operation (the parent of the entry block's parent body)
-         * is an instance of {@link Op.Invokable}, that that instance is returned,
+         * is an instance of {@link Op.Invokable}, then that instance is returned,
          * otherwise {@code null} is returned.
          * <p>
          * A non-{@code null} result implies this parameter is an invokable parameter.

--- a/src/java.base/share/classes/java/lang/reflect/code/Block.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Block.java
@@ -58,6 +58,46 @@ public final class Block implements CodeElement<Block, Op> {
         public Set<Value> dependsOn() {
             return Set.of();
         }
+
+        /**
+         * Returns the invokable operation associated with this block parameter.
+         * <p>
+         * If this block parameter is declared in an entry block and that
+         * block's ancestor operation (the parent of the entry block's parent body)
+         * is an instance of {@link Op.Invokable}, that that instance is returned,
+         * otherwise {@code null} is returned.
+         * <p>
+         * A non-{@code null} result implies this parameter is an invokable parameter.
+         *
+         * @apiNote
+         * This method may be used to pattern match on the returned result:
+         * {@snippet lang = "java" :
+         *     if (p.invokableOperation() instanceof CoreOps.FuncOp f) {
+         *         assert f.parameters().indexOf(p) == p.index(); // @link substring="parameters()" target="Op.Invokable#parameters()"
+         *     }
+         * }
+         *
+         * @return the invokable operation, otherwise {@code null} if the operation
+         * is not an instance of {@link Op.Invokable}.
+         * @see Op.Invokable#parameters()
+         */
+        public Op.Invokable invokableOperation() {
+            if (declaringBlock().isEntryBlock() &&
+                    declaringBlock().parentBody().parentOp() instanceof Op.Invokable o) {
+                return o;
+            } else {
+                return null;
+            }
+        }
+
+        /**
+         * {@return the index of this block parameter in the parameters of its declaring block.}
+         * @see Value#declaringBlock()
+         * @see Block#parameters()
+         */
+        public int index() {
+            return declaringBlock().parameters().indexOf(this);
+        }
     }
 
     /**
@@ -149,7 +189,7 @@ public final class Block implements CodeElement<Block, Op> {
      * Returns this block's index within the parent body's blocks.
      * <p>
      * The following identity holds true:
-     * {@snippet lang = "java"
+     * {@snippet lang = "java" :
      *     this.parentBody().blocks().indexOf(this) == this.index();
      * }
      *

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -78,14 +78,21 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     public interface Invokable extends Nested {
         /**
-         * @return the body of the invokable operation.
+         * {@return the body of the invokable operation.}
          */
         Body body();
 
         /**
-         * @return the function type describing the invokable operation's parameter types and return type.
+         * {@return the function type describing the invokable operation's parameter types and return type.}
          */
         FunctionType invokableType();
+
+        /**
+         * {@return the entry block parameters of this operation's body}
+         */
+        default List<Block.Parameter> parameters() {
+            return body().entryBlock().parameters();
+        }
     }
 
     /**

--- a/test/jdk/java/lang/reflect/code/TestBlockParameters.java
+++ b/test/jdk/java/lang/reflect/code/TestBlockParameters.java
@@ -1,2 +1,81 @@
-package PACKAGE_NAME;public class TestBlockParameters {
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestBlockParameters
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.code.Block;
+import java.lang.reflect.code.CodeElement;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.type.FunctionType;
+import java.lang.reflect.code.type.JavaType;
+
+import static java.lang.reflect.code.op.CoreOps.*;
+import static java.lang.reflect.code.type.FunctionType.functionType;
+import static java.lang.reflect.code.type.JavaType.INT;
+
+public class TestBlockParameters {
+    static FuncOp m() {
+        return func("f", functionType(INT, INT, INT))
+                .body(fe -> {
+                    LambdaOp lop = lambda(fe.parentBody(), functionType(INT, INT), JavaType.type(FunctionType.class))
+                            .body(le -> {
+                                le.op(_return(le.parameters().get(0)));
+                            });
+                    fe.op(lop);
+                    Block.Builder b = fe.block(INT, INT);
+                    fe.op(branch(b.successor(fe.parameters())));
+
+                    b.op(_return(b.parameters().get(0)));
+                });
+    }
+
+    @Test
+    public void t() {
+        FuncOp m = m();
+        m.traverse(null, CodeElement.blockVisitor((_, b) -> {
+            for (Block.Parameter p : b.parameters()) {
+                testBlockParameter(p);
+            }
+
+            return null;
+        }));
+    }
+
+    void testBlockParameter(Block.Parameter p) {
+        Assert.assertEquals(p.index(), p.declaringBlock().parameters().indexOf(p));
+
+        if (p.invokableOperation() instanceof Op.Invokable iop) {
+            Assert.assertTrue(p.declaringBlock().isEntryBlock());
+            Assert.assertEquals(p.index(), iop.parameters().indexOf(p));
+        } else {
+            // There are no non-invokable operations with bodies in the model
+            Assert.assertFalse(p.declaringBlock().isEntryBlock());
+        }
+    }
 }

--- a/test/jdk/java/lang/reflect/code/TestBlockParameters.java
+++ b/test/jdk/java/lang/reflect/code/TestBlockParameters.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class TestBlockParameters {
+}


### PR DESCRIPTION
The parameters of functions, lambdas, and closures (invokable operations) are modeled as entry block parameters. This is a pattern or idiom of invokable operations. We add methods that help reason about that pattern.

We also a method to obtain the block's index in the parameter list of its declared block.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/babylon.git pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/26.diff">https://git.openjdk.org/babylon/pull/26.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/26#issuecomment-1947488702)