### PR TITLE
Issues with captures in quotable lambdas

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -623,7 +623,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             if (useImplMethodHandle) {
                 visitLdcInsn(implMethodCondy);
             }
-            for (int i = 0; i < argNames.length; i++) {
+            for (int i = 0; i < argNames.length - reflectiveCaptureCount(); i++) {
                 visitVarInsn(ALOAD, 0);
                 visitFieldInsn(GETFIELD, lambdaClassName, argNames[i], argDescs[i]);
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -303,7 +303,12 @@ public class ReflectMethods extends TreeTranslator {
                 capturedArgs.add(make.at(pos).Ident(recvDecl.sym));
             } else if (capturedSym.kind == Kind.VAR) {
                 // captured var
-                capturedArgs.add(make.at(pos).Ident(capturedSym));
+                VarSymbol var = (VarSymbol)capturedSym;
+                if (var.getConstValue() == null) {
+                    capturedArgs.add(make.at(pos).Ident(capturedSym));
+                } else {
+                    capturedArgs.add(make.at(pos).Literal(var.getConstValue()));
+                }
             } else {
                 throw new AssertionError("Unexpected captured symbol: " + capturedSym);
             }

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -36,6 +36,7 @@ import java.lang.reflect.code.Quoted;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandles;
 import java.util.function.IntUnaryOperator;
+import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
 
 import static org.testng.Assert.*;
@@ -51,6 +52,19 @@ public class TestCaptureQuotable {
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
         assertEquals(res, x + 1);
+    }
+
+    @Test
+    public void testCaptureRefAndIntConstant() {
+        final int x = 100;
+        String hello = "hello";
+        Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + hello.length() + x;
+        Quoted quoted = quotable.quoted();
+        assertEquals(quoted.capturedValues().size(), 2);
+        assertEquals(((Var)quoted.capturedValues().values().iterator().next()).value(), x);
+        int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
+                quoted.capturedValues(), 1);
+        assertEquals(res, x + 1 + hello.length());
     }
 
     @Test(dataProvider = "ints")


### PR DESCRIPTION
Two issues were found in the code for capturing values in quotable lambdas:

* If the captured value is a constant (e.g. a local variable that is declared as `final`), we end up generating bad code. The problem is that constant variables are not normally captured by `LambdaToMethod` and `Lower`, on the basis that they will "disappear" from the bytecode, and replaced from their constant value. But in the code model IR, such variables are very much real, so the generated `Quoted` op will feature them as captured values nevertheless. This issue is easily fixed by tweaking the code which creates the captured values in `ReflectMethods` so that, instead of generating a reference to a variable that no longer exists, we generate a literal (the constant value we want).
* There's also a latent issue in `InnerClassLambdaMetafactory.ForwardingMethodGenerator`: before calling the lambda method generated by javac, this generator will attempt to load all the captured fields in the generated class. But, for quoted lambdas, some fields are used for generating the corresponding quoted ops and should not be used to invoke the lambda bytecode. Surprisingly, in most cases, the verifier does not detect the additional field loads, as long as the type match (which is always the case if the quoted capture list is identical to the bytecode capture list). But in some cases (e.g. when `final` are involved), the two lists might be different, and it is possible for the verifier to detect type mismatches. This issue can be fixed by making sure that `ForwardingGenerator` only loads the captured fields that matters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/babylon.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/53.diff">https://git.openjdk.org/babylon/pull/53.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/53#issuecomment-2061142662)