### PR TITLE
Support location information

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Location.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Location.java
@@ -1,0 +1,42 @@
+package java.lang.reflect.code;
+
+/**
+ * Source location information.
+ *
+ * @param sourceRef the reference to the source
+ * @param line the line in the source
+ * @param column the column in the source
+ */
+public record Location(String sourceRef, int line, int column) {
+
+    public Location(int line, int column) {
+        this(null, line, column);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+        s.append(line).append(":").append(column);
+        if (sourceRef != null) {
+            s.append(":").append(sourceRef);
+        }
+        return s.toString();
+    }
+
+    public static Location fromString(String s) {
+        String[] split = s.split(":", 3);
+        if (split.length < 2) {
+            throw new IllegalArgumentException();
+        }
+
+        int line = Integer.parseInt(split[0]);
+        int column = Integer.parseInt(split[1]);
+        String sourceRef;
+        if (split.length == 3) {
+            sourceRef = split[2];
+        } else {
+            sourceRef = null;
+        }
+        return new Location(sourceRef, line, column);
+    }
+}

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -179,6 +179,9 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     // Set when op is bound to block, otherwise null when unbound
     Result result;
 
+    // null if not specified
+    Location location;
+
     final String name;
 
     final List<Value> operands;
@@ -193,6 +196,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     protected Op(Op that, CopyContext cc) {
         this(that.name, cc.getValues(that.operands));
+        this.location = that.location;
     }
 
     /**
@@ -241,6 +245,28 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     protected Op(String name, List<? extends Value> operands) {
         this.name = name;
         this.operands = List.copyOf(operands);
+    }
+
+    /**
+     * Sets the originating source location of this operation, if unbound.
+     *
+     * @param l the location, a {@code null} value indicates the location is not specified.
+     * @throws IllegalStateException if this operation is bound
+     */
+    public final void setLocation(Location l) {
+        // @@@ Fail if location != null?
+        if (result != null && result.block.isBound()) {
+            throw new IllegalStateException();
+        }
+
+        location = l;
+    }
+
+    /**
+     * {@return the originating source location of this operation, otherwise {@code null} if not specified}
+     */
+    public final Location location() {
+        return location;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/op/OpWithDefinition.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/OpWithDefinition.java
@@ -25,9 +25,7 @@
 
 package java.lang.reflect.code.op;
 
-import java.lang.reflect.code.CopyContext;
-import java.lang.reflect.code.Op;
-import java.lang.reflect.code.Value;
+import java.lang.reflect.code.*;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +33,11 @@ import java.util.Map;
  * An operation that may be constructed with an operation {@link OpDefinition definition}.
  */
 public abstract class OpWithDefinition extends Op {
-    final Map<String, Object> attributes;
+
+    /**
+     * The attribute name associated with the location attribute.
+     */
+    public static final String ATTRIBUTE_LOCATION = "loc";
 
     /**
      * Constructs an operation by copying given operation.
@@ -47,8 +49,6 @@ public abstract class OpWithDefinition extends Op {
      */
     protected OpWithDefinition(Op that, CopyContext cc) {
         super(that, cc);
-
-        this.attributes = Map.of();
     }
 
     /**
@@ -59,8 +59,6 @@ public abstract class OpWithDefinition extends Op {
      */
     protected OpWithDefinition(String name, List<? extends Value> operands) {
         super(name, operands);
-
-        this.attributes = Map.of();
     }
 
     /**
@@ -77,12 +75,22 @@ public abstract class OpWithDefinition extends Op {
      */
     protected OpWithDefinition(OpDefinition def) {
         super(def.name(), def.operands());
+        setLocation(extractLocation(def));
+    }
 
-        this.attributes = Map.copyOf(def.attributes());
+    static Location extractLocation(OpDefinition def) {
+        Object v = def.attributes().get(ATTRIBUTE_LOCATION);
+        return switch(v) {
+            case String s -> Location.fromString(s);
+            case Location loc -> loc;
+            case null -> null;
+            default -> throw new UnsupportedOperationException("Unsupported location value:" + v);
+        };
     }
 
     @Override
     public Map<String, Object> attributes() {
-        return attributes;
+        Location l = location();
+        return l == null ? Map.of() : Map.of(ATTRIBUTE_LOCATION, l);
     }
 }


### PR DESCRIPTION
Enable operations to have originating source location information, specifically source reference, line and column information.

The location information may be set (one or more times) on an operation while it is unbound. Once it is bound, when it is a member of a block, it can longer be set. Copying an operation will also copy the location. This enables preservation when transforming, especially for lowering.

The compiler generates location information from a tree node, and sets it on the associated operation(s). For the operations associated with a reflected method (FuncOp) or quoted lambda expression (LambdaOp or ClosureOp) the source reference (a URI) is added to the location, whereas for all other operations the source reference is absent.

Example:

```
    @CodeReflection                          // 47
    static int f(int n) {                          // 48
        int sum = 0;                               // 49
        for (int i = 0; i < n; i++)  {          // 50
            sum += i;                               // 51
        }                                                 // 52
        return sum;                               // 53
    }                                                     // 54
```

Model:

```
func @"f" @loc="47:5:file:///Users/sandoz/Projects/jdk/test/babylon-test/src/test/java/T.java" (%0 : int)int -> {
    %1 : Var<int> = var %0 @"n" @loc="47:5";
    %2 : int = constant @"0" @loc="49:19";
    %3 : Var<int> = var %2 @"sum" @loc="49:9";
    java.for @loc="50:9"
        ()Var<int> -> {
            %4 : int = constant @"0" @loc="50:22";
            %5 : Var<int> = var %4 @"i" @loc="50:14";
            yield %5 @loc="50:9";
        }
        (%6 : Var<int>)boolean -> {
            %7 : int = var.load %6 @loc="50:25";
            %8 : int = var.load %1 @loc="50:29";
            %9 : boolean = lt %7 %8 @loc="50:25";
            yield %9 @loc="50:9";
        }
        (%10 : Var<int>)void -> {
            %11 : int = var.load %10 @loc="50:32";
            %12 : int = constant @"1" @loc="50:32";
            %13 : int = add %11 %12 @loc="50:32";
            var.store %10 %13 @loc="50:32";
            yield @loc="50:9";
        }
        (%14 : Var<int>)void -> {
            %15 : int = var.load %3 @loc="51:13";
            %16 : int = var.load %14 @loc="51:20";
            %17 : int = add %15 %16 @loc="51:13";
            var.store %3 %17 @loc="51:13";
            java.continue @loc="50:9";
        };
    %18 : int = var.load %3 @loc="53:16";
    return %18 @loc="53:9";
};
```

Lowered model:

```
func @"f" @loc="47:5:file:///Users/sandoz/Projects/jdk/test/babylon-test/src/test/java/T.java" (%0 : int)int -> {
    %1 : Var<int> = var %0 @"n" @loc="47:5";
    %2 : int = constant @"0" @loc="49:19";
    %3 : Var<int> = var %2 @"sum" @loc="49:9";
    %4 : int = constant @"0" @loc="50:22";
    %5 : Var<int> = var %4 @"i" @loc="50:14";
    branch ^block_0;
  
  ^block_0:
    %6 : int = var.load %5;
    %7 : int = var.load %1;
    %8 : boolean = lt %6 %7 @loc="50:25";
    cbranch %8 ^block_1 ^block_2;
  
  ^block_1:
    %9 : int = var.load %3;
    %10 : int = var.load %5;
    %11 : int = add %9 %10 @loc="51:13";
    var.store %3 %11;
    branch ^block_3;
  
  ^block_3:
    %12 : int = var.load %5;
    %13 : int = constant @"1" @loc="50:32";
    %14 : int = add %12 %13 @loc="50:32";
    var.store %5 %14;
    branch ^block_0;
  
  ^block_2:
    %15 : int = var.load %3;
    return %15 @loc="53:9";
};
```

### Further work for this PR

Some finessing is likely required by the compiler as to when location information should be present on an operation, and if so what location information, or otherwise can be absent. When lowering we can see some operations, which were added by the transformation, have no source information, only those that were copied do. Bytecode generation of the line number table will help guide in this respect.

It is also likely we will need to support the easy removal of location information. For the numerous compiler tests such information is not important. Removal is likely best implemented as a transformation. At the moment this is not easy. A block builder could set location information (`null` meaning unspecified location), overriding that provided by an operation that is added to the builder's block.

This work has also exposed limitations with operation attributes. Operation attributes are really a mechanism for serialization and deserialization of code models. An operation that has additional state needs to convey and consume that state when serializing and deserializing. Therefore we should consider attributes part of `OpWithDefinition` rather than `Op`, and likely rename the former `ExternalizableOp`. We don't need a general open-ended mechanism for adding state to operations. Instead operations should use all the facilities of the language for managing and exposing specific state, and where applicable use common operation abstractions that facilitate pattern matching.