### PR TITLE
A transformer of code models to models that build them.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
@@ -322,7 +322,8 @@ public class OpBuilder {
                 yield builder.op(fieldLoad(FieldRef.field(Op.class, "NULL_ATTRIBUTE_VALUE", Object.class)));
             }
             default -> {
-                throw new UnsupportedOperationException(value + " " + value.getClass().toString());
+                // @@@ use the result of value.toString()?
+                throw new UnsupportedOperationException("Unsupported attribute value: " + value);
             }
         };
     }

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
@@ -1,0 +1,293 @@
+package java.lang.reflect.code.writer;
+
+import java.lang.reflect.code.*;
+import java.lang.reflect.code.op.OpDefinition;
+import java.lang.reflect.code.op.OpFactory;
+import java.lang.reflect.code.type.*;
+import java.util.*;
+
+import static java.lang.reflect.code.op.CoreOps.*;
+import static java.lang.reflect.code.type.FunctionType.functionType;
+import static java.lang.reflect.code.type.JavaType.*;
+
+/**
+ * A transformer of code models to models that build them.
+ * <p>
+ * A building code model when executed will construct the same code model it was transformed from.
+ * Such a building code model could be transformed to bytecode and stored in class files.
+ */
+public class OpBuilder {
+
+    static final JavaType J_C_O_OP_DEFINITION = type(OpDefinition.class);
+
+    static final MethodRef OP_FACTORY_CONSTRUCT = MethodRef.method(OpFactory.class, "constructOp",
+            Op.class, OpDefinition.class);
+
+    static final MethodRef TYPE_ELEMENT_FACTORY_CONSTRUCT = MethodRef.method(TypeElementFactory.class, "constructType",
+            TypeElement.class, TypeDefinition.class);
+
+    static final MethodRef TYPE_DEFINITION_OF_STRING = MethodRef.method(TypeDefinition.class, "ofString",
+            TypeDefinition.class, String.class);
+
+    static final MethodRef BODY_BUILDER_OF = MethodRef.method(Body.Builder.class, "of",
+            Body.Builder.class, Body.Builder.class, FunctionType.class);
+
+    static final MethodRef BODY_BUILDER_ENTRY_BLOCK = MethodRef.method(Body.Builder.class, "entryBlock",
+            Block.Builder.class);
+
+    static final MethodRef BLOCK_BUILDER_SUCCESSOR = MethodRef.method(Block.Builder.class, "successor",
+            Block.Reference.class, Value[].class);
+
+    static final MethodRef BLOCK_BUILDER_OP = MethodRef.method(Block.Builder.class, "op",
+            Op.Result.class, Op.class);
+
+    static final MethodRef BLOCK_BUILDER_BLOCK = MethodRef.method(Block.Builder.class, "block",
+            Block.Builder.class, TypeElement[].class);
+
+    static final MethodRef BLOCK_BUILDER_PARAMETER = MethodRef.method(Block.Builder.class, "parameter",
+            Block.Parameter.class, TypeElement.class);
+
+    static final MethodRef FUNCTION_TYPE_FUNCTION_TYPE = MethodRef.method(FunctionType.class, "functionType",
+            FunctionType.class, TypeElement.class, TypeElement[].class);
+
+
+    static final JavaType J_U_LIST = type(List.class);
+
+    static final MethodRef LIST_OF_ARRAY = MethodRef.method(J_U_LIST, "of",
+            J_U_LIST, type(J_L_OBJECT, 1));
+
+    static final JavaType J_U_MAP = type(Map.class);
+
+    static final JavaType J_U_HASH_MAP = type(HashMap.class);
+
+    static final JavaType J_U_MAP_ENTRY = type(Map.Entry.class);
+
+    static final MethodRef MAP_ENTRY = MethodRef.method(J_U_MAP, "entry",
+            J_U_MAP, J_L_OBJECT, J_L_OBJECT);
+
+    static final MethodRef MAP_OF = MethodRef.method(J_U_MAP, "of",
+            J_U_MAP);
+
+    static final MethodRef MAP_OF_ARRAY = MethodRef.method(J_U_MAP, "of",
+            J_U_MAP, type(J_U_MAP_ENTRY, 1));
+
+    static final MethodRef MAP_PUT = MethodRef.method(J_U_MAP, "put",
+            J_L_OBJECT, J_L_OBJECT, J_L_OBJECT);
+
+
+    static final FunctionType OP_DEFINITION_F_TYPE = functionType(
+            J_C_O_OP_DEFINITION,
+            J_L_STRING,
+            J_U_LIST,
+            J_U_LIST,
+            type(TypeElement.class),
+            J_U_MAP,
+            J_U_LIST);
+
+    static final FunctionType BUILDER_F_TYPE = functionType(type(Op.class),
+            type(OpFactory.class),
+            type(TypeElementFactory.class));
+
+
+    Map<Value, Value> valueMap;
+
+    Map<Block, Value> blockMap;
+
+    Block.Builder builder;
+
+    Value opFactory;
+
+    Value typeElementFactory;
+
+    /**
+     * Transform the given code model to one that builds it.
+     *
+     * @param op the code model
+     * @return the building code model.
+     */
+    public static FuncOp createBuilderFunction(Op op) {
+        return new OpBuilder().build(op);
+    }
+
+    OpBuilder() {
+        this.valueMap = new HashMap<>();
+        this.blockMap = new HashMap<>();
+    }
+
+    FuncOp build(Op op) {
+        Body.Builder body = Body.Builder.of(null, BUILDER_F_TYPE);
+
+        builder = body.entryBlock();
+        opFactory = builder.parameters().get(0);
+        typeElementFactory = builder.parameters().get(1);
+
+        Value ancestorBody = builder.op(constant(type(Body.Builder.class), null));
+        Value result = buildOp(ancestorBody, op);
+        builder.op(_return(result));
+
+        return func("builder." + op.opName(), body);
+    }
+
+
+    Value buildOp(Value ancestorBody, Op inputOp) {
+        List<Value> bodies = new ArrayList<>();
+        for (Body inputBody : inputOp.bodies()) {
+            Value body = buildBody(ancestorBody, inputBody);
+            bodies.add(body);
+        }
+
+        List<Value> operands = new ArrayList<>();
+        for (Value inputOperand : inputOp.operands()) {
+            Value operand = valueMap.get(inputOperand);
+            operands.add(operand);
+        }
+
+        List<Value> successors = new ArrayList<>();
+        for (Block.Reference inputSuccessor : inputOp.successors()) {
+            List<Value> successorArgs = new ArrayList<>();
+            for (Value inputOperand : inputSuccessor.arguments()) {
+                Value operand = valueMap.get(inputOperand);
+                successorArgs.add(operand);
+            }
+            Value referencedBlock = blockMap.get(inputSuccessor.targetBlock());
+
+            List<Value> args = new ArrayList<>();
+            args.add(referencedBlock);
+            args.addAll(successorArgs);
+            Value successor = builder.op(invoke(BLOCK_BUILDER_SUCCESSOR, args));
+            successors.add(successor);
+        }
+
+        Value opDef = buildOpDefinition(
+                inputOp.opName(),
+                operands,
+                successors,
+                inputOp.resultType(),
+                inputOp.attributes(),
+                bodies);
+        return builder.op(invoke(OP_FACTORY_CONSTRUCT, opFactory, opDef));
+    }
+
+
+    Value buildOpDefinition(String name,
+                            List<Value> operands,
+                            List<Value> successors,
+                            TypeElement resultType,
+                            Map<String, Object> attributes,
+                            List<Value> bodies) {
+        List<Value> args = List.of(
+                builder.op(constant(J_L_STRING, name)),
+                buildList(type(Value.class), operands),
+                buildList(type(Block.Reference.class), successors),
+                buildType(resultType),
+                buildAttributeMap(attributes),
+                buildList(type(Body.Builder.class), bodies));
+        return builder.op(_new(OP_DEFINITION_F_TYPE, args));
+    }
+
+    Value buildBody(Value ancestorBodyValue, Body inputBody) {
+        Value yieldType = buildType(inputBody.yieldType());
+        Value bodyType = builder.op(invoke(FUNCTION_TYPE_FUNCTION_TYPE, yieldType));
+        Value body = builder.op(invoke(BODY_BUILDER_OF, ancestorBodyValue, bodyType));
+
+        Value entryBlock = null;
+        for (Block inputBlock : inputBody.blocks()) {
+            Value block;
+            if (inputBlock.isEntryBlock()) {
+                block = entryBlock = builder.op(invoke(BODY_BUILDER_ENTRY_BLOCK, body));
+            } else {
+                assert entryBlock != null;
+                block = builder.op(invoke(BLOCK_BUILDER_BLOCK, entryBlock));
+            }
+            blockMap.put(inputBlock, block);
+
+            for (Block.Parameter inputP : inputBlock.parameters()) {
+                Value type = buildType(inputP.type());
+                Value blockParameter = builder.op(invoke(BLOCK_BUILDER_PARAMETER, block, type));
+                valueMap.put(inputP, blockParameter);
+            }
+        }
+
+        for (Block inputBlock : inputBody.blocks()) {
+            Value block = blockMap.get(inputBlock);
+            for (Op inputOp : inputBlock.ops()) {
+                Value op = buildOp(body, inputOp);
+                Value result = builder.op(invoke(BLOCK_BUILDER_OP, block, op));
+                valueMap.put(inputOp.result(), result);
+            }
+        }
+
+        return body;
+    }
+
+    Value buildType(TypeElement t) {
+        Value typeString = builder.op(constant(J_L_STRING, t.toString()));
+        Value typeDef = builder.op(invoke(TYPE_DEFINITION_OF_STRING, typeString));
+        return builder.op(invoke(TYPE_ELEMENT_FACTORY_CONSTRUCT, typeElementFactory, typeDef));
+    }
+
+    Value buildAttributeMap(Map<String, Object> attributes) {
+        List<Value> keysAndValues = new ArrayList<>();
+        for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+            Value key = builder.op(constant(J_L_STRING, entry.getKey()));
+            Value value = buildAttributeValue(entry.getValue());
+            keysAndValues.add(key);
+            keysAndValues.add(value);
+        }
+        return buildMap(J_L_STRING, J_L_OBJECT, keysAndValues);
+    }
+
+    Value buildAttributeValue(Object value) {
+        return switch (value) {
+            case String s -> {
+                yield builder.op(constant(J_L_STRING, value));
+            }
+            case Integer i -> {
+                yield builder.op(constant(INT, value));
+            }
+            default -> {
+                throw new UnsupportedOperationException(value.getClass().toString());
+            }
+        };
+    }
+
+
+    Value buildMap(JavaType keyType, JavaType valueType, List<Value> keysAndValues) {
+        JavaType mapType = type(J_U_MAP, keyType, valueType);
+        if (keysAndValues.isEmpty()) {
+            return builder.op(invoke(MAP_OF));
+        } else {
+            Value map = builder.op(_new(mapType, functionType(J_U_HASH_MAP)));
+            for (int i = 0; i < keysAndValues.size(); i += 2) {
+                Value key = keysAndValues.get(i);
+                Value value = keysAndValues.get(i + 1);
+                builder.op(invoke(MAP_PUT, map, key, value));
+            }
+            return map;
+        }
+    }
+
+
+    Value buildList(JavaType elementType, List<Value> elements) {
+        JavaType listType = type(J_U_LIST, elementType);
+        if (elements.size() < 11) {
+            MethodRef listOf = MethodRef.method(J_U_LIST, "of",
+                    J_U_LIST, Collections.nCopies(elements.size(), J_L_OBJECT));
+            return builder.op(invoke(listType, listOf, elements));
+        } else {
+            Value array = buildArray(elementType, elements);
+            return builder.op(invoke(listType, LIST_OF_ARRAY, array));
+        }
+    }
+
+
+    Value buildArray(JavaType elementType, List<Value> elements) {
+        Value array = builder.op(newArray(elementType,
+                builder.op(constant(INT, elements.size()))));
+        for (int i = 0; i < elements.size(); i++) {
+            builder.op(arrayStoreOp(array, elements.get(i),
+                    builder.op(constant(INT, i))));
+        }
+        return array;
+    }
+}

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package java.lang.reflect.code.writer;
 
 import java.lang.reflect.code.*;
@@ -49,6 +74,15 @@ public class OpBuilder {
 
     static final MethodRef FUNCTION_TYPE_FUNCTION_TYPE = MethodRef.method(FunctionType.class, "functionType",
             FunctionType.class, TypeElement.class, TypeElement[].class);
+
+    static final MethodRef METHOD_REF_OF_STRING = MethodRef.method(MethodRef.class, "ofString",
+            MethodRef.class, String.class);
+
+    static final MethodRef FIELD_REF_OF_STRING = MethodRef.method(FieldRef.class, "ofString",
+            FieldRef.class, String.class);
+
+    static final MethodRef RECORD_TYPE_REF_OF_STRING = MethodRef.method(RecordTypeRef.class, "ofString",
+            RecordTypeRef.class, String.class);
 
 
     static final JavaType J_U_LIST = type(List.class);
@@ -239,14 +273,56 @@ public class OpBuilder {
 
     Value buildAttributeValue(Object value) {
         return switch (value) {
+            case Boolean v -> {
+                yield builder.op(constant(BOOLEAN, value));
+            }
+            case Byte v -> {
+                yield builder.op(constant(BYTE, value));
+            }
+            case Short v -> {
+                yield builder.op(constant(SHORT, value));
+            }
+            case Character v -> {
+                yield builder.op(constant(CHAR, value));
+            }
+            case Integer v -> {
+                yield builder.op(constant(INT, value));
+            }
+            case Long v -> {
+                yield builder.op(constant(LONG, value));
+            }
+            case Float v -> {
+                yield builder.op(constant(FLOAT, value));
+            }
+            case Double v -> {
+                yield builder.op(constant(DOUBLE, value));
+            }
+            case Class<?> v -> {
+                yield buildType(JavaType.type(v));
+            }
             case String s -> {
                 yield builder.op(constant(J_L_STRING, value));
             }
-            case Integer i -> {
-                yield builder.op(constant(INT, value));
+            case MethodRef r -> {
+                Value string = builder.op(constant(J_L_STRING, value.toString()));
+                yield builder.op(invoke(METHOD_REF_OF_STRING, string));
+            }
+            case FieldRef r -> {
+                Value string = builder.op(constant(J_L_STRING, value.toString()));
+                yield builder.op(invoke(FIELD_REF_OF_STRING, string));
+            }
+            case RecordTypeRef r -> {
+                Value string = builder.op(constant(J_L_STRING, value.toString()));
+                yield builder.op(invoke(RECORD_TYPE_REF_OF_STRING, string));
+            }
+            case TypeElement f -> {
+                yield buildType(f);
+            }
+            case Object o when value == Op.NULL_ATTRIBUTE_VALUE -> {
+                yield builder.op(fieldLoad(FieldRef.field(Op.class, "NULL_ATTRIBUTE_VALUE", Object.class)));
             }
             default -> {
-                throw new UnsupportedOperationException(value.getClass().toString());
+                throw new UnsupportedOperationException(value + " " + value.getClass().toString());
             }
         };
     }

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -36,7 +36,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * A writer of code models (operations) to the textual form.
+ * A writer of code models to the textual form.
  * <p>
  * A code model in textual form may be parsed back into the runtime form by parsing it.
  */

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/package-info.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
- * Functionality for writing text description of code models.
+ * Functionality for writing and storing code models.
  */
 package java.lang.reflect.code.writer;

--- a/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.analysis.SSA;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.code.op.CoreOps;
+import java.lang.reflect.code.op.ExtendedOps;
+import java.lang.reflect.code.type.CoreTypeFactory;
+import java.lang.reflect.code.writer.OpBuilder;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/*
+ * @test
+ * @run testng TestCodeBuilder
+ */
+
+public class TestCodeBuilder {
+
+    @CodeReflection
+    static double f(double i, double j) {
+        int sum = 0;
+        for (int k = 0; k < 10; k++) {
+            sum += j;
+        }
+
+        String s = "HELLO";
+        int k = s.length();
+        s = null;
+        return i + j + k;
+    }
+
+    @Test
+    public void testF() {
+        CoreOps.FuncOp f = getFuncOp("f");
+        test(f);
+
+        f = f.transform((block, op) -> {
+            if (op instanceof Op.Lowerable l) {
+                return l.lower(block);
+            } else {
+                block.op(op);
+                return block;
+            }
+        });
+        test(f);
+
+        f = SSA.transform(f);
+        test(f);
+    }
+
+    static void test(CoreOps.FuncOp fExpected) {
+        CoreOps.FuncOp fb = OpBuilder.createBuilderFunction(fExpected);
+        CoreOps.FuncOp fActual = (CoreOps.FuncOp) Interpreter.invoke(MethodHandles.lookup(),
+                fb, ExtendedOps.FACTORY, CoreTypeFactory.CORE_TYPE_FACTORY);
+        Assert.assertEquals(fActual.toText(), fExpected.toText());
+    }
+
+    static CoreOps.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestCodeBuilder.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+
+}

--- a/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
@@ -45,21 +45,70 @@ import java.util.stream.Stream;
 public class TestCodeBuilder {
 
     @CodeReflection
-    static double f(double i, double j) {
-        int sum = 0;
-        for (int k = 0; k < 10; k++) {
-            sum += j;
-        }
-
-        String s = "HELLO";
-        int k = s.length();
-        s = null;
-        return i + j + k;
+    static void constants() {
+        boolean bool = false;
+        byte b = 1;
+        char c = 'a';
+        short s = 1;
+        int i = 1;
+        long l = 1L;
+        float f = 1.0f;
+        double d = 1.0;
+        String str = "1";
+        Object obj = null;
+        Class<?> klass = Object.class;
     }
 
     @Test
-    public void testF() {
-        CoreOps.FuncOp f = getFuncOp("f");
+    public void testConstants() {
+        testWithTransforms(getFuncOp("constants"));
+    }
+
+    static record X(int f) {
+        void m() {}
+    }
+
+    @CodeReflection
+    static void reflect() {
+        X x = new X(1);
+        int i = x.f;
+        x.m();
+        X[] ax = new X[1];
+        int l = ax.length;
+        x = ax[0];
+
+        Object o = x;
+        x = (X) o;
+        if (o instanceof X) {
+            return;
+        }
+        if (o instanceof X(var a)) {
+            return;
+        }
+    }
+
+    @Test
+    public void testReflect() {
+        testWithTransforms(getFuncOp("reflect"));
+    }
+
+    @CodeReflection
+    static int bodies(int m, int n) {
+        int sum = 0;
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                sum += i + j;
+            }
+        }
+        return m > 10 ? sum : 0;
+    }
+
+    @Test
+    public void testBodies() {
+        testWithTransforms(getFuncOp("bodies"));
+    }
+
+    public void testWithTransforms(CoreOps.FuncOp f) {
         test(f);
 
         f = f.transform((block, op) -> {
@@ -91,5 +140,4 @@ public class TestCodeBuilder {
         Method m = om.get();
         return m.getCodeModel().get();
     }
-
 }


### PR DESCRIPTION
A building code model when executed will construct the same code model it was transformed from. Such a building code model could be transformed to bytecode and stored in class files. This may be a better cross platform alternative than storing the textual form in class files (the form of which would need to be specified).

The implementation is using the operation factory and type factory to construct operations and types from their more general definitions (similarly to how they are used by the parser).

It would be interesting to compare the size of class files with the embedded textual form of a code model and the generated bytecode to build the code model. We could be more efficient but the implementation cost is not worth it, at least for now and would require further evaluation of that cost.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/babylon.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/37.diff">https://git.openjdk.org/babylon/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/37#issuecomment-1992095008)