### PR TITLE
Separate TypeElement from Type.

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
@@ -128,7 +128,7 @@ public class ArithMathOps {
                     return n.doubleValue();
                 }
             } else if (t instanceof TensorType tt) {
-                return processConstantValue(TritonType.fromType(tt.eType()), value);
+                return processConstantValue(tt.eType(), value);
             }
 
             throw new UnsupportedOperationException("Unsupported constant type and value: " + t + " " + value);
@@ -450,9 +450,9 @@ public class ArithMathOps {
 
     static String maxMinSuffixFromType(TypeElement t) {
         if (t instanceof TensorType tt) {
-            return maxMinSuffixFromType(TritonType.fromType(tt.eType()));
+            return maxMinSuffixFromType(tt.eType());
         } else if (t instanceof PtrType pt) {
-            return maxMinSuffixFromType(TritonType.fromType(pt.rType()));
+            return maxMinSuffixFromType(pt.rType());
         } else if (t.equals(JavaType.INT)) {
             return "";
         } else if (t.equals(JavaType.FLOAT)) {
@@ -464,9 +464,9 @@ public class ArithMathOps {
 
     static String nameSuffixFromType(TypeElement t, boolean signed) {
         if (t instanceof TensorType tt) {
-            return nameSuffixFromType(TritonType.fromType(tt.eType()), signed);
+            return nameSuffixFromType(tt.eType(), signed);
         } else if (t instanceof PtrType pt) {
-            return nameSuffixFromType(TritonType.fromType(pt.rType()), signed);
+            return nameSuffixFromType(pt.rType(), signed);
         } else if (t.equals(JavaType.INT) || t.equals(JavaType.LONG)) {
             return (signed ? "s" : "") + "i";
         } else if (t.equals(JavaType.FLOAT) || t.equals(JavaType.DOUBLE) ||

--- a/cr-examples/triton/src/main/java/oracle/code/triton/ConstantType.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/ConstantType.java
@@ -25,24 +25,23 @@
 
 package oracle.code.triton;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.type.TypeDefinition;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public final class ConstantType extends TritonType {
     static final String NAME = "constant";
 
-    final Type cType;
+    final TypeElement cType;
     final Object value;
 
-    public ConstantType(Type cType, Object value) {
+    public ConstantType(TypeElement cType, Object value) {
         this.cType = cType;
         this.value = value;
     }
 
-    public Type cType() {
+    public TypeElement cType() {
         return cType;
     }
 
@@ -66,7 +65,7 @@ public final class ConstantType extends TritonType {
     @Override
     public TypeDefinition toTypeDefinition() {
         return new TypeDefinition(NAME,
-                List.of(fromType(cType).toTypeDefinition(),
+                List.of(cType.toTypeDefinition(),
                         new TypeDefinition("c" + value, List.of())));
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/PtrType.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/PtrType.java
@@ -25,20 +25,20 @@
 
 package oracle.code.triton;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.type.TypeDefinition;
 import java.util.List;
 import java.util.Objects;
 
 public final class PtrType extends TritonType {
     static final String NAME = "ptr";
-    final Type rType;
+    final TypeElement rType;
 
-    public PtrType(Type rType) {
+    public PtrType(TypeElement rType) {
         this.rType = rType;
     }
 
-    public Type rType() {
+    public TypeElement rType() {
         return rType;
     }
 
@@ -57,7 +57,7 @@ public final class PtrType extends TritonType {
 
     @Override
     public TypeDefinition toTypeDefinition() {
-        return new TypeDefinition(NAME, List.of(fromType(rType).toTypeDefinition()));
+        return new TypeDefinition(NAME, List.of(rType.toTypeDefinition()));
     }
 
     @Override

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TensorType.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TensorType.java
@@ -25,21 +25,20 @@
 
 package oracle.code.triton;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.type.TypeDefinition;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public final class TensorType extends TritonType {
     static final String NAME = "tensor";
 
-    final Type eType;
+    final TypeElement eType;
     final List<Integer> shape;
     final int size;
 
-    public TensorType(Type eType, List<Integer> shape) {
+    public TensorType(TypeElement eType, List<Integer> shape) {
         this.eType = eType;
         this.shape = List.copyOf(shape);
         int s = 1;
@@ -49,7 +48,7 @@ public final class TensorType extends TritonType {
         this.size = s;
     }
 
-    public Type eType() {
+    public TypeElement eType() {
         return eType;
     }
 
@@ -80,7 +79,7 @@ public final class TensorType extends TritonType {
         for (int i : shape) {
             args.add(new TypeDefinition("x" + i, List.of()));
         }
-        args.add(fromType(eType).toTypeDefinition());
+        args.add(eType.toTypeDefinition());
         return new TypeDefinition(NAME, args);
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -25,7 +25,6 @@
 
 package oracle.code.triton;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.*;
 import java.lang.reflect.code.op.*;
 import java.lang.reflect.code.type.*;
@@ -511,7 +510,7 @@ public class TritonOps {
         }
 
         static TensorType tensorType(int start, int end) {
-            return new TensorType(int.class, List.of(end - start));
+            return new TensorType(JavaType.INT, List.of(end - start));
         }
 
         @Override
@@ -837,10 +836,8 @@ public class TritonOps {
                     if (v == null) {
                         throw new IllegalArgumentException("Bad type: " + tree);
                     }
-                    if (v instanceof JavaType jt) {
-                        yield new PtrType(resolve(jt));
-                    } else if (v instanceof TensorType tt) {
-                        yield new PtrType(tt);
+                    if (v instanceof JavaType || v instanceof TritonType) {
+                        yield new PtrType(v);
                     } else {
                         throw new IllegalArgumentException("Bad type: " + tree);
                     }
@@ -869,10 +866,8 @@ public class TritonOps {
                     if (v == null) {
                         throw new IllegalArgumentException("Bad type: " + tree);
                     }
-                    if (v instanceof JavaType jt) {
-                        yield new TensorType(resolve(jt), shape);
-                    } else if (v instanceof TritonType tt) {
-                        yield new TensorType(tt, shape);
+                    if (v instanceof JavaType || v instanceof TritonType) {
+                        yield new TensorType(v, shape);
                     } else {
                         throw new IllegalArgumentException("Bad type: " + tree);
                     }
@@ -881,14 +876,6 @@ public class TritonOps {
             };
         }
     };
-
-    static Class<?> resolve(JavaType t) {
-        try {
-            return t.resolve(MethodHandles.lookup());
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalArgumentException("Bad type: " + t, e);
-        }
-    }
 
     // Triton types then Java types
     static final TypeElementFactory TRITON_JAVA_TYPE_FACTORY =

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonType.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonType.java
@@ -25,20 +25,8 @@
 
 package oracle.code.triton;
 
-import java.lang.reflect.Type;
 import java.lang.reflect.code.TypeElement;
-import java.lang.reflect.code.type.JavaType;
 
-public abstract sealed class TritonType implements Type, TypeElement
+public abstract sealed class TritonType implements TypeElement
         permits ConstantType, PtrType, TensorType {
-
-    public static TypeElement fromType(Type t) {
-        if (t instanceof Class<?> c) {
-            return JavaType.type(c);
-        } else if (t instanceof TritonType tt) {
-            return tt;
-        } else {
-            throw new UnsupportedOperationException("Unsupported type: " + t);
-        }
-    }
 }

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestAddKernel.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestAddKernel.java
@@ -27,7 +27,8 @@ import oracle.code.triton.TritonTestExtension.TritonTestData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -92,12 +93,12 @@ public class TestAddKernel {
     @TritonTestExtension.Kernel("add_kernel")
     @Test
     public void test(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new PtrType(float.class),
-                new PtrType(float.class),
-                new PtrType(float.class),
-                int.class,
-                new ConstantType(int.class, 64));
+        List<TypeElement> argTypes = List.of(
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                JavaType.INT,
+                new ConstantType(JavaType.INT, 64));
 
         t.test(argTypes);
     }
@@ -161,12 +162,12 @@ public class TestAddKernel {
     @TritonTestExtension.Kernel("add_kernel2")
     @Test
     public void test2(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new PtrType(float.class),
-                new PtrType(float.class),
-                new PtrType(float.class),
-                int.class,
-                new ConstantType(int.class, 64));
+        List<TypeElement> argTypes = List.of(
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                JavaType.INT,
+                new ConstantType(JavaType.INT, 64));
 
         t.test(argTypes);
     }

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestBroadcast.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestBroadcast.java
@@ -27,7 +27,8 @@ import oracle.code.triton.TritonTestExtension.TritonTestData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -73,10 +74,10 @@ public class TestBroadcast {
 
     @Test
     public void test1(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new PtrType(int.class),
-                int.class,
-                new ConstantType(int.class, 64));
+        List<TypeElement> argTypes = List.of(
+                new PtrType(JavaType.INT),
+                JavaType.INT,
+                new ConstantType(JavaType.INT, 64));
 
         t.test(argTypes);
     }
@@ -117,10 +118,10 @@ public class TestBroadcast {
 
     @Test
     public void test2(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                int.class,
-                new ConstantType(int.class, 64),
-                new ConstantType(int.class, 32)
+        List<TypeElement> argTypes = List.of(
+                JavaType.INT,
+                new ConstantType(JavaType.INT, 64),
+                new ConstantType(JavaType.INT, 32)
         );
 
         t.test(argTypes);

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestCdiv.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestCdiv.java
@@ -27,7 +27,8 @@ import oracle.code.triton.TritonTestExtension.TritonTestData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -62,9 +63,9 @@ public class TestCdiv {
 
     @Test
     public void testScalar(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                int.class,
-                int.class);
+        List<TypeElement> argTypes = List.of(
+                JavaType.INT,
+                JavaType.INT);
 
         t.test(argTypes);
     }
@@ -96,9 +97,9 @@ public class TestCdiv {
 
     @Test
     public void testConstant(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                int.class,
-                new ConstantType(int.class, 10));
+        List<TypeElement> argTypes = List.of(
+                JavaType.INT,
+                new ConstantType(JavaType.INT, 10));
 
         t.test(argTypes);
     }
@@ -153,10 +154,10 @@ public class TestCdiv {
 
     @Test
     public void testCalls(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                int.class,
-                int.class,
-                new ConstantType(int.class, 10));
+        List<TypeElement> argTypes = List.of(
+                JavaType.INT,
+                JavaType.INT,
+                new ConstantType(JavaType.INT, 10));
 
         t.test(argTypes);
     }

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestCountedLoop.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestCountedLoop.java
@@ -27,7 +27,8 @@ import oracle.code.triton.TritonTestExtension.TritonTestData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -75,9 +76,9 @@ public class TestCountedLoop {
 
     @Test
     public void test1(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                int.class,
-                new ConstantType(int.class, 64));
+        List<TypeElement> argTypes = List.of(
+                JavaType.INT,
+                new ConstantType(JavaType.INT, 64));
 
         t.test(argTypes);
     }

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestMatrix.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestMatrix.java
@@ -26,7 +26,8 @@ package oracle.code.triton;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -299,17 +300,17 @@ public class TestMatrix {
     @TritonTestExtension.Kernel("matmul_kernel_broadcast")
     @Test
     public void testWithBroadcast(TritonTestExtension.TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new PtrType(float.class),
-                new PtrType(float.class),
-                new PtrType(float.class),
-                int.class, int.class, int.class,
-                int.class, int.class,
-                int.class, int.class,
-                int.class, int.class,
-                new ConstantType(int.class, 32), new ConstantType(int.class, 64), new ConstantType(int.class, 32),
-                new ConstantType(int.class, 8),
-                new ConstantType(int.class, false));
+        List<TypeElement> argTypes = List.of(
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                JavaType.INT, JavaType.INT, JavaType.INT,
+                JavaType.INT, JavaType.INT,
+                JavaType.INT, JavaType.INT,
+                JavaType.INT, JavaType.INT,
+                new ConstantType(JavaType.INT, 32), new ConstantType(JavaType.INT, 64), new ConstantType(JavaType.INT, 32),
+                new ConstantType(JavaType.INT, 8),
+                new ConstantType(JavaType.INT, false));
 
         t.test(argTypes);
     }
@@ -546,17 +547,17 @@ public class TestMatrix {
     @TritonTestExtension.Kernel("matmul_kernel")
     @Test
     public void test(TritonTestExtension.TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new PtrType(Float16.class),
-                new PtrType(Float16.class),
-                new PtrType(Float16.class),
-                int.class, int.class, int.class,
-                int.class, int.class,
-                int.class, int.class,
-                int.class, int.class,
-                new ConstantType(int.class, 32), new ConstantType(int.class, 64), new ConstantType(int.class, 32),
-                new ConstantType(int.class, 8),
-                new ConstantType(int.class, false));
+        List<TypeElement> argTypes = List.of(
+                new PtrType(Float16.FLOAT_16_TYPE),
+                new PtrType(Float16.FLOAT_16_TYPE),
+                new PtrType(Float16.FLOAT_16_TYPE),
+                JavaType.INT, JavaType.INT, JavaType.INT,
+                JavaType.INT, JavaType.INT,
+                JavaType.INT, JavaType.INT,
+                JavaType.INT, JavaType.INT,
+                new ConstantType(JavaType.INT, 32), new ConstantType(JavaType.INT, 64), new ConstantType(JavaType.INT, 32),
+                new ConstantType(JavaType.INT, 8),
+                new ConstantType(JavaType.INT, false));
 
         t.test(argTypes);
     }

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestSoftMax.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestSoftMax.java
@@ -28,7 +28,8 @@ import oracle.code.triton.TritonTestExtension.TritonTestData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -123,13 +124,13 @@ public class TestSoftMax {
     @Kernel("softmax_kernel")
     @Test
     public void test(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new PtrType(float.class),
-                new PtrType(float.class),
-                new ConstantType(int.class, 1),
-                new ConstantType(int.class, 1),
-                new ConstantType(int.class, 10),
-                new ConstantType(int.class, 64));
+        List<TypeElement> argTypes = List.of(
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                new ConstantType(JavaType.INT, 1),
+                new ConstantType(JavaType.INT, 1),
+                new ConstantType(JavaType.INT, 10),
+                new ConstantType(JavaType.INT, 64));
 
         t.test(argTypes);
     }
@@ -220,13 +221,13 @@ public class TestSoftMax {
     @Kernel("softmax_kernel2")
     @Test
     public void test2(TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new PtrType(float.class),
-                new PtrType(float.class),
-                new ConstantType(int.class, 1),
-                new ConstantType(int.class, 1),
-                new ConstantType(int.class, 10),
-                new ConstantType(int.class, 64));
+        List<TypeElement> argTypes = List.of(
+                new PtrType(JavaType.FLOAT),
+                new PtrType(JavaType.FLOAT),
+                new ConstantType(JavaType.INT, 1),
+                new ConstantType(JavaType.INT, 1),
+                new ConstantType(JavaType.INT, 10),
+                new ConstantType(JavaType.INT, 64));
 
         t.test(argTypes);
     }

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestVariables.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestVariables.java
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -49,8 +50,8 @@ public class TestVariables {
 
     @Test
     public void test1(TritonTestExtension.TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new ConstantType(int.class, 32));
+        List<TypeElement> argTypes = List.of(
+                new ConstantType(JavaType.INT, 32));
 
         Assertions.assertThrows(IllegalStateException.class, () -> {
             t.test(argTypes);

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TestZeros.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TestZeros.java
@@ -26,7 +26,8 @@ package oracle.code.triton;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 
@@ -54,9 +55,9 @@ public class TestZeros {
 
     @Test
     public void test1(TritonTestExtension.TritonTestData t) {
-        List<Type> argTypes = List.of(
-                new ConstantType(int.class, 32),
-                new ConstantType(int.class, 64));
+        List<TypeElement> argTypes = List.of(
+                new ConstantType(JavaType.INT, 32),
+                new ConstantType(JavaType.INT, 64));
 
         t.test(argTypes);
     }

--- a/cr-examples/triton/src/test/java/oracle/code/triton/TritonTestExtension.java
+++ b/cr-examples/triton/src/test/java/oracle/code/triton/TritonTestExtension.java
@@ -33,9 +33,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.parser.OpParser;
+import java.lang.reflect.code.type.JavaType;
 import java.lang.runtime.CodeReflection;
 import java.util.List;
 import java.util.Optional;
@@ -73,7 +74,7 @@ public class TritonTestExtension implements ParameterResolver {
             this.javaKernelName = javaKernelName;
         }
 
-        public void test(List<Type> argTypes) {
+        public void test(List<? extends TypeElement> argTypes) {
             Optional<Method> om = Stream.of(testClass.getDeclaredMethods())
                     .filter(m -> m.getName().equals(javaKernelName))
                     .filter(m -> m.getAnnotation(CodeReflection.class) != null)
@@ -99,11 +100,11 @@ public class TritonTestExtension implements ParameterResolver {
         }
 
         void test(CoreOps.FuncOp javaKernel,
-                  List<Type> argTypes,
+                  List<? extends TypeElement> argTypes,
                   TritonOps.ModuleOp expectedTritonKernel,
                   boolean doSSA) {
             TritonOps.ModuleOp actualTritonKernel = ScopedValue.getWhere(TritonTransformer.SV_SSA, doSSA,() -> {
-                return TritonTransformer.tritonModule(javaKernel, void.class, argTypes);
+                return TritonTransformer.tritonModule(javaKernel, JavaType.VOID, argTypes);
             });
 
             Assertions.assertEquals(


### PR DESCRIPTION
`TritonType` currently extends from `TypeElement` and `Type` to allow for the convenient composition of a code model type (symbolical description of a type) and a runtime type. This is confusing, and is mixing layers. `TritonType` should only extended from `TypeElement` and same for any arguments of.