### PR TITLE
Lower StringTemplateOp

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -2815,12 +2815,12 @@ public class ExtendedOps {
 
             List<Value> expressions = new ArrayList<>();
             for (int i = 0; i < expressions().size(); i++) {
-                Block.Builder bb = builders.get(i);
-                int ci = i;
-                bb.transformBody(expressions().get(i), List.of(), opT.andThen((block, op) -> {
+                Block.Builder current = builders.get(i);
+                Block.Builder next = builders.get(i + 1);
+                current.transformBody(expressions().get(i), List.of(), opT.andThen((block, op) -> {
                     if (op instanceof YieldOp yop) {
                         expressions.add(block.context().getValue(yop.yieldValue()));
-                        block.op(branch(builders.get(ci + 1).successor()));
+                        block.op(branch(next.successor()));
                     } else if (op instanceof Lowerable lop) {
                         block = lop.lower(block, opT);
                     } else {

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -2819,7 +2819,7 @@ public class ExtendedOps {
 
             Block.Builder builder = builders[0];
 
-            MethodRef listOfArray = MethodRef.method(JavaType.J_L_LIST, "of", JavaType.J_L_LIST, J_L_OBJECT_ARRAY);
+            MethodRef listOfArray = MethodRef.method(JavaType.J_U_LIST, "of", JavaType.J_U_LIST, J_L_OBJECT_ARRAY);
 
             Op.Result fragmentsList = builder.op(invoke(listOfArray,
                     buildArrayObject(builder, builder.context().getValues(fragments()))));
@@ -2827,7 +2827,7 @@ public class ExtendedOps {
             Op.Result expressionsList = builder.op(invoke(listOfArray, buildArrayObject(builder, expressions)));
 
             MethodRef stOf = MethodRef.method(JavaType.J_L_STRING_TEMPLATE, "of", JavaType.J_L_STRING_TEMPLATE,
-                    JavaType.J_L_LIST, JavaType.J_L_LIST);
+                    JavaType.J_U_LIST, JavaType.J_U_LIST);
             Op.Result st = builder.op(invoke(stOf, fragmentsList, expressionsList));
 
             MethodRef stpProcess = MethodRef.method(JavaType.J_L_STRING_TEMPLATE_PROCESSOR, "process",

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -153,7 +153,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -279,7 +279,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -320,7 +320,7 @@ public class ExtendedOps {
             super(NAME, List.of());
 
             this.body = bodyC.build(this);
-            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+            if (!body.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
             if (!body.bodyType().parameterTypes().isEmpty()) {
@@ -361,7 +361,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -400,7 +400,7 @@ public class ExtendedOps {
             super(NAME, List.of());
 
             this.body = bodyC.build(this);
-            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+            if (!body.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
             if (!body.bodyType().parameterTypes().isEmpty()) {
@@ -452,7 +452,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -462,7 +462,7 @@ public class ExtendedOps {
     @OpDeclaration(JavaIfOp.NAME)
     public static final class JavaIfOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
 
-        static final FunctionType PREDICATE_TYPE = FunctionType.functionType(JavaType.BOOLEAN);
+        static final FunctionType PREDICATE_TYPE = FunctionType.functionType(BOOLEAN);
 
         static final FunctionType ACTION_TYPE = FunctionType.VOID;
 
@@ -598,7 +598,7 @@ public class ExtendedOps {
                 } else {
                     action = bodies.get(i + 1);
                     Body fromPred = bodies.get(i);
-                    if (!fromPred.bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+                    if (!fromPred.bodyType().equals(FunctionType.functionType(BOOLEAN))) {
                         throw new IllegalArgumentException("Illegal predicate body descriptor: " + fromPred.bodyType());
                     }
                 }
@@ -677,7 +677,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -774,7 +774,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -818,7 +818,7 @@ public class ExtendedOps {
 
             public JavaForOp.UpdateBuilder cond(Consumer<Block.Builder> c) {
                 Body.Builder cond = Body.Builder.of(ancestorBody,
-                        FunctionType.functionType(JavaType.BOOLEAN, initTypes));
+                        FunctionType.functionType(BOOLEAN, initTypes));
                 c.accept(cond.entryBlock());
 
                 return new UpdateBuilder(ancestorBody, initTypes, init, cond);
@@ -842,7 +842,7 @@ public class ExtendedOps {
 
             public JavaForOp.BodyBuilder cond(Consumer<Block.Builder> c) {
                 Body.Builder update = Body.Builder.of(ancestorBody,
-                        FunctionType.functionType(JavaType.VOID, initTypes));
+                        FunctionType.functionType(VOID, initTypes));
                 c.accept(update.entryBlock());
 
                 return new BodyBuilder(ancestorBody, initTypes, init, cond, update);
@@ -869,7 +869,7 @@ public class ExtendedOps {
 
             public JavaForOp body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(ancestorBody,
-                        FunctionType.functionType(JavaType.VOID, initTypes));
+                        FunctionType.functionType(VOID, initTypes));
                 c.accept(body.entryBlock());
 
                 return new JavaForOp(init, cond, update, body);
@@ -921,12 +921,12 @@ public class ExtendedOps {
             this.cond = condC.build(this);
 
             this.update = updateC.build(this);
-            if (!update.bodyType().returnType().equals(JavaType.VOID)) {
+            if (!update.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Update should return void: " + update.bodyType());
             }
 
             this.body = bodyC.build(this);
-            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+            if (!body.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
         }
@@ -1033,7 +1033,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -1105,7 +1105,7 @@ public class ExtendedOps {
 
             public JavaEnhancedForOp body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(ancestorBody,
-                        FunctionType.functionType(JavaType.VOID, elementType));
+                        FunctionType.functionType(VOID, elementType));
                 c.accept(body.entryBlock());
 
                 return new JavaEnhancedForOp(expression, definition, body);
@@ -1147,7 +1147,7 @@ public class ExtendedOps {
             super(NAME, List.of());
 
             this.expression = expressionC.build(this);
-            if (expression.bodyType().returnType().equals(JavaType.VOID)) {
+            if (expression.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Expression should return non-void value: " + expression.bodyType());
             }
             if (!expression.bodyType().parameterTypes().isEmpty()) {
@@ -1155,7 +1155,7 @@ public class ExtendedOps {
             }
 
             this.init = initC.build(this);
-            if (init.bodyType().returnType().equals(JavaType.VOID)) {
+            if (init.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Initialization should return non-void value: " + init.bodyType());
             }
             if (init.bodyType().parameterTypes().size() != 1) {
@@ -1163,7 +1163,7 @@ public class ExtendedOps {
             }
 
             this.body = bodyC.build(this);
-            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+            if (!body.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Body should return void: " + body.bodyType());
             }
             if (body.bodyType().parameterTypes().size() != 1) {
@@ -1199,7 +1199,7 @@ public class ExtendedOps {
             boolean isArray = ((JavaType) expression.bodyType().returnType()).isArray();
 
             Block.Builder preHeader = b.block(expression.bodyType().returnType());
-            Block.Builder header = b.block(isArray ? List.of(JavaType.INT) : List.of());
+            Block.Builder header = b.block(isArray ? List.of(INT) : List.of());
             Block.Builder init = b.block();
             Block.Builder body = b.block();
             Block.Builder exit = b.block();
@@ -1218,7 +1218,7 @@ public class ExtendedOps {
             if (isArray) {
                 Value array = preHeader.parameters().get(0);
                 Value arrayLength = preHeader.op(arrayLength(array));
-                Value i = preHeader.op(constant(JavaType.INT, 0));
+                Value i = preHeader.op(constant(INT, 0));
                 preHeader.op(branch(header.successor(i)));
 
                 i = header.parameters().get(0);
@@ -1252,10 +1252,10 @@ public class ExtendedOps {
                     return block;
                 }));
 
-                i = update.op(add(i, update.op(constant(JavaType.INT, 1))));
+                i = update.op(add(i, update.op(constant(INT, 1))));
                 update.op(branch(header.successor(i)));
             } else {
-                JavaType iterable = JavaType.type(JavaType.type(Iterator.class), elementType);
+                JavaType iterable = type(type(Iterator.class), elementType);
                 Value iterator = preHeader.op(CoreOps.invoke(iterable, ITERABLE_ITERATOR, preHeader.parameters().get(0)));
                 preHeader.op(branch(header.successor()));
 
@@ -1293,7 +1293,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -1311,7 +1311,7 @@ public class ExtendedOps {
             }
 
             public JavaWhileOp.BodyBuilder predicate(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(BOOLEAN));
                 c.accept(body.entryBlock());
 
                 return new JavaWhileOp.BodyBuilder(ancestorBody, body);
@@ -1361,14 +1361,14 @@ public class ExtendedOps {
                     .map(bc -> bc.build(this)).toList();
 
             // @@@ This will change with pattern bindings
-            if (!bodies.get(0).bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+            if (!bodies.get(0).bodyType().equals(FunctionType.functionType(BOOLEAN))) {
                 throw new IllegalArgumentException(
-                        "Predicate body descriptor should be " + FunctionType.functionType(JavaType.BOOLEAN) +
+                        "Predicate body descriptor should be " + FunctionType.functionType(BOOLEAN) +
                                 " but is " + bodies.get(0).bodyType());
             }
             if (!bodies.get(1).bodyType().equals(FunctionType.VOID)) {
                 throw new IllegalArgumentException(
-                        "Body descriptor should be " + FunctionType.functionType(JavaType.VOID) +
+                        "Body descriptor should be " + FunctionType.functionType(VOID) +
                                 " but is " + bodies.get(1).bodyType());
             }
         }
@@ -1437,7 +1437,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -1458,7 +1458,7 @@ public class ExtendedOps {
             }
 
             public JavaDoWhileOp predicate(Consumer<Block.Builder> c) {
-                Body.Builder predicate = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
+                Body.Builder predicate = Body.Builder.of(ancestorBody, FunctionType.functionType(BOOLEAN));
                 c.accept(predicate.entryBlock());
 
                 return new JavaDoWhileOp(List.of(body, predicate));
@@ -1507,12 +1507,12 @@ public class ExtendedOps {
 
             if (!bodies.get(0).bodyType().equals(FunctionType.VOID)) {
                 throw new IllegalArgumentException(
-                        "Body descriptor should be " + FunctionType.functionType(JavaType.VOID) +
+                        "Body descriptor should be " + FunctionType.functionType(VOID) +
                                 " but is " + bodies.get(1).bodyType());
             }
-            if (!bodies.get(1).bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+            if (!bodies.get(1).bodyType().equals(FunctionType.functionType(BOOLEAN))) {
                 throw new IllegalArgumentException(
-                        "Predicate body descriptor should be " + FunctionType.functionType(JavaType.BOOLEAN) +
+                        "Predicate body descriptor should be " + FunctionType.functionType(BOOLEAN) +
                                 " but is " + bodies.get(0).bodyType());
             }
         }
@@ -1581,7 +1581,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -1619,7 +1619,7 @@ public class ExtendedOps {
 
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
             for (Body b : bodies) {
-                if (!b.bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+                if (!b.bodyType().equals(FunctionType.functionType(BOOLEAN))) {
                     throw new IllegalArgumentException("Body conditional body descriptor: " + b.bodyType());
                 }
             }
@@ -1693,7 +1693,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.BOOLEAN;
+            return BOOLEAN;
         }
     }
 
@@ -1715,7 +1715,7 @@ public class ExtendedOps {
             }
 
             public Builder and(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(BOOLEAN));
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -1770,7 +1770,7 @@ public class ExtendedOps {
             }
 
             public Builder or(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(JavaType.BOOLEAN));
+                Body.Builder body = Body.Builder.of(ancestorBody, FunctionType.functionType(BOOLEAN));
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -1858,7 +1858,7 @@ public class ExtendedOps {
             }
 
             Body cond = bodies.get(0);
-            if (!cond.bodyType().equals(FunctionType.functionType(JavaType.BOOLEAN))) {
+            if (!cond.bodyType().equals(FunctionType.functionType(BOOLEAN))) {
                 throw new IllegalArgumentException("Illegal cond body descriptor: " + cond.bodyType());
             }
         }
@@ -1931,7 +1931,7 @@ public class ExtendedOps {
 
             public CatchBuilder body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(ancestorBody,
-                        FunctionType.functionType(JavaType.VOID, resourceTypes));
+                        FunctionType.functionType(VOID, resourceTypes));
                 c.accept(body.entryBlock());
 
                 return new CatchBuilder(ancestorBody, resources, body);
@@ -1954,7 +1954,7 @@ public class ExtendedOps {
             // @@@ multi-catch
             public CatchBuilder _catch(TypeElement exceptionType, Consumer<Block.Builder> c) {
                 Body.Builder _catch = Body.Builder.of(ancestorBody,
-                        FunctionType.functionType(JavaType.VOID, exceptionType));
+                        FunctionType.functionType(VOID, exceptionType));
                 c.accept(_catch.entryBlock());
                 catchers.add(_catch);
 
@@ -1989,7 +1989,7 @@ public class ExtendedOps {
 
             List<Body> bodies = def.bodyDefinitions().stream().map(b -> b.build(this)).toList();
             Body first = bodies.get(0);
-            if (first.bodyType().returnType().equals(JavaType.VOID)) {
+            if (first.bodyType().returnType().equals(VOID)) {
                 this.resources = null;
                 this.body = first;
             } else {
@@ -2040,7 +2040,7 @@ public class ExtendedOps {
 
             if (resourcesC != null) {
                 this.resources = resourcesC.build(this);
-                if (resources.bodyType().returnType().equals(JavaType.VOID)) {
+                if (resources.bodyType().returnType().equals(VOID)) {
                     throw new IllegalArgumentException("Resources should not return void: " + resources.bodyType());
                 }
                 if (!resources.bodyType().parameterTypes().isEmpty()) {
@@ -2051,13 +2051,13 @@ public class ExtendedOps {
             }
 
             this.body = bodyC.build(this);
-            if (!body.bodyType().returnType().equals(JavaType.VOID)) {
+            if (!body.bodyType().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Try should return void: " + body.bodyType());
             }
 
             this.catchers = catchersC.stream().map(c -> c.build(this)).toList();
             for (Body _catch : catchers) {
-                if (!_catch.bodyType().returnType().equals(JavaType.VOID)) {
+                if (!_catch.bodyType().returnType().equals(VOID)) {
                     throw new IllegalArgumentException("Catch should return void: " + _catch.bodyType());
                 }
                 if (_catch.bodyType().parameterTypes().size() != 1) {
@@ -2067,7 +2067,7 @@ public class ExtendedOps {
 
             if (finalizerC != null) {
                 this.finalizer = finalizerC.build(this);
-                if (!finalizer.bodyType().returnType().equals(JavaType.VOID)) {
+                if (!finalizer.bodyType().returnType().equals(VOID)) {
                     throw new IllegalArgumentException("Finally should return void: " + finalizer.bodyType());
                 }
                 if (!finalizer.bodyType().parameterTypes().isEmpty()) {
@@ -2291,7 +2291,7 @@ public class ExtendedOps {
             // Inline the finally body as a catcher of Throwable and adjusting to throw
             if (finalizer != null) {
                 // Create the throwable argument
-                Block.Parameter t = catcherFinally.parameter(JavaType.type(Throwable.class));
+                Block.Parameter t = catcherFinally.parameter(type(Throwable.class));
 
                 catcherFinally.transformBody(finalizer, List.of(), opT.andThen((block, op) -> {
                     if (op instanceof YieldOp) {
@@ -2351,7 +2351,7 @@ public class ExtendedOps {
 
         @Override
         public TypeElement resultType() {
-            return JavaType.VOID;
+            return VOID;
         }
     }
 
@@ -2396,11 +2396,11 @@ public class ExtendedOps {
                 "$" + Pattern.Record.class.getSimpleName());
 
         static JavaType bindingType(TypeElement t) {
-            return JavaType.type(PATTERN_BINDING_TYPE, (JavaType) t);
+            return type(PATTERN_BINDING_TYPE, (JavaType) t);
         }
 
         static JavaType recordType(TypeElement t) {
-            return JavaType.type(PATTERN_RECORD_TYPE, (JavaType) t);
+            return type(PATTERN_RECORD_TYPE, (JavaType) t);
         }
 
         static TypeElement targetType(TypeElement t) {
@@ -2646,14 +2646,14 @@ public class ExtendedOps {
                 // No match block
                 // Pass false
                 endNoMatchBlock.op(branch(endBlock.successor(
-                        endNoMatchBlock.op(constant(JavaType.BOOLEAN, false)))));
+                        endNoMatchBlock.op(constant(BOOLEAN, false)))));
 
                 // Match block
                 // Lower match body and pass true
                 endMatchBlock.transformBody(match, patternValues, opT.andThen((block, op) -> {
                     if (op instanceof YieldOp) {
                         block.op(branch(endBlock.successor(
-                                block.op(constant(JavaType.BOOLEAN, true)))));
+                                block.op(constant(BOOLEAN, true)))));
                     } else if (op instanceof Lowerable lop) {
                         // @@@ Composition of lowerable ops
                         block = lop.lower(block, opT);
@@ -2727,7 +2727,7 @@ public class ExtendedOps {
 
             @Override
             public TypeElement resultType() {
-                return JavaType.BOOLEAN;
+                return BOOLEAN;
             }
         }
     }
@@ -2799,35 +2799,28 @@ public class ExtendedOps {
 
         @Override
         public Block.Builder lower(Block.Builder b, OpTransformer opT) {
-            /*
-            create block for every expression body
-            when yield branch to the next block
-            also create a block for after expressions
-            *
-            * */
+            // Creates a block for each expression and a last block
+            // to continue building from. An expression block branches
+            // to the next expression block or the last block
             List<Block.Builder> builders = new ArrayList<>();
-            for (Body expression : expressions()) {
-                builders.add(b.block());
-            }
-            if (expressions().isEmpty()) {
-                builders.add(b);
-            } else {
-                builders.add(b.block());
-            }
-            // if no expression, we should work with b
-
-            // for the first expression body, branch to its block
-            List<Value> expressions = new ArrayList<>();
-            for (Body expression : expressions()) {
-                int exprIndex = expressions().indexOf(expression);
-                Block.Builder bb = builders.get(exprIndex);
-                if (exprIndex == 0) {
+            for (int i = 0; i < expressions().size(); i++) {
+                Block.Builder bb = b.block();
+                if (i == 0) {
                     b.op(branch(bb.successor()));
                 }
-                bb.transformBody(expression, List.of(), opT.andThen((block, op) -> {
+                builders.add(bb);
+            }
+            Block.Builder last = expressions().isEmpty() ? b : b.block();
+            builders.add(last);
+
+            List<Value> expressions = new ArrayList<>();
+            for (int i = 0; i < expressions().size(); i++) {
+                Block.Builder bb = builders.get(i);
+                int ci = i;
+                bb.transformBody(expressions().get(i), List.of(), opT.andThen((block, op) -> {
                     if (op instanceof YieldOp yop) {
                         expressions.add(block.context().getValue(yop.yieldValue()));
-                        block.op(branch(builders.get(exprIndex + 1).successor()));
+                        block.op(branch(builders.get(ci + 1).successor()));
                     } else if (op instanceof Lowerable lop) {
                         block = lop.lower(block, opT);
                     } else {
@@ -2837,30 +2830,28 @@ public class ExtendedOps {
                 }));
             }
 
-            Block.Builder builder = builders.getLast();
+            MethodRef listOfArray = MethodRef.method(J_U_LIST, "of", J_U_LIST, J_L_OBJECT_ARRAY);
 
-            MethodRef listOfArray = MethodRef.method(JavaType.J_U_LIST, "of", JavaType.J_U_LIST, J_L_OBJECT_ARRAY);
+            Op.Result fragmentsList = last.op(invoke(listOfArray,
+                    buildArrayObject(last, last.context().getValues(fragments()))));
 
-            Op.Result fragmentsList = builder.op(invoke(listOfArray,
-                    buildArrayObject(builder, builder.context().getValues(fragments()))));
+            Op.Result expressionsList = last.op(invoke(listOfArray, buildArrayObject(last, expressions)));
 
-            Op.Result expressionsList = builder.op(invoke(listOfArray, buildArrayObject(builder, expressions)));
+            MethodRef stOf = MethodRef.method(J_L_STRING_TEMPLATE, "of", J_L_STRING_TEMPLATE,
+                    J_U_LIST, J_U_LIST);
+            Op.Result st = last.op(invoke(stOf, fragmentsList, expressionsList));
 
-            MethodRef stOf = MethodRef.method(JavaType.J_L_STRING_TEMPLATE, "of", JavaType.J_L_STRING_TEMPLATE,
-                    JavaType.J_U_LIST, JavaType.J_U_LIST);
-            Op.Result st = builder.op(invoke(stOf, fragmentsList, expressionsList));
+            MethodRef stpProcess = MethodRef.method(J_L_STRING_TEMPLATE_PROCESSOR, "process",
+                    J_L_OBJECT, J_L_STRING_TEMPLATE);
+            Op.Result res = last.op(invoke(resultType(), stpProcess, last.context().getValue(processor()), st));
 
-            MethodRef stpProcess = MethodRef.method(JavaType.J_L_STRING_TEMPLATE_PROCESSOR, "process",
-                    JavaType.J_L_OBJECT, JavaType.J_L_STRING_TEMPLATE);
-            Op.Result res = builder.op(invoke(resultType(), stpProcess, builder.context().getValue(processor()), st));
+            last.context().mapValue(result(), res);
 
-            builder.context().mapValue(result(), res);
-
-            return builder;
+            return last;
         }
 
         private static Value buildArrayObject(Block.Builder builder, List<Value> elements) {
-            Value array = builder.op(newArray(J_L_OBJECT_ARRAY, builder.op(constant(JavaType.INT, elements.size()))));
+            Value array = builder.op(newArray(J_L_OBJECT_ARRAY, builder.op(constant(INT, elements.size()))));
             for (int i = 0; i < elements.size(); i++) {
                 Value ele = elements.get(i);
                 if (isPrimitive(ele.type())) {
@@ -2868,30 +2859,9 @@ public class ExtendedOps {
                     MethodRef valueOf = MethodRef.method(wt, "valueOf", wt, ele.type());
                     ele = builder.op(invoke(valueOf, ele));
                 }
-                builder.op(arrayStoreOp(array, builder.op(constant(JavaType.INT, i)), ele));
+                builder.op(arrayStoreOp(array, builder.op(constant(INT, i)), ele));
             }
             return array;
-        }
-
-        private static boolean isPrimitive(TypeElement te) {
-            return primitiveToWrapper().containsKey(te);
-        }
-
-        private static TypeElement getWrapperType(TypeElement te) {
-            return primitiveToWrapper().get(te);
-        };
-
-        private static Map<TypeElement, TypeElement> primitiveToWrapper() {
-            return Map.of(
-                    BYTE, J_L_BYTE,
-                    SHORT, J_L_SHORT,
-                    JavaType.INT, J_L_INTEGER,
-                    LONG, J_L_LONG,
-                    FLOAT, J_L_FLOAT,
-                    DOUBLE, J_L_DOUBLE,
-                    CHAR, J_L_CHARACTER,
-                    BOOLEAN, J_L_BOOLEAN
-            );
         }
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
@@ -100,6 +100,8 @@ public sealed interface JavaType extends TypeElement permits JavaTypeImpl {
 
     JavaType J_L_STRING_TEMPLATE_PROCESSOR = new JavaTypeImpl("java.lang.StringTemplate$Processor");
 
+    JavaType J_L_LIST = new JavaTypeImpl("java.util.List");
+
     //
 
     boolean isArray();

--- a/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
@@ -100,7 +100,7 @@ public sealed interface JavaType extends TypeElement permits JavaTypeImpl {
 
     JavaType J_L_STRING_TEMPLATE_PROCESSOR = new JavaTypeImpl("java.lang.StringTemplate$Processor");
 
-    JavaType J_L_LIST = new JavaTypeImpl("java.util.List");
+    JavaType J_U_LIST = new JavaTypeImpl("java.util.List");
 
     //
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
@@ -30,6 +30,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.type.impl.JavaTypeImpl;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The symbolic description of a Java type.
@@ -103,6 +104,25 @@ public sealed interface JavaType extends TypeElement permits JavaTypeImpl {
     JavaType J_U_LIST = new JavaTypeImpl("java.util.List");
 
     //
+
+    Map<TypeElement, TypeElement> primitiveToWrapper = Map.of(
+            BYTE, J_L_BYTE,
+            SHORT, J_L_SHORT,
+            INT, J_L_INTEGER,
+            LONG, J_L_LONG,
+            FLOAT, J_L_FLOAT,
+            DOUBLE, J_L_DOUBLE,
+            CHAR, J_L_CHARACTER,
+            BOOLEAN, J_L_BOOLEAN
+    );
+
+    static boolean isPrimitive(TypeElement te) {
+        return primitiveToWrapper.containsKey(te);
+    }
+
+    static TypeElement getWrapperType(TypeElement te) {
+        return primitiveToWrapper.get(te);
+    };
 
     boolean isArray();
 

--- a/test/jdk/java/lang/reflect/code/TestStringTemplateOp.java
+++ b/test/jdk/java/lang/reflect/code/TestStringTemplateOp.java
@@ -1,0 +1,56 @@
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.code.op.CoreOps;
+import java.lang.runtime.CodeReflection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/*
+ * @test
+ * @enablePreview
+ * @run testng TestStringTemplateOp
+ */
+
+public class TestStringTemplateOp {
+
+    @CodeReflection
+    static String f(int x, int y) {
+        String s = STR."x = \{x}, y = \{y}, x + y = \{x + y}";
+        return s;
+    }
+
+    @Test
+    public void testf() {
+        CoreOps.FuncOp f = getFuncOp("f");
+
+        f.writeTo(System.out);
+
+        CoreOps.FuncOp lf = f.transform((block, op) -> {
+            if (op instanceof Op.Lowerable lop) {
+                return lop.lower(block);
+            } else {
+                block.op(op);
+                return block;
+            }
+        });
+
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, 1, 2), f(1, 2));
+    }
+
+
+    static CoreOps.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestStringTemplateOp.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}

--- a/test/jdk/java/lang/reflect/code/TestStringTemplateOp.java
+++ b/test/jdk/java/lang/reflect/code/TestStringTemplateOp.java
@@ -1,6 +1,8 @@
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
@@ -20,13 +22,36 @@ public class TestStringTemplateOp {
 
     @CodeReflection
     static String f(int x, int y) {
-        String s = STR."x = \{x}, y = \{y}, x + y = \{x + y}";
-        return s;
+        return STR."x = \{x}, y = \{y}, x + y = \{x + y}" ;
     }
 
-    @Test
-    public void testf() {
-        CoreOps.FuncOp f = getFuncOp("f");
+    @CodeReflection
+    static String f2(int a, int b) {
+        return STR."\{a > b ? STR."\{a} greater than \{b}" : STR."\{b} greater than or equal \{a}"}";
+    }
+
+    @CodeReflection
+    static String f3() {
+        return STR."\{(byte) 1} \{(short) 2} \{3} \{4L} \{5f} \{6d} \{'c'} \{true} \{List.of()}";
+    }
+
+    @CodeReflection
+    static String f4() {
+        // test with a number of expressions that is greater than the List.of parameter threshold where varargs is used
+        return STR."\{(byte) 1} \{(short) 2} \{3} \{4L} \{5f} \{6d} \{'c'} \{true} \{List.of()}, \{!true}, \{System.out}";
+    }
+    @DataProvider
+    public Object[][] cases() {
+        return new Object[][] {
+                {"f", new Object[] {2, 42}},
+                {"f2", new Object[] {13, 7}},
+                {"f3", new Object[] {}},
+                {"f4", new Object[] {}}
+        };
+    }
+    @Test(dataProvider = "cases")
+    public void test(String caseName, Object[] args) throws InvocationTargetException, IllegalAccessException {
+        CoreOps.FuncOp f = getFuncOp(caseName);
 
         f.writeTo(System.out);
 
@@ -41,16 +66,20 @@ public class TestStringTemplateOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, 1, 2), f(1, 2));
+        Assert.assertEquals(Interpreter.invoke(lf, args), getMethod(caseName).invoke(null, args));
     }
 
-
     static CoreOps.FuncOp getFuncOp(String name) {
+        Method m = getMethod(name);
+        return m.getCodeModel().get();
+    }
+
+    static Method getMethod(String name) {
         Optional<Method> om = Stream.of(TestStringTemplateOp.class.getDeclaredMethods())
                 .filter(m -> m.getName().equals(name))
                 .findFirst();
 
         Method m = om.get();
-        return m.getCodeModel().get();
+        return m;
     }
 }


### PR DESCRIPTION
The lowering of the StringTemplateOp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [6c69f620](https://git.openjdk.org/babylon/pull/39/files/6c69f6208086408b68e3a5fc5be22a27c2a124b2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/babylon.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/39.diff">https://git.openjdk.org/babylon/pull/39.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/39#issuecomment-1994502170)