### PR TITLE
Obtain parent code element from code element

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Block.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Block.java
@@ -176,6 +176,17 @@ public final class Block implements CodeElement<Block, Op> {
         this.predecessors = new LinkedHashSet<>();
     }
 
+
+    /**
+     * Returns this block's parent body.
+     *
+     * @return this block's parent body.
+     */
+    @Override
+    public Body parent() {
+        return parentBody;
+    }
+
     /**
      * Returns this block's parent body.
      *
@@ -183,6 +194,20 @@ public final class Block implements CodeElement<Block, Op> {
      */
     public Body parentBody() {
         return parentBody;
+    }
+
+    @Override
+    public List<Op> children() {
+        return ops();
+    }
+
+    /**
+     * Returns the sequence of operations contained in this block.
+     *
+     * @return returns the sequence operations, as an unmodifiable list.
+     */
+    public List<Op> ops() {
+        return Collections.unmodifiableList(ops);
     }
 
     /**
@@ -222,15 +247,6 @@ public final class Block implements CodeElement<Block, Op> {
     }
 
     /**
-     * Returns the sequence of operations contained in this block.
-     *
-     * @return returns the sequence operations, as an unmodifiable list.
-     */
-    public List<Op> ops() {
-        return Collections.unmodifiableList(ops);
-    }
-
-    /**
      * Finds the operation in this block that is the ancestor of the given operation.
      *
      * @param op the given operation.
@@ -250,11 +266,6 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         return op;
-    }
-
-    @Override
-    public List<Op> children() {
-        return ops();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/Body.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Body.java
@@ -72,6 +72,39 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
+     * Returns this body's parent operation.
+     *
+     * @return the body's parent operation.
+     */
+    @Override
+    public Op parent() {
+        return parentOp;
+    }
+
+    /**
+     * Returns this body's parent operation.
+     *
+     * @return the body's parent operation.
+     */
+    public Op parentOp() {
+        return parentOp;
+    }
+
+    @Override
+    public List<Block> children() {
+        return blocks();
+    }
+
+    /**
+     * Returns body's blocks in reverse-postorder as an unmodifiable list.
+     *
+     * @return the body's blocks in reverse-postorder.
+     */
+    public List<Block> blocks() {
+        return Collections.unmodifiableList(blocks);
+    }
+
+    /**
      * {@return the yield type of this body}
      */
     public TypeElement yieldType() {
@@ -91,15 +124,6 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * Returns this body's parent operation.
-     *
-     * @return the body's parent operation.
-     */
-    public Op parentOp() {
-        return parentOp;
-    }
-
-    /**
      * Finds the block in this body that is the ancestor of the given block.
      *
      * @param b the given block.
@@ -114,20 +138,6 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         return b;
-    }
-
-    /**
-     * Returns body's blocks in reverse-postorder as an unmodifiable list.
-     *
-     * @return the body's blocks in reverse-postorder.
-     */
-    public List<Block> blocks() {
-        return Collections.unmodifiableList(blocks);
-    }
-
-    @Override
-    public List<Block> children() {
-        return blocks();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/CodeElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/CodeElement.java
@@ -126,6 +126,16 @@ public sealed interface CodeElement<
     }
 
     /**
+     * Returns the parent code element.
+     * <p>
+     * If this element is an instance of {@code Op} then the parent may be {@code null}
+     * if operation is not assigned to a block.
+     *
+     * @return the parent code element
+     */
+    CodeElement<?, E> parent();
+
+    /**
      * Returns the child code elements, as an unmodifiable list.
      *
      * @return the child code elements

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -237,12 +237,13 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Returns the operation's result, otherwise {@code null} if the operation is not assigned to a block.
+     * Returns this operation's parent block, otherwise {@code null} if the operation is not assigned to a block.
      *
-     * @return the operation's result, or {@code null} if not assigned to a block.
+     * @return operation's parent block, or {@code null} if the operation is not assigned to a block.
      */
-    public final Result result() {
-        return result;
+    @Override
+    public final Block parent() {
+        return parentBlock();
     }
 
     /**
@@ -261,6 +262,29 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
         return result.block;
     }
+
+    @Override
+    public final List<Body> children() {
+        return bodies();
+    }
+
+    /**
+     * {@return the operation's bodies, as an unmodifiable list}
+     * @implSpec this implementation returns an unmodifiable empty list.
+     */
+    public List<Body> bodies() {
+        return List.of();
+    }
+
+    /**
+     * Returns the operation's result, otherwise {@code null} if the operation is not assigned to a block.
+     *
+     * @return the operation's result, or {@code null} if not assigned to a block.
+     */
+    public final Result result() {
+        return result;
+    }
+
 
     /**
      * Returns this operation's nearest ancestor body (the parent body of this operation's parent block),
@@ -333,19 +357,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     public FunctionType opType() {
         List<TypeElement> operandTypes = operands.stream().map(Value::type).toList();
         return FunctionType.functionType(resultType(), operandTypes);
-    }
-
-    /**
-     * {@return the operation's bodies, as an unmodifiable list}
-     * @implSpec this implementation returns an unmodifiable empty list.
-     */
-    public List<Body> bodies() {
-        return List.of();
-    }
-
-    @Override
-    public final List<Body> children() {
-        return bodies();
     }
 
     /**


### PR DESCRIPTION
`CodeElement` allows access to its children but not its parent. We can add a method to support that.

Subclasses `Op`, `Body`, and `Block` have duplicate methods for accessing their parent and children (the subclasses have covariant overrides of the `CodeElement` methods) e.g., `CodeElement::parent` and Op::parentBlock,  `CodeElement::children` and `Op::bodies`. We may not require the subclass specific methods, but i am leaving there for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/babylon.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/35.diff">https://git.openjdk.org/babylon/pull/35.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/35#issuecomment-1981966074)