### PR TITLE
HAT needs public access to TranslateToSpirvModel

### DIFF
--- a/cr-examples/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
+++ b/cr-examples/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
@@ -48,7 +48,7 @@ public class TranslateToSpirvModel  {
         return new SpirvOps.FuncOp(lowFunc.funcName(), lowFunc.invokableType(), bodyBuilder);
     }
 
-    private TranslateToSpirvModel() {
+    public TranslateToSpirvModel() {
         blockMap = new HashMap<>();
         valueMap = new HashMap<>();
     }


### PR DESCRIPTION
In prep for HAT code we need to give new hat code access to SPIRV

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/babylon.git pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/82.diff">https://git.openjdk.org/babylon/pull/82.diff</a>

</details>
