### PR TITLE
Erase receiver type before calling Gen::binaryQualifier

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -2236,7 +2236,7 @@ public class ReflectMethods extends TreeTranslator {
             // @@@ Made Gen::binaryQualifier public, duplicate logic?
             // Ensure correct qualifying class is used in the reference, see JLS 13.1
             // https://docs.oracle.com/javase/specs/jls/se20/html/jls-13.html#jls-13.1
-            return symbolToFieldRef(gen.binaryQualifier(s, site));
+            return symbolToFieldRef(gen.binaryQualifier(s, types.erasure(site)));
         }
 
         FieldRef symbolToFieldRef(Symbol s) {
@@ -2258,7 +2258,7 @@ public class ReflectMethods extends TreeTranslator {
             // @@@ Made Gen::binaryQualifier public, duplicate logic?
             // Ensure correct qualifying class is used in the reference, see JLS 13.1
             // https://docs.oracle.com/javase/specs/jls/se20/html/jls-13.html#jls-13.1
-            return symbolToErasedMethodRef(gen.binaryQualifier(s, site));
+            return symbolToErasedMethodRef(gen.binaryQualifier(s, types.erasure(site)));
         }
 
         MethodRef symbolToErasedMethodRef(Symbol s) {

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -146,4 +146,46 @@ public class DenotableTypesTest {
         X x = null;
         consume(x);
     }
+
+    interface Adder<X> {
+        void add(Adder<X> adder);
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test8" (%0 : java.util.List)void -> {
+                  %1 : Var<java.util.List> = var %0 @"list";
+                  %2 : java.util.List = var.load %1;
+                  %3 : int = constant @"0";
+                  %4 : DenotableTypesTest$Adder = invoke %2 %3 @"java.util.List::get(int)java.lang.Object";
+                  %5 : java.util.List = var.load %1;
+                  %6 : int = constant @"1";
+                  %7 : DenotableTypesTest$Adder = invoke %5 %6 @"java.util.List::get(int)java.lang.Object";
+                  invoke %4 %7 @"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder)void";
+                  return;
+            };
+            """)
+    static void test8(List<? extends Adder<Integer>> list) {
+        list.get(0).add(list.get(1));
+    }
+
+    static class Box<X> {
+        X x;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test9" (%0 : java.util.List)void -> {
+                  %1 : Var<java.util.List> = var %0 @"list";
+                  %2 : java.util.List = var.load %1;
+                  %3 : int = constant @"0";
+                  %4 : DenotableTypesTest$Box = invoke %2 %3 @"java.util.List::get(int)java.lang.Object";
+                  %5 : java.lang.Integer = field.load %4 @"DenotableTypesTest$Box::x()java.lang.Object";
+                  %6 : Var<java.lang.Integer> = var %5 @"i";
+                  return;
+            };
+            """)
+    static void test9(List<? extends Box<Integer>> list) {
+        Integer i = list.get(0).x;
+    }
 }


### PR DESCRIPTION
I found an issue where `Gen::binaryQualifier` was called on a non-denotable reveiver type. This led to a crash, as `binaryQualifier` ended up creating a new symbol whose owner was the non-denotable receiver and, at least for some symbols, we check in the constructor that the owner can't be a type-variable.

The solution is to make sure that the receiver type (`site`) passed to `binaryQualifier` is always erased, which is also the assumption `Gen` makes (obviously).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/babylon.git pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/50.diff">https://git.openjdk.org/babylon/pull/50.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/50#issuecomment-2051632798)