### PR TITLE
Clean up support for boxing

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOps.java
@@ -638,8 +638,8 @@ public final class CoreOps {
 
         private static boolean isBoxOrUnboxInvocation(CoreOps.InvokeOp iop) {
             MethodRef mr = iop.invokeDescriptor();
-            Collection<TypeElement> boxTypes = JavaType.primitiveToWrapper.values();
-            return boxTypes.contains(mr.refType()) && (UNBOX_NAMES.contains(mr.name()) || mr.name().equals("valueOf"));
+            return mr.refType() instanceof ClassType ct && ct.unbox().isPresent() &&
+                    (UNBOX_NAMES.contains(mr.name()) || mr.name().equals("valueOf"));
         }
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -2857,8 +2857,8 @@ public class ExtendedOps {
             Value array = builder.op(newArray(J_L_OBJECT_ARRAY, builder.op(constant(INT, elements.size()))));
             for (int i = 0; i < elements.size(); i++) {
                 Value ele = elements.get(i);
-                if (ele.type() instanceof PrimitiveType pt) {
-                    TypeElement wt = pt.box();
+                if (ele.type() instanceof PrimitiveType pt && pt.box().isPresent()) {
+                    ClassType wt = pt.box().get();
                     MethodRef valueOf = MethodRef.method(wt, "valueOf", wt, ele.type());
                     ele = builder.op(invoke(valueOf, ele));
                 }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOps.java
@@ -30,6 +30,7 @@ import java.lang.reflect.code.*;
 import java.lang.reflect.code.type.ArrayType;
 import java.lang.reflect.code.type.ClassType;
 import java.lang.reflect.code.type.MethodRef;
+import java.lang.reflect.code.type.PrimitiveType;
 import java.lang.reflect.code.type.RecordTypeRef;
 import java.lang.reflect.code.type.FunctionType;
 import java.lang.reflect.code.type.JavaType;
@@ -2856,8 +2857,8 @@ public class ExtendedOps {
             Value array = builder.op(newArray(J_L_OBJECT_ARRAY, builder.op(constant(INT, elements.size()))));
             for (int i = 0; i < elements.size(); i++) {
                 Value ele = elements.get(i);
-                if (isPrimitive(ele.type())) {
-                    TypeElement wt = getWrapperType(ele.type());
+                if (ele.type() instanceof PrimitiveType pt) {
+                    TypeElement wt = pt.box();
                     MethodRef valueOf = MethodRef.method(wt, "valueOf", wt, ele.type());
                     ele = builder.op(invoke(valueOf, ele));
                 }

--- a/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
@@ -28,6 +28,7 @@ package java.lang.reflect.code.type;
 import java.lang.reflect.code.TypeElement;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A class type.
@@ -82,6 +83,25 @@ public final class ClassType implements JavaType {
         int result = type.hashCode();
         result = 31 * result + typeArguments.hashCode();
         return result;
+    }
+
+    /**
+     * {@return the unboxed primitive type associated with this class type (if any)}
+     */
+    public Optional<PrimitiveType> unbox() {
+        class LazyHolder {
+            static final Map<ClassType, PrimitiveType> wrapperToPrimitive = Map.of(
+                    J_L_BYTE, BYTE,
+                    J_L_SHORT, SHORT,
+                    J_L_INTEGER, INT,
+                    J_L_LONG, LONG,
+                    J_L_FLOAT, FLOAT,
+                    J_L_DOUBLE, DOUBLE,
+                    J_L_CHARACTER, CHAR,
+                    J_L_BOOLEAN, BOOLEAN
+            );
+        }
+        return Optional.ofNullable(LazyHolder.wrapperToPrimitive.get(this));
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/JavaType.java
@@ -30,7 +30,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.type.WildcardType.BoundKind;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -40,90 +39,69 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
                                                              PrimitiveType, WildcardType, TypeVarRef {
 
     // @@@ Share with general void type?
-    JavaType VOID = new PrimitiveType("void");
+    PrimitiveType VOID = new PrimitiveType("void");
 
-    JavaType BOOLEAN = new PrimitiveType("boolean");
+    PrimitiveType BOOLEAN = new PrimitiveType("boolean");
 
-    JavaType J_L_BOOLEAN = new ClassType("java.lang.Boolean");
+    ClassType J_L_BOOLEAN = new ClassType("java.lang.Boolean");
 
-    JavaType BOOLEAN_ARRAY = new ArrayType(BOOLEAN);
+    ArrayType BOOLEAN_ARRAY = new ArrayType(BOOLEAN);
 
-    JavaType BYTE = new PrimitiveType("byte");
+    PrimitiveType BYTE = new PrimitiveType("byte");
 
-    JavaType J_L_BYTE = new ClassType("java.lang.Byte");
+    ClassType J_L_BYTE = new ClassType("java.lang.Byte");
 
-    JavaType BYTE_ARRAY = new ArrayType(BYTE);
+    ArrayType BYTE_ARRAY = new ArrayType(BYTE);
 
-    JavaType CHAR = new PrimitiveType("char");
+    PrimitiveType CHAR = new PrimitiveType("char");
 
-    JavaType J_L_CHARACTER = new ClassType("java.lang.Character");
+    ClassType J_L_CHARACTER = new ClassType("java.lang.Character");
 
-    JavaType CHAR_ARRAY = new ArrayType(CHAR);
+    ArrayType CHAR_ARRAY = new ArrayType(CHAR);
 
-    JavaType SHORT = new PrimitiveType("short");
+    PrimitiveType SHORT = new PrimitiveType("short");
 
-    JavaType J_L_SHORT = new ClassType("java.lang.Short");
+    ClassType J_L_SHORT = new ClassType("java.lang.Short");
 
-    JavaType SHORT_ARRAY = new ArrayType(SHORT);
+    ArrayType SHORT_ARRAY = new ArrayType(SHORT);
 
-    JavaType INT = new PrimitiveType("int");
+    PrimitiveType INT = new PrimitiveType("int");
 
-    JavaType J_L_INTEGER = new ClassType("java.lang.Integer");
+    ClassType J_L_INTEGER = new ClassType("java.lang.Integer");
 
-    JavaType INT_ARRAY = new ArrayType(INT);
+    ArrayType INT_ARRAY = new ArrayType(INT);
 
-    JavaType LONG = new PrimitiveType("long");
+    PrimitiveType LONG = new PrimitiveType("long");
 
-    JavaType J_L_LONG = new ClassType("java.lang.Long");
+    ClassType J_L_LONG = new ClassType("java.lang.Long");
 
-    JavaType LONG_ARRAY = new ArrayType(LONG);
+    ArrayType LONG_ARRAY = new ArrayType(LONG);
 
-    JavaType FLOAT = new PrimitiveType("float");
+    PrimitiveType FLOAT = new PrimitiveType("float");
 
-    JavaType J_L_FLOAT = new ClassType("java.lang.Float");
+    ClassType J_L_FLOAT = new ClassType("java.lang.Float");
 
-    JavaType FLOAT_ARRAY = new ArrayType(FLOAT);
+    ArrayType FLOAT_ARRAY = new ArrayType(FLOAT);
 
-    JavaType DOUBLE = new PrimitiveType("double");
+    PrimitiveType DOUBLE = new PrimitiveType("double");
 
-    JavaType J_L_DOUBLE = new ClassType("java.lang.Double");
+    ClassType J_L_DOUBLE = new ClassType("java.lang.Double");
 
-    JavaType DOUBLE_ARRAY = new ArrayType(DOUBLE);
+    ArrayType DOUBLE_ARRAY = new ArrayType(DOUBLE);
 
-    JavaType J_L_OBJECT = new ClassType("java.lang.Object");
+    ClassType J_L_OBJECT = new ClassType("java.lang.Object");
 
-    JavaType J_L_OBJECT_ARRAY = new ArrayType(J_L_OBJECT);
+    ArrayType J_L_OBJECT_ARRAY = new ArrayType(J_L_OBJECT);
 
-    JavaType J_L_CLASS = new ClassType("java.lang.Class");
+    ClassType J_L_CLASS = new ClassType("java.lang.Class");
 
-    JavaType J_L_STRING = new ClassType("java.lang.String");
+    ClassType J_L_STRING = new ClassType("java.lang.String");
 
-    JavaType J_L_STRING_TEMPLATE = new ClassType("java.lang.StringTemplate");
+    ClassType J_L_STRING_TEMPLATE = new ClassType("java.lang.StringTemplate");
 
-    JavaType J_L_STRING_TEMPLATE_PROCESSOR = new ClassType("java.lang.StringTemplate$Processor");
+    ClassType J_L_STRING_TEMPLATE_PROCESSOR = new ClassType("java.lang.StringTemplate$Processor");
 
-    JavaType J_U_LIST = new ClassType("java.util.List");
-
-    //
-
-    Map<TypeElement, TypeElement> primitiveToWrapper = Map.of(
-            BYTE, J_L_BYTE,
-            SHORT, J_L_SHORT,
-            INT, J_L_INTEGER,
-            LONG, J_L_LONG,
-            FLOAT, J_L_FLOAT,
-            DOUBLE, J_L_DOUBLE,
-            CHAR, J_L_CHARACTER,
-            BOOLEAN, J_L_BOOLEAN
-    );
-
-    static boolean isPrimitive(TypeElement te) {
-        return primitiveToWrapper.containsKey(te);
-    }
-
-    static TypeElement getWrapperType(TypeElement te) {
-        return primitiveToWrapper.get(te);
-    };
+    ClassType J_U_LIST = new ClassType("java.util.List");
 
     // Conversions
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
@@ -25,6 +25,7 @@
 
 package java.lang.reflect.code.type;
 
+import java.lang.reflect.code.TypeElement;
 import java.util.List;
 import java.util.Map;
 
@@ -80,6 +81,25 @@ public final class PrimitiveType implements JavaType {
             default -> JavaType.INT;
         };
     }
+
+    /**
+     * {@return the boxed class type associated with this primitive type}
+     */
+    public ClassType box() {
+        class LazyHolder {
+            static final Map<PrimitiveType, ClassType> primitiveToWrapper = Map.of(
+                    BYTE, J_L_BYTE,
+                    SHORT, J_L_SHORT,
+                    INT, J_L_INTEGER,
+                    LONG, J_L_LONG,
+                    FLOAT, J_L_FLOAT,
+                    DOUBLE, J_L_DOUBLE,
+                    CHAR, J_L_CHARACTER,
+                    BOOLEAN, J_L_BOOLEAN
+            );
+        }
+        return LazyHolder.primitiveToWrapper.get(this);
+    };
 
     @Override
     public String toNominalDescriptorString() {

--- a/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
@@ -28,6 +28,7 @@ package java.lang.reflect.code.type;
 import java.lang.reflect.code.TypeElement;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A primitive type.
@@ -83,9 +84,9 @@ public final class PrimitiveType implements JavaType {
     }
 
     /**
-     * {@return the boxed class type associated with this primitive type}
+     * {@return the boxed class type associated with this primitive type (if any)}
      */
-    public ClassType box() {
+    public Optional<ClassType> box() {
         class LazyHolder {
             static final Map<PrimitiveType, ClassType> primitiveToWrapper = Map.of(
                     BYTE, J_L_BYTE,
@@ -98,7 +99,7 @@ public final class PrimitiveType implements JavaType {
                     BOOLEAN, J_L_BOOLEAN
             );
         }
-        return LazyHolder.primitiveToWrapper.get(this);
+        return Optional.ofNullable(LazyHolder.primitiveToWrapper.get(this));
     };
 
     @Override


### PR DESCRIPTION
This PR does a couple of things:
* it sharpens the types of the various `JavaType` constants to the correct sealed sub-interface
* it consolidates support for boxing/unboxing. More specifically there's now a pair of functions:

```
ClassType::unbox() -> Optional<PrimitiveType>
```

and

```
PrimitiveType::box() -> Optional<ClassType>
```

Note that both functions are partial: there are classes that are not wrappers (e.g. String) and there are primitive types that cannot be boxed (e.g. `void`).

I'm on the fence whether to use `Optional` for this, or just return null. Suggestions welcome.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.org/babylon.git pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/67.diff">https://git.openjdk.org/babylon/pull/67.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/67#issuecomment-2085024027)