### PR TITLE
Implement bitwise/shift assignment operations

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
@@ -131,6 +131,180 @@ final class InvokableLeafOps {
         return l <= r;
     }
 
+    // byte
+
+    public static byte neg(byte l) {
+        return (byte) -l;
+    }
+
+    public static byte add(byte l, byte r) {
+        return (byte) (l + r);
+    }
+
+    public static byte sub(byte l, byte r) {
+        return (byte) (l - r);
+    }
+
+    public static byte mul(byte l, byte r) {
+        return (byte) (l * r);
+    }
+
+    public static byte div(byte l, byte r) {
+        return (byte) (l / r);
+    }
+
+    public static byte mod(byte l, byte r) {
+        return (byte) (l % r);
+    }
+
+    public static byte or(byte l, byte r) {
+        return (byte) (l | r);
+    }
+
+    public static byte and(byte l, byte r) {
+        return (byte) (l & r);
+    }
+
+    public static byte xor(byte l, byte r) {
+        return (byte) (l ^ r);
+    }
+
+    public static byte ashr(byte l, long r) {
+        return (byte) (l >> r);
+    }
+
+    public static byte lshr(byte l, long r) {
+        return (byte) (l >>> r);
+    }
+
+    public static byte lshl(byte l, int r) {
+        return (byte) (l << r);
+    }
+
+    public static byte ashr(byte l, int r) {
+        return (byte) (l >> r);
+    }
+
+    public static byte lshr(byte l, int r) {
+        return (byte) (l >>> r);
+    }
+
+    // short
+
+    public static short neg(short l) {
+        return (short) -l;
+    }
+
+    public static short add(short l, short r) {
+        return (short) (l + r);
+    }
+
+    public static short sub(short l, short r) {
+        return (short) (l - r);
+    }
+
+    public static short mul(short l, short r) {
+        return (short) (l * r);
+    }
+
+    public static short div(short l, short r) {
+        return (short) (l / r);
+    }
+
+    public static short mod(short l, short r) {
+        return (short) (l % r);
+    }
+
+    public static short or(short l, short r) {
+        return (short) (l | r);
+    }
+
+    public static short and(short l, short r) {
+        return (short) (l & r);
+    }
+
+    public static short xor(short l, short r) {
+        return (short) (l ^ r);
+    }
+
+    public static short ashr(short l, long r) {
+        return (short) (l >> r);
+    }
+
+    public static short lshr(short l, long r) {
+        return (short) (l >>> r);
+    }
+
+    public static short lshl(short l, int r) {
+        return (short) (l << r);
+    }
+
+    public static short ashr(short l, int r) {
+        return (short) (l >> r);
+    }
+
+    public static short lshr(short l, int r) {
+        return (short) (l >>> r);
+    }
+
+    // char
+
+    public static char neg(char l) {
+        return (char) -l;
+    }
+
+    public static char add(char l, char r) {
+        return (char) (l + r);
+    }
+
+    public static char sub(char l, char r) {
+        return (char) (l - r);
+    }
+
+    public static char mul(char l, char r) {
+        return (char) (l * r);
+    }
+
+    public static char div(char l, char r) {
+        return (char) (l / r);
+    }
+
+    public static char mod(char l, char r) {
+        return (char) (l % r);
+    }
+
+    public static char or(char l, char r) {
+        return (char) (l | r);
+    }
+
+    public static char and(char l, char r) {
+        return (char) (l & r);
+    }
+
+    public static char xor(char l, char r) {
+        return (char) (l ^ r);
+    }
+
+    public static char ashr(char l, long r) {
+        return (char) (l >> r);
+    }
+
+    public static char lshr(char l, long r) {
+        return (char) (l >>> r);
+    }
+
+    public static char lshl(char l, int r) {
+        return (char) (l << r);
+    }
+
+    public static char ashr(char l, int r) {
+        return (char) (l >> r);
+    }
+
+    public static char lshr(char l, int r) {
+        return (char) (l >>> r);
+    }
+
    // long
 
     public static long neg(long l) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -817,14 +817,14 @@ public class ReflectMethods extends TreeTranslator {
                     case MOD_ASG -> append(CoreOp.mod(lhs, rhs));
 
                     // Bitwise operations (including their boolean variants)
-                    case BITOR_ASG -> append(CoreOps.or(lhs, rhs));
-                    case BITAND_ASG -> append(CoreOps.and(lhs, rhs));
-                    case BITXOR_ASG -> append(CoreOps.xor(lhs, rhs));
+                    case BITOR_ASG -> append(CoreOp.or(lhs, rhs));
+                    case BITAND_ASG -> append(CoreOp.and(lhs, rhs));
+                    case BITXOR_ASG -> append(CoreOp.xor(lhs, rhs));
 
                     // Shift operations
-                    case SL_ASG -> append(CoreOps.lshl(lhs, rhs));
-                    case SR_ASG -> append(CoreOps.ashr(lhs, rhs));
-                    case USR_ASG -> append(CoreOps.lshr(lhs, rhs));
+                    case SL_ASG -> append(CoreOp.lshl(lhs, rhs));
+                    case SR_ASG -> append(CoreOp.ashr(lhs, rhs));
+                    case USR_ASG -> append(CoreOp.lshr(lhs, rhs));
 
 
                     default -> throw unsupported(tree);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -438,7 +438,9 @@ public class ReflectMethods extends TreeTranslator {
                         Tag.PLUS, Tag.MINUS, Tag.MUL, Tag.DIV, Tag.MOD,
                         Tag.NEG, Tag.NOT,
                         Tag.BITOR, Tag.BITAND, Tag.BITXOR,
+                        Tag.BITOR_ASG, Tag.BITAND_ASG, Tag.BITXOR_ASG,
                         Tag.SL, Tag.SR, Tag.USR,
+                        Tag.SL_ASG, Tag.SR_ASG, Tag.USR_ASG,
                         Tag.PLUS_ASG, Tag.MINUS_ASG, Tag.MUL_ASG, Tag.DIV_ASG, Tag.MOD_ASG,
                         Tag.POSTINC, Tag.PREINC, Tag.POSTDEC, Tag.PREDEC,
                         Tag.EQ, Tag.NE, Tag.LT, Tag.LE, Tag.GT, Tag.GE,
@@ -802,7 +804,6 @@ public class ReflectMethods extends TreeTranslator {
             // Capture applying rhs and operation
             Function<Value, Value> scanRhs = (lhs) -> {
                 Type unboxedType = types.unboxedTypeOrType(tree.type);
-                JavaType resultType = typeToTypeElement(unboxedType);
                 Value rhs = toValue(tree.rhs, unboxedType);
                 lhs = unboxIfNeeded(lhs);
 
@@ -814,6 +815,17 @@ public class ReflectMethods extends TreeTranslator {
                     case MUL_ASG -> append(CoreOp.mul(lhs, rhs));
                     case DIV_ASG -> append(CoreOp.div(lhs, rhs));
                     case MOD_ASG -> append(CoreOp.mod(lhs, rhs));
+
+                    // Bitwise operations (including their boolean variants)
+                    case BITOR_ASG -> append(CoreOps.or(lhs, rhs));
+                    case BITAND_ASG -> append(CoreOps.and(lhs, rhs));
+                    case BITXOR_ASG -> append(CoreOps.xor(lhs, rhs));
+
+                    // Shift operations
+                    case SL_ASG -> append(CoreOps.lshl(lhs, rhs));
+                    case SR_ASG -> append(CoreOps.ashr(lhs, rhs));
+                    case USR_ASG -> append(CoreOps.lshr(lhs, rhs));
+
 
                     default -> throw unsupported(tree);
                 };

--- a/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
+++ b/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
@@ -63,25 +63,25 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CoreBinaryOpsTest {
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, boolean.class})
+    @SupportedTypes(TypeList.INTEGRAL_BOOLEAN)
     static int and(int left, int right) {
         return left & right;
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, float.class, double.class})
+    @SupportedTypes(TypeList.INTEGRAL_FLOATING_POINT)
     static int add(int left, int right) {
         return left + right;
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, float.class, double.class})
+    @SupportedTypes(TypeList.INTEGRAL_FLOATING_POINT)
     static int div(int left, int right) {
         return left / right;
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class})
+    @SupportedTypes(TypeList.INT_LONG)
     static int leftShift(int left, int right) {
         return left << right;
     }
@@ -99,25 +99,25 @@ public class CoreBinaryOpsTest {
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, float.class, double.class})
+    @SupportedTypes(TypeList.INTEGRAL_FLOATING_POINT)
     static int mod(int left, int right) {
         return left % right;
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, float.class, double.class})
+    @SupportedTypes(TypeList.INTEGRAL_FLOATING_POINT)
     static int mul(int left, int right) {
         return left * right;
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, boolean.class})
+    @SupportedTypes(TypeList.INTEGRAL_BOOLEAN)
     static int or(int left, int right) {
         return left | right;
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class})
+    @SupportedTypes(TypeList.INT_LONG)
     static int signedRightShift(int left, int right) {
         return left >> right;
     }
@@ -135,13 +135,13 @@ public class CoreBinaryOpsTest {
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, float.class, double.class})
+    @SupportedTypes(TypeList.INTEGRAL_FLOATING_POINT)
     static int sub(int left, int right) {
         return left - right;
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class})
+    @SupportedTypes(TypeList.INT_LONG)
     static int unsignedRightShift(int left, int right) {
         return left >>> right;
     }
@@ -159,7 +159,7 @@ public class CoreBinaryOpsTest {
     }
 
     @CodeReflection
-    @SupportedTypes(types = {int.class, long.class, byte.class, short.class, char.class, boolean.class})
+    @SupportedTypes(TypeList.INTEGRAL_BOOLEAN)
     static int xor(int left, int right) {
         return left ^ right;
     }
@@ -175,7 +175,23 @@ public class CoreBinaryOpsTest {
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @interface SupportedTypes {
-        Class<?>[] types();
+        TypeList value();
+    }
+
+    enum TypeList {
+        INT_LONG(int.class, long.class),
+        INTEGRAL_BOOLEAN(int.class, long.class, byte.class, short.class, char.class, boolean.class),
+        INTEGRAL_FLOATING_POINT(int.class, long.class, byte.class, short.class, char.class, float.class, double.class);
+
+        private final Class<?>[] types;
+
+        TypeList(Class<?>... types) {
+            this.types = types;
+        }
+
+        public Class<?>[] types() {
+            return types;
+        }
     }
 
     // mark as "do not transform"
@@ -218,10 +234,10 @@ public class CoreBinaryOpsTest {
                             }
                             return Stream.of(funcOp);
                         }
-                        if (supportedTypes == null || supportedTypes.types().length == 0) {
+                        if (supportedTypes == null || supportedTypes.value().types().length == 0) {
                             throw new IllegalArgumentException("Missing supported types");
                         }
-                        return Arrays.stream(supportedTypes.types())
+                        return Arrays.stream(supportedTypes.value().types())
                                 .map(type -> retype(funcOp, type));
                     })
                     .flatMap(transformedFunc -> argumentsForMethod(transformedFunc, testMethod));

--- a/test/langtools/tools/javac/reflect/BinopTest.java
+++ b/test/langtools/tools/javac/reflect/BinopTest.java
@@ -269,4 +269,55 @@ public class BinopTest {
 
         d %= 1;
     }
+
+    @CodeReflection
+    @IR("""
+            func @"test9" (%0 : BinopTest, %1 : byte, %2 : byte, %3 : short)void -> {
+                %4 : Var<byte> = var %1 @"a";
+                %5 : Var<byte> = var %2 @"b";
+                %6 : Var<short> = var %3 @"s";
+                %7 : byte = var.load %4;
+                %8 : byte = var.load %5;
+                %9 : byte = add %7 %8;
+                var.store %4 %9;
+                %10 : byte = var.load %4;
+                %11 : short = var.load %6;
+                %12 : byte = conv %11;
+                %13 : byte = div %10 %12;
+                var.store %4 %13;
+                %14 : byte = var.load %4;
+                %15 : double = constant @"3.5";
+                %16 : byte = conv %15;
+                %17 : byte = mul %14 %16;
+                var.store %4 %17;
+                %18 : byte = var.load %4;
+                %19 : byte = var.load %5;
+                %20 : byte = lshl %18 %19;
+                var.store %4 %20;
+                %21 : byte = var.load %4;
+                %22 : int = constant @"1";
+                %23 : byte = conv %22;
+                %24 : byte = ashr %21 %23;
+                var.store %4 %24;
+                %25 : byte = var.load %4;
+                %26 : long = constant @"1";
+                %27 : byte = conv %26;
+                %28 : byte = ashr %25 %27;
+                var.store %4 %28;
+                return;
+            };
+            """)
+    void test9(byte a, byte b, short s) {
+        a += b;
+
+        a /= s;
+
+        a *= 3.5d;
+
+        a <<= b;
+
+        a >>= 1;
+
+        a >>= 1L;
+    }
 }


### PR DESCRIPTION
This change adds support for compound assignments for bitwise operations and shift operations. Tests are also enhanced to cover those cases.

As with already existing operations, input types `byte`, `char`,  `short` are not converted to `int`. Again, we have the special case of shift operations where the spec dictates unary promotion. That's why currently the rhs is promoted to `int` even in shift compound assignments.

The additional methods in `InvokableLeafOps` are needed in the current design.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/babylon.git pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/77.diff">https://git.openjdk.org/babylon/pull/77.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/77#issuecomment-2111829910)