### PR TITLE
Refine support for captured values.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -95,7 +95,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
 
         /**
-         * Computes the values captured by this invokable operation's body.
+         * Computes values captured by this invokable operation's body.
          *
          * @return the captured values.
          * @see Body#capturedValues()

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -95,7 +95,10 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
 
         /**
-         * {@return the captured values}
+         * Computes the values captured by this invokable operation's body.
+         *
+         * @return the captured values.
+         * @see Body#capturedValues()
          */
         default List<Value> capturedValues() {
             return List.of();
@@ -388,6 +391,29 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
 
         return t;
+    }
+
+    /**
+     * Computes values captured by this operation. A captured value is a value that dominates
+     * this operation and is used by a descendant operation.
+     * <p>
+     * The order of the captured values is first use encountered in depth
+     * first search of this operation's descendant operations.
+     *
+     * @return the list of captured values, modifiable
+     * @see Body#capturedValues()
+     */
+    public List<Value> capturedValues() {
+        Set<Value> cvs = new LinkedHashSet<>();
+
+        capturedValues(cvs, new ArrayDeque<>(), this);
+        return new ArrayList<>(cvs);
+    }
+
+    static void capturedValues(Set<Value> capturedValues, Deque<Body> bodyStack, Op op) {
+        for (Body childBody : op.bodies()) {
+            Body.capturedValues(capturedValues, bodyStack, childBody);
+        }
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
@@ -25,6 +25,7 @@
 
 package java.lang.reflect.code;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -50,10 +51,10 @@ public final class Quoted {
     /**
      * Constructs the quoted form of a given operation.
      * <p>
-     * The captured values key set should contain all the operation's captured values,
-     * specifically the following expression should evaluate to true:
+     * The captured values key set must have the same elements and same encounter order as
+     * operation's captured values, specifically the following expression should evaluate to true:
      * {@snippet lang=java :
-     * capturedValues.keySet().containsAll(op.capturedValues());
+     * op.capturedValues().equals(new ArrayList<>(capturedValues.keySet()));
      * }
      * The captured values key set is not required to preserve the encounter
      * order of the operation's captured values.
@@ -64,7 +65,8 @@ public final class Quoted {
      */
     public Quoted(Op op, Map<Value, Object> capturedValues) {
         // @@@ This check is potentially expensive, remove or keep as assert?
-        assert capturedValues.keySet().containsAll(op.capturedValues());
+        // @@@ Or make Quoted an interface, with a module private implementation?
+        assert op.capturedValues().equals(new ArrayList<>(capturedValues.keySet()));
         this.op = op;
         this.capturedValues = Map.copyOf(capturedValues);
     }
@@ -80,6 +82,12 @@ public final class Quoted {
 
     /**
      * Returns the captured values.
+     * <p>
+     * The captured values key set has the same elements and same encounter order as
+     * operation's captured values, specifically the following expression should evaluate to true:
+     * {@snippet lang=java :
+     * op().capturedValues().equals(new ArrayList<>(capturedValues().keySet()));
+     * }
      *
      * @return the captured values, as an unmodifiable map.
      */

--- a/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
@@ -56,8 +56,6 @@ public final class Quoted {
      * {@snippet lang=java :
      * op.capturedValues().equals(new ArrayList<>(capturedValues.keySet()));
      * }
-     * The captured values key set is not required to preserve the encounter
-     * order of the operation's captured values.
      *
      * @param op             the operation.
      * @param capturedValues the captured values referred to by the operation

--- a/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
@@ -39,7 +39,7 @@ public final class Quoted {
     private final Map<Value, Object> capturedValues;
 
     /**
-     * Constructs the quoted form of a given invokable operation.
+     * Constructs the quoted form of a given operation.
      *
      * @param op the invokable operation.
      */
@@ -48,20 +48,31 @@ public final class Quoted {
     }
 
     /**
-     * Constructs the quoted form of a given invokable operation.
+     * Constructs the quoted form of a given operation.
+     * <p>
+     * The captured values key set should contain all the operation's captured values,
+     * specifically the following expression should evaluate to true:
+     * {@snippet lang=java :
+     * capturedValues.keySet().containsAll(op.capturedValues());
+     * }
+     * The captured values key set is not required to preserve the encounter
+     * order of the operation's captured values.
      *
-     * @param op             the invokable operation.
-     * @param capturedValues the capture values referred to by the operation
+     * @param op             the operation.
+     * @param capturedValues the captured values referred to by the operation
+     * @see Op#capturedValues()
      */
     public Quoted(Op op, Map<Value, Object> capturedValues) {
+        // @@@ This check is potentially expensive, remove or keep as assert?
+        assert capturedValues.keySet().containsAll(op.capturedValues());
         this.op = op;
         this.capturedValues = Map.copyOf(capturedValues);
     }
 
     /**
-     * Returns the invokable operation.
+     * Returns the operation.
      *
-     * @return the invokable operation.
+     * @return the operation.
      */
     public Op op() {
         return op;
@@ -74,9 +85,5 @@ public final class Quoted {
      */
     public Map<Value, Object> capturedValues() {
         return capturedValues;
-    }
-
-    public static Quoted quote(Op t) {
-        return new Quoted(t);
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
@@ -84,7 +84,7 @@ public final class Quoted {
      * Returns the captured values.
      * <p>
      * The captured values key set has the same elements and same encounter order as
-     * operation's captured values, specifically the following expression should evaluate to true:
+     * operation's captured values, specifically the following expression evaluates to true:
      * {@snippet lang=java :
      * op().capturedValues().equals(new ArrayList<>(capturedValues().keySet()));
      * }

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
@@ -436,11 +436,11 @@ public final class Interpreter {
             }
         } else if (o instanceof CoreOps.QuotedOp qo) {
             Map<Value, Object> capturedValues = qo.capturedValues().stream()
-                    .collect(toMap(v -> v, oc::getValue));
+                    .collect(toMap(v -> v, oc::getValue, (v, _) -> v, LinkedHashMap::new));
             return new Quoted(qo.quotedOp(), capturedValues);
         } else if (o instanceof CoreOps.LambdaOp lo) {
             Map<Value, Object> capturedValues = lo.capturedValues().stream()
-                    .collect(toMap(v -> v, oc::getValue));
+                    .collect(toMap(v -> v, oc::getValue, (v, _) -> v, LinkedHashMap::new));
             Class<?> fi = resolveToClass(l, lo.functionalInterface());
 
             MethodHandle fProxy = INVOKE_LAMBDA_MH.bindTo(l).bindTo(lo).bindTo(capturedValues)
@@ -450,7 +450,7 @@ public final class Interpreter {
             // If a quotable lambda proxy again to implement Quotable
             if (Quotable.class.isAssignableFrom(fi)) {
                 return Proxy.newProxyInstance(l.lookupClass().getClassLoader(), new Class<?>[]{fi},
-                        (proxy, method, args) -> {
+                        (_, method, args) -> {
                             if (method.getDeclaringClass() == Quotable.class) {
                                 // Implement Quotable::quoted
                                 return new Quoted(lo, capturedValues);

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -391,31 +391,15 @@ public final class CoreOps {
         }
 
         // Returns the set of values used in but declared outside the lambda's body
+
+        /**
+         * Computes the values captured by this quoted operation's body.
+         * 
+         * @return the captured values.
+         * @see Body#capturedValues()
+         */
         public List<Value> capturedValues() {
-            Set<Value> cvs = new LinkedHashSet<>();
-
-            capturedValues(cvs, new ArrayDeque<>(), quotedBody);
-            return new ArrayList<>(cvs);
-        }
-
-        void capturedValues(Set<Value> capturedValues, Deque<Body> bodyStack, Body body) {
-            bodyStack.push(body);
-
-            for (Block b : body.blocks()) {
-                for (Op op : b.ops()) {
-                    for (Body childBody : op.bodies()) {
-                        capturedValues(capturedValues, bodyStack, childBody);
-                    }
-
-                    for (Value a : op.operands()) {
-                        if (!bodyStack.contains(a.declaringBlock().parentBody())) {
-                            capturedValues.add(a);
-                        }
-                    }
-                }
-            }
-
-            bodyStack.pop();
+            return quotedBody.capturedValues();
         }
 
         @Override
@@ -507,34 +491,15 @@ public final class CoreOps {
             return body;
         }
 
-        // Returns the set of values used in but declared outside the lambda's body
+        /**
+         * Computes the values captured by this lambda operation's body.
+         *
+         * @return the captured values.
+         * @see Body#capturedValues()
+         */
         @Override
         public List<Value> capturedValues() {
-            Set<Value> cvs = new LinkedHashSet<>();
-            Body body = body();
-
-            capturedValues(cvs, new ArrayDeque<>(), body);
-            return new ArrayList<>(cvs);
-        }
-
-        void capturedValues(Set<Value> capturedValues, Deque<Body> bodyStack, Body body) {
-            bodyStack.push(body);
-
-            for (Block b : body.blocks()) {
-                for (Op op : b.ops()) {
-                    for (Body childBody : op.bodies()) {
-                        capturedValues(capturedValues, bodyStack, childBody);
-                    }
-
-                    for (Value a : op.operands()) {
-                        if (!bodyStack.contains(a.declaringBlock().parentBody())) {
-                            capturedValues.add(a);
-                        }
-                    }
-                }
-            }
-
-            bodyStack.pop();
+            return body.capturedValues();
         }
 
         @Override
@@ -623,34 +588,15 @@ public final class CoreOps {
             return body;
         }
 
-        // Returns the set of values used in but declared outside the lambda's body
+        /**
+         * Computes the values captured by this closure operation's body.
+         *
+         * @return the captured values.
+         * @see Body#capturedValues()
+         */
         @Override
         public List<Value> capturedValues() {
-            Set<Value> cvs = new LinkedHashSet<>();
-            Body body = body();
-
-            capturedValues(cvs, new ArrayDeque<>(), body);
-            return new ArrayList<>(cvs);
-        }
-
-        void capturedValues(Set<Value> capturedValues, Deque<Body> bodyStack, Body body) {
-            bodyStack.push(body);
-
-            for (Block b : body.blocks()) {
-                for (Op op : b.ops()) {
-                    for (Body childBody : op.bodies()) {
-                        capturedValues(capturedValues, bodyStack, childBody);
-                    }
-
-                    for (Value a : op.operands()) {
-                        if (!bodyStack.contains(a.declaringBlock().parentBody())) {
-                            capturedValues.add(a);
-                        }
-                    }
-                }
-            }
-
-            bodyStack.pop();
+            return body.capturedValues();
         }
 
         @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -390,14 +390,7 @@ public final class CoreOps {
             return quotedOp;
         }
 
-        // Returns the set of values used in but declared outside the lambda's body
-
-        /**
-         * Computes the values captured by this quoted operation's body.
-         *
-         * @return the captured values.
-         * @see Body#capturedValues()
-         */
+        @Override
         public List<Value> capturedValues() {
             return quotedBody.capturedValues();
         }
@@ -491,12 +484,6 @@ public final class CoreOps {
             return body;
         }
 
-        /**
-         * Computes the values captured by this lambda operation's body.
-         *
-         * @return the captured values.
-         * @see Body#capturedValues()
-         */
         @Override
         public List<Value> capturedValues() {
             return body.capturedValues();
@@ -588,12 +575,6 @@ public final class CoreOps {
             return body;
         }
 
-        /**
-         * Computes the values captured by this closure operation's body.
-         *
-         * @return the captured values.
-         * @see Body#capturedValues()
-         */
         @Override
         public List<Value> capturedValues() {
             return body.capturedValues();

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -394,7 +394,7 @@ public final class CoreOps {
 
         /**
          * Computes the values captured by this quoted operation's body.
-         * 
+         *
          * @return the captured values.
          * @see Body#capturedValues()
          */


### PR DESCRIPTION
Strengthen the specification of quoted captured values in relation to the operations captured values.

Consolidate duplicated code that computes captured values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/babylon.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/57.diff">https://git.openjdk.org/babylon/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/57#issuecomment-2067345099)