### PR TITLE
Externalizable operations

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -362,22 +362,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * The attribute value that represents null.
-     */
-    public static final Object NULL_ATTRIBUTE_VALUE = new Object();
-
-    /**
-     * Returns the operation's attributes.
-     *
-     * <p>A null attribute value is represented by the constant value {@link #NULL_ATTRIBUTE_VALUE}.
-     *
-     * @return the operation's attributes, as an unmodifiable map
-     */
-    public Map<String, Object> attributes() {
-        return Map.of();
-    }
-
-    /**
      * {@return the operation's result type}
      */
     public abstract TypeElement resultType();

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
@@ -246,8 +246,8 @@ public final class BytecodeLift {
                         case IFLE -> CoreOps.gt(operand, op(CoreOps.constant(JavaType.INT, 0)));
                         case IFGT -> CoreOps.le(operand, op(CoreOps.constant(JavaType.INT, 0)));
                         case IFLT -> CoreOps.ge(operand, op(CoreOps.constant(JavaType.INT, 0)));
-                        case IFNULL -> CoreOps.neq(operand, op(CoreOps.constant(JavaType.J_L_OBJECT, Op.NULL_ATTRIBUTE_VALUE)));
-                        case IFNONNULL -> CoreOps.eq(operand, op(CoreOps.constant(JavaType.J_L_OBJECT, Op.NULL_ATTRIBUTE_VALUE)));
+                        case IFNULL -> CoreOps.neq(operand, op(CoreOps.constant(JavaType.J_L_OBJECT, null)));
+                        case IFNONNULL -> CoreOps.eq(operand, op(CoreOps.constant(JavaType.J_L_OBJECT, null)));
                         case IF_ICMPNE -> CoreOps.eq(stack.pop(), operand);
                         case IF_ICMPEQ -> CoreOps.neq(stack.pop(), operand);
                         case IF_ICMPGE -> CoreOps.lt(stack.pop(), operand);

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -55,7 +55,7 @@ public final class CoreOps {
      * The function operation, that can model a Java method.
      */
     @OpDeclaration(FuncOp.NAME)
-    public static final class FuncOp extends OpWithDefinition implements Op.Invokable, Op.Isolated, Op.Lowerable {
+    public static final class FuncOp extends ExternalizableOp implements Op.Invokable, Op.Isolated, Op.Lowerable {
 
         public static class Builder {
             final Body.Builder ancestorBody;
@@ -81,7 +81,7 @@ public final class CoreOps {
         final String funcName;
         final Body body;
 
-        public static FuncOp create(OpDefinition def) {
+        public static FuncOp create(ExternalOpContents def) {
             if (!def.operands().isEmpty()) {
                 throw new IllegalStateException("Bad op " + def.name());
             }
@@ -94,7 +94,7 @@ public final class CoreOps {
             return new FuncOp(def, funcName);
         }
 
-        FuncOp(OpDefinition def, String funcName) {
+        FuncOp(ExternalOpContents def, String funcName) {
             super(def);
 
             this.funcName = funcName;
@@ -179,14 +179,14 @@ public final class CoreOps {
      */
     // @@@ stack effects equivalent to the call operation as if the function were a Java method?
     @OpDeclaration(FuncCallOp.NAME)
-    public static final class FuncCallOp extends OpWithDefinition {
+    public static final class FuncCallOp extends ExternalizableOp {
         public static final String NAME = "func.call";
         public static final String ATTRIBUTE_FUNC_NAME = NAME + ".name";
 
         final String funcName;
         final TypeElement resultType;
 
-        public static FuncCallOp create(OpDefinition def) {
+        public static FuncCallOp create(ExternalOpContents def) {
             String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
@@ -196,7 +196,7 @@ public final class CoreOps {
             return new FuncCallOp(def, funcName);
         }
 
-        FuncCallOp(OpDefinition def, String funcName) {
+        FuncCallOp(ExternalOpContents def, String funcName) {
             super(def);
 
             this.funcName = funcName;
@@ -244,14 +244,14 @@ public final class CoreOps {
      * and creating a symbol table of function name to function
      */
     @OpDeclaration(ModuleOp.NAME)
-    public static final class ModuleOp extends OpWithDefinition implements Op.Isolated {
+    public static final class ModuleOp extends ExternalizableOp implements Op.Isolated {
 
         public static final String NAME = "module";
 
         final Map<String, FuncOp> table;
         final Body body;
 
-        public static ModuleOp create(OpDefinition def) {
+        public static ModuleOp create(ExternalOpContents def) {
             if (!def.operands().isEmpty()) {
                 throw new IllegalStateException("Bad op " + def.name());
             }
@@ -259,7 +259,7 @@ public final class CoreOps {
             return new ModuleOp(def);
         }
 
-        ModuleOp(OpDefinition def) {
+        ModuleOp(ExternalOpContents def) {
             super(def);
 
             this.body = def.bodyDefinitions().get(0).build(this);
@@ -328,7 +328,7 @@ public final class CoreOps {
      * The quoted operation, that models the quoting of an operation.
      */
     @OpDeclaration(QuotedOp.NAME)
-    public static final class QuotedOp extends OpWithDefinition implements Op.Nested, Op.Lowerable, Op.Pure {
+    public static final class QuotedOp extends ExternalizableOp implements Op.Nested, Op.Lowerable, Op.Pure {
         public static final String NAME = "quoted";
 
         // Type name must be the same in the java.base and jdk.compiler module
@@ -340,7 +340,7 @@ public final class CoreOps {
 
         final Op quotedOp;
 
-        public QuotedOp(OpDefinition def) {
+        public QuotedOp(ExternalOpContents def) {
             super(def);
 
             this.quotedBody = def.bodyDefinitions().get(0).build(this);
@@ -414,7 +414,7 @@ public final class CoreOps {
      * The lambda operation, that can model a Java lambda expression.
      */
     @OpDeclaration(LambdaOp.NAME)
-    public static final class LambdaOp extends OpWithDefinition implements Op.Invokable, Op.Lowerable {
+    public static final class LambdaOp extends ExternalizableOp implements Op.Invokable, Op.Lowerable {
 
         public static class Builder {
             final Body.Builder ancestorBody;
@@ -439,7 +439,7 @@ public final class CoreOps {
         final TypeElement functionalInterface;
         final Body body;
 
-        public LambdaOp(OpDefinition def) {
+        public LambdaOp(ExternalOpContents def) {
             super(def);
 
             this.functionalInterface = def.resultType();
@@ -648,7 +648,7 @@ public final class CoreOps {
      * that has no target type (a functional interface).
      */
     @OpDeclaration(ClosureOp.NAME)
-    public static final class ClosureOp extends OpWithDefinition implements Op.Invokable, Op.Lowerable {
+    public static final class ClosureOp extends ExternalizableOp implements Op.Invokable, Op.Lowerable {
 
         public static class Builder {
             final Body.Builder ancestorBody;
@@ -670,7 +670,7 @@ public final class CoreOps {
 
         final Body body;
 
-        public ClosureOp(OpDefinition def) {
+        public ClosureOp(ExternalOpContents def) {
             super(def);
 
             this.body = def.bodyDefinitions().get(0).build(this);
@@ -740,10 +740,10 @@ public final class CoreOps {
 //  @@@ stack effects equivalent to the invocation of an SAM of on an instance of an anonymous functional interface
 //  that is the target of the closures lambda expression.
     @OpDeclaration(ClosureCallOp.NAME)
-    public static final class ClosureCallOp extends OpWithDefinition {
+    public static final class ClosureCallOp extends ExternalizableOp {
         public static final String NAME = "closure.call";
 
-        public ClosureCallOp(OpDefinition def) {
+        public ClosureCallOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -773,10 +773,10 @@ public final class CoreOps {
      * This operation exits an isolated body.
      */
     @OpDeclaration(ReturnOp.NAME)
-    public static final class ReturnOp extends OpWithDefinition implements Op.BodyTerminating {
+    public static final class ReturnOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "return";
 
-        public ReturnOp(OpDefinition def) {
+        public ReturnOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() > 1) {
@@ -820,10 +820,10 @@ public final class CoreOps {
      * The terminating throw operation, that can model the Java language throw statement.
      */
     @OpDeclaration(ThrowOp.NAME)
-    public static final class ThrowOp extends OpWithDefinition implements Op.BodyTerminating {
+    public static final class ThrowOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "throw";
 
-        public ThrowOp(OpDefinition def) {
+        public ThrowOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -858,11 +858,11 @@ public final class CoreOps {
      * The assertion operation. Supporting assertions in statement form.
      */
     @OpDeclaration(AssertOp.NAME)
-    public static final class AssertOp extends OpWithDefinition implements Op.Nested {
+    public static final class AssertOp extends ExternalizableOp implements Op.Nested {
         public static final String NAME = "assert";
         public final List<Body> bodies;
 
-        public AssertOp(OpDefinition def) {
+        public AssertOp(ExternalOpContents def) {
             super(def);
             var bodies = def.bodyDefinitions().stream().map(b -> b.build(this)).toList();
             checkBodies(bodies);
@@ -909,10 +909,10 @@ public final class CoreOps {
      * This operation models termination that is unreachable.
      */
     @OpDeclaration(UnreachableOp.NAME)
-    public static class UnreachableOp extends OpWithDefinition implements Op.BodyTerminating {
+    public static class UnreachableOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "unreachable";
 
-        public UnreachableOp(OpDefinition def) {
+        public UnreachableOp(ExternalOpContents def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -946,10 +946,10 @@ public final class CoreOps {
      * or void)
      */
     @OpDeclaration(YieldOp.NAME)
-    public static class YieldOp extends OpWithDefinition implements Op.BodyTerminating {
+    public static class YieldOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "yield";
 
-        public YieldOp(OpDefinition def) {
+        public YieldOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() > 1) {
@@ -995,12 +995,12 @@ public final class CoreOps {
      * This operation accepts a successor to the next block to branch to.
      */
     @OpDeclaration(BranchOp.NAME)
-    public static class BranchOp extends OpWithDefinition implements Op.BlockTerminating {
+    public static class BranchOp extends ExternalizableOp implements Op.BlockTerminating {
         public static final String NAME = "branch";
 
         final Block.Reference b;
 
-        public BranchOp(OpDefinition def) {
+        public BranchOp(ExternalOpContents def) {
             super(def);
 
             if (!def.operands().isEmpty() || def.successors().size() != 1) {
@@ -1050,13 +1050,13 @@ public final class CoreOps {
      * The selected successor refers to the next block to branch to.
      */
     @OpDeclaration(ConditionalBranchOp.NAME)
-    public static class ConditionalBranchOp extends OpWithDefinition implements Op.BlockTerminating {
+    public static class ConditionalBranchOp extends ExternalizableOp implements Op.BlockTerminating {
         public static final String NAME = "cbranch";
 
         final Block.Reference t;
         final Block.Reference f;
 
-        public ConditionalBranchOp(OpDefinition def) {
+        public ConditionalBranchOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 1 || def.successors().size() != 2) {
@@ -1113,7 +1113,7 @@ public final class CoreOps {
      * The constant operation, that can model Java language literal and constant expressions.
      */
     @OpDeclaration(ConstantOp.NAME)
-    public static class ConstantOp extends OpWithDefinition implements Op.Pure {
+    public static class ConstantOp extends ExternalizableOp implements Op.Pure {
         public static final String NAME = "constant";
 
         public static final String ATTRIBUTE_CONSTANT_VALUE = NAME + ".value";
@@ -1121,7 +1121,7 @@ public final class CoreOps {
         final Object value;
         final TypeElement type;
 
-        public static ConstantOp create(OpDefinition def) {
+        public static ConstantOp create(ExternalOpContents def) {
             if (!def.operands().isEmpty()) {
                 throw new IllegalArgumentException("Operation must have zero operands");
             }
@@ -1192,7 +1192,7 @@ public final class CoreOps {
             throw new UnsupportedOperationException("Unsupported constant type and value: " + t + " " + value);
         }
 
-        ConstantOp(OpDefinition def, Object value) {
+        ConstantOp(ExternalOpContents def, Object value) {
             super(def);
 
             this.type = def.resultType();
@@ -1248,14 +1248,14 @@ public final class CoreOps {
      * The invoke operation, that can model Java language method invocation expressions.
      */
     @OpDeclaration(InvokeOp.NAME)
-    public static final class InvokeOp extends OpWithDefinition implements ReflectiveOp {
+    public static final class InvokeOp extends ExternalizableOp implements ReflectiveOp {
         public static final String NAME = "invoke";
         public static final String ATTRIBUTE_INVOKE_DESCRIPTOR = NAME + ".descriptor";
 
         final MethodRef invokeDescriptor;
         final TypeElement resultType;
 
-        public static InvokeOp create(OpDefinition def) {
+        public static InvokeOp create(ExternalOpContents def) {
             MethodRef invokeDescriptor = def.extractAttributeValue(ATTRIBUTE_INVOKE_DESCRIPTOR,
                     true, v -> switch (v) {
                         case String s -> MethodRef.ofString(s);
@@ -1266,7 +1266,7 @@ public final class CoreOps {
             return new InvokeOp(def, invokeDescriptor);
         }
 
-        InvokeOp(OpDefinition def, MethodRef invokeDescriptor) {
+        InvokeOp(ExternalOpContents def, MethodRef invokeDescriptor) {
             super(def);
 
             this.invokeDescriptor = invokeDescriptor;
@@ -1322,12 +1322,12 @@ public final class CoreOps {
      * conversions such as widening and narrowing.
      */
     @OpDeclaration(ConvOp.NAME)
-    public static final class ConvOp extends OpWithDefinition implements Op.Pure {
+    public static final class ConvOp extends ExternalizableOp implements Op.Pure {
         public static final String NAME = "conv";
 
         final TypeElement resultType;
 
-        public ConvOp(OpDefinition def) {
+        public ConvOp(ExternalOpContents def) {
             super(def);
 
             this.resultType = def.resultType();
@@ -1360,14 +1360,14 @@ public final class CoreOps {
      * The new operation, that can models Java language instance creation expressions.
      */
     @OpDeclaration(NewOp.NAME)
-    public static final class NewOp extends OpWithDefinition implements ReflectiveOp {
+    public static final class NewOp extends ExternalizableOp implements ReflectiveOp {
         public static final String NAME = "new";
         public static final String ATTRIBUTE_NEW_DESCRIPTOR = NAME + ".descriptor";
 
         final FunctionType constructorType;
         final TypeElement resultType;
 
-        public static NewOp create(OpDefinition def) {
+        public static NewOp create(ExternalOpContents def) {
             FunctionType constructorType = def.extractAttributeValue(ATTRIBUTE_NEW_DESCRIPTOR, true,
                     v -> switch (v) {
                         case String s -> {
@@ -1384,7 +1384,7 @@ public final class CoreOps {
             return new NewOp(def, constructorType);
         }
 
-        NewOp(OpDefinition def, FunctionType constructorType) {
+        NewOp(ExternalOpContents def, FunctionType constructorType) {
             super(def);
 
             this.constructorType = constructorType;
@@ -1444,12 +1444,12 @@ public final class CoreOps {
     /**
      * A field access operation, that can model Java langauge field access expressions.
      */
-    public abstract static sealed class FieldAccessOp extends OpWithDefinition implements AccessOp, ReflectiveOp {
+    public abstract static sealed class FieldAccessOp extends ExternalizableOp implements AccessOp, ReflectiveOp {
         public static final String ATTRIBUTE_FIELD_DESCRIPTOR = "field.descriptor";
 
         final FieldRef fieldDescriptor;
 
-        FieldAccessOp(OpDefinition def, FieldRef fieldDescriptor) {
+        FieldAccessOp(ExternalOpContents def, FieldRef fieldDescriptor) {
             super(def);
 
             this.fieldDescriptor = fieldDescriptor;
@@ -1489,7 +1489,7 @@ public final class CoreOps {
 
             final TypeElement resultType;
 
-            public static FieldLoadOp create(OpDefinition def) {
+            public static FieldLoadOp create(ExternalOpContents def) {
                 if (def.operands().size() > 1) {
                     throw new IllegalArgumentException("Operation must accept zero or one operand");
                 }
@@ -1504,7 +1504,7 @@ public final class CoreOps {
                 return new FieldLoadOp(def, fieldDescriptor);
             }
 
-            FieldLoadOp(OpDefinition opdef, FieldRef fieldDescriptor) {
+            FieldLoadOp(ExternalOpContents opdef, FieldRef fieldDescriptor) {
                 super(opdef, fieldDescriptor);
 
                 resultType = opdef.resultType();
@@ -1549,7 +1549,7 @@ public final class CoreOps {
         public static final class FieldStoreOp extends FieldAccessOp {
             public static final String NAME = "field.store";
 
-            public static FieldStoreOp create(OpDefinition def) {
+            public static FieldStoreOp create(ExternalOpContents def) {
                 if (def.operands().size() > 2) {
                     throw new IllegalArgumentException("Operation must accept one or two operands");
                 }
@@ -1564,7 +1564,7 @@ public final class CoreOps {
                 return new FieldStoreOp(def, fieldDescriptor);
             }
 
-            FieldStoreOp(OpDefinition opdef, FieldRef fieldDescriptor) {
+            FieldStoreOp(ExternalOpContents opdef, FieldRef fieldDescriptor) {
                 super(opdef, fieldDescriptor);
             }
 
@@ -1601,10 +1601,10 @@ public final class CoreOps {
      * array.
      */
     @OpDeclaration(ArrayLengthOp.NAME)
-    public static final class ArrayLengthOp extends OpWithDefinition implements ReflectiveOp {
+    public static final class ArrayLengthOp extends ExternalizableOp implements ReflectiveOp {
         public static final String NAME = "array.length";
 
-        public ArrayLengthOp(OpDefinition def) {
+        public ArrayLengthOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -1630,8 +1630,8 @@ public final class CoreOps {
     /**
      * The array access operation, that can model Java language array access expressions.
      */
-    public abstract static sealed class ArrayAccessOp extends OpWithDefinition implements AccessOp, ReflectiveOp {
-        ArrayAccessOp(OpDefinition def) {
+    public abstract static sealed class ArrayAccessOp extends ExternalizableOp implements AccessOp, ReflectiveOp {
+        ArrayAccessOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 2 && def.operands().size() != 3) {
@@ -1683,7 +1683,7 @@ public final class CoreOps {
         public static final class ArrayLoadOp extends ArrayAccessOp implements Op.Pure {
             public static final String NAME = "array.load";
 
-            public ArrayLoadOp(OpDefinition def) {
+            public ArrayLoadOp(ExternalOpContents def) {
                 super(def);
             }
 
@@ -1716,7 +1716,7 @@ public final class CoreOps {
         public static final class ArrayStoreOp extends ArrayAccessOp {
             public static final String NAME = "array.store";
 
-            public ArrayStoreOp(OpDefinition def) {
+            public ArrayStoreOp(ExternalOpContents def) {
                 super(def);
             }
 
@@ -1745,13 +1745,13 @@ public final class CoreOps {
      * type comparison operator.
      */
     @OpDeclaration(InstanceOfOp.NAME)
-    public static final class InstanceOfOp extends OpWithDefinition implements Op.Pure, ReflectiveOp {
+    public static final class InstanceOfOp extends ExternalizableOp implements Op.Pure, ReflectiveOp {
         public static final String NAME = "instanceof";
         public static final String ATTRIBUTE_TYPE_DESCRIPTOR = NAME + ".descriptor";
 
         final TypeElement typeDescriptor;
 
-        public static InstanceOfOp create(OpDefinition def) {
+        public static InstanceOfOp create(ExternalOpContents def) {
             if (def.operands().size() != 1) {
                 throw new IllegalArgumentException("Operation must have one operand " + def.name());
             }
@@ -1765,7 +1765,7 @@ public final class CoreOps {
             return new InstanceOfOp(def, typeDescriptor);
         }
 
-        InstanceOfOp(OpDefinition def, TypeElement typeDescriptor) {
+        InstanceOfOp(ExternalOpContents def, TypeElement typeDescriptor) {
             super(def);
 
             this.typeDescriptor = typeDescriptor;
@@ -1810,14 +1810,14 @@ public final class CoreOps {
      * The cast operation, that can model Java language cast expressions.
      */
     @OpDeclaration(CastOp.NAME)
-    public static final class CastOp extends OpWithDefinition implements Op.Pure, ReflectiveOp {
+    public static final class CastOp extends ExternalizableOp implements Op.Pure, ReflectiveOp {
         public static final String NAME = "cast";
         public static final String ATTRIBUTE_TYPE_DESCRIPTOR = NAME + ".descriptor";
 
         final TypeElement resultType;
         final TypeElement typeDescriptor;
 
-        public static CastOp create(OpDefinition def) {
+        public static CastOp create(ExternalOpContents def) {
             if (def.operands().size() != 1) {
                 throw new IllegalArgumentException("Operation must have one operand " + def.name());
             }
@@ -1831,7 +1831,7 @@ public final class CoreOps {
             return new CastOp(def, type);
         }
 
-        CastOp(OpDefinition def, TypeElement typeDescriptor) {
+        CastOp(ExternalOpContents def, TypeElement typeDescriptor) {
             super(def);
 
             this.resultType = def.resultType();
@@ -1905,14 +1905,14 @@ public final class CoreOps {
      * lambda parameters.
      */
     @OpDeclaration(VarOp.NAME)
-    public static final class VarOp extends OpWithDefinition {
+    public static final class VarOp extends ExternalizableOp {
         public static final String NAME = "var";
         public static final String ATTRIBUTE_NAME = NAME + ".name";
 
         final String varName;
         final TypeElement resultType;
 
-        public static VarOp create(OpDefinition def) {
+        public static VarOp create(ExternalOpContents def) {
             if (def.operands().size() != 1) {
                 throw new IllegalStateException("Operation must have one operand");
             }
@@ -1925,7 +1925,7 @@ public final class CoreOps {
             return new VarOp(def, name);
         }
 
-        VarOp(OpDefinition def, String varName) {
+        VarOp(ExternalOpContents def, String varName) {
             super(def);
 
             this.varName = varName;
@@ -1984,8 +1984,8 @@ public final class CoreOps {
      * The var access operation, that can model access to Java language local variables, method parameters, or
      * lambda parameters.
      */
-    public abstract static sealed class VarAccessOp extends OpWithDefinition implements AccessOp {
-        VarAccessOp(OpDefinition opdef) {
+    public abstract static sealed class VarAccessOp extends ExternalizableOp implements AccessOp {
+        VarAccessOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2019,7 +2019,7 @@ public final class CoreOps {
         public static final class VarLoadOp extends VarAccessOp {
             public static final String NAME = "var.load";
 
-            public VarLoadOp(OpDefinition opdef) {
+            public VarLoadOp(ExternalOpContents opdef) {
                 super(opdef);
 
                 if (opdef.operands().size() != 1) {
@@ -2060,7 +2060,7 @@ public final class CoreOps {
         public static final class VarStoreOp extends VarAccessOp {
             public static final String NAME = "var.store";
 
-            public VarStoreOp(OpDefinition opdef) {
+            public VarStoreOp(ExternalOpContents opdef) {
                 super(opdef);
 
                 if (opdef.operands().size() != 2) {
@@ -2102,10 +2102,10 @@ public final class CoreOps {
      * The tuple operation. A tuple contain a fixed set of values accessible by their component index.
      */
     @OpDeclaration(TupleOp.NAME)
-    public static final class TupleOp extends OpWithDefinition {
+    public static final class TupleOp extends ExternalizableOp {
         public static final String NAME = "tuple";
 
-        public TupleOp(OpDefinition def) {
+        public TupleOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -2132,13 +2132,13 @@ public final class CoreOps {
      * The tuple component load operation, that access the component of a tuple at a given, constant, component index.
      */
     @OpDeclaration(TupleLoadOp.NAME)
-    public static final class TupleLoadOp extends OpWithDefinition {
+    public static final class TupleLoadOp extends ExternalizableOp {
         public static final String NAME = "tuple.load";
         public static final String ATTRIBUTE_INDEX = NAME + ".index";
 
         final int index;
 
-        public static TupleLoadOp create(OpDefinition def) {
+        public static TupleLoadOp create(ExternalOpContents def) {
             if (def.operands().size() != 1) {
                 throw new IllegalStateException("Operation must have one operand");
             }
@@ -2152,7 +2152,7 @@ public final class CoreOps {
             return new TupleLoadOp(def, index);
         }
 
-        TupleLoadOp(OpDefinition def, int index) {
+        TupleLoadOp(ExternalOpContents def, int index) {
             super(def);
 
             // @@@ Validate tuple type and index
@@ -2203,13 +2203,13 @@ public final class CoreOps {
      * The tuple component set operation, that access the component of a tuple at a given, constant, component index.
      */
     @OpDeclaration(TupleWithOp.NAME)
-    public static final class TupleWithOp extends OpWithDefinition {
+    public static final class TupleWithOp extends ExternalizableOp {
         public static final String NAME = "tuple.with";
         public static final String ATTRIBUTE_INDEX = NAME + ".index";
 
         final int index;
 
-        public static TupleWithOp create(OpDefinition def) {
+        public static TupleWithOp create(ExternalOpContents def) {
             if (def.operands().size() != 2) {
                 throw new IllegalStateException("Operation must have two operands");
             }
@@ -2223,7 +2223,7 @@ public final class CoreOps {
             return new TupleWithOp(def, index);
         }
 
-        TupleWithOp(OpDefinition def, int index) {
+        TupleWithOp(ExternalOpContents def, int index) {
             super(def);
 
             // @@@ Validate tuple type and index
@@ -2292,7 +2292,7 @@ public final class CoreOps {
      * The exception region start operation.
      */
     @OpDeclaration(ExceptionRegionEnter.NAME)
-    public static final class ExceptionRegionEnter extends OpWithDefinition implements Op.BlockTerminating {
+    public static final class ExceptionRegionEnter extends ExternalizableOp implements Op.BlockTerminating {
         public static final String NAME = "exception.region.enter";
 
         // First successor is the non-exceptional successor whose target indicates
@@ -2301,7 +2301,7 @@ public final class CoreOps {
         // each of which have one block argument whose type is an exception type.
         final List<Block.Reference> s;
 
-        public ExceptionRegionEnter(OpDefinition def) {
+        public ExceptionRegionEnter(ExternalOpContents def) {
             super(def);
 
             if (def.successors().size() < 2) {
@@ -2355,12 +2355,12 @@ public final class CoreOps {
      * The exception region end operation.
      */
     @OpDeclaration(ExceptionRegionExit.NAME)
-    public static final class ExceptionRegionExit extends OpWithDefinition implements Op.BlockTerminating {
+    public static final class ExceptionRegionExit extends ExternalizableOp implements Op.BlockTerminating {
         public static final String NAME = "exception.region.exit";
 
         final Block.Reference end;
 
-        public ExceptionRegionExit(OpDefinition def) {
+        public ExceptionRegionExit(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -2428,14 +2428,14 @@ public final class CoreOps {
      */
 
     @OpDeclaration(ConcatOp.NAME)
-    public static final class ConcatOp extends OpWithDefinition implements Op.Pure {
+    public static final class ConcatOp extends ExternalizableOp implements Op.Pure {
         public static final String NAME = "concat";
 
         public ConcatOp(ConcatOp that, CopyContext cc) {
             super(that, cc);
         }
 
-        public ConcatOp(OpDefinition def) {
+        public ConcatOp(ExternalOpContents def) {
             super(def);
             if (def.operands().size() != 2) {
                 throw new IllegalArgumentException("Concatenation Operation must have two operands.");
@@ -2463,8 +2463,8 @@ public final class CoreOps {
     /**
      * The arithmetic operation.
      */
-    public static abstract class ArithmeticOperation extends OpWithDefinition implements Op.Pure {
-        protected ArithmeticOperation(OpDefinition def) {
+    public static abstract class ArithmeticOperation extends ExternalizableOp implements Op.Pure {
+        protected ArithmeticOperation(ExternalOpContents def) {
             super(def);
 
             if (def.operands().isEmpty()) {
@@ -2484,8 +2484,8 @@ public final class CoreOps {
     /**
      * The test operation.
      */
-    public static abstract class TestOperation extends OpWithDefinition implements Op.Pure {
-        protected TestOperation(OpDefinition def) {
+    public static abstract class TestOperation extends ExternalizableOp implements Op.Pure {
+        protected TestOperation(ExternalOpContents def) {
             super(def);
 
             if (def.operands().isEmpty()) {
@@ -2506,7 +2506,7 @@ public final class CoreOps {
      * The binary arithmetic operation.
      */
     public static abstract class BinaryOp extends ArithmeticOperation {
-        protected BinaryOp(OpDefinition def) {
+        protected BinaryOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 2) {
@@ -2532,7 +2532,7 @@ public final class CoreOps {
      * The unary arithmetic operation.
      */
     public static abstract class UnaryOp extends ArithmeticOperation {
-        protected UnaryOp(OpDefinition def) {
+        protected UnaryOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -2558,7 +2558,7 @@ public final class CoreOps {
      * The unary test operation.
      */
     public static abstract class UnaryTestOp extends TestOperation {
-        protected UnaryTestOp(OpDefinition def) {
+        protected UnaryTestOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -2579,7 +2579,7 @@ public final class CoreOps {
      * The binary test operation.
      */
     public static abstract class BinaryTestOp extends TestOperation {
-        protected BinaryTestOp(OpDefinition def) {
+        protected BinaryTestOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 2) {
@@ -2608,7 +2608,7 @@ public final class CoreOps {
     public static final class AddOp extends BinaryOp {
         public static final String NAME = "add";
 
-        public AddOp(OpDefinition def) {
+        public AddOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -2633,7 +2633,7 @@ public final class CoreOps {
     public static final class SubOp extends BinaryOp {
         public static final String NAME = "sub";
 
-        public SubOp(OpDefinition opdef) {
+        public SubOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2658,7 +2658,7 @@ public final class CoreOps {
     public static final class MulOp extends BinaryOp {
         public static final String NAME = "mul";
 
-        public MulOp(OpDefinition opdef) {
+        public MulOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2683,7 +2683,7 @@ public final class CoreOps {
     public static final class DivOp extends BinaryOp {
         public static final String NAME = "div";
 
-        public DivOp(OpDefinition opdef) {
+        public DivOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2708,7 +2708,7 @@ public final class CoreOps {
     public static final class ModOp extends BinaryOp {
         public static final String NAME = "mod";
 
-        public ModOp(OpDefinition opdef) {
+        public ModOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2734,7 +2734,7 @@ public final class CoreOps {
     public static final class OrOp extends BinaryOp {
         public static final String NAME = "or";
 
-        public OrOp(OpDefinition opdef) {
+        public OrOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2760,7 +2760,7 @@ public final class CoreOps {
     public static final class AndOp extends BinaryOp {
         public static final String NAME = "and";
 
-        public AndOp(OpDefinition opdef) {
+        public AndOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2786,7 +2786,7 @@ public final class CoreOps {
     public static final class XorOp extends BinaryOp {
         public static final String NAME = "xor";
 
-        public XorOp(OpDefinition opdef) {
+        public XorOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2811,7 +2811,7 @@ public final class CoreOps {
     public static final class LshlOp extends BinaryOp {
         public static final String NAME = "lshl";
 
-        public LshlOp(OpDefinition opdef) {
+        public LshlOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2836,7 +2836,7 @@ public final class CoreOps {
     public static final class AshrOp extends CoreOps.BinaryOp {
         public static final String NAME = "ashr";
 
-        public AshrOp(OpDefinition opdef) {
+        public AshrOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2861,7 +2861,7 @@ public final class CoreOps {
     public static final class LshrOp extends CoreOps.BinaryOp {
         public static final String NAME = "lshr";
 
-        public LshrOp(OpDefinition opdef) {
+        public LshrOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2886,7 +2886,7 @@ public final class CoreOps {
     public static final class NegOp extends UnaryOp {
         public static final String NAME = "neg";
 
-        public NegOp(OpDefinition opdef) {
+        public NegOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2911,7 +2911,7 @@ public final class CoreOps {
     public static final class NotOp extends UnaryOp {
         public static final String NAME = "not";
 
-        public NotOp(OpDefinition opdef) {
+        public NotOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2937,7 +2937,7 @@ public final class CoreOps {
     public static final class EqOp extends BinaryTestOp {
         public static final String NAME = "eq";
 
-        public EqOp(OpDefinition opdef) {
+        public EqOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2963,7 +2963,7 @@ public final class CoreOps {
     public static final class NeqOp extends BinaryTestOp {
         public static final String NAME = "neq";
 
-        public NeqOp(OpDefinition opdef) {
+        public NeqOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -2988,7 +2988,7 @@ public final class CoreOps {
     public static final class GtOp extends BinaryTestOp {
         public static final String NAME = "gt";
 
-        public GtOp(OpDefinition opdef) {
+        public GtOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -3014,7 +3014,7 @@ public final class CoreOps {
     public static final class GeOp extends BinaryTestOp {
         public static final String NAME = "ge";
 
-        public GeOp(OpDefinition opdef) {
+        public GeOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -3040,7 +3040,7 @@ public final class CoreOps {
     public static final class LtOp extends BinaryTestOp {
         public static final String NAME = "lt";
 
-        public LtOp(OpDefinition opdef) {
+        public LtOp(ExternalOpContents opdef) {
             super(opdef);
         }
 
@@ -3066,7 +3066,7 @@ public final class CoreOps {
     public static final class LeOp extends BinaryTestOp {
         public static final String NAME = "le";
 
-        public LeOp(OpDefinition opdef) {
+        public LeOp(ExternalOpContents opdef) {
             super(opdef);
         }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -81,7 +81,7 @@ public final class CoreOps {
         final String funcName;
         final Body body;
 
-        public static FuncOp create(ExternalOpContents def) {
+        public static FuncOp create(ExternalOpContent def) {
             if (!def.operands().isEmpty()) {
                 throw new IllegalStateException("Bad op " + def.name());
             }
@@ -94,7 +94,7 @@ public final class CoreOps {
             return new FuncOp(def, funcName);
         }
 
-        FuncOp(ExternalOpContents def, String funcName) {
+        FuncOp(ExternalOpContent def, String funcName) {
             super(def);
 
             this.funcName = funcName;
@@ -186,7 +186,7 @@ public final class CoreOps {
         final String funcName;
         final TypeElement resultType;
 
-        public static FuncCallOp create(ExternalOpContents def) {
+        public static FuncCallOp create(ExternalOpContent def) {
             String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
@@ -196,7 +196,7 @@ public final class CoreOps {
             return new FuncCallOp(def, funcName);
         }
 
-        FuncCallOp(ExternalOpContents def, String funcName) {
+        FuncCallOp(ExternalOpContent def, String funcName) {
             super(def);
 
             this.funcName = funcName;
@@ -251,7 +251,7 @@ public final class CoreOps {
         final Map<String, FuncOp> table;
         final Body body;
 
-        public static ModuleOp create(ExternalOpContents def) {
+        public static ModuleOp create(ExternalOpContent def) {
             if (!def.operands().isEmpty()) {
                 throw new IllegalStateException("Bad op " + def.name());
             }
@@ -259,7 +259,7 @@ public final class CoreOps {
             return new ModuleOp(def);
         }
 
-        ModuleOp(ExternalOpContents def) {
+        ModuleOp(ExternalOpContent def) {
             super(def);
 
             this.body = def.bodyDefinitions().get(0).build(this);
@@ -340,7 +340,7 @@ public final class CoreOps {
 
         final Op quotedOp;
 
-        public QuotedOp(ExternalOpContents def) {
+        public QuotedOp(ExternalOpContent def) {
             super(def);
 
             this.quotedBody = def.bodyDefinitions().get(0).build(this);
@@ -439,7 +439,7 @@ public final class CoreOps {
         final TypeElement functionalInterface;
         final Body body;
 
-        public LambdaOp(ExternalOpContents def) {
+        public LambdaOp(ExternalOpContent def) {
             super(def);
 
             this.functionalInterface = def.resultType();
@@ -670,7 +670,7 @@ public final class CoreOps {
 
         final Body body;
 
-        public ClosureOp(ExternalOpContents def) {
+        public ClosureOp(ExternalOpContent def) {
             super(def);
 
             this.body = def.bodyDefinitions().get(0).build(this);
@@ -743,7 +743,7 @@ public final class CoreOps {
     public static final class ClosureCallOp extends ExternalizableOp {
         public static final String NAME = "closure.call";
 
-        public ClosureCallOp(ExternalOpContents def) {
+        public ClosureCallOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -776,7 +776,7 @@ public final class CoreOps {
     public static final class ReturnOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "return";
 
-        public ReturnOp(ExternalOpContents def) {
+        public ReturnOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() > 1) {
@@ -823,7 +823,7 @@ public final class CoreOps {
     public static final class ThrowOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "throw";
 
-        public ThrowOp(ExternalOpContents def) {
+        public ThrowOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -862,7 +862,7 @@ public final class CoreOps {
         public static final String NAME = "assert";
         public final List<Body> bodies;
 
-        public AssertOp(ExternalOpContents def) {
+        public AssertOp(ExternalOpContent def) {
             super(def);
             var bodies = def.bodyDefinitions().stream().map(b -> b.build(this)).toList();
             checkBodies(bodies);
@@ -912,7 +912,7 @@ public final class CoreOps {
     public static class UnreachableOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "unreachable";
 
-        public UnreachableOp(ExternalOpContents def) {
+        public UnreachableOp(ExternalOpContent def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -949,7 +949,7 @@ public final class CoreOps {
     public static class YieldOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "yield";
 
-        public YieldOp(ExternalOpContents def) {
+        public YieldOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() > 1) {
@@ -1000,7 +1000,7 @@ public final class CoreOps {
 
         final Block.Reference b;
 
-        public BranchOp(ExternalOpContents def) {
+        public BranchOp(ExternalOpContent def) {
             super(def);
 
             if (!def.operands().isEmpty() || def.successors().size() != 1) {
@@ -1056,7 +1056,7 @@ public final class CoreOps {
         final Block.Reference t;
         final Block.Reference f;
 
-        public ConditionalBranchOp(ExternalOpContents def) {
+        public ConditionalBranchOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 1 || def.successors().size() != 2) {
@@ -1121,7 +1121,7 @@ public final class CoreOps {
         final Object value;
         final TypeElement type;
 
-        public static ConstantOp create(ExternalOpContents def) {
+        public static ConstantOp create(ExternalOpContent def) {
             if (!def.operands().isEmpty()) {
                 throw new IllegalArgumentException("Operation must have zero operands");
             }
@@ -1192,7 +1192,7 @@ public final class CoreOps {
             throw new UnsupportedOperationException("Unsupported constant type and value: " + t + " " + value);
         }
 
-        ConstantOp(ExternalOpContents def, Object value) {
+        ConstantOp(ExternalOpContent def, Object value) {
             super(def);
 
             this.type = def.resultType();
@@ -1255,7 +1255,7 @@ public final class CoreOps {
         final MethodRef invokeDescriptor;
         final TypeElement resultType;
 
-        public static InvokeOp create(ExternalOpContents def) {
+        public static InvokeOp create(ExternalOpContent def) {
             MethodRef invokeDescriptor = def.extractAttributeValue(ATTRIBUTE_INVOKE_DESCRIPTOR,
                     true, v -> switch (v) {
                         case String s -> MethodRef.ofString(s);
@@ -1266,7 +1266,7 @@ public final class CoreOps {
             return new InvokeOp(def, invokeDescriptor);
         }
 
-        InvokeOp(ExternalOpContents def, MethodRef invokeDescriptor) {
+        InvokeOp(ExternalOpContent def, MethodRef invokeDescriptor) {
             super(def);
 
             this.invokeDescriptor = invokeDescriptor;
@@ -1327,7 +1327,7 @@ public final class CoreOps {
 
         final TypeElement resultType;
 
-        public ConvOp(ExternalOpContents def) {
+        public ConvOp(ExternalOpContent def) {
             super(def);
 
             this.resultType = def.resultType();
@@ -1367,7 +1367,7 @@ public final class CoreOps {
         final FunctionType constructorType;
         final TypeElement resultType;
 
-        public static NewOp create(ExternalOpContents def) {
+        public static NewOp create(ExternalOpContent def) {
             FunctionType constructorType = def.extractAttributeValue(ATTRIBUTE_NEW_DESCRIPTOR, true,
                     v -> switch (v) {
                         case String s -> {
@@ -1384,7 +1384,7 @@ public final class CoreOps {
             return new NewOp(def, constructorType);
         }
 
-        NewOp(ExternalOpContents def, FunctionType constructorType) {
+        NewOp(ExternalOpContent def, FunctionType constructorType) {
             super(def);
 
             this.constructorType = constructorType;
@@ -1449,7 +1449,7 @@ public final class CoreOps {
 
         final FieldRef fieldDescriptor;
 
-        FieldAccessOp(ExternalOpContents def, FieldRef fieldDescriptor) {
+        FieldAccessOp(ExternalOpContent def, FieldRef fieldDescriptor) {
             super(def);
 
             this.fieldDescriptor = fieldDescriptor;
@@ -1489,7 +1489,7 @@ public final class CoreOps {
 
             final TypeElement resultType;
 
-            public static FieldLoadOp create(ExternalOpContents def) {
+            public static FieldLoadOp create(ExternalOpContent def) {
                 if (def.operands().size() > 1) {
                     throw new IllegalArgumentException("Operation must accept zero or one operand");
                 }
@@ -1504,7 +1504,7 @@ public final class CoreOps {
                 return new FieldLoadOp(def, fieldDescriptor);
             }
 
-            FieldLoadOp(ExternalOpContents opdef, FieldRef fieldDescriptor) {
+            FieldLoadOp(ExternalOpContent opdef, FieldRef fieldDescriptor) {
                 super(opdef, fieldDescriptor);
 
                 resultType = opdef.resultType();
@@ -1549,7 +1549,7 @@ public final class CoreOps {
         public static final class FieldStoreOp extends FieldAccessOp {
             public static final String NAME = "field.store";
 
-            public static FieldStoreOp create(ExternalOpContents def) {
+            public static FieldStoreOp create(ExternalOpContent def) {
                 if (def.operands().size() > 2) {
                     throw new IllegalArgumentException("Operation must accept one or two operands");
                 }
@@ -1564,7 +1564,7 @@ public final class CoreOps {
                 return new FieldStoreOp(def, fieldDescriptor);
             }
 
-            FieldStoreOp(ExternalOpContents opdef, FieldRef fieldDescriptor) {
+            FieldStoreOp(ExternalOpContent opdef, FieldRef fieldDescriptor) {
                 super(opdef, fieldDescriptor);
             }
 
@@ -1604,7 +1604,7 @@ public final class CoreOps {
     public static final class ArrayLengthOp extends ExternalizableOp implements ReflectiveOp {
         public static final String NAME = "array.length";
 
-        public ArrayLengthOp(ExternalOpContents def) {
+        public ArrayLengthOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -1631,7 +1631,7 @@ public final class CoreOps {
      * The array access operation, that can model Java language array access expressions.
      */
     public abstract static sealed class ArrayAccessOp extends ExternalizableOp implements AccessOp, ReflectiveOp {
-        ArrayAccessOp(ExternalOpContents def) {
+        ArrayAccessOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 2 && def.operands().size() != 3) {
@@ -1683,7 +1683,7 @@ public final class CoreOps {
         public static final class ArrayLoadOp extends ArrayAccessOp implements Op.Pure {
             public static final String NAME = "array.load";
 
-            public ArrayLoadOp(ExternalOpContents def) {
+            public ArrayLoadOp(ExternalOpContent def) {
                 super(def);
             }
 
@@ -1716,7 +1716,7 @@ public final class CoreOps {
         public static final class ArrayStoreOp extends ArrayAccessOp {
             public static final String NAME = "array.store";
 
-            public ArrayStoreOp(ExternalOpContents def) {
+            public ArrayStoreOp(ExternalOpContent def) {
                 super(def);
             }
 
@@ -1751,7 +1751,7 @@ public final class CoreOps {
 
         final TypeElement typeDescriptor;
 
-        public static InstanceOfOp create(ExternalOpContents def) {
+        public static InstanceOfOp create(ExternalOpContent def) {
             if (def.operands().size() != 1) {
                 throw new IllegalArgumentException("Operation must have one operand " + def.name());
             }
@@ -1765,7 +1765,7 @@ public final class CoreOps {
             return new InstanceOfOp(def, typeDescriptor);
         }
 
-        InstanceOfOp(ExternalOpContents def, TypeElement typeDescriptor) {
+        InstanceOfOp(ExternalOpContent def, TypeElement typeDescriptor) {
             super(def);
 
             this.typeDescriptor = typeDescriptor;
@@ -1817,7 +1817,7 @@ public final class CoreOps {
         final TypeElement resultType;
         final TypeElement typeDescriptor;
 
-        public static CastOp create(ExternalOpContents def) {
+        public static CastOp create(ExternalOpContent def) {
             if (def.operands().size() != 1) {
                 throw new IllegalArgumentException("Operation must have one operand " + def.name());
             }
@@ -1831,7 +1831,7 @@ public final class CoreOps {
             return new CastOp(def, type);
         }
 
-        CastOp(ExternalOpContents def, TypeElement typeDescriptor) {
+        CastOp(ExternalOpContent def, TypeElement typeDescriptor) {
             super(def);
 
             this.resultType = def.resultType();
@@ -1912,7 +1912,7 @@ public final class CoreOps {
         final String varName;
         final TypeElement resultType;
 
-        public static VarOp create(ExternalOpContents def) {
+        public static VarOp create(ExternalOpContent def) {
             if (def.operands().size() != 1) {
                 throw new IllegalStateException("Operation must have one operand");
             }
@@ -1925,7 +1925,7 @@ public final class CoreOps {
             return new VarOp(def, name);
         }
 
-        VarOp(ExternalOpContents def, String varName) {
+        VarOp(ExternalOpContent def, String varName) {
             super(def);
 
             this.varName = varName;
@@ -1985,7 +1985,7 @@ public final class CoreOps {
      * lambda parameters.
      */
     public abstract static sealed class VarAccessOp extends ExternalizableOp implements AccessOp {
-        VarAccessOp(ExternalOpContents opdef) {
+        VarAccessOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2019,7 +2019,7 @@ public final class CoreOps {
         public static final class VarLoadOp extends VarAccessOp {
             public static final String NAME = "var.load";
 
-            public VarLoadOp(ExternalOpContents opdef) {
+            public VarLoadOp(ExternalOpContent opdef) {
                 super(opdef);
 
                 if (opdef.operands().size() != 1) {
@@ -2060,7 +2060,7 @@ public final class CoreOps {
         public static final class VarStoreOp extends VarAccessOp {
             public static final String NAME = "var.store";
 
-            public VarStoreOp(ExternalOpContents opdef) {
+            public VarStoreOp(ExternalOpContent opdef) {
                 super(opdef);
 
                 if (opdef.operands().size() != 2) {
@@ -2105,7 +2105,7 @@ public final class CoreOps {
     public static final class TupleOp extends ExternalizableOp {
         public static final String NAME = "tuple";
 
-        public TupleOp(ExternalOpContents def) {
+        public TupleOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -2138,7 +2138,7 @@ public final class CoreOps {
 
         final int index;
 
-        public static TupleLoadOp create(ExternalOpContents def) {
+        public static TupleLoadOp create(ExternalOpContent def) {
             if (def.operands().size() != 1) {
                 throw new IllegalStateException("Operation must have one operand");
             }
@@ -2152,7 +2152,7 @@ public final class CoreOps {
             return new TupleLoadOp(def, index);
         }
 
-        TupleLoadOp(ExternalOpContents def, int index) {
+        TupleLoadOp(ExternalOpContent def, int index) {
             super(def);
 
             // @@@ Validate tuple type and index
@@ -2209,7 +2209,7 @@ public final class CoreOps {
 
         final int index;
 
-        public static TupleWithOp create(ExternalOpContents def) {
+        public static TupleWithOp create(ExternalOpContent def) {
             if (def.operands().size() != 2) {
                 throw new IllegalStateException("Operation must have two operands");
             }
@@ -2223,7 +2223,7 @@ public final class CoreOps {
             return new TupleWithOp(def, index);
         }
 
-        TupleWithOp(ExternalOpContents def, int index) {
+        TupleWithOp(ExternalOpContent def, int index) {
             super(def);
 
             // @@@ Validate tuple type and index
@@ -2301,7 +2301,7 @@ public final class CoreOps {
         // each of which have one block argument whose type is an exception type.
         final List<Block.Reference> s;
 
-        public ExceptionRegionEnter(ExternalOpContents def) {
+        public ExceptionRegionEnter(ExternalOpContent def) {
             super(def);
 
             if (def.successors().size() < 2) {
@@ -2360,7 +2360,7 @@ public final class CoreOps {
 
         final Block.Reference end;
 
-        public ExceptionRegionExit(ExternalOpContents def) {
+        public ExceptionRegionExit(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -2435,7 +2435,7 @@ public final class CoreOps {
             super(that, cc);
         }
 
-        public ConcatOp(ExternalOpContents def) {
+        public ConcatOp(ExternalOpContent def) {
             super(def);
             if (def.operands().size() != 2) {
                 throw new IllegalArgumentException("Concatenation Operation must have two operands.");
@@ -2464,7 +2464,7 @@ public final class CoreOps {
      * The arithmetic operation.
      */
     public static abstract class ArithmeticOperation extends ExternalizableOp implements Op.Pure {
-        protected ArithmeticOperation(ExternalOpContents def) {
+        protected ArithmeticOperation(ExternalOpContent def) {
             super(def);
 
             if (def.operands().isEmpty()) {
@@ -2485,7 +2485,7 @@ public final class CoreOps {
      * The test operation.
      */
     public static abstract class TestOperation extends ExternalizableOp implements Op.Pure {
-        protected TestOperation(ExternalOpContents def) {
+        protected TestOperation(ExternalOpContent def) {
             super(def);
 
             if (def.operands().isEmpty()) {
@@ -2506,7 +2506,7 @@ public final class CoreOps {
      * The binary arithmetic operation.
      */
     public static abstract class BinaryOp extends ArithmeticOperation {
-        protected BinaryOp(ExternalOpContents def) {
+        protected BinaryOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 2) {
@@ -2532,7 +2532,7 @@ public final class CoreOps {
      * The unary arithmetic operation.
      */
     public static abstract class UnaryOp extends ArithmeticOperation {
-        protected UnaryOp(ExternalOpContents def) {
+        protected UnaryOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -2558,7 +2558,7 @@ public final class CoreOps {
      * The unary test operation.
      */
     public static abstract class UnaryTestOp extends TestOperation {
-        protected UnaryTestOp(ExternalOpContents def) {
+        protected UnaryTestOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -2579,7 +2579,7 @@ public final class CoreOps {
      * The binary test operation.
      */
     public static abstract class BinaryTestOp extends TestOperation {
-        protected BinaryTestOp(ExternalOpContents def) {
+        protected BinaryTestOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 2) {
@@ -2608,7 +2608,7 @@ public final class CoreOps {
     public static final class AddOp extends BinaryOp {
         public static final String NAME = "add";
 
-        public AddOp(ExternalOpContents def) {
+        public AddOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -2633,7 +2633,7 @@ public final class CoreOps {
     public static final class SubOp extends BinaryOp {
         public static final String NAME = "sub";
 
-        public SubOp(ExternalOpContents opdef) {
+        public SubOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2658,7 +2658,7 @@ public final class CoreOps {
     public static final class MulOp extends BinaryOp {
         public static final String NAME = "mul";
 
-        public MulOp(ExternalOpContents opdef) {
+        public MulOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2683,7 +2683,7 @@ public final class CoreOps {
     public static final class DivOp extends BinaryOp {
         public static final String NAME = "div";
 
-        public DivOp(ExternalOpContents opdef) {
+        public DivOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2708,7 +2708,7 @@ public final class CoreOps {
     public static final class ModOp extends BinaryOp {
         public static final String NAME = "mod";
 
-        public ModOp(ExternalOpContents opdef) {
+        public ModOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2734,7 +2734,7 @@ public final class CoreOps {
     public static final class OrOp extends BinaryOp {
         public static final String NAME = "or";
 
-        public OrOp(ExternalOpContents opdef) {
+        public OrOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2760,7 +2760,7 @@ public final class CoreOps {
     public static final class AndOp extends BinaryOp {
         public static final String NAME = "and";
 
-        public AndOp(ExternalOpContents opdef) {
+        public AndOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2786,7 +2786,7 @@ public final class CoreOps {
     public static final class XorOp extends BinaryOp {
         public static final String NAME = "xor";
 
-        public XorOp(ExternalOpContents opdef) {
+        public XorOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2811,7 +2811,7 @@ public final class CoreOps {
     public static final class LshlOp extends BinaryOp {
         public static final String NAME = "lshl";
 
-        public LshlOp(ExternalOpContents opdef) {
+        public LshlOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2836,7 +2836,7 @@ public final class CoreOps {
     public static final class AshrOp extends CoreOps.BinaryOp {
         public static final String NAME = "ashr";
 
-        public AshrOp(ExternalOpContents opdef) {
+        public AshrOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2861,7 +2861,7 @@ public final class CoreOps {
     public static final class LshrOp extends CoreOps.BinaryOp {
         public static final String NAME = "lshr";
 
-        public LshrOp(ExternalOpContents opdef) {
+        public LshrOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2886,7 +2886,7 @@ public final class CoreOps {
     public static final class NegOp extends UnaryOp {
         public static final String NAME = "neg";
 
-        public NegOp(ExternalOpContents opdef) {
+        public NegOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2911,7 +2911,7 @@ public final class CoreOps {
     public static final class NotOp extends UnaryOp {
         public static final String NAME = "not";
 
-        public NotOp(ExternalOpContents opdef) {
+        public NotOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2937,7 +2937,7 @@ public final class CoreOps {
     public static final class EqOp extends BinaryTestOp {
         public static final String NAME = "eq";
 
-        public EqOp(ExternalOpContents opdef) {
+        public EqOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2963,7 +2963,7 @@ public final class CoreOps {
     public static final class NeqOp extends BinaryTestOp {
         public static final String NAME = "neq";
 
-        public NeqOp(ExternalOpContents opdef) {
+        public NeqOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -2988,7 +2988,7 @@ public final class CoreOps {
     public static final class GtOp extends BinaryTestOp {
         public static final String NAME = "gt";
 
-        public GtOp(ExternalOpContents opdef) {
+        public GtOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -3014,7 +3014,7 @@ public final class CoreOps {
     public static final class GeOp extends BinaryTestOp {
         public static final String NAME = "ge";
 
-        public GeOp(ExternalOpContents opdef) {
+        public GeOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -3040,7 +3040,7 @@ public final class CoreOps {
     public static final class LtOp extends BinaryTestOp {
         public static final String NAME = "lt";
 
-        public LtOp(ExternalOpContents opdef) {
+        public LtOp(ExternalOpContent opdef) {
             super(opdef);
         }
 
@@ -3066,7 +3066,7 @@ public final class CoreOps {
     public static final class LeOp extends BinaryTestOp {
         public static final String NAME = "le";
 
-        public LeOp(ExternalOpContents opdef) {
+        public LeOp(ExternalOpContent opdef) {
             super(opdef);
         }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -72,8 +72,8 @@ public class ExtendedOps {
     /**
      * The label operation, that can model Java language statements with label identifiers.
      */
-    public static sealed abstract class JavaLabelOp extends OpWithDefinition implements Op.Lowerable, Op.BodyTerminating {
-        JavaLabelOp(OpDefinition def) {
+    public static sealed abstract class JavaLabelOp extends ExternalizableOp implements Op.Lowerable, Op.BodyTerminating {
+        JavaLabelOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() > 1) {
@@ -166,7 +166,7 @@ public class ExtendedOps {
     public static final class JavaBreakOp extends JavaLabelOp {
         public static final String NAME = "java.break";
 
-        public JavaBreakOp(OpDefinition def) {
+        public JavaBreakOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -196,7 +196,7 @@ public class ExtendedOps {
     public static final class JavaContinueOp extends JavaLabelOp {
         public static final String NAME = "java.continue";
 
-        public JavaContinueOp(OpDefinition def) {
+        public JavaContinueOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -245,10 +245,10 @@ public class ExtendedOps {
      * The yield operation, that can model Java language yield statements.
      */
     @OpDeclaration(JavaYieldOp.NAME)
-    public static final class JavaYieldOp extends OpWithDefinition implements Op.BodyTerminating {
+    public static final class JavaYieldOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "java.yield";
 
-        public JavaYieldOp(OpDefinition def) {
+        public JavaYieldOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -290,12 +290,12 @@ public class ExtendedOps {
      */
     @OpDeclaration(JavaBlockOp.NAME)
     // @@@ Support synchronized attribute
-    public static final class JavaBlockOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static final class JavaBlockOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
         public static final String NAME = "java.block";
 
         final Body body;
 
-        public JavaBlockOp(OpDefinition def) {
+        public JavaBlockOp(ExternalOpContents def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -371,12 +371,12 @@ public class ExtendedOps {
      * The labeled operation, that can model Java language labeled statements.
      */
     @OpDeclaration(JavaLabeledOp.NAME)
-    public static final class JavaLabeledOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static final class JavaLabeledOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
         public static final String NAME = "java.labeled";
 
         final Body body;
 
-        public JavaLabeledOp(OpDefinition def) {
+        public JavaLabeledOp(ExternalOpContents def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -462,7 +462,7 @@ public class ExtendedOps {
      * The if operation, that can model Java language if, if-then, and if-then-else statements.
      */
     @OpDeclaration(JavaIfOp.NAME)
-    public static final class JavaIfOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static final class JavaIfOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
 
         static final FunctionType PREDICATE_TYPE = FunctionType.functionType(BOOLEAN);
 
@@ -550,7 +550,7 @@ public class ExtendedOps {
 
         final List<Body> bodies;
 
-        public JavaIfOp(OpDefinition def) {
+        public JavaIfOp(ExternalOpContents def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -687,13 +687,13 @@ public class ExtendedOps {
      * The switch expression operation, that can model Java language switch expressions.
      */
     @OpDeclaration(JavaSwitchExpressionOp.NAME)
-    public static final class JavaSwitchExpressionOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static final class JavaSwitchExpressionOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
         public static final String NAME = "java.switch.expression";
 
         final TypeElement resultType;
         final List<Body> bodies;
 
-        public JavaSwitchExpressionOp(OpDefinition def) {
+        public JavaSwitchExpressionOp(ExternalOpContents def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -754,10 +754,10 @@ public class ExtendedOps {
      * the last statement of the current switch label.
      */
     @OpDeclaration(JavaSwitchFallthroughOp.NAME)
-    public static final class JavaSwitchFallthroughOp extends OpWithDefinition implements Op.BodyTerminating {
+    public static final class JavaSwitchFallthroughOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "java.switch.fallthrough";
 
-        public JavaSwitchFallthroughOp(OpDefinition def) {
+        public JavaSwitchFallthroughOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -784,7 +784,7 @@ public class ExtendedOps {
      * The for operation, that can model a Java language for statement.
      */
     @OpDeclaration(JavaForOp.NAME)
-    public static final class JavaForOp extends OpWithDefinition implements Op.Loop, Op.Lowerable {
+    public static final class JavaForOp extends ExternalizableOp implements Op.Loop, Op.Lowerable {
 
         public static final class InitBuilder {
             final Body.Builder ancestorBody;
@@ -885,11 +885,11 @@ public class ExtendedOps {
         final Body update;
         final Body body;
 
-        public static JavaForOp create(OpDefinition def) {
+        public static JavaForOp create(ExternalOpContents def) {
             return new JavaForOp(def);
         }
 
-        public JavaForOp(OpDefinition def) {
+        public JavaForOp(ExternalOpContents def) {
             super(def);
 
             this.init = def.bodyDefinitions().get(0).build(this);
@@ -1043,7 +1043,7 @@ public class ExtendedOps {
      * The enhanced for operation, that can model a Java language enhanced for statement.
      */
     @OpDeclaration(JavaEnhancedForOp.NAME)
-    public static final class JavaEnhancedForOp extends OpWithDefinition implements Op.Loop, Op.Lowerable {
+    public static final class JavaEnhancedForOp extends ExternalizableOp implements Op.Loop, Op.Lowerable {
 
         public static final class ExpressionBuilder {
             final Body.Builder ancestorBody;
@@ -1120,11 +1120,11 @@ public class ExtendedOps {
         final Body init;
         final Body body;
 
-        public static JavaEnhancedForOp create(OpDefinition def) {
+        public static JavaEnhancedForOp create(ExternalOpContents def) {
             return new JavaEnhancedForOp(def);
         }
 
-        public JavaEnhancedForOp(OpDefinition def) {
+        public JavaEnhancedForOp(ExternalOpContents def) {
             super(def);
 
             this.expression = def.bodyDefinitions().get(0).build(this);
@@ -1303,7 +1303,7 @@ public class ExtendedOps {
      * The while operation, that can model a Java language while statement.
      */
     @OpDeclaration(JavaWhileOp.NAME)
-    public static final class JavaWhileOp extends OpWithDefinition implements Op.Loop, Op.Lowerable {
+    public static final class JavaWhileOp extends ExternalizableOp implements Op.Loop, Op.Lowerable {
 
         public static class PredicateBuilder {
             final Body.Builder ancestorBody;
@@ -1341,7 +1341,7 @@ public class ExtendedOps {
 
         private final List<Body> bodies;
 
-        public JavaWhileOp(OpDefinition def) {
+        public JavaWhileOp(ExternalOpContents def) {
             super(def);
 
             // @@@ Validate
@@ -1448,7 +1448,7 @@ public class ExtendedOps {
      */
     // @@@ Unify JavaDoWhileOp and JavaWhileOp with common abstract superclass
     @OpDeclaration(JavaDoWhileOp.NAME)
-    public static final class JavaDoWhileOp extends OpWithDefinition implements Op.Loop, Op.Lowerable {
+    public static final class JavaDoWhileOp extends ExternalizableOp implements Op.Loop, Op.Lowerable {
 
         public static class PredicateBuilder {
             final Body.Builder ancestorBody;
@@ -1486,7 +1486,7 @@ public class ExtendedOps {
 
         private final List<Body> bodies;
 
-        public JavaDoWhileOp(OpDefinition def) {
+        public JavaDoWhileOp(ExternalOpContents def) {
             super(def);
 
             // @@@ Validate
@@ -1590,10 +1590,10 @@ public class ExtendedOps {
     /**
      * The conditional-and-or operation, that can model Java language condition-or or conditional-and expressions.
      */
-    public static sealed abstract class JavaConditionalOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static sealed abstract class JavaConditionalOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
         final List<Body> bodies;
 
-        public JavaConditionalOp(OpDefinition def) {
+        public JavaConditionalOp(ExternalOpContents def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -1731,7 +1731,7 @@ public class ExtendedOps {
 
         public static final String NAME = "java.cand";
 
-        public JavaConditionalAndOp(OpDefinition def) {
+        public JavaConditionalAndOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -1786,7 +1786,7 @@ public class ExtendedOps {
 
         public static final String NAME = "java.cor";
 
-        public JavaConditionalOrOp(OpDefinition def) {
+        public JavaConditionalOrOp(ExternalOpContents def) {
             super(def);
         }
 
@@ -1813,7 +1813,7 @@ public class ExtendedOps {
      * The conditional operation, that can model Java language conditional operator {@code ?} expressions.
      */
     @OpDeclaration(JavaConditionalExpressionOp.NAME)
-    public static final class JavaConditionalExpressionOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static final class JavaConditionalExpressionOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
 
         public static final String NAME = "java.cexpression";
 
@@ -1821,7 +1821,7 @@ public class ExtendedOps {
         // {cond, truepart, falsepart}
         final List<Body> bodies;
 
-        public JavaConditionalExpressionOp(OpDefinition def) {
+        public JavaConditionalExpressionOp(ExternalOpContents def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -1918,7 +1918,7 @@ public class ExtendedOps {
      * The try operation, that can model Java language try statements.
      */
     @OpDeclaration(JavaTryOp.NAME)
-    public static final class JavaTryOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static final class JavaTryOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
 
         public static final class BodyBuilder {
             final Body.Builder ancestorBody;
@@ -1982,11 +1982,11 @@ public class ExtendedOps {
         final List<Body> catchers;
         final Body finalizer;
 
-        public static JavaTryOp create(OpDefinition def) {
+        public static JavaTryOp create(ExternalOpContents def) {
             return new JavaTryOp(def);
         }
 
-        public JavaTryOp(OpDefinition def) {
+        public JavaTryOp(ExternalOpContents def) {
             super(def);
 
             List<Body> bodies = def.bodyDefinitions().stream().map(b -> b.build(this)).toList();
@@ -2420,8 +2420,8 @@ public class ExtendedOps {
         /**
          * The pattern operation.
          */
-        public static sealed abstract class PatternOp extends OpWithDefinition implements Op.Pure {
-            PatternOp(OpDefinition def) {
+        public static sealed abstract class PatternOp extends ExternalizableOp implements Op.Pure {
+            PatternOp(ExternalOpContents def) {
                 super(def);
             }
 
@@ -2446,7 +2446,7 @@ public class ExtendedOps {
             final TypeElement resultType;
             final String bindingName;
 
-            public static BindingPatternOp create(OpDefinition def) {
+            public static BindingPatternOp create(ExternalOpContents def) {
                 String name = def.extractAttributeValue(ATTRIBUTE_BINDING_NAME, true,
                         v -> switch (v) {
                             case String s -> s;
@@ -2455,7 +2455,7 @@ public class ExtendedOps {
                 return new BindingPatternOp(def, name);
             }
 
-            BindingPatternOp(OpDefinition def, String bindingName) {
+            BindingPatternOp(ExternalOpContents def, String bindingName) {
                 super(def);
 
                 this.bindingName = bindingName;
@@ -2513,7 +2513,7 @@ public class ExtendedOps {
 
             final RecordTypeRef recordDescriptor;
 
-            public static RecordPatternOp create(OpDefinition def) {
+            public static RecordPatternOp create(ExternalOpContents def) {
                 RecordTypeRef recordDescriptor = def.extractAttributeValue(ATTRIBUTE_RECORD_DESCRIPTOR,true,
                         v -> switch (v) {
                             case String s -> RecordTypeRef.ofString(s);
@@ -2524,7 +2524,7 @@ public class ExtendedOps {
                 return new RecordPatternOp(def, recordDescriptor);
             }
 
-            RecordPatternOp(OpDefinition def, RecordTypeRef recordDescriptor) {
+            RecordPatternOp(ExternalOpContents def, RecordTypeRef recordDescriptor) {
                 super(def);
 
                 this.recordDescriptor = recordDescriptor;
@@ -2574,13 +2574,13 @@ public class ExtendedOps {
          * The match operation, that can model Java language pattern matching.
          */
         @OpDeclaration(MatchOp.NAME)
-        public static final class MatchOp extends OpWithDefinition implements Op.Isolated, Op.Lowerable {
+        public static final class MatchOp extends ExternalizableOp implements Op.Isolated, Op.Lowerable {
             public static final String NAME = "pattern.match";
 
             final Body pattern;
             final Body match;
 
-            public MatchOp(OpDefinition def) {
+            public MatchOp(ExternalOpContents def) {
                 super(def);
 
                 this.pattern = def.bodyDefinitions().get(0).build(this);
@@ -2735,14 +2735,14 @@ public class ExtendedOps {
     }
 
     @OpDeclaration(StringTemplateOp.NAME)
-    public static final class StringTemplateOp extends OpWithDefinition implements Op.Nested, Op.Lowerable {
+    public static final class StringTemplateOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
 
         public static final String NAME = "java.stringTemplate";
 
         private final TypeElement resultType;
         private final List<Body> expressions;
 
-        public StringTemplateOp(OpDefinition def) {
+        public StringTemplateOp(ExternalOpContents def) {
             super(def);
 
             this.expressions = def.bodyDefinitions().stream().map(bd -> bd.build(this)).toList();

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -73,7 +73,7 @@ public class ExtendedOps {
      * The label operation, that can model Java language statements with label identifiers.
      */
     public static sealed abstract class JavaLabelOp extends ExternalizableOp implements Op.Lowerable, Op.BodyTerminating {
-        JavaLabelOp(ExternalOpContents def) {
+        JavaLabelOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() > 1) {
@@ -166,7 +166,7 @@ public class ExtendedOps {
     public static final class JavaBreakOp extends JavaLabelOp {
         public static final String NAME = "java.break";
 
-        public JavaBreakOp(ExternalOpContents def) {
+        public JavaBreakOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -196,7 +196,7 @@ public class ExtendedOps {
     public static final class JavaContinueOp extends JavaLabelOp {
         public static final String NAME = "java.continue";
 
-        public JavaContinueOp(ExternalOpContents def) {
+        public JavaContinueOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -248,7 +248,7 @@ public class ExtendedOps {
     public static final class JavaYieldOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "java.yield";
 
-        public JavaYieldOp(ExternalOpContents def) {
+        public JavaYieldOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -295,7 +295,7 @@ public class ExtendedOps {
 
         final Body body;
 
-        public JavaBlockOp(ExternalOpContents def) {
+        public JavaBlockOp(ExternalOpContent def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -376,7 +376,7 @@ public class ExtendedOps {
 
         final Body body;
 
-        public JavaLabeledOp(ExternalOpContents def) {
+        public JavaLabeledOp(ExternalOpContent def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -550,7 +550,7 @@ public class ExtendedOps {
 
         final List<Body> bodies;
 
-        public JavaIfOp(ExternalOpContents def) {
+        public JavaIfOp(ExternalOpContent def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -693,7 +693,7 @@ public class ExtendedOps {
         final TypeElement resultType;
         final List<Body> bodies;
 
-        public JavaSwitchExpressionOp(ExternalOpContents def) {
+        public JavaSwitchExpressionOp(ExternalOpContent def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -757,7 +757,7 @@ public class ExtendedOps {
     public static final class JavaSwitchFallthroughOp extends ExternalizableOp implements Op.BodyTerminating {
         public static final String NAME = "java.switch.fallthrough";
 
-        public JavaSwitchFallthroughOp(ExternalOpContents def) {
+        public JavaSwitchFallthroughOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -885,11 +885,11 @@ public class ExtendedOps {
         final Body update;
         final Body body;
 
-        public static JavaForOp create(ExternalOpContents def) {
+        public static JavaForOp create(ExternalOpContent def) {
             return new JavaForOp(def);
         }
 
-        public JavaForOp(ExternalOpContents def) {
+        public JavaForOp(ExternalOpContent def) {
             super(def);
 
             this.init = def.bodyDefinitions().get(0).build(this);
@@ -1120,11 +1120,11 @@ public class ExtendedOps {
         final Body init;
         final Body body;
 
-        public static JavaEnhancedForOp create(ExternalOpContents def) {
+        public static JavaEnhancedForOp create(ExternalOpContent def) {
             return new JavaEnhancedForOp(def);
         }
 
-        public JavaEnhancedForOp(ExternalOpContents def) {
+        public JavaEnhancedForOp(ExternalOpContent def) {
             super(def);
 
             this.expression = def.bodyDefinitions().get(0).build(this);
@@ -1341,7 +1341,7 @@ public class ExtendedOps {
 
         private final List<Body> bodies;
 
-        public JavaWhileOp(ExternalOpContents def) {
+        public JavaWhileOp(ExternalOpContent def) {
             super(def);
 
             // @@@ Validate
@@ -1486,7 +1486,7 @@ public class ExtendedOps {
 
         private final List<Body> bodies;
 
-        public JavaDoWhileOp(ExternalOpContents def) {
+        public JavaDoWhileOp(ExternalOpContent def) {
             super(def);
 
             // @@@ Validate
@@ -1593,7 +1593,7 @@ public class ExtendedOps {
     public static sealed abstract class JavaConditionalOp extends ExternalizableOp implements Op.Nested, Op.Lowerable {
         final List<Body> bodies;
 
-        public JavaConditionalOp(ExternalOpContents def) {
+        public JavaConditionalOp(ExternalOpContent def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -1731,7 +1731,7 @@ public class ExtendedOps {
 
         public static final String NAME = "java.cand";
 
-        public JavaConditionalAndOp(ExternalOpContents def) {
+        public JavaConditionalAndOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -1786,7 +1786,7 @@ public class ExtendedOps {
 
         public static final String NAME = "java.cor";
 
-        public JavaConditionalOrOp(ExternalOpContents def) {
+        public JavaConditionalOrOp(ExternalOpContent def) {
             super(def);
         }
 
@@ -1821,7 +1821,7 @@ public class ExtendedOps {
         // {cond, truepart, falsepart}
         final List<Body> bodies;
 
-        public JavaConditionalExpressionOp(ExternalOpContents def) {
+        public JavaConditionalExpressionOp(ExternalOpContent def) {
             super(def);
 
             if (!def.operands().isEmpty()) {
@@ -1982,11 +1982,11 @@ public class ExtendedOps {
         final List<Body> catchers;
         final Body finalizer;
 
-        public static JavaTryOp create(ExternalOpContents def) {
+        public static JavaTryOp create(ExternalOpContent def) {
             return new JavaTryOp(def);
         }
 
-        public JavaTryOp(ExternalOpContents def) {
+        public JavaTryOp(ExternalOpContent def) {
             super(def);
 
             List<Body> bodies = def.bodyDefinitions().stream().map(b -> b.build(this)).toList();
@@ -2421,7 +2421,7 @@ public class ExtendedOps {
          * The pattern operation.
          */
         public static sealed abstract class PatternOp extends ExternalizableOp implements Op.Pure {
-            PatternOp(ExternalOpContents def) {
+            PatternOp(ExternalOpContent def) {
                 super(def);
             }
 
@@ -2446,7 +2446,7 @@ public class ExtendedOps {
             final TypeElement resultType;
             final String bindingName;
 
-            public static BindingPatternOp create(ExternalOpContents def) {
+            public static BindingPatternOp create(ExternalOpContent def) {
                 String name = def.extractAttributeValue(ATTRIBUTE_BINDING_NAME, true,
                         v -> switch (v) {
                             case String s -> s;
@@ -2455,7 +2455,7 @@ public class ExtendedOps {
                 return new BindingPatternOp(def, name);
             }
 
-            BindingPatternOp(ExternalOpContents def, String bindingName) {
+            BindingPatternOp(ExternalOpContent def, String bindingName) {
                 super(def);
 
                 this.bindingName = bindingName;
@@ -2513,7 +2513,7 @@ public class ExtendedOps {
 
             final RecordTypeRef recordDescriptor;
 
-            public static RecordPatternOp create(ExternalOpContents def) {
+            public static RecordPatternOp create(ExternalOpContent def) {
                 RecordTypeRef recordDescriptor = def.extractAttributeValue(ATTRIBUTE_RECORD_DESCRIPTOR,true,
                         v -> switch (v) {
                             case String s -> RecordTypeRef.ofString(s);
@@ -2524,7 +2524,7 @@ public class ExtendedOps {
                 return new RecordPatternOp(def, recordDescriptor);
             }
 
-            RecordPatternOp(ExternalOpContents def, RecordTypeRef recordDescriptor) {
+            RecordPatternOp(ExternalOpContent def, RecordTypeRef recordDescriptor) {
                 super(def);
 
                 this.recordDescriptor = recordDescriptor;
@@ -2580,7 +2580,7 @@ public class ExtendedOps {
             final Body pattern;
             final Body match;
 
-            public MatchOp(ExternalOpContents def) {
+            public MatchOp(ExternalOpContent def) {
                 super(def);
 
                 this.pattern = def.bodyDefinitions().get(0).build(this);
@@ -2742,7 +2742,7 @@ public class ExtendedOps {
         private final TypeElement resultType;
         private final List<Body> expressions;
 
-        public StringTemplateOp(ExternalOpContents def) {
+        public StringTemplateOp(ExternalOpContent def) {
             super(def);
 
             this.expressions = def.bodyDefinitions().stream().map(bd -> bd.build(this)).toList();

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExternalOpContent.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExternalOpContent.java
@@ -33,26 +33,24 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * An operation in an external form (a record) that can be utilized to construct an instance
+ * An operation's external content (a record) that can be utilized to construct an instance
  * of an {@link ExternalizableOp} associated with the operation's name.
- * <p>
- * The externalized contents of the operation are represented as record components.
  *
  * @param name            the operation name
  * @param operands        the list of operands
  * @param successors      the list of successors
  * @param resultType      the operation result type
- * @param attributes      the operation's specific state as an attribute map, modifiable
+ * @param attributes      the operation's specific content as an attributes map, modifiable
  * @param bodyDefinitions the list of body builders for building the operation's bodies
  * @apiNote Deserializers of operations may utilize this record to construct operations,
  * thereby separating the specifics of deserializing from construction.
  */
-public record ExternalOpContents(String name,
-                                 List<Value> operands,
-                                 List<Block.Reference> successors,
-                                 TypeElement resultType,
-                                 Map<String, Object> attributes,
-                                 List<Body.Builder> bodyDefinitions) {
+public record ExternalOpContent(String name,
+                                List<Value> operands,
+                                List<Block.Reference> successors,
+                                TypeElement resultType,
+                                Map<String, Object> attributes,
+                                List<Body.Builder> bodyDefinitions) {
 
     /**
      * Removes an attribute value from the attributes map, converts the value by applying it
@@ -87,14 +85,14 @@ public record ExternalOpContents(String name,
     }
 
     /**
-     * Externalizes an operation to its external operation definition.
+     * Externalizes an operation to its external content.
      *
      * @param cc the copy context
      * @param op the operation
-     * @return the copied operation definition.
+     * @return the operation's external content.
      */
-    public static ExternalOpContents fromOp(CopyContext cc, Op op) {
-        return new ExternalOpContents(
+    public static ExternalOpContent fromOp(CopyContext cc, Op op) {
+        return new ExternalOpContent(
                 op.opName(),
                 cc.getValues(op.operands()),
                 op.successors().stream().map(cc::getSuccessorOrCreate).toList(),

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExternalizableOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExternalizableOp.java
@@ -31,16 +31,17 @@ import java.util.Map;
 
 /**
  * An operation that supports externalization of its content and reconstruction
- * via an instance of {@link ExternalOpContents}.
+ * via an instance of {@link ExternalOpContent}.
  * <p>
- * The specific state of an externalizable operation can is externalized to a
+ * The specific content of an externalizable operation can be externalized to a
  * map of {@link #attributes attributes}, and is reconstructed from the
- * attributes component by an instance of {@link ExternalOpContents}.
+ * attributes component of an instance of {@link ExternalOpContent}.
  * <p>
  * An externalizable operation could be externalized via serialization to
  * a textual representation. That textual representation could then be deserialized,
- * via parsing, into an instance of {@link ExternalOpContents} from which a new
- * externalizable operation can be reconstructed that is identical to the original.
+ * via parsing, into an instance of {@link ExternalOpContent} from which a new
+ * externalizable operation can be reconstructed that is identical to one that
+ * was serialized.
  */
 public abstract class ExternalizableOp extends Op {
 
@@ -77,23 +78,22 @@ public abstract class ExternalizableOp extends Op {
     }
 
     /**
-     * Constructs an operation from its externalized operation definition.
+     * Constructs an operation from its external content.
      *
-     * @param def the operation definition.
+     * @param def the operation's external content.
      * @implSpec This implementation invokes the {@link Op#Op(String, List) constructor}
-     * accepting the non-optional components of the operation definition, {@code name}, {@code resultType},
+     * accepting the non-optional components of the operation's content, {@code name},
      * and {@code operands}:
      * <pre> {@code
-     *  this(def.name(), def.resultType(), def.operands());
+     *  this(def.name(), def.operands());
      * }</pre>
-     * If the attributes component of the operation definition is copied as if by {@code Map.copyOf}.
      */
-    protected ExternalizableOp(ExternalOpContents def) {
+    protected ExternalizableOp(ExternalOpContent def) {
         super(def.name(), def.operands());
         setLocation(extractLocation(def));
     }
 
-    static Location extractLocation(ExternalOpContents def) {
+    static Location extractLocation(ExternalOpContent def) {
         Object v = def.attributes().get(ATTRIBUTE_LOCATION);
         return switch (v) {
             case String s -> Location.fromString(s);
@@ -104,8 +104,7 @@ public abstract class ExternalizableOp extends Op {
     }
 
     /**
-     * Returns the operation's specific state as a map of attributes,
-     * such that the specific state can be externalized.
+     * Externalizes the operation's specific content as a map of attributes.
      *
      * <p>A null attribute value is represented by the constant
      * value {@link #NULL_ATTRIBUTE_VALUE}.

--- a/src/java.base/share/classes/java/lang/reflect/code/op/OpFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/OpFactory.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * An operation factory for constructing an {@link Op operation} from its {@link OpDefinition operation definition}.
+ * An operation factory for constructing an {@link Op operation} from its {@link ExternalOpContents operation definition}.
  */
 @FunctionalInterface
 public interface OpFactory {
@@ -45,9 +45,9 @@ public interface OpFactory {
      * annotated with {@link OpDeclaration} and enclosed within a given class to compute over.
      * <p>
      * Each enclosed class annotated with {@code OpDeclaration} must declare a public static method named {@code create}
-     * with one parameter type of {@link OpDefinition} and return type that is the concrete class type.
+     * with one parameter type of {@link ExternalOpContents} and return type that is the concrete class type.
      * Alternatively, the concrete class must declare public constructor with one parameter type of
-     * {@link OpDefinition}.
+     * {@link ExternalOpContents}.
      */
     ClassValue<OpFactory> OP_FACTORY = new ClassValue<>() {
         @Override
@@ -75,7 +75,7 @@ public interface OpFactory {
      * @param def the operation definition
      * @return the operation, otherwise null
      */
-    Op constructOp(OpDefinition def);
+    Op constructOp(ExternalOpContents def);
 
     /**
      * Constructs an {@link Op operation} from its operation definition.
@@ -88,7 +88,7 @@ public interface OpFactory {
      * @throws UnsupportedOperationException if there is no mapping from the operation definition's
      *                                       name to a concrete class of an {@code Op}
      */
-    default Op constructOpOrFail(OpDefinition def) {
+    default Op constructOpOrFail(ExternalOpContents def) {
         Op op = constructOp(def);
         if (op == null) {
             throw new UnsupportedOperationException("Unsupported operation: " + def.name());
@@ -146,7 +146,7 @@ public interface OpFactory {
     private static MethodHandle getOpConstructorMethodHandle(Class<?> opClass) {
         Method method = null;
         try {
-            method = opClass.getMethod("create", OpDefinition.class);
+            method = opClass.getMethod("create", ExternalOpContents.class);
         } catch (NoSuchMethodException e) {
         }
 
@@ -165,7 +165,7 @@ public interface OpFactory {
 
         Constructor<?> constructor;
         try {
-            constructor = opClass.getConstructor(OpDefinition.class);
+            constructor = opClass.getConstructor(ExternalOpContents.class);
         } catch (NoSuchMethodException e) {
             return null;
         }
@@ -178,11 +178,11 @@ public interface OpFactory {
         }
     }
 
-    private static Op constructOp(Class<? extends Op> opClass, OpDefinition opDef) {
+    private static Op constructOp(Class<? extends Op> opClass, ExternalOpContents opDef) {
         class Enclosed {
-            private static final ClassValue<Function<OpDefinition, Op>> OP_CONSTRUCTOR = new ClassValue<>() {
+            private static final ClassValue<Function<ExternalOpContents, Op>> OP_CONSTRUCTOR = new ClassValue<>() {
                 @Override
-                protected Function<OpDefinition, Op> computeValue(Class<?> opClass) {
+                protected Function<ExternalOpContents, Op> computeValue(Class<?> opClass) {
                     final MethodHandle opConstructorMH = getOpConstructorMethodHandle(opClass);
                     assert opConstructorMH != null;
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/OpFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/OpFactory.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * An operation factory for constructing an {@link Op operation} from its {@link ExternalOpContents operation definition}.
+ * An operation factory for constructing an {@link Op operation} from its {@link ExternalOpContent external content}.
  */
 @FunctionalInterface
 public interface OpFactory {
@@ -45,9 +45,9 @@ public interface OpFactory {
      * annotated with {@link OpDeclaration} and enclosed within a given class to compute over.
      * <p>
      * Each enclosed class annotated with {@code OpDeclaration} must declare a public static method named {@code create}
-     * with one parameter type of {@link ExternalOpContents} and return type that is the concrete class type.
+     * with one parameter type of {@link ExternalOpContent} and return type that is the concrete class type.
      * Alternatively, the concrete class must declare public constructor with one parameter type of
-     * {@link ExternalOpContents}.
+     * {@link ExternalOpContent}.
      */
     ClassValue<OpFactory> OP_FACTORY = new ClassValue<>() {
         @Override
@@ -67,28 +67,28 @@ public interface OpFactory {
     };
 
     /**
-     * Constructs an {@link Op operation} from its operation definition.
+     * Constructs an {@link Op operation} from its external content.
      * <p>
-     * If there is no mapping from the operation definition's name to a concrete
+     * If there is no mapping from the operation's name to a concrete
      * class of an {@code Op} then this method returns null.
      *
-     * @param def the operation definition
+     * @param def the operation's external content
      * @return the operation, otherwise null
      */
-    Op constructOp(ExternalOpContents def);
+    Op constructOp(ExternalOpContent def);
 
     /**
-     * Constructs an {@link Op operation} from its operation definition.
+     * Constructs an {@link Op operation} from its external content.
      * <p>
-     * If there is no mapping from the operation definition's name to a concrete
+     * If there is no mapping from the operation's name to a concrete
      * class of an {@code Op} then this method throws UnsupportedOperationException.
      *
-     * @param def the operation definition
+     * @param def the operation's external content
      * @return the operation, otherwise null
-     * @throws UnsupportedOperationException if there is no mapping from the operation definition's
+     * @throws UnsupportedOperationException if there is no mapping from the operation's
      *                                       name to a concrete class of an {@code Op}
      */
-    default Op constructOpOrFail(ExternalOpContents def) {
+    default Op constructOpOrFail(ExternalOpContent def) {
         Op op = constructOp(def);
         if (op == null) {
             throw new UnsupportedOperationException("Unsupported operation: " + def.name());
@@ -146,7 +146,7 @@ public interface OpFactory {
     private static MethodHandle getOpConstructorMethodHandle(Class<?> opClass) {
         Method method = null;
         try {
-            method = opClass.getMethod("create", ExternalOpContents.class);
+            method = opClass.getMethod("create", ExternalOpContent.class);
         } catch (NoSuchMethodException e) {
         }
 
@@ -165,7 +165,7 @@ public interface OpFactory {
 
         Constructor<?> constructor;
         try {
-            constructor = opClass.getConstructor(ExternalOpContents.class);
+            constructor = opClass.getConstructor(ExternalOpContent.class);
         } catch (NoSuchMethodException e) {
             return null;
         }
@@ -178,11 +178,11 @@ public interface OpFactory {
         }
     }
 
-    private static Op constructOp(Class<? extends Op> opClass, ExternalOpContents opDef) {
+    private static Op constructOp(Class<? extends Op> opClass, ExternalOpContent opDef) {
         class Enclosed {
-            private static final ClassValue<Function<ExternalOpContents, Op>> OP_CONSTRUCTOR = new ClassValue<>() {
+            private static final ClassValue<Function<ExternalOpContent, Op>> OP_CONSTRUCTOR = new ClassValue<>() {
                 @Override
-                protected Function<ExternalOpContents, Op> computeValue(Class<?> opClass) {
+                protected Function<ExternalOpContent, Op> computeValue(Class<?> opClass) {
                     final MethodHandle opConstructorMH = getOpConstructorMethodHandle(opClass);
                     assert opConstructorMH != null;
 

--- a/src/java.base/share/classes/java/lang/reflect/code/parser/OpParser.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/parser/OpParser.java
@@ -239,18 +239,18 @@ public final class OpParser {
     }
 
     static Op nodeToOp(OpNode opNode, TypeDefinition rtype, Context c, Body.Builder ancestorBody) {
-        OpDefinition opdef = nodeToOpDef(opNode, rtype, c, ancestorBody);
+        ExternalOpContents opdef = nodeToOpDef(opNode, rtype, c, ancestorBody);
         return c.opFactory.constructOpOrFail(opdef);
     }
 
-    static OpDefinition nodeToOpDef(OpNode opNode, TypeDefinition rtype, Context c, Body.Builder ancestorBody) {
+    static ExternalOpContents nodeToOpDef(OpNode opNode, TypeDefinition rtype, Context c, Body.Builder ancestorBody) {
         String operationName = opNode.name;
         List<Value> operands = opNode.operands.stream().map(c::getValue).toList();
         List<Block.Reference> successors = opNode.successors.stream()
                 .map(n -> nodeToSuccessor(n, c)).toList();
         List<Body.Builder> bodies = opNode.bodies.stream()
                 .map(n -> nodeToBody(n, c.fork(false), ancestorBody)).toList();
-        return new OpDefinition(operationName,
+        return new ExternalOpContents(operationName,
                 operands,
                 successors,
                 c.typeFactory.constructType(rtype),
@@ -429,7 +429,7 @@ public final class OpParser {
     Object parseLiteral(Tokens.Token t) {
         return switch (t.kind) {
             case STRINGLITERAL -> t.stringVal();
-            case NULL -> Op.NULL_ATTRIBUTE_VALUE;
+            case NULL -> ExternalizableOp.NULL_ATTRIBUTE_VALUE;
             default -> throw lexer.unexpected();
         };
     }

--- a/src/java.base/share/classes/java/lang/reflect/code/parser/OpParser.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/parser/OpParser.java
@@ -239,18 +239,18 @@ public final class OpParser {
     }
 
     static Op nodeToOp(OpNode opNode, TypeDefinition rtype, Context c, Body.Builder ancestorBody) {
-        ExternalOpContents opdef = nodeToOpDef(opNode, rtype, c, ancestorBody);
+        ExternalOpContent opdef = nodeToOpDef(opNode, rtype, c, ancestorBody);
         return c.opFactory.constructOpOrFail(opdef);
     }
 
-    static ExternalOpContents nodeToOpDef(OpNode opNode, TypeDefinition rtype, Context c, Body.Builder ancestorBody) {
+    static ExternalOpContent nodeToOpDef(OpNode opNode, TypeDefinition rtype, Context c, Body.Builder ancestorBody) {
         String operationName = opNode.name;
         List<Value> operands = opNode.operands.stream().map(c::getValue).toList();
         List<Block.Reference> successors = opNode.successors.stream()
                 .map(n -> nodeToSuccessor(n, c)).toList();
         List<Body.Builder> bodies = opNode.bodies.stream()
                 .map(n -> nodeToBody(n, c.fork(false), ancestorBody)).toList();
-        return new ExternalOpContents(operationName,
+        return new ExternalOpContent(operationName,
                 operands,
                 successors,
                 c.typeFactory.constructType(rtype),

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
@@ -26,7 +26,7 @@
 package java.lang.reflect.code.writer;
 
 import java.lang.reflect.code.*;
-import java.lang.reflect.code.op.ExternalOpContents;
+import java.lang.reflect.code.op.ExternalOpContent;
 import java.lang.reflect.code.op.OpFactory;
 import java.lang.reflect.code.op.ExternalizableOp;
 import java.lang.reflect.code.type.*;
@@ -44,10 +44,10 @@ import static java.lang.reflect.code.type.JavaType.*;
  */
 public class OpBuilder {
 
-    static final JavaType J_C_O_OP_DEFINITION = type(ExternalOpContents.class);
+    static final JavaType J_C_O_OP_DEFINITION = type(ExternalOpContent.class);
 
     static final MethodRef OP_FACTORY_CONSTRUCT = MethodRef.method(OpFactory.class, "constructOp",
-            Op.class, ExternalOpContents.class);
+            Op.class, ExternalOpContent.class);
 
     static final MethodRef TYPE_ELEMENT_FACTORY_CONSTRUCT = MethodRef.method(TypeElementFactory.class, "constructType",
             TypeElement.class, TypeDefinition.class);

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpBuilder.java
@@ -26,8 +26,9 @@
 package java.lang.reflect.code.writer;
 
 import java.lang.reflect.code.*;
-import java.lang.reflect.code.op.OpDefinition;
+import java.lang.reflect.code.op.ExternalOpContents;
 import java.lang.reflect.code.op.OpFactory;
+import java.lang.reflect.code.op.ExternalizableOp;
 import java.lang.reflect.code.type.*;
 import java.util.*;
 
@@ -43,10 +44,10 @@ import static java.lang.reflect.code.type.JavaType.*;
  */
 public class OpBuilder {
 
-    static final JavaType J_C_O_OP_DEFINITION = type(OpDefinition.class);
+    static final JavaType J_C_O_OP_DEFINITION = type(ExternalOpContents.class);
 
     static final MethodRef OP_FACTORY_CONSTRUCT = MethodRef.method(OpFactory.class, "constructOp",
-            Op.class, OpDefinition.class);
+            Op.class, ExternalOpContents.class);
 
     static final MethodRef TYPE_ELEMENT_FACTORY_CONSTRUCT = MethodRef.method(TypeElementFactory.class, "constructType",
             TypeElement.class, TypeDefinition.class);
@@ -197,7 +198,7 @@ public class OpBuilder {
                 operands,
                 successors,
                 inputOp.resultType(),
-                inputOp.attributes(),
+                inputOp instanceof ExternalizableOp exop ? exop.attributes() : Map.of(),
                 bodies);
         return builder.op(invoke(OP_FACTORY_CONSTRUCT, opFactory, opDef));
     }
@@ -322,8 +323,9 @@ public class OpBuilder {
                 // @@@ Construct location explicitly
                 yield builder.op(constant(J_L_STRING, l.toString()));
             }
-            case Object o when value == Op.NULL_ATTRIBUTE_VALUE -> {
-                yield builder.op(fieldLoad(FieldRef.field(Op.class, "NULL_ATTRIBUTE_VALUE", Object.class)));
+            case Object o when value == ExternalizableOp.NULL_ATTRIBUTE_VALUE -> {
+                yield builder.op(fieldLoad(FieldRef.field(ExternalizableOp.class,
+                        "NULL_ATTRIBUTE_VALUE", Object.class)));
             }
             default -> {
                 // @@@ use the result of value.toString()?

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.lang.reflect.code.*;
-import java.lang.reflect.code.op.OpWithDefinition;
+import java.lang.reflect.code.op.ExternalizableOp;
 import java.lang.reflect.code.type.JavaType;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,7 +65,7 @@ public final class OpWriter {
 
     static final class AttributeMapper {
         static String toString(Object value) {
-            return value == Op.NULL_ATTRIBUTE_VALUE
+            return value == ExternalizableOp.NULL_ATTRIBUTE_VALUE
                     ? "null"
                     : "\"" + quote(value.toString()) + "\"";
         }
@@ -351,11 +351,11 @@ public final class OpWriter {
             writeSpaceSeparatedList(op.successors(), this::writeSuccessor);
         }
 
-        Map<String, Object> attributes = op.attributes();
+        Map<String, Object> attributes = op instanceof ExternalizableOp exop ? exop.attributes() : Map.of();
         if (dropLocation && !attributes.isEmpty() &&
-                attributes.containsKey(OpWithDefinition.ATTRIBUTE_LOCATION)) {
+                attributes.containsKey(ExternalizableOp.ATTRIBUTE_LOCATION)) {
             attributes = new HashMap<>(attributes);
-            attributes.remove(OpWithDefinition.ATTRIBUTE_LOCATION);
+            attributes.remove(ExternalizableOp.ATTRIBUTE_LOCATION);
         }
         if (!attributes.isEmpty()) {
             write(" ");

--- a/src/jdk.code.tools/share/classes/jdk/code/tools/renderer/SRRenderer.java
+++ b/src/jdk.code.tools/share/classes/jdk/code/tools/renderer/SRRenderer.java
@@ -32,6 +32,7 @@ import java.lang.reflect.code.Op;
 import java.lang.reflect.code.Value;
 
 import java.io.*;
+import java.lang.reflect.code.op.ExternalizableOp;
 import java.lang.reflect.code.type.JavaType;
 import java.nio.charset.StandardCharsets;
 
@@ -149,15 +150,17 @@ public final class SRRenderer extends CommonRenderer<SRRenderer> {
             }
         }
 
-        if (!op.attributes().isEmpty()) {
-            space().spaceSeparatedList();
-            for (var e : op.attributes().entrySet()) {
-                spaceSeparator();
-                String name = e.getKey();
-                if (!name.isEmpty()) {
-                    atIdentifier(name).equal().identifier(AttributeMapper.toString(e.getValue()));
-                } else {
-                    atIdentifier(AttributeMapper.toString(e.getValue()));
+        if (op instanceof ExternalizableOp exop) {
+            if (!exop.attributes().isEmpty()) {
+                space().spaceSeparatedList();
+                for (var e : exop.attributes().entrySet()) {
+                    spaceSeparator();
+                    String name = e.getKey();
+                    if (!name.isEmpty()) {
+                        atIdentifier(name).equal().identifier(AttributeMapper.toString(e.getValue()));
+                    } else {
+                        atIdentifier(AttributeMapper.toString(e.getValue()));
+                    }
                 }
             }
         }

--- a/test/jdk/java/lang/reflect/code/TestCopy.java
+++ b/test/jdk/java/lang/reflect/code/TestCopy.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.code.CopyContext;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.op.CoreOps;
-import java.lang.reflect.code.op.ExternalOpContents;
+import java.lang.reflect.code.op.ExternalOpContent;
 import java.lang.runtime.CodeReflection;
 import java.util.Optional;
 import java.util.function.IntUnaryOperator;
@@ -60,7 +60,7 @@ public class TestCopy {
     public void testCopyWithDefinition() {
         CoreOps.FuncOp f = getFuncOp("f");
 
-        ExternalOpContents odef = ExternalOpContents.fromOp(CopyContext.create(), f);
+        ExternalOpContent odef = ExternalOpContent.fromOp(CopyContext.create(), f);
         Op copy = CoreOps.FACTORY.constructOp(odef);
 
         Assert.assertEquals(f.toText(), copy.toText());

--- a/test/jdk/java/lang/reflect/code/TestCopy.java
+++ b/test/jdk/java/lang/reflect/code/TestCopy.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.code.CopyContext;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.op.CoreOps;
-import java.lang.reflect.code.op.OpDefinition;
+import java.lang.reflect.code.op.ExternalOpContents;
 import java.lang.runtime.CodeReflection;
 import java.util.Optional;
 import java.util.function.IntUnaryOperator;
@@ -60,7 +60,7 @@ public class TestCopy {
     public void testCopyWithDefinition() {
         CoreOps.FuncOp f = getFuncOp("f");
 
-        OpDefinition odef = OpDefinition.fromOp(CopyContext.create(), f);
+        ExternalOpContents odef = ExternalOpContents.fromOp(CopyContext.create(), f);
         Op copy = CoreOps.FACTORY.constructOp(odef);
 
         Assert.assertEquals(f.toText(), copy.toText());


### PR DESCRIPTION
Rename `OpWithDefinition` to `ExternalizableOp` and specify as an operation whose contents may be externalized.
Rename `OpDefintion` to `ExternalOpContents`, an instance of which represents the external contents of an operation.
An externaliziable operation may be constructed from its external contents, for example by using an operation factory. 

The method `Op::attributes` is removed, and the method is defined on `ExternalizableOp`. The attribute map returned by the method is the external representation of specific contents of an operation.