### PR TITLE
Implement shift ops

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -557,7 +557,7 @@ public final class BytecodeGenerator {
                             default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
                         }
                     }
-                    case LeftShiftOp op -> {
+                    case LshlOp op -> {
                         processOperands(op, isLastOpResultOnStack);
                         adjustRightTypeToInt(op);
                         switch (rvt) { //this can be moved to CodeBuilder::shl(TypeKind)
@@ -566,7 +566,7 @@ public final class BytecodeGenerator {
                             default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
                         }
                     }
-                    case RightShiftOp op -> {
+                    case AshrOp op -> {
                         processOperands(op, isLastOpResultOnStack);
                         adjustRightTypeToInt(op);
                         switch (rvt) { //this can be moved to CodeBuilder::shr(TypeKind)
@@ -575,7 +575,7 @@ public final class BytecodeGenerator {
                             default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
                         }
                     }
-                    case UnsignedRightShiftOp op -> {
+                    case LshrOp op -> {
                         processOperands(op, isLastOpResultOnStack);
                         adjustRightTypeToInt(op);
                         switch (rvt) { //this can be moved to CodeBuilder::ushr(TypeKind)

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -557,6 +557,33 @@ public final class BytecodeGenerator {
                             default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
                         }
                     }
+                    case LeftShiftOp op -> {
+                        processOperands(op, isLastOpResultOnStack);
+                        adjustRightTypeToInt(op);
+                        switch (rvt) { //this can be moved to CodeBuilder::shl(TypeKind)
+                            case IntType -> cob.ishl();
+                            case LongType -> cob.lshl();
+                            default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
+                        }
+                    }
+                    case RightShiftOp op -> {
+                        processOperands(op, isLastOpResultOnStack);
+                        adjustRightTypeToInt(op);
+                        switch (rvt) { //this can be moved to CodeBuilder::shr(TypeKind)
+                            case IntType -> cob.ishr();
+                            case LongType -> cob.lshr();
+                            default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
+                        }
+                    }
+                    case UnsignedRightShiftOp op -> {
+                        processOperands(op, isLastOpResultOnStack);
+                        adjustRightTypeToInt(op);
+                        switch (rvt) { //this can be moved to CodeBuilder::ushr(TypeKind)
+                            case IntType -> cob.iushr();
+                            case LongType -> cob.lushr();
+                            default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
+                        }
+                    }
                     case ArrayAccessOp.ArrayLoadOp op -> {
                         processOperands(op, isLastOpResultOnStack);
                         cob.arrayLoadInstruction(rvt);
@@ -746,6 +773,14 @@ public final class BytecodeGenerator {
                 default ->
                     throw new UnsupportedOperationException("Terminating operation not supported: " + top);
             }
+        }
+    }
+
+    // the rhs of any shift instruction must be int or smaller -> convert longs
+    private void adjustRightTypeToInt(Op op) {
+        TypeElement right = op.operands().getLast().type();
+        if (right.equals(JavaType.LONG)) {
+            cob.convertInstruction(toTypeKind(right), TypeKind.IntType);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
@@ -83,27 +83,27 @@ final class InvokableLeafOps {
         return l ^ r;
     }
 
-    public static int leftShift(int l, int r) {
+    public static int lshl(int l, int r) {
         return l << r;
     }
 
-    public static int rightShift(int l, int r) {
+    public static int ashr(int l, int r) {
         return l >> r;
     }
 
-    public static int unsignedRightShift(int l, int r) {
+    public static int lshr(int l, int r) {
         return l >>> r;
     }
 
-    public static int leftShift(int l, long r) {
+    public static int lshl(int l, long r) {
         return l << r;
     }
 
-    public static int rightShift(int l, long r) {
+    public static int ashr(int l, long r) {
         return l >> r;
     }
 
-    public static int unsignedRightShift(int l, long r) {
+    public static int lshr(int l, long r) {
         return l >>> r;
     }
 
@@ -169,27 +169,27 @@ final class InvokableLeafOps {
         return l ^ r;
     }
 
-    public static long leftShift(long l, long r) {
+    public static long lshl(long l, long r) {
         return l << r;
     }
 
-    public static long rightShift(long l, long r) {
+    public static long ashr(long l, long r) {
         return l >> r;
     }
 
-    public static long unsignedRightShift(long l, long r) {
+    public static long lshr(long l, long r) {
         return l >>> r;
     }
 
-    public static long leftShift(long l, int r) {
+    public static long lshl(long l, int r) {
         return l << r;
     }
 
-    public static long rightShift(long l, int r) {
+    public static long ashr(long l, int r) {
         return l >> r;
     }
 
-    public static long unsignedRightShift(long l, int r) {
+    public static long lshr(long l, int r) {
         return l >>> r;
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
@@ -95,6 +95,18 @@ final class InvokableLeafOps {
         return l >>> r;
     }
 
+    public static int leftShift(int l, long r) {
+        return l << r;
+    }
+
+    public static int rightShift(int l, long r) {
+        return l >> r;
+    }
+
+    public static int unsignedRightShift(int l, long r) {
+        return l >>> r;
+    }
+
     public static boolean eq(int l, int r) {
         return l == r;
     }
@@ -166,6 +178,18 @@ final class InvokableLeafOps {
     }
 
     public static long unsignedRightShift(long l, long r) {
+        return l >>> r;
+    }
+
+    public static long leftShift(long l, int r) {
+        return l << r;
+    }
+
+    public static long rightShift(long l, int r) {
+        return l >> r;
+    }
+
+    public static long unsignedRightShift(long l, int r) {
         return l >>> r;
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
@@ -83,6 +83,18 @@ final class InvokableLeafOps {
         return l ^ r;
     }
 
+    public static int leftShift(int l, int r) {
+        return l << r;
+    }
+
+    public static int rightShift(int l, int r) {
+        return l >> r;
+    }
+
+    public static int unsignedRightShift(int l, int r) {
+        return l >>> r;
+    }
+
     public static boolean eq(int l, int r) {
         return l == r;
     }
@@ -145,6 +157,17 @@ final class InvokableLeafOps {
         return l ^ r;
     }
 
+    public static long leftShift(long l, long r) {
+        return l << r;
+    }
+
+    public static long rightShift(long l, long r) {
+        return l >> r;
+    }
+
+    public static long unsignedRightShift(long l, long r) {
+        return l >>> r;
+    }
 
     public static boolean eq(long l, long r) {
         return l == r;

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -2737,76 +2737,76 @@ public final class CoreOps {
     }
 
     /**
-     * The shift left operation, that can model the Java language binary {@code <<} operator for integral types
+     * The (logical) shift left operation, that can model the Java language binary {@code <<} operator for integral types
      */
-    @OpDeclaration(LeftShiftOp.NAME)
-    public static final class LeftShiftOp extends BinaryOp {
-        public static final String NAME = "leftShift";
+    @OpDeclaration(LshlOp.NAME)
+    public static final class LshlOp extends BinaryOp {
+        public static final String NAME = "lshl";
 
-        public LeftShiftOp(OpDefinition opdef) {
+        public LshlOp(OpDefinition opdef) {
             super(opdef);
         }
 
-        LeftShiftOp(LeftShiftOp that, CopyContext cc) {
+        LshlOp(LshlOp that, CopyContext cc) {
             super(that, cc);
         }
 
         @Override
-        public LeftShiftOp transform(CopyContext cc, OpTransformer ot) {
-            return new LeftShiftOp(this, cc);
+        public LshlOp transform(CopyContext cc, OpTransformer ot) {
+            return new LshlOp(this, cc);
         }
 
-        LeftShiftOp(Value lhs, Value rhs) {
+        LshlOp(Value lhs, Value rhs) {
             super(NAME, lhs, rhs);
         }
     }
 
     /**
-     * The shift right operation, that can model the Java language binary {@code >>} operator for integral types
+     * The (arithmetic) shift right operation, that can model the Java language binary {@code >>} operator for integral types
      */
-    @OpDeclaration(RightShiftOp.NAME)
-    public static final class RightShiftOp extends CoreOps.BinaryOp {
-        public static final String NAME = "rightShift";
+    @OpDeclaration(AshrOp.NAME)
+    public static final class AshrOp extends CoreOps.BinaryOp {
+        public static final String NAME = "ashr";
 
-        public RightShiftOp(OpDefinition opdef) {
+        public AshrOp(OpDefinition opdef) {
             super(opdef);
         }
 
-        RightShiftOp(RightShiftOp that, CopyContext cc) {
+        AshrOp(AshrOp that, CopyContext cc) {
             super(that, cc);
         }
 
         @Override
-        public RightShiftOp transform(CopyContext cc, OpTransformer ot) {
-            return new RightShiftOp(this, cc);
+        public AshrOp transform(CopyContext cc, OpTransformer ot) {
+            return new AshrOp(this, cc);
         }
 
-        RightShiftOp(Value lhs, Value rhs) {
+        AshrOp(Value lhs, Value rhs) {
             super(NAME, lhs, rhs);
         }
     }
 
     /**
-     * The unsigned shift right operation, that can model the Java language binary {@code >>>} operator for integral types
+     * The unsigned (logical) shift right operation, that can model the Java language binary {@code >>>} operator for integral types
      */
-    @OpDeclaration(UnsignedRightShiftOp.NAME)
-    public static final class UnsignedRightShiftOp extends CoreOps.BinaryOp {
-        public static final String NAME = "unsignedRightShift";
+    @OpDeclaration(LshrOp.NAME)
+    public static final class LshrOp extends CoreOps.BinaryOp {
+        public static final String NAME = "lshr";
 
-        public UnsignedRightShiftOp(OpDefinition opdef) {
+        public LshrOp(OpDefinition opdef) {
             super(opdef);
         }
 
-        UnsignedRightShiftOp(UnsignedRightShiftOp that, CopyContext cc) {
+        LshrOp(LshrOp that, CopyContext cc) {
             super(that, cc);
         }
 
         @Override
-        public UnsignedRightShiftOp transform(CopyContext cc, OpTransformer ot) {
-            return new UnsignedRightShiftOp(this, cc);
+        public LshrOp transform(CopyContext cc, OpTransformer ot) {
+            return new LshrOp(this, cc);
         }
 
-        UnsignedRightShiftOp(Value lhs, Value rhs) {
+        LshrOp(Value lhs, Value rhs) {
             super(NAME, lhs, rhs);
         }
     }
@@ -3760,8 +3760,8 @@ public final class CoreOps {
      * @param rhs the second operand
      * @return the xor operation
      */
-    public static BinaryOp leftShift(Value lhs, Value rhs) {
-        return new LeftShiftOp(lhs, rhs);
+    public static BinaryOp lshl(Value lhs, Value rhs) {
+        return new LshlOp(lhs, rhs);
     }
 
     /**
@@ -3771,8 +3771,8 @@ public final class CoreOps {
      * @param rhs the second operand
      * @return the xor operation
      */
-    public static BinaryOp rightShift(Value lhs, Value rhs) {
-        return new RightShiftOp(lhs, rhs);
+    public static BinaryOp ashr(Value lhs, Value rhs) {
+        return new AshrOp(lhs, rhs);
     }
 
     /**
@@ -3782,8 +3782,8 @@ public final class CoreOps {
      * @param rhs the second operand
      * @return the xor operation
      */
-    public static BinaryOp unsignedRightShift(Value lhs, Value rhs) {
-        return new UnsignedRightShiftOp(lhs, rhs);
+    public static BinaryOp lshr(Value lhs, Value rhs) {
+        return new LshrOp(lhs, rhs);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -2737,6 +2737,81 @@ public final class CoreOps {
     }
 
     /**
+     * The shift left operation, that can model the Java language binary {@code <<} operator for integral types
+     */
+    @OpDeclaration(LeftShiftOp.NAME)
+    public static final class LeftShiftOp extends BinaryOp {
+        public static final String NAME = "leftShift";
+
+        public LeftShiftOp(OpDefinition opdef) {
+            super(opdef);
+        }
+
+        LeftShiftOp(LeftShiftOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public LeftShiftOp transform(CopyContext cc, OpTransformer ot) {
+            return new LeftShiftOp(this, cc);
+        }
+
+        LeftShiftOp(Value lhs, Value rhs) {
+            super(NAME, lhs, rhs);
+        }
+    }
+
+    /**
+     * The shift right operation, that can model the Java language binary {@code >>} operator for integral types
+     */
+    @OpDeclaration(RightShiftOp.NAME)
+    public static final class RightShiftOp extends CoreOps.BinaryOp {
+        public static final String NAME = "rightShift";
+
+        public RightShiftOp(OpDefinition opdef) {
+            super(opdef);
+        }
+
+        RightShiftOp(RightShiftOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public RightShiftOp transform(CopyContext cc, OpTransformer ot) {
+            return new RightShiftOp(this, cc);
+        }
+
+        RightShiftOp(Value lhs, Value rhs) {
+            super(NAME, lhs, rhs);
+        }
+    }
+
+    /**
+     * The unsigned shift right operation, that can model the Java language binary {@code >>>} operator for integral types
+     */
+    @OpDeclaration(UnsignedRightShiftOp.NAME)
+    public static final class UnsignedRightShiftOp extends CoreOps.BinaryOp {
+        public static final String NAME = "unsignedRightShift";
+
+        public UnsignedRightShiftOp(OpDefinition opdef) {
+            super(opdef);
+        }
+
+        UnsignedRightShiftOp(UnsignedRightShiftOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public UnsignedRightShiftOp transform(CopyContext cc, OpTransformer ot) {
+            return new UnsignedRightShiftOp(this, cc);
+        }
+
+        UnsignedRightShiftOp(Value lhs, Value rhs) {
+            super(NAME, lhs, rhs);
+        }
+    }
+
+    /**
      * The neg operation, that can model the Java language unary {@code -} operator for numeric types
      */
     @OpDeclaration(NegOp.NAME)
@@ -3676,6 +3751,39 @@ public final class CoreOps {
      */
     public static BinaryOp xor(Value lhs, Value rhs) {
         return new XorOp(lhs, rhs);
+    }
+
+    /**
+     * Creates a left shift operation.
+     *
+     * @param lhs the first operand
+     * @param rhs the second operand
+     * @return the xor operation
+     */
+    public static BinaryOp leftShift(Value lhs, Value rhs) {
+        return new LeftShiftOp(lhs, rhs);
+    }
+
+    /**
+     * Creates a right shift operation.
+     *
+     * @param lhs the first operand
+     * @param rhs the second operand
+     * @return the xor operation
+     */
+    public static BinaryOp rightShift(Value lhs, Value rhs) {
+        return new RightShiftOp(lhs, rhs);
+    }
+
+    /**
+     * Creates an unsigned right shift operation.
+     *
+     * @param lhs the first operand
+     * @param rhs the second operand
+     * @return the xor operation
+     */
+    public static BinaryOp unsignedRightShift(Value lhs, Value rhs) {
+        return new UnsignedRightShiftOp(lhs, rhs);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -423,7 +423,7 @@ public class ReflectMethods extends TreeTranslator {
                         Tag.PLUS, Tag.MINUS, Tag.MUL, Tag.DIV, Tag.MOD,
                         Tag.NEG, Tag.NOT,
                         Tag.BITOR, Tag.BITAND, Tag.BITXOR,
-                        Tag.SL, Tag.SR, Tag.USR, Tag.SL_ASG, Tag.SR_ASG, Tag.USR_ASG,
+                        Tag.SL, Tag.SR, Tag.USR,
                         Tag.PLUS_ASG, Tag.MINUS_ASG, Tag.MUL_ASG, Tag.DIV_ASG, Tag.MOD_ASG,
                         Tag.POSTINC, Tag.PREINC, Tag.POSTDEC, Tag.PREDEC,
                         Tag.EQ, Tag.NE, Tag.LT, Tag.LE, Tag.GT, Tag.GE,
@@ -769,11 +769,6 @@ public class ReflectMethods extends TreeTranslator {
                     case MUL_ASG -> append(CoreOps.mul(lhs, rhs));
                     case DIV_ASG -> append(CoreOps.div(lhs, rhs));
                     case MOD_ASG -> append(CoreOps.mod(lhs, rhs));
-
-                    // Shift operations
-                    case SL_ASG -> append(CoreOps.leftShift(lhs, rhs));
-                    case SR_ASG -> append(CoreOps.rightShift(lhs, rhs));
-                    case USR_ASG -> append(CoreOps.unsignedRightShift(lhs, rhs));
 
                     default -> throw unsupported(tree);
                 };

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -2070,6 +2070,7 @@ public class ReflectMethods extends TreeTranslator {
             }
             else {
                 Type opType = tree.operator.type.getParameterTypes().getFirst();
+                // @@@ potentially handle shift input conversion like other binary ops
                 boolean isShift = tag == Tag.SL || tag == Tag.SR || tag == Tag.USR;
                 Value lhs = toValue(tree.lhs, opType);
                 Value rhs = toValue(tree.rhs, isShift ? tree.operator.type.getParameterTypes().getLast() : opType);
@@ -2096,9 +2097,10 @@ public class ReflectMethods extends TreeTranslator {
                     case BITAND -> append(CoreOps.and(lhs, rhs));
                     case BITXOR -> append(CoreOps.xor(lhs, rhs));
 
-                    case SL -> append(CoreOps.leftShift(lhs, rhs));
-                    case SR -> append(CoreOps.rightShift(lhs, rhs));
-                    case USR -> append(CoreOps.unsignedRightShift(lhs, rhs));
+                    // Shift operations
+                    case SL -> append(CoreOps.lshl(lhs, rhs));
+                    case SR -> append(CoreOps.ashr(lhs, rhs));
+                    case USR -> append(CoreOps.lshr(lhs, rhs));
 
                     default -> throw unsupported(tree);
                 };

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -423,6 +423,7 @@ public class ReflectMethods extends TreeTranslator {
                         Tag.PLUS, Tag.MINUS, Tag.MUL, Tag.DIV, Tag.MOD,
                         Tag.NEG, Tag.NOT,
                         Tag.BITOR, Tag.BITAND, Tag.BITXOR,
+                        Tag.SL, Tag.SR, Tag.USR, Tag.SL_ASG, Tag.SR_ASG, Tag.USR_ASG,
                         Tag.PLUS_ASG, Tag.MINUS_ASG, Tag.MUL_ASG, Tag.DIV_ASG, Tag.MOD_ASG,
                         Tag.POSTINC, Tag.PREINC, Tag.POSTDEC, Tag.PREDEC,
                         Tag.EQ, Tag.NE, Tag.LT, Tag.LE, Tag.GT, Tag.GE,
@@ -768,6 +769,11 @@ public class ReflectMethods extends TreeTranslator {
                     case MUL_ASG -> append(CoreOps.mul(lhs, rhs));
                     case DIV_ASG -> append(CoreOps.div(lhs, rhs));
                     case MOD_ASG -> append(CoreOps.mod(lhs, rhs));
+
+                    // Shift operations
+                    case SL_ASG -> append(CoreOps.leftShift(lhs, rhs));
+                    case SR_ASG -> append(CoreOps.rightShift(lhs, rhs));
+                    case USR_ASG -> append(CoreOps.unsignedRightShift(lhs, rhs));
 
                     default -> throw unsupported(tree);
                 };
@@ -2068,9 +2074,10 @@ public class ReflectMethods extends TreeTranslator {
                 result = append(CoreOps.concat(lhs, rhs));
             }
             else {
-                Type opType = tree.operator.type.getParameterTypes().get(0);
+                Type opType = tree.operator.type.getParameterTypes().getFirst();
+                boolean isShift = tag == Tag.SL || tag == Tag.SR || tag == Tag.USR;
                 Value lhs = toValue(tree.lhs, opType);
-                Value rhs = toValue(tree.rhs, opType);
+                Value rhs = toValue(tree.rhs, isShift ? tree.operator.type.getParameterTypes().getLast() : opType);
 
                 result = switch (tag) {
                     // Arithmetic operations
@@ -2093,6 +2100,10 @@ public class ReflectMethods extends TreeTranslator {
                     case BITOR -> append(CoreOps.or(lhs, rhs));
                     case BITAND -> append(CoreOps.and(lhs, rhs));
                     case BITXOR -> append(CoreOps.xor(lhs, rhs));
+
+                    case SL -> append(CoreOps.leftShift(lhs, rhs));
+                    case SR -> append(CoreOps.rightShift(lhs, rhs));
+                    case USR -> append(CoreOps.unsignedRightShift(lhs, rhs));
 
                     default -> throw unsupported(tree);
                 };

--- a/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
+++ b/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
@@ -314,8 +314,7 @@ public class CoreBinaryOpsTest {
         private static Stream<Method> codeReflectionMethods(Class<?> testClass) {
             return Arrays.stream(testClass.getDeclaredMethods())
                     .filter(method -> method.accessFlags().contains(AccessFlag.STATIC))
-                    .filter(method -> method.isAnnotationPresent(CodeReflection.class))
-                    .peek(m -> m.getCodeModel().ifPresent(f -> System.out.println(f.toText())));
+                    .filter(method -> method.isAnnotationPresent(CodeReflection.class));
         }
 
     }

--- a/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
+++ b/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
@@ -80,6 +80,24 @@ public class CoreBinaryOpsTest {
     }
 
     @CodeReflection
+    @SupportedTypes(types = {int.class, long.class})
+    static int leftShift(int left, int right) {
+        return left << right;
+    }
+
+    @CodeReflection
+    @Direct
+    static int leftShiftIL(int left, long right) {
+        return left << right;
+    }
+
+    @CodeReflection
+    @Direct
+    static long leftShiftLI(long left, int right) {
+        return left << right;
+    }
+
+    @CodeReflection
     @SupportedTypes(types = {int.class, long.class, float.class, double.class})
     static int mod(int left, int right) {
         return left % right;
@@ -98,11 +116,46 @@ public class CoreBinaryOpsTest {
     }
 
     @CodeReflection
+    @SupportedTypes(types = {int.class, long.class})
+    static int signedRightShift(int left, int right) {
+        return left >> right;
+    }
+
+    @CodeReflection
+    @Direct
+    static int signedRightShiftIL(int left, long right) {
+        return left >> right;
+    }
+
+    @CodeReflection
+    @Direct
+    static long signedRightShiftLI(long left, int right) {
+        return left >> right;
+    }
+
+    @CodeReflection
     @SupportedTypes(types = {int.class, long.class, float.class, double.class})
     static int sub(int left, int right) {
         return left - right;
     }
 
+    @CodeReflection
+    @SupportedTypes(types = {int.class, long.class})
+    static int unsignedRightShift(int left, int right) {
+        return left >>> right;
+    }
+
+    @CodeReflection
+    @Direct
+    static int unsignedRightShiftIL(int left, long right) {
+        return left >>> right;
+    }
+
+    @CodeReflection
+    @Direct
+    static long unsignedRightShiftLI(long left, int right) {
+        return left >>> right;
+    }
 
     @CodeReflection
     @SupportedTypes(types = {int.class, long.class, boolean.class})
@@ -124,6 +177,12 @@ public class CoreBinaryOpsTest {
         Class<?>[] types();
     }
 
+    // mark as "do not transform"
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface Direct {
+    }
+
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @ArgumentsSource(CodeReflectionSourceProvider.class)
@@ -131,12 +190,12 @@ public class CoreBinaryOpsTest {
     }
 
     static class CodeReflectionSourceProvider implements ArgumentsProvider {
-        private static final Map<Class<?>, List<Object>> INTERESTING_INPUTS = Map.of(
-                int.class, List.of(Integer.MIN_VALUE, Integer.MAX_VALUE, 1, 0, -1),
-                long.class, List.of(Long.MIN_VALUE, Long.MAX_VALUE, 1, 0, -1),
-                double.class, List.of(Double.MIN_VALUE, Double.MAX_VALUE, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.MIN_NORMAL, 1, 0, -1),
-                float.class, List.of(Float.MIN_VALUE, Float.MAX_VALUE, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.MIN_NORMAL, 1, 0, -1),
-                boolean.class, List.of(true, false)
+        private static final Map<JavaType, List<Object>> INTERESTING_INPUTS = Map.of(
+                JavaType.INT, List.of(Integer.MIN_VALUE, Integer.MAX_VALUE, 1, 0, -1),
+                JavaType.LONG, List.of(Long.MIN_VALUE, Long.MAX_VALUE, 1, 0, -1),
+                JavaType.DOUBLE, List.of(Double.MIN_VALUE, Double.MAX_VALUE, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.MIN_NORMAL, 1, 0, -1),
+                JavaType.FLOAT, List.of(Float.MIN_VALUE, Float.MAX_VALUE, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.MIN_NORMAL, 1, 0, -1),
+                JavaType.BOOLEAN, List.of(true, false)
         );
 
         @Override
@@ -144,26 +203,35 @@ public class CoreBinaryOpsTest {
             Method testMethod = extensionContext.getRequiredTestMethod();
             return codeReflectionMethods(extensionContext.getRequiredTestClass())
                     .flatMap(method -> {
-                        CoreOps.FuncOp funcOp = method.getCodeModel().orElseThrow(() -> new IllegalStateException("Expected code model to be present"));
+                        CoreOps.FuncOp funcOp = method.getCodeModel().orElseThrow(
+                                () -> new IllegalStateException("Expected code model to be present for method " + method)
+                        );
                         SupportedTypes supportedTypes = method.getAnnotation(SupportedTypes.class);
+                        if (method.isAnnotationPresent(Direct.class)) {
+                            if (supportedTypes != null) {
+                                throw new IllegalArgumentException("Direct should not be combined with SupportedTypes");
+                            }
+                            return Stream.of(funcOp);
+                        }
                         if (supportedTypes == null || supportedTypes.types().length == 0) {
                             throw new IllegalArgumentException("Missing supported types");
                         }
                         return Arrays.stream(supportedTypes.types())
-                                .map(type -> new TransformedFunc(retype(funcOp, type), type));
+                                .map(type -> retype(funcOp, type));
                     })
-                    .flatMap(tf -> argumentsForMethod(tf, testMethod));
+                    .flatMap(transformedFunc -> argumentsForMethod(transformedFunc, testMethod));
         }
 
-        private static <T> Stream<List<T>> cartesianPower(List<T> source, int n) {
-            if (n == 0) {
+        private static <T> Stream<List<T>> cartesianProduct(List<List<T>> source) {
+            if (source.isEmpty()) {
                 return Stream.of(new ArrayList<>());
             }
-            return source.stream().flatMap(e -> cartesianPower(source, n - 1).map(l -> {
-                ArrayList<T> newList = new ArrayList<>(l);
-                newList.add(e);
-                return newList;
-            }));
+            return source.getFirst().stream()
+                    .flatMap(e -> cartesianProduct(source.subList(1, source.size())).map(l -> {
+                        ArrayList<T> newList = new ArrayList<>(l);
+                        newList.add(e);
+                        return newList;
+                    }));
         }
 
         private static CoreOps.FuncOp retype(CoreOps.FuncOp original, Class<?> newType) {
@@ -196,28 +264,42 @@ public class CoreBinaryOpsTest {
             };
         }
 
-        private static Stream<Arguments> argumentsForMethod(TransformedFunc tf, Method testMethod) {
-            Parameter[] parameters = testMethod.getParameters();
-            List<Object> inputs = INTERESTING_INPUTS.get(tf.type());
-            if (parameters.length == 0) {
-                throw new IllegalArgumentException("method " + testMethod + " does not take any arguments");
+        private static Stream<Arguments> argumentsForMethod(CoreOps.FuncOp funcOp, Method testMethod) {
+            Parameter[] testMethodParameters = testMethod.getParameters();
+            List<TypeElement> funcParameters = funcOp.invokableType().parameterTypes();
+            if (testMethodParameters.length - 1 != funcParameters.size()) {
+                throw new IllegalArgumentException("method " + testMethod + " does not take the correct number of parameters");
             }
-            if (parameters[0].getType() != CoreOps.FuncOp.class) {
+            if (testMethodParameters[0].getType() != CoreOps.FuncOp.class) {
                 throw new IllegalArgumentException("method " + testMethod + " does not take a leading FuncOp argument");
             }
-            Named<CoreOps.FuncOp> opNamed = Named.of(tf.funcOp().funcName() + "{" + tf.funcOp().invokableType() + "}", tf.funcOp());
-            for (int i = 1; i < parameters.length; i++) {
-                if (!isCompatible(tf.type(), parameters[i].getType())) {
-                    System.out.println(testMethod + " does not accept inputs of type " + tf.type());
+            Named<CoreOps.FuncOp> opNamed = Named.of(funcOp.funcName() + "{" + funcOp.invokableType() + "}", funcOp);
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            for (int i = 1; i < testMethodParameters.length; i++) {
+                Class<?> resolved = resolveParameter(funcParameters.get(i - 1), lookup);
+                if (!isCompatible(resolved, testMethodParameters[i].getType())) {
+                    System.out.println(testMethod + " does not accept inputs of type " + resolved + " at index " + i);
                     return Stream.empty();
                 }
             }
-            return cartesianPower(inputs, parameters.length - 1)
+            List<List<Object>> allInputs = new ArrayList<>();
+            for (TypeElement parameterType : funcParameters) {
+                allInputs.add(INTERESTING_INPUTS.get((JavaType) parameterType));
+            }
+            return cartesianProduct(allInputs)
                     .map(objects -> {
                         objects.add(opNamed);
                         return objects.reversed().toArray(); // reverse so FuncOp is at the beginning
                     })
                     .map(Arguments::of);
+        }
+
+        private static Class<?> resolveParameter(TypeElement typeElement, MethodHandles.Lookup lookup) {
+            try {
+                return ((JavaType) typeElement).resolve(lookup);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         // check whether elements of type sourceType can be passed to a parameter of parameterType
@@ -232,10 +314,8 @@ public class CoreBinaryOpsTest {
         private static Stream<Method> codeReflectionMethods(Class<?> testClass) {
             return Arrays.stream(testClass.getDeclaredMethods())
                     .filter(method -> method.accessFlags().contains(AccessFlag.STATIC))
-                    .filter(method -> method.getCodeModel().isPresent());
-        }
-
-        record TransformedFunc(CoreOps.FuncOp funcOp, Class<?> type) {
+                    .filter(method -> method.isAnnotationPresent(CodeReflection.class))
+                    .peek(m -> m.getCodeModel().ifPresent(f -> System.out.println(f.toText())));
         }
 
     }
@@ -262,8 +342,8 @@ public class CoreBinaryOpsTest {
         System.out.println("second: " + second);
         // either the same error occurred on both or no error occurred
         if (first.throwable != null || second.throwable != null) {
-            assertNotNull(first.throwable);
-            assertNotNull(second.throwable);
+            assertNotNull(first.throwable, "only second threw an exception");
+            assertNotNull(second.throwable, "only first threw an exception");
             if (first.throwable.getClass() != second.throwable.getClass()) {
                 first.throwable.printStackTrace();
                 second.throwable.printStackTrace();

--- a/test/langtools/tools/javac/reflect/BinopTest.java
+++ b/test/langtools/tools/javac/reflect/BinopTest.java
@@ -269,15 +269,4 @@ public class BinopTest {
 
         d %= 1;
     }
-
-    @CodeReflection
-    @IR("""
-            TODO
-            """)
-    int test9(short s) {
-        s <<= 1;
-        s <<= 2L;
-        return s << s;
-    }
-
 }

--- a/test/langtools/tools/javac/reflect/BinopTest.java
+++ b/test/langtools/tools/javac/reflect/BinopTest.java
@@ -269,4 +269,15 @@ public class BinopTest {
 
         d %= 1;
     }
+
+    @CodeReflection
+    @IR("""
+            TODO
+            """)
+    int test9(short s) {
+        s <<= 1;
+        s <<= 2L;
+        return s << s;
+    }
+
 }


### PR DESCRIPTION
This PR implements the three shift operations. There are a few points to discuss:
- naming: I chose the names as the operators are called in the JLS, but e.g. for comparisons we currently have short names. The Compiler also uses a different naming scheme here. Which way do we want to go here?
- shift operations are different from other binary ops as their operands undergo unary numeric promotion rather than binary numeric promotion. However, on bytecode level the rhs will always be an int anyway. I'm currently handling that in the bytecode generator, and the model is close to the JLS otherwise. Any objections here?
- I reworked the testing to allow for combinations of different types, as that's important for the current design of shifts (especially `int shift long` should result in an int again)

I also noticed that I missed assignment operators when I did and, or, xor before. I left it out here as well, as this needs additional care, at least for the interpreter. Code like
```java
void m(byte b) {
    b *= 2;
}
```
doesn't run when using the interpreter currently. Should I add assignment operator handling here anyway?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/babylon.git pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/49.diff">https://git.openjdk.org/babylon/pull/49.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/49#issuecomment-2047876648)