### PR TITLE
Enhance OpWriter

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -450,8 +450,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @return the textual form of this operation.
      */
     public String toText() {
-        StringWriter w = new StringWriter();
-        writeTo(w);
-        return w.toString();
+        return OpWriter.toText(this);
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -444,6 +444,10 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         OpWriter.writeTo(w, this);
     }
 
+    public void writeTo(Writer w, OpWriter.Option... options) {
+        OpWriter.writeTo(w, this, options);
+    }
+
     /**
      * Returns the textual form of this operation.
      *
@@ -452,6 +456,12 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     public String toText() {
         StringWriter w = new StringWriter();
         writeTo(w);
+        return w.toString();
+    }
+
+    public String toText(OpWriter.Option... options) {
+        StringWriter w = new StringWriter();
+        writeTo(w, options);
         return w.toString();
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/Op.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Op.java
@@ -444,10 +444,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         OpWriter.writeTo(w, this);
     }
 
-    public void writeTo(Writer w, OpWriter.Option... options) {
-        OpWriter.writeTo(w, this, options);
-    }
-
     /**
      * Returns the textual form of this operation.
      *
@@ -456,12 +452,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     public String toText() {
         StringWriter w = new StringWriter();
         writeTo(w);
-        return w.toString();
-    }
-
-    public String toText(OpWriter.Option... options) {
-        StringWriter w = new StringWriter();
-        writeTo(w, options);
         return w.toString();
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -183,8 +183,7 @@ public final class OpWriter {
     /**
      * Writes a code model (an operation) to the character stream.
      * <p>
-     * A carriage return will be written after the model is writen, and
-     * then character stream will be flushed.
+     * The character stream will be flushed after the model is writen.
      *
      * @param w the character stream
      * @param op the code model
@@ -192,7 +191,6 @@ public final class OpWriter {
     public static void writeTo(Writer w, Op op) {
         OpWriter ow = new OpWriter(w);
         ow.writeOp(op);
-        ow.write("\n");
         try {
             w.flush();
         } catch (IOException e) {
@@ -218,6 +216,17 @@ public final class OpWriter {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    /**
+     * Writes a code model (an operation) to a string.
+     *
+     * @param op the code model
+     */
+    public static String toText(Op op) {
+        StringWriter w = new StringWriter();
+        writeTo(w, op);
+        return w.toString();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -26,6 +26,7 @@
 package java.lang.reflect.code.writer;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.lang.reflect.code.*;
@@ -202,8 +203,7 @@ public final class OpWriter {
     /**
      * Writes a code model (an operation) to the character stream.
      * <p>
-     * A carriage return will be written after the model is writen, and
-     * then character stream will be flushed.
+     * The character stream will be flushed after the model is writen.
      *
      * @param w the character stream
      * @param op the code model
@@ -212,12 +212,24 @@ public final class OpWriter {
     public static void writeTo(Writer w, Op op, Option... options) {
         OpWriter ow = new OpWriter(w, options);
         ow.writeOp(op);
-        ow.write("\n");
         try {
+            // @@@ Is this needed?
             w.flush();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    /**
+     * Writes a code model (an operation) to a string.
+     *
+     * @param op the code model
+     * @param options the writer options
+     */
+    public static String toText(Op op, OpWriter.Option... options) {
+        StringWriter w = new StringWriter();
+        writeTo(w, op, options);
+        return w.toString();
     }
 
     /**

--- a/test/jdk/java/lang/reflect/code/writer/TestNaming.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestNaming.java
@@ -40,6 +40,7 @@ import java.lang.reflect.code.writer.OpWriter;
 import java.lang.runtime.CodeReflection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class TestNaming {
@@ -75,10 +76,10 @@ public class TestNaming {
     }
 
     static void testModel(Op op) {
-        Map<CodeItem, String> cNamer = OpWriter.computeGlobalNames(op);
+        Function<CodeItem, String> cNamer = OpWriter.computeGlobalNames(op);
 
         StringWriter w = new StringWriter();
-        new OpWriter(w, OpWriter.CodeItemNamerOption.of(cNamer::get)).writeOp(op);
+        new OpWriter(w, OpWriter.CodeItemNamerOption.of(cNamer::apply)).writeOp(op);
         w.write("\n");
         String actual = w.toString();
 

--- a/test/jdk/java/lang/reflect/code/writer/TestNaming.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestNaming.java
@@ -78,11 +78,7 @@ public class TestNaming {
     static void testModel(Op op) {
         Function<CodeItem, String> cNamer = OpWriter.computeGlobalNames(op);
 
-        StringWriter w = new StringWriter();
-        new OpWriter(w, OpWriter.CodeItemNamerOption.of(cNamer::apply)).writeOp(op);
-        w.write("\n");
-        String actual = w.toString();
-
+        String actual = OpWriter.toText(op, OpWriter.CodeItemNamerOption.of(cNamer));
         String expected = op.toText();
 
         Assert.assertEquals(actual, expected);

--- a/test/jdk/java/lang/reflect/code/writer/TestOptions.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestOptions.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestOptions
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.writer.OpWriter;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class TestOptions {
+
+    @CodeReflection
+    static int f(int n) {
+        return n;
+    }
+
+    @Test
+    public void testDropWriteVoid() {
+        CoreOp.FuncOp f = getFuncOp("f");
+
+        Assert.assertFalse(OpWriter.toText(f).contains("void"));
+        Assert.assertFalse(OpWriter.toText(f, OpWriter.VoidOpResultOption.DROP_VOID).contains("void"));
+        Assert.assertTrue(OpWriter.toText(f, OpWriter.VoidOpResultOption.WRITE_VOID).contains("void"));
+    }
+
+    @Test
+    public void testDropWriteDescendants() {
+        CoreOp.FuncOp f = getFuncOp("f");
+
+        Assert.assertTrue(OpWriter.toText(f).lines().count() > 1);
+        Assert.assertTrue(OpWriter.toText(f, OpWriter.OpDescendantsOption.WRITE_DESCENDANTS).lines().count() > 1);
+        Assert.assertTrue(OpWriter.toText(f, OpWriter.OpDescendantsOption.DROP_DESCENDANTS).lines().count() == 1);
+    }
+
+
+    static CoreOp.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestOptions.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}


### PR DESCRIPTION
Enhance OpWriter to support the following options
1. Drop an operation's descendants. This allows for writing just the operation "header".
2. Write an operation's result even if it is void. This allows for improved debugging and presentation in some cases, esp. when we refer to values uniformly (an operation whose result is void still has a value, just one that is not used.)

Also, consolidate the write operations, and remove the explicit insertion of a live feed at the end of writing an operation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/babylon.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/79.diff">https://git.openjdk.org/babylon/pull/79.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/79#issuecomment-2115953150)