### PR TITLE
Fix compilation issue with CodeElement.elements

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
@@ -308,6 +308,7 @@ public final class TritonTransformer {
 
         //                Tensor load(Tensor ptr, Tensor mask)
         public static TensorType load(TensorType ptr, TensorType mask) {
+            checkTensorShape(ptr, mask);
             if (ptr.eType() instanceof PtrType eptr) {
                 return new TensorType(eptr.rType(), ptr.shape());
             }
@@ -495,6 +496,12 @@ public final class TritonTransformer {
         }
 
         static TensorType checkTensorTypes(TensorType a, TensorType b) {
+            List<Integer> s = checkTensorShape(a, b);
+            Type e = checkScalarTypes(a.eType(), b.eType());
+            return new TensorType(e, s);
+        }
+
+        static List<Integer> checkTensorShape(TensorType a, TensorType b) {
             if (a.shape().size() != b.shape().size()) {
                 // Shape mismatch
                 throw new IllegalStateException();
@@ -523,8 +530,7 @@ public final class TritonTransformer {
                 s.add(d);
             }
 
-            Type e = checkScalarTypes(a.eType(), b.eType());
-            return new TensorType(e, s);
+            return s;
         }
 
         static Type checkScalarTypes(Type a, Type b) {
@@ -671,7 +677,7 @@ public final class TritonTransformer {
                 }
             }
             default -> kblock.op(op);
-        };
+        }
         return kblock;
     }
 
@@ -832,7 +838,7 @@ public final class TritonTransformer {
         if (doSSA) {
             f = SSA.transform(f);
         }
-        // Remove unsued ops
+        // Remove unused ops
         f = f.transform((fblock, op) -> {
             if (op instanceof Op.Pure && op.result().uses().isEmpty()) {
                 return fblock;

--- a/src/java.base/share/classes/java/lang/reflect/code/CodeElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/CodeElement.java
@@ -27,7 +27,7 @@ package java.lang.reflect.code;
 
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.stream.Gatherer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -49,12 +49,14 @@ public sealed interface CodeElement<
     /**
      * {@return a stream of code elements sorted topologically in pre-order traversal.}
      */
+    // Code copied into the compiler cannot depend on new gatherer API
     default Stream<CodeElement<?, ?>> elements() {
-        return Stream.of(Void.class).gather(() -> (_, _, downstream) -> traversePreOrder(downstream));
+/*__throw new UnsupportedOperationException();__*/        return Stream.of(Void.class).gather(() -> (_, _, downstream) -> traversePreOrder(downstream::push));
     }
 
-    private boolean traversePreOrder(Gatherer.Downstream<? super CodeElement<?, ?>> v) {
-        if (!v.push(this)) {
+//    private boolean traversePreOrder(Gatherer.Downstream<? super CodeElement<?, ?>> v) {
+    private boolean traversePreOrder(Predicate<? super CodeElement<?, ?>> v) {
+        if (!v.test(this)) {
             return false;
         }
         for (C c : children()) {

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -1962,7 +1962,7 @@ public final class CoreOps {
 
             @Override
             public TypeElement resultType() {
-                return operands().get(0).type();
+                return JavaType.VOID;
             }
         }
     }


### PR DESCRIPTION
Code copied into the jdk.compiler module cannot compile against new APIs added in the current release.

Also, correct result type of `VarStoreOp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/babylon.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/28.diff">https://git.openjdk.org/babylon/pull/28.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/28#issuecomment-1962059703)