### PR TITLE
Test for creating a module of functions from invocations

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
@@ -48,7 +48,7 @@ public final class SSA {
     }
 
     /**
-     * Applies an SSA transformation to an invokable operation, replacing operations that declare variables and
+     * Applies an SSA transformation to an operation with bodies, replacing operations that declare variables and
      * access them with the use of values they depend on or additional block parameters.
      * <p>
      * The operation should first be in lowered form before applying this transformation.
@@ -57,11 +57,11 @@ public final class SSA {
      * region and read from outside as a result of catching an exception. In such cases a complete transformation may be
      * not possible and such variables will need to be retained.
      *
-     * @param iop the invokable operation
+     * @param nestedOp the operation with bodies
      * @return the transformed operation
-     * @param <T> the invokable type
+     * @param <T> the operation type
      */
-    public static <T extends Op & Op.Invokable> T transform(T iop) {
+    public static <T extends Op & Op.Nested> T transform(T nestedOp) {
         Map<Block, Set<CoreOp.VarOp>> joinPoints = new HashMap<>();
         Map<CoreOp.VarAccessOp.VarLoadOp, Object> loadValues = new HashMap<>();
         Map<Block.Reference, List<Object>> joinSuccessorValues = new HashMap<>();
@@ -69,7 +69,7 @@ public final class SSA {
         Map<Body, Boolean> visited = new HashMap<>();
         Map<Block, Map<CoreOp.VarOp, Block.Parameter>> joinBlockArguments = new HashMap<>();
         @SuppressWarnings("unchecked")
-        T liop = (T) iop.transform(CopyContext.create(), (block, op) -> {
+        T ssaOp = (T) nestedOp.transform(CopyContext.create(), (block, op) -> {
             // Compute join points and value mappings for body
             visited.computeIfAbsent(op.ancestorBody(), b -> {
                 findJoinPoints(b, joinPoints);
@@ -127,7 +127,7 @@ public final class SSA {
 
             return block;
         });
-        return liop;
+        return ssaOp;
     }
 
     record VarOpBlockArgument(Block b, CoreOp.VarOp vop) {

--- a/test/jdk/java/lang/reflect/code/TestTransitiveInvokeModule.java
+++ b/test/jdk/java/lang/reflect/code/TestTransitiveInvokeModule.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestTransitiveInvokeModule
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.analysis.SSA;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.type.MethodRef;
+import java.lang.runtime.CodeReflection;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class TestTransitiveInvokeModule {
+
+    @CodeReflection
+    static void m(int i, List<Integer> l) {
+        if (i < 0) {
+            return;
+        }
+
+        n(i - 1, l);
+    }
+
+    @CodeReflection
+    static void n(int i, List<Integer> l) {
+        l.add(i);
+        m(i - 1, l);
+    }
+
+    @Test
+    public void test() {
+        Optional<Method> om = Stream.of(TestTransitiveInvokeModule.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals("m"))
+                .findFirst();
+
+        CoreOp.ModuleOp module = createTransitiveInvokeModule(MethodHandles.lookup(), om.get());
+        System.out.println(module.toText());
+        module = module.transform(OpTransformer.LOWERING_TRANSFORMER);
+        System.out.println(module.toText());
+        module = SSA.transform(module);
+        System.out.println(module.toText());
+
+        module.functionTable().forEach((s, funcOp) -> {
+            System.out.println(s + " -> " + funcOp);
+        });
+
+        List<Integer> r = new ArrayList<>();
+        Interpreter.invoke(module.functionTable().firstEntry().getValue(), 10, r);
+        Assert.assertEquals(r, List.of(9, 7, 5, 3, 1, -1));
+    }
+
+    static CoreOp.ModuleOp createTransitiveInvokeModule(MethodHandles.Lookup l,
+                                                        Method m) {
+        Optional<CoreOp.FuncOp> codeModel = m.getCodeModel();
+        if (codeModel.isPresent()) {
+            return createTransitiveInvokeModule(l, MethodRef.method(m), codeModel.get());
+        } else {
+            return CoreOp.module(List.of());
+        }
+    }
+
+    static CoreOp.ModuleOp createTransitiveInvokeModule(MethodHandles.Lookup l,
+                                                        MethodRef entryRef, CoreOp.FuncOp entry) {
+        LinkedHashSet<MethodRef> funcsVisited = new LinkedHashSet<>();
+        List<CoreOp.FuncOp> funcs = new ArrayList<>();
+
+        record RefAndFunc(MethodRef r, CoreOp.FuncOp f) {
+        }
+        Deque<RefAndFunc> work = new ArrayDeque<>();
+        work.push(new RefAndFunc(entryRef, entry));
+        while (!work.isEmpty()) {
+            RefAndFunc rf = work.pop();
+            if (!funcsVisited.add(rf.r)) {
+                continue;
+            }
+
+            CoreOp.FuncOp tf = rf.f.transform(rf.r.toString(), (block, op) -> {
+                if (op instanceof CoreOp.InvokeOp iop) {
+                    MethodRef r = iop.invokeDescriptor();
+                    Executable em = null;
+                    try {
+                        em = r.resolveToMember(l);
+                    } catch (ReflectiveOperationException _) {
+                    }
+                    if (em instanceof Method m) {
+                        Optional<CoreOp.FuncOp> f = m.getCodeModel();
+                        if (f.isPresent()) {
+                            RefAndFunc call = new RefAndFunc(r, f.get());
+                            // Place model on work queue
+                            work.push(call);
+
+                            // Replace invocation with function call
+                            block.op(CoreOp.funcCall(
+                                    call.r.toString(),
+                                    call.f.invokableType(),
+                                    block.context().getValues(iop.operands())));
+                            return block;
+                        }
+                    }
+                }
+                block.op(op);
+                return block;
+            });
+            funcs.add(tf);
+        }
+
+        return CoreOp.module(funcs);
+    }
+}


### PR DESCRIPTION
Given a set of reflectable methods that form a call graph, we can create a code model that is a module operation containing the functions in that graph where invocation operations are replaced with function call operations.
Starting from the a model of a method, we can traverse it for invocation operations. If the invocation operation's method reference can be resolved to a method and the method has a model then that model is added to the module, the invocation operation is replaced with a function call operation, and it is traversed for invocation operations and so on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/babylon.git pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/81.diff">https://git.openjdk.org/babylon/pull/81.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/81#issuecomment-2123477741)