### PR TITLE
Fix test failure after PR/51

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/parser/impl/DescParser.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/parser/impl/DescParser.java
@@ -91,7 +91,6 @@ public final class DescParser {
         StringBuilder identifier = new StringBuilder();
         if (l.token().kind == TokenKind.HASH) {
             // Quoted identifier
-            l.accept(TokenKind.HASH);
             Token t = l.token();
             while (t.kind != TokenKind.LT) {
                 identifier.append(t.kind == TokenKind.IDENTIFIER ? t.name() : t.kind.name);

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -125,7 +125,7 @@ public final class CoreTypeFactory {
                 if (typeArguments.size() != 1) {
                     throw new IllegalArgumentException("Bad type-variable bounds: " + tree);
                 }
-                String[] parts = identifier.split("::");
+                String[] parts = identifier.substring(1).split("::");
                 if (parts.length == 2) {
                     // class type-var
                     return JavaType.typeVarRef(parts[1],


### PR DESCRIPTION
A test is failing after my push of https://git.openjdk.org/babylon/pull/51

The problem is that I've tweaked the logic for parsing type-variables, so that now we check for a starting `#` in the core type factory.
But the `#` char is not copied into the identifier, hence the issue.

Unfortunately sometimes tests seem to pass even though they are run after a `make images`. The problem is that after changes in the `j.l.reflect.code` packages, only `java.base` is rebuilt, and the `jdk.compiler` copy is not. This means that, unless one does `make images` all the time, some tests might pass (or fail) spuriously. We might need to look at the build again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/babylon.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/63.diff">https://git.openjdk.org/babylon/pull/63.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/63#issuecomment-2079832985)