### PR TITLE
Fix test

### DIFF
--- a/test/jdk/java/lang/reflect/Method/cr/TreeAccessTest.java
+++ b/test/jdk/java/lang/reflect/Method/cr/TreeAccessTest.java
@@ -27,8 +27,8 @@ import org.testng.annotations.Test;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.Op;
-import java.lang.reflect.code.op.CoreOps;
-import java.lang.reflect.code.op.ExtendedOps;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.op.ExtendedOp;
 import java.lang.reflect.code.parser.OpParser;
 import java.lang.reflect.code.writer.OpWriter;
 import java.lang.runtime.CodeReflection;
@@ -51,10 +51,10 @@ public class TreeAccessTest {
     void testTreeAccess() throws Exception {
         Method m = TreeAccessTest.class.getDeclaredMethod("m", String.class);
 
-        Optional<CoreOps.FuncOp> tree = m.getCodeModel();
+        Optional<CoreOp.FuncOp> tree = m.getCodeModel();
         Assert.assertTrue(tree.isPresent());
 
-        CoreOps.FuncOp methodTree = tree.get();
+        CoreOp.FuncOp methodTree = tree.get();
 
         String expectedTree = """
                 func @"m" (%0 : TreeAccessTest, %1 : java.lang.String)int -> {
@@ -77,7 +77,7 @@ public class TreeAccessTest {
     void testNoTree() throws Exception {
         Method m = TreeAccessTest.class.getDeclaredMethod("n", String.class);
 
-        Optional<CoreOps.FuncOp> tree = m.getCodeModel();
+        Optional<CoreOp.FuncOp> tree = m.getCodeModel();
         Assert.assertTrue(tree.isEmpty());
     }
 
@@ -91,7 +91,7 @@ public class TreeAccessTest {
     static String canonicalizeModel(String d) {
         Op o;
         try {
-            o = OpParser.fromString(ExtendedOps.FACTORY, d).get(0);
+            o = OpParser.fromString(ExtendedOp.FACTORY, d).get(0);
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
Fix test after `CoreOps` to `CoreOp` refactor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/babylon.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/74.diff">https://git.openjdk.org/babylon/pull/74.diff</a>

</details>
