### PR TITLE
Code model from method reference

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
@@ -27,6 +27,7 @@ package java.lang.reflect.code.type;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
+import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.type.impl.MethodRefImpl;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -35,6 +36,7 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.TypeElement;
 import java.util.List;
+import java.util.Optional;
 
 import static java.lang.reflect.code.type.FunctionType.functionType;
 
@@ -57,11 +59,13 @@ public sealed interface MethodRef permits MethodRefImpl {
 
     FunctionType type();
 
-    // Conversions
+    // Resolutions and model access
 
     Executable resolveToMember(MethodHandles.Lookup l) throws ReflectiveOperationException;
 
     MethodHandle resolveToHandle(MethodHandles.Lookup l) throws ReflectiveOperationException;
+
+    Optional<CoreOps.FuncOp> codeModel(MethodHandles.Lookup l) throws ReflectiveOperationException;
 
     // Factories
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/impl/MethodRefImpl.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/impl/MethodRefImpl.java
@@ -25,6 +25,7 @@
 
 package java.lang.reflect.code.type.impl;
 
+import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.type.MethodRef;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleInfo;
@@ -34,6 +35,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.TypeElement;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.joining;
 
@@ -65,6 +67,7 @@ public final class MethodRefImpl implements MethodRef {
 
     @Override
     public Method resolveToMember(MethodHandles.Lookup l) throws ReflectiveOperationException {
+        // @@@ Constructor
         MethodHandleInfo methodHandleInfo = l.revealDirect(resolveToHandle(l));
         return methodHandleInfo.reflectAs(Method.class, l);
     }
@@ -109,6 +112,12 @@ public final class MethodRefImpl implements MethodRef {
             // @@@
             throw new ReflectiveOperationException();
         }
+    }
+
+    // Copied code in jdk.compiler module throws UOE
+    @Override
+    public Optional<CoreOps.FuncOp> codeModel(MethodHandles.Lookup l) throws ReflectiveOperationException {
+/*__throw new UnsupportedOperationException();__*/        return resolveToMember(l).getCodeModel();
     }
 
     @Override

--- a/test/jdk/java/lang/reflect/code/type/TestReferences.java
+++ b/test/jdk/java/lang/reflect/code/type/TestReferences.java
@@ -25,9 +25,14 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.code.op.CoreOps;
 import java.lang.reflect.code.type.FieldRef;
 import java.lang.reflect.code.type.MethodRef;
 import java.lang.reflect.code.type.RecordTypeRef;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
 
 /*
  * @test
@@ -94,4 +99,14 @@ public class TestReferences {
         Assert.assertEquals(rtr.toString(), rtds);
     }
 
+
+    @CodeReflection
+    static void x() {}
+
+    @Test
+    public void testAccessCodeModel() throws ReflectiveOperationException {
+        MethodRef xr = MethodRef.method(TestReferences.class, "x", void.class);
+        Optional<CoreOps.FuncOp> m = xr.codeModel(MethodHandles.lookup());
+        Assert.assertTrue(m.isPresent());
+    }
 }


### PR DESCRIPTION
Obtain a code model from method reference. The implementation is simple and resolves the method reference to an instance of `Method`, and returns the result of `Method::getCodeModel`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/babylon.git pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/34.diff">https://git.openjdk.org/babylon/pull/34.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/34#issuecomment-1979679624)