### PR TITLE
Add common supertype for type-variable owners

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * A class type.
  */
-public final class ClassType implements JavaType {
+public final class ClassType implements TypeVarRef.Owner, JavaType {
     // Fully qualified name
     private final String type;
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -129,7 +129,7 @@ public final class CoreTypeFactory {
                 if (parts.length == 2) {
                     // class type-var
                     return JavaType.typeVarRef(parts[1],
-                            (JavaType)constructType(parseTypeDef(parts[0])),
+                            (ClassType)constructType(parseTypeDef(parts[0])),
                             typeArguments.get(0));
                 } else {
                     // method type-var

--- a/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
@@ -265,24 +265,13 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
     }
 
     /**
-     * Constructs a reference to a class type-variable.
+     * Constructs a reference to a type-variable with the given owner.
      *
      * @param bound the type-variable bound.
-     * @param owner the class where the type-variable is declared.
+     * @param owner the type-variable owner.
      * @return a type-variable reference.
      */
-    static TypeVarRef typeVarRef(String name, ClassType owner, JavaType bound) {
-        return new TypeVarRef(name, owner, bound);
-    }
-
-    /**
-     * Constructs a reference to a method type-variable.
-     *
-     * @param bound the type-variable bound.
-     * @param owner the method where the type-variable is declared.
-     * @return a type-variable reference.
-     */
-    static TypeVarRef typeVarRef(String name, MethodRef owner, JavaType bound) {
+    static TypeVarRef typeVarRef(String name, TypeVarRef.Owner owner, JavaType bound) {
         return new TypeVarRef(name, owner, bound);
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
@@ -271,7 +271,7 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
      * @param owner the class where the type-variable is declared.
      * @return a type-variable reference.
      */
-    static TypeVarRef typeVarRef(String name, JavaType owner, JavaType bound) {
+    static TypeVarRef typeVarRef(String name, ClassType owner, JavaType bound) {
         return new TypeVarRef(name, owner, bound);
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
@@ -51,7 +51,7 @@ import static java.lang.reflect.code.type.FunctionType.functionType;
 //  constant pool entry of CONSTANT_Methodref_info or CONSTANT_InterfaceMethodref_info.
 //
 //  We can infer the kind, if we can resolve the types and lookup the declared method
-public sealed interface MethodRef permits MethodRefImpl {
+public sealed interface MethodRef extends TypeVarRef.Owner permits MethodRefImpl {
 
     TypeElement refType();
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
@@ -34,10 +34,10 @@ import java.util.Optional;
 public final class TypeVarRef implements JavaType {
 
     final String name;
-    final Object owner;
+    final Owner owner;
     final JavaType bound;
 
-    TypeVarRef(String name, Object owner, JavaType bound) {
+    TypeVarRef(String name, Owner owner, JavaType bound) {
         this.name = name;
         this.owner = owner;
         this.bound = bound;
@@ -58,19 +58,10 @@ public final class TypeVarRef implements JavaType {
     }
 
     /**
-     * {@return the method owner of this type-variable}
+     * {@return the owner of this type-variable}
      */
-    public Optional<MethodRef> methodOwner() {
-        return owner instanceof MethodRef methodRef ?
-                Optional.of(methodRef) : Optional.empty();
-    }
-
-    /**
-     * {@return the class owner of this type-variable}
-     */
-    public Optional<JavaType> classOwner() {
-        return owner instanceof JavaType typeRef ?
-                Optional.of(typeRef) : Optional.empty();
+    public Owner owner() {
+        return owner;
     }
 
     @Override
@@ -111,4 +102,9 @@ public final class TypeVarRef implements JavaType {
     public String toNominalDescriptorString() {
         throw new UnsupportedOperationException("Type var");
     }
+
+    /**
+     * The owner of a type-variable - either a class or a method.
+     */
+    public sealed interface Owner permits ClassType, MethodRef { }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -2267,7 +2267,8 @@ public class ReflectMethods extends TreeTranslator {
                 case TYPEVAR -> t.tsym.owner.kind == Kind.MTH ?
                         JavaType.typeVarRef(t.tsym.name.toString(), symbolToErasedMethodRef(t.tsym.owner),
                                 typeToTypeElement(t.getUpperBound())) :
-                        JavaType.typeVarRef(t.tsym.name.toString(), symbolToErasedDesc(t.tsym.owner),
+                        JavaType.typeVarRef(t.tsym.name.toString(),
+                                (jdk.internal.java.lang.reflect.code.type.ClassType)symbolToErasedDesc(t.tsym.owner),
                                 typeToTypeElement(t.getUpperBound()));
                 case CLASS -> {
                     Assert.check(!t.isIntersection() && !t.isUnion());

--- a/test/jdk/java/lang/reflect/code/TestErasure.java
+++ b/test/jdk/java/lang/reflect/code/TestErasure.java
@@ -29,6 +29,7 @@
 import static org.testng.Assert.*;
 import org.testng.annotations.*;
 
+import java.lang.reflect.code.type.ClassType;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.type.WildcardType.BoundKind;
 import java.util.ArrayList;
@@ -117,13 +118,13 @@ public class TestErasure {
         List<TypeAndErasure> typeVars = new ArrayList<>();
         for (int dims = 1 ; dims <= 3 ; dims++) {
             for (TypeAndErasure t : references()) {
-                typeVars.add(new TypeAndErasure(JavaType.typeVarRef("X", JavaType.J_L_OBJECT, t.type), t.erasure));
+                typeVars.add(new TypeAndErasure(JavaType.typeVarRef("X", (ClassType)JavaType.J_L_OBJECT, t.type), t.erasure));
             }
             for (TypeAndErasure t : genericReferences()) {
-                typeVars.add(new TypeAndErasure(JavaType.typeVarRef("X", JavaType.J_L_OBJECT, t.type), t.erasure));
+                typeVars.add(new TypeAndErasure(JavaType.typeVarRef("X", (ClassType)JavaType.J_L_OBJECT, t.type), t.erasure));
             }
             for (TypeAndErasure t : arrays()) {
-                typeVars.add(new TypeAndErasure(JavaType.typeVarRef("X", JavaType.J_L_OBJECT, t.type), t.erasure));
+                typeVars.add(new TypeAndErasure(JavaType.typeVarRef("X", (ClassType)JavaType.J_L_OBJECT, t.type), t.erasure));
             }
         }
         return typeVars;

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -129,7 +129,7 @@ public class TestJavaType {
         JavaType jt = JavaType.ofString(tds);
         Assert.assertEquals(jt.toString(), tds);
 
-        while (jt.isArray()) {
+        while (jt instanceof ArrayType) {
             jt = ((ArrayType)jt).componentType();
         }
         ClassType ct = (ClassType)jt;


### PR DESCRIPTION
This is a followup of https://git.openjdk.org/babylon/pull/64

The goal is to define a common supertype for type-variable owner, namely `Type>

This is a sealed interface implemented by both `MethodRef` and `ClassType`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [b666cce2](https://git.openjdk.org/babylon/pull/66/files/b666cce2d1ec8ceb28ee30652f7816f81abe8043)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/babylon.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/66.diff">https://git.openjdk.org/babylon/pull/66.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/66#issuecomment-2083239677)