### PR TITLE
Determine if lambda operation originates from a method reference

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -26,7 +26,6 @@
 package java.lang.reflect.code.op;
 
 import java.lang.constant.ClassDesc;
-import java.lang.reflect.Method;
 import java.lang.reflect.code.*;
 import java.lang.reflect.code.type.FieldRef;
 import java.lang.reflect.code.type.MethodRef;
@@ -533,14 +532,10 @@ public final class CoreOps {
          * contains only nodes with single edges terminating in V1, and the graph of what depends on V1
          * is bidirectionally equal to the graph of what V2 depends on.
          *
-         *
-         * and the graph of what
-         * depends on V1 are equal
-         *
          * @return the invocation operation to the method referenced by the lambda
-         * expression operation, otherwise empty.
+         * operation, otherwise empty.
          */
-        public Optional<InvokeOp> isMethodReference() {
+        public Optional<InvokeOp> methodReference() {
             // Single block
             if (body().blocks().size() > 1) {
                 return Optional.empty();

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -524,7 +524,7 @@ public final class CoreOps {
          *     <li>if the return operation returns a non-void result then that result is,
          *     or uniquely depends on, the result of the referencing invoke operation.
          *     <li>If the lambda operation captures one value then the first operand corresponds
-         *     to captured value, and subsequent operands of the referencing invocation
+         *     to captured the value, and subsequent operands of the referencing invocation
          *     operation are, or uniquely depend on, the lambda operation's parameters, in order.
          *     Otherwise, the first and subsequent operands of the referencing invocation
          *     operation are, or uniquely depend on, the lambda operation's parameters, in order.

--- a/test/jdk/java/lang/reflect/code/TestLambdaOps.java
+++ b/test/jdk/java/lang/reflect/code/TestLambdaOps.java
@@ -237,7 +237,7 @@ public class TestLambdaOps {
     public void testIsMethodReference(Quotable q) {
         Quoted quoted = q.quoted();
         CoreOps.LambdaOp lop = (CoreOps.LambdaOp) quoted.op();
-        Assert.assertTrue(lop.isMethodReference().isPresent());
+        Assert.assertTrue(lop.methodReference().isPresent());
     }
 
     static int m1(int i) {

--- a/test/jdk/java/lang/reflect/code/TestLambdaOps.java
+++ b/test/jdk/java/lang/reflect/code/TestLambdaOps.java
@@ -27,6 +27,7 @@
  */
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.code.*;
@@ -38,9 +39,9 @@ import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.IntSupplier;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.Stream;
@@ -212,6 +213,49 @@ public class TestLambdaOps {
             Assert.assertEquals(r, 0);
         }
     }
+
+
+    interface QuotableIntUnaryOperator extends IntUnaryOperator, Quotable {}
+
+    interface QuotableFunction<T, R> extends Function<T, R>, Quotable {}
+
+    interface QuotableBiFunction<T, U, R> extends BiFunction<T, U, R>, Quotable {}
+
+    @DataProvider
+    Iterator<Quotable> methodRefLambdas() {
+        return List.of(
+                (QuotableIntUnaryOperator) TestLambdaOps::m1,
+                (QuotableIntUnaryOperator) TestLambdaOps::m2,
+                (QuotableFunction<Integer, Integer>) TestLambdaOps::m1,
+                (QuotableFunction<Integer, Integer>) TestLambdaOps::m2,
+                (QuotableIntUnaryOperator) this::m3,
+                (QuotableBiFunction<TestLambdaOps, Integer, Integer>) TestLambdaOps::m4
+        ).iterator();
+    }
+
+    @Test(dataProvider = "methodRefLambdas")
+    public void testIsMethodReference(Quotable q) {
+        Quoted quoted = q.quoted();
+        CoreOps.LambdaOp lop = (CoreOps.LambdaOp) quoted.op();
+        Assert.assertTrue(lop.isMethodReference().isPresent());
+    }
+
+    static int m1(int i) {
+        return i;
+    }
+
+    static Integer m2(Integer i) {
+        return i;
+    }
+
+    int m3(int i) {
+        return i;
+    }
+
+    static int m4(TestLambdaOps tl, int i) {
+        return i;
+    }
+
 
     static CoreOps.FuncOp getFuncOp(String name) {
         Optional<Method> om = Stream.of(TestLambdaOps.class.getDeclaredMethods())


### PR DESCRIPTION
Add a method to determines if a lambda operation could have originated from a method reference declared in Java source code.

Consider later generalizing to a lambda operation that may have originated from a lambda expression that only invokes another method, which may include the capturing of some or all method arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [b80889c7](https://git.openjdk.org/babylon/pull/60/files/b80889c74f847858f7ccb53dc687c1278fb2fdf2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/babylon.git pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/60.diff">https://git.openjdk.org/babylon/pull/60.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/60#issuecomment-2070936245)