### PR TITLE
Missing conversion for some unary operators

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -2021,11 +2021,11 @@ public class ReflectMethods extends TreeTranslator {
                     applyCompoundAssign(tree.arg, scanRhs);
                 }
                 case NEG -> {
-                    Value rhs = toValue(tree.arg);
+                    Value rhs = toValue(tree.arg, tree.type);
                     result = append(CoreOps.neg(rhs));
                 }
                 case NOT -> {
-                    Value rhs = toValue(tree.arg);
+                    Value rhs = toValue(tree.arg, tree.type);
                     result = append(CoreOps.not(rhs));
                 }
                 default -> throw unsupported(tree);

--- a/test/langtools/tools/javac/reflect/BoxingConversionTest.java
+++ b/test/langtools/tools/javac/reflect/BoxingConversionTest.java
@@ -650,4 +650,64 @@ public class BoxingConversionTest {
     void test29(int i) {
         new Box2(i, i, i, i);
     }
+
+    @CodeReflection
+    @IR("""
+            func @"test30" (%0 : java.lang.Integer)void -> {
+                  %1 : Var<java.lang.Integer> = var %0 @"i";
+                  %2 : java.lang.Integer = var.load %1;
+                  %3 : int = invoke %2 @"java.lang.Integer::intValue()int";
+                  %4 : int = neg %3;
+                  %5 : Var<int> = var %4 @"j";
+                  return;
+            };
+            """)
+    static void test30(Integer i) {
+        int j = -i;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test31" (%0 : int)void -> {
+                  %1 : Var<int> = var %0 @"i";
+                  %2 : int = var.load %1;
+                  %3 : int = neg %2;
+                  %4 : java.lang.Integer = invoke %3 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+                  %5 : Var<java.lang.Integer> = var %4 @"j";
+                  return;
+            };
+            """)
+    static void test31(int i) {
+        Integer j = -i;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test32" (%0 : boolean)void -> {
+                  %1 : Var<boolean> = var %0 @"i";
+                  %2 : boolean = var.load %1;
+                  %3 : boolean = not %2;
+                  %4 : java.lang.Boolean = invoke %3 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
+                  %5 : Var<java.lang.Boolean> = var %4 @"j";
+                  return;
+            };
+            """)
+    static void test32(boolean i) {
+        Boolean j = !i;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test33" (%0 : java.lang.Boolean)void -> {
+                  %1 : Var<java.lang.Boolean> = var %0 @"i";
+                  %2 : java.lang.Boolean = var.load %1;
+                  %3 : boolean = invoke %2 @"java.lang.Boolean::booleanValue()boolean";
+                  %4 : boolean = not %3;
+                  %5 : Var<boolean> = var %4 @"j";
+                  return;
+            };
+            """)
+    static void test33(Boolean i) {
+        boolean j = !i;
+    }
 }

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -29,12 +29,14 @@
 
 import org.testng.annotations.*;
 
+import java.lang.reflect.code.Value;
 import java.lang.reflect.code.op.CoreOps.Var;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.Quotable;
 import java.lang.reflect.code.Quoted;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
 import java.util.function.IntUnaryOperator;
 import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
@@ -61,7 +63,9 @@ public class TestCaptureQuotable {
         Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + hello.length() + x;
         Quoted quoted = quotable.quoted();
         assertEquals(quoted.capturedValues().size(), 2);
-        assertEquals(((Var)quoted.capturedValues().values().iterator().next()).value(), x);
+        Iterator<Object> it = quoted.capturedValues().values().iterator();
+        assertEquals(((Var)it.next()).value(), hello);
+        assertEquals(((Var)it.next()).value(), x);
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
         assertEquals(res, x + 1 + hello.length());


### PR DESCRIPTION
`ReflectMethods` is missing the logic for converting operands for unary operators `!` and `-`.

I've fixed calling the correct `value` method (the one with a target type).

When running tests, it seems like the test `CoreBinaryOpsTest` fails.

This failure also occurs w/o my patch, so it seems unrelated.

The problem is likely due to another missing conversion - e.g. for this code:

```
    @CodeReflection
    static int leftShiftIL(int left, long right) {
        return left << right;
    }
```

We get this model:

```
func @"leftShiftIL" (%0 : int, %1 : long)int -> {
      %2 : Var<int> = var %0 @"left";
      %3 : Var<long> = var %1 @"right";
      %4 : int = var.load %2;
      %5 : long = var.load %3;
      %6 : int = lshl %4 %5;
      return %6;
};
```

This seems to want to do a shift between an int and a long (so should use a long shift, whose result is also long). But there's no conversion on the way in and also on the way out.

Since this is unrelated with the fix here, I'd suggest to integrate this in the meantime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/babylon.git pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/55.diff">https://git.openjdk.org/babylon/pull/55.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/55#issuecomment-2064498340)