### PR TITLE
Enable pattern matching for JavaType hierarchy

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -1661,9 +1661,8 @@ public final class CoreOps {
         }
 
         static TypeElement resultType(Value array, Value v) {
-            ArrayType arrayType = (ArrayType) array.type();
-            if (!arrayType.isArray()) {
-                throw new IllegalArgumentException("Type is not an array type: " + arrayType);
+            if (!(array.type() instanceof ArrayType arrayType)) {
+                throw new IllegalArgumentException("Type is not an array type: " + array.type());
             }
 
             // @@@ restrict to indexes of int?

--- a/src/java.base/share/classes/java/lang/reflect/code/type/ArrayType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/ArrayType.java
@@ -99,19 +99,4 @@ public final class ArrayType implements JavaType {
     public String toNominalDescriptorString() {
         return "[" + componentType.toNominalDescriptorString();
     }
-
-    @Override
-    public boolean isClass() {
-        return false;
-    }
-
-    @Override
-    public boolean isArray() {
-        return true;
-    }
-
-    @Override
-    public boolean isPrimitive() {
-        return false;
-    }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
@@ -89,21 +89,6 @@ public final class ClassType implements JavaType {
         return rawType();
     }
 
-    @Override
-    public boolean isArray() {
-        return false;
-    }
-
-    @Override
-    public boolean isPrimitive() {
-        return false;
-    }
-
-    @Override
-    public boolean isClass() {
-        return true;
-    }
-
     // Conversions
 
     public ClassType rawType() {

--- a/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * A primitive type.
  */
-/* package */ final class PrimitiveType implements JavaType {
+public final class PrimitiveType implements JavaType {
     // Fully qualified name
     private final String type;
 
@@ -67,21 +67,6 @@ import java.util.Map;
     @Override
     public JavaType erasure() {
         return this;
-    }
-
-    @Override
-    public boolean isArray() {
-        return false;
-    }
-
-    @Override
-    public boolean isPrimitive() {
-        return true;
-    }
-
-    @Override
-    public boolean isClass() {
-        return false;
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
@@ -111,19 +111,4 @@ public final class TypeVarRef implements JavaType {
     public String toNominalDescriptorString() {
         throw new UnsupportedOperationException("Type var");
     }
-
-    @Override
-    public boolean isClass() {
-        return false;
-    }
-
-    @Override
-    public boolean isArray() {
-        return false;
-    }
-
-    @Override
-    public boolean isPrimitive() {
-        return false;
-    }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/type/WildcardType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/WildcardType.java
@@ -94,21 +94,6 @@ public final class WildcardType implements JavaType {
         throw new UnsupportedOperationException("Wildcard type");
     }
 
-    @Override
-    public boolean isClass() {
-        return false;
-    }
-
-    @Override
-    public boolean isArray() {
-        return false;
-    }
-
-    @Override
-    public boolean isPrimitive() {
-        return false;
-    }
-
     public enum BoundKind {
         EXTENDS,
         SUPER


### PR DESCRIPTION
The `JavaType` hierarchy has now several types under it:

* `ClassType`
* `ArrayType`
* `PrimitiveType`
* `TypeVarRef`
* `WildcardType`

All these types are `public`, except `PrimitiveType`. This limits applicability of pattern matching.

In addition, `JavaType` defines a bunch of predicates:

* `isClass()`
* `isArray()`
* `isPrimitive()`

This set of predicates is now incomplete, as it doesn't support all the possible leaves in the type hierarchy.

Overall, it would be much better to just lean into pattern matching more, and drop the predicates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/babylon.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/64.diff">https://git.openjdk.org/babylon/pull/64.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/64#issuecomment-2079835529)