### PR TITLE
Uncomment a String Template Test

### DIFF
--- a/test/langtools/tools/javac/reflect/StringTemplateTest.java
+++ b/test/langtools/tools/javac/reflect/StringTemplateTest.java
@@ -124,26 +124,22 @@ public class StringTemplateTest {
         String s2 = STR."y = \{y}, \{s}";
     }
 
-    // this test will fail for now
-    // the reason is wildcard types not modeled
-    // the type of the processor X will be java.lang.StringTemplate$Processor
-    // but the expected type is java.lang.StringTemplate$Processor<java.lang.Object, java.lang.RuntimeException>
-//    @CodeReflection
-//    @IR("""
-//            func @"f4" ()void -> {
-//                  %0 : java.lang.StringTemplate$Processor<java.lang.String, java.lang.RuntimeException> = field.load @"java.lang.StringTemplate::STR()java.lang.StringTemplate$Processor<java.lang.String, java.lang.RuntimeException>";
-//                  %1 : Var<java.lang.StringTemplate$Processor<java.lang.Object, java.lang.RuntimeException>> = var %0 @"X";
-//                  %2 : java.lang.StringTemplate$Processor<java.lang.Object, java.lang.RuntimeException> = var.load %1;
-//                  %3 : java.lang.String = constant @"some template";
-//                  %4 : java.lang.Object = java.stringTemplate %2 %3;
-//                  %5 : Var<java.lang.Object> = var %4 @"o";
-//                  return;
-//            };
-//            """)
-//    static void f4() {
-//        StringTemplate.Processor<?, RuntimeException> X = STR;
-//        Object o = X."some template";
-//    }
+    @CodeReflection
+    @IR("""
+            func @"f4" ()void -> {
+                  %0 : java.lang.StringTemplate$Processor<java.lang.String, java.lang.RuntimeException> = field.load @"java.lang.StringTemplate::STR()java.lang.StringTemplate$Processor<java.lang.String, java.lang.RuntimeException>";
+                  %1 : Var<java.lang.StringTemplate$Processor> = var %0 @"X";
+                  %2 : java.lang.StringTemplate$Processor = var.load %1;
+                  %3 : java.lang.String = constant @"some template";
+                  %4 : java.lang.Object = java.stringTemplate %2 %3;
+                  %5 : Var<java.lang.Object> = var %4 @"o";
+                  return;
+            };
+            """)
+    static void f4() {
+        StringTemplate.Processor<?, RuntimeException> X = STR;
+        Object o = X."some template";
+    }
 
     @CodeReflection
     @IR("""


### PR DESCRIPTION
A test of String Template was commented because the code uses wildcard type that's not yet modeled., but the produced IR can still be interpreted or lowered to bytecode then executed without issues, so we can test against what the compiler generates for now .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/babylon.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/43.diff">https://git.openjdk.org/babylon/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/43#issuecomment-2010273064)