### PR TITLE
Fix unbox invocation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -646,6 +646,7 @@ public class ReflectMethods extends TreeTranslator {
         }
 
         Value box(Value valueExpr, Type box) {
+            // Boxing is a static method e.g., java.lang.Integer::valueOf(int)java.lang.Integer
             MethodRef boxMethod = MethodRef.method(typeToTypeElement(box), names.valueOf.toString(),
                     FunctionType.functionType(typeToTypeElement(box), typeToTypeElement(types.unboxedType(box))));
             return append(CoreOps.invoke(boxMethod, valueExpr));
@@ -655,11 +656,13 @@ public class ReflectMethods extends TreeTranslator {
             if (unboxedType.hasTag(NONE)) {
                 // Object target, first downcast to correct wrapper type
                 unboxedType = primitive;
-                valueExpr = append(CoreOps.cast(typeToTypeElement(types.boxedClass(unboxedType).type), valueExpr));
+                box = types.boxedClass(unboxedType).type;
+                valueExpr = append(CoreOps.cast(typeToTypeElement(box), valueExpr));
             }
+            // Unboxing is a virtual method e.g., java.lang.Integer::intValue()int
             MethodRef unboxMethod = MethodRef.method(typeToTypeElement(box),
                     unboxedType.tsym.name.append(names.Value).toString(),
-                    FunctionType.functionType(typeToTypeElement(unboxedType), typeToTypeElement(box)));
+                    FunctionType.functionType(typeToTypeElement(unboxedType)));
             return append(CoreOps.invoke(unboxMethod, valueExpr));
         }
 

--- a/test/langtools/tools/javac/reflect/BoxingConversionTest.java
+++ b/test/langtools/tools/javac/reflect/BoxingConversionTest.java
@@ -51,7 +51,7 @@ public class BoxingConversionTest {
             func @"test2" (%0 : BoxingConversionTest, %1 : java.lang.Long)void -> {
                 %2 : Var<java.lang.Long> = var %1 @"L";
                 %3 : java.lang.Long = var.load %2;
-                %4 : long = invoke %3 @"java.lang.Long::longValue(java.lang.Long)long";
+                %4 : long = invoke %3 @"java.lang.Long::longValue()long";
                 %5 : Var<long> = var %4 @"l";
                 return;
             };
@@ -79,7 +79,7 @@ public class BoxingConversionTest {
                 %2 : Var<java.lang.Object> = var %1 @"o";
                 %3 : java.lang.Object = var.load %2;
                 %4 : java.lang.Long = cast %3 @"java.lang.Long";
-                %5 : long = invoke %4 @"java.lang.Object::longValue(java.lang.Object)long";
+                %5 : long = invoke %4 @"java.lang.Long::longValue()long";
                 %6 : Var<long> = var %5 @"l";
                 return;
             };
@@ -94,7 +94,7 @@ public class BoxingConversionTest {
                 %2 : Var<java.lang.Integer> = var %1 @"i2";
                 %3 : java.lang.Integer = var.load %2;
                 %4 : int = constant @"1";
-                %5 : int = invoke %3 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                %5 : int = invoke %3 @"java.lang.Integer::intValue()int";
                 %6 : int = add %5 %4;
                 %7 : java.lang.Integer = invoke %6 @"java.lang.Integer::valueOf(int)java.lang.Integer";
                 var.store %2 %7;
@@ -111,7 +111,7 @@ public class BoxingConversionTest {
                 %2 : Var<java.lang.Integer> = var %1 @"i2";
                 %3 : java.lang.Integer = var.load %2;
                 %4 : int = constant @"3";
-                %5 : int = invoke %3 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                %5 : int = invoke %3 @"java.lang.Integer::intValue()int";
                 %6 : int = add %5 %4;
                 %7 : java.lang.Integer = invoke %6 @"java.lang.Integer::valueOf(int)java.lang.Integer";
                 var.store %2 %7;
@@ -132,7 +132,7 @@ public class BoxingConversionTest {
                 %1 : BoxingConversionTest$Box = new @"func<BoxingConversionTest$Box>";
                 %2 : java.lang.Integer = field.load %1 @"BoxingConversionTest$Box::i()java.lang.Integer";
                 %3 : int = constant @"1";
-                %4 : int = invoke %2 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                %4 : int = invoke %2 @"java.lang.Integer::intValue()int";
                 %5 : int = add %4 %3;
                 %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
                 field.store %1 %6 @"BoxingConversionTest$Box::i()java.lang.Integer";
@@ -149,7 +149,7 @@ public class BoxingConversionTest {
                 %1 : BoxingConversionTest$Box = new @"func<BoxingConversionTest$Box>";
                 %2 : java.lang.Integer = field.load %1 @"BoxingConversionTest$Box::i()java.lang.Integer";
                 %3 : int = constant @"3";
-                %4 : int = invoke %2 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                %4 : int = invoke %2 @"java.lang.Integer::intValue()int";
                 %5 : int = add %4 %3;
                 %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
                 field.store %1 %6 @"BoxingConversionTest$Box::i()java.lang.Integer";
@@ -169,7 +169,7 @@ public class BoxingConversionTest {
                 %6 : int = constant @"0";
                 %7 : int = array.load %5 %6;
                 %8 : java.lang.Integer = var.load %4;
-                %9 : int = invoke %8 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                %9 : int = invoke %8 @"java.lang.Integer::intValue()int";
                 %10 : int = add %7 %9;
                 array.store %5 %6 %10;
                 return;
@@ -191,7 +191,7 @@ public class BoxingConversionTest {
                     }
                     ^truepart()int -> {
                         %7 : java.lang.Integer = var.load %4;
-                        %8 : int = invoke %7 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                        %8 : int = invoke %7 @"java.lang.Integer::intValue()int";
                         yield %8;
                     }
                     ^falsepart()int -> {
@@ -222,7 +222,7 @@ public class BoxingConversionTest {
                     }
                     ^falsepart()int -> {
                         %8 : java.lang.Integer = var.load %4;
-                        %9 : int = invoke %8 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                        %9 : int = invoke %8 @"java.lang.Integer::intValue()int";
                         yield %9;
                     };
                 %10 : Var<int> = var %5 @"res";
@@ -305,7 +305,7 @@ public class BoxingConversionTest {
                     }
                     ()int -> {
                         %10 : java.lang.Integer = var.load %4;
-                        %11 : int = invoke %10 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                        %11 : int = invoke %10 @"java.lang.Integer::intValue()int";
                         yield %11;
                     }
                     ^defaultCaseLabel()void -> {
@@ -347,7 +347,7 @@ public class BoxingConversionTest {
                     }
                     ()int -> {
                         %11 : java.lang.Integer = var.load %4;
-                        %12 : int = invoke %11 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                        %12 : int = invoke %11 @"java.lang.Integer::intValue()int";
                         yield %12;
                     };
                 %13 : Var<int> = var %6 @"x";
@@ -410,7 +410,7 @@ public class BoxingConversionTest {
                     }
                     ()int -> {
                         %10 : java.lang.Integer = var.load %4;
-                        %11 : int = invoke %10 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                        %11 : int = invoke %10 @"java.lang.Integer::intValue()int";
                         java.yield %11;
                     }
                     ^defaultCaseLabel()void -> {
@@ -452,7 +452,7 @@ public class BoxingConversionTest {
                     }
                     ()int -> {
                         %11 : java.lang.Integer = var.load %4;
-                        %12 : int = invoke %11 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                        %12 : int = invoke %11 @"java.lang.Integer::intValue()int";
                         java.yield %12;
                     };
                 %13 : Var<int> = var %6 @"x";
@@ -508,7 +508,7 @@ public class BoxingConversionTest {
                 %4 : Var<java.lang.Integer> = var %2 @"I";
                 %5 : int = var.load %3;
                 %6 : java.lang.Integer = var.load %4;
-                %7 : int = invoke %6 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                %7 : int = invoke %6 @"java.lang.Integer::intValue()int";
                 %8 : int = add %5 %7;
                 %9 : Var<int> = var %8 @"l";
                 return;

--- a/test/langtools/tools/javac/reflect/LambdaTest.java
+++ b/test/langtools/tools/javac/reflect/LambdaTest.java
@@ -139,7 +139,7 @@ public class LambdaTest {
                     %20 : int = var.load %3;
                     %21 : java.util.function.Supplier<java.lang.Integer> = var.load %19;
                     %22 : java.lang.Integer = invoke %21 @"java.util.function.Supplier::get()java.lang.Object";
-                    %23 : int = invoke %22 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                    %23 : int = invoke %22 @"java.lang.Integer::intValue()int";
                     %24 : int = add %20 %23;
                     %25 : Var<int> = var %24 @"r";
                     %26 : int = var.load %25;

--- a/test/langtools/tools/javac/reflect/MethodReferenceTest.java
+++ b/test/langtools/tools/javac/reflect/MethodReferenceTest.java
@@ -152,7 +152,7 @@ public class MethodReferenceTest {
                 %1 : java.util.function.Function<java.lang.Integer, MethodReferenceTest$X> = lambda (%2 : java.lang.Integer)MethodReferenceTest$X -> {
                     %3 : Var<java.lang.Integer> = var %2 @"x$0";
                     %4 : java.lang.Integer = var.load %3;
-                    %5 : int = invoke %4 @"java.lang.Integer::intValue(java.lang.Integer)int";
+                    %5 : int = invoke %4 @"java.lang.Integer::intValue()int";
                     %6 : MethodReferenceTest$X = new %5 @"func<MethodReferenceTest$X, int>";
                     return %6;
                 };


### PR DESCRIPTION
The compiler generated incorrect models for unboxing:
1. The unboxing method is a virtual method on the box class, not a static method (as is the case for boxing).
2. When primitive casting to a box we need to use the boxed type as the referencing class of the invocation not `Object`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/babylon.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/41.diff">https://git.openjdk.org/babylon/pull/41.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/41#issuecomment-2004584337)