### PR TITLE
Fixed Race Condition in PTX nvcc compiler. Also atomicInc->atomicAdd

### DIFF
--- a/hat/backends/cuda/include/cuda_backend.h
+++ b/hat/backends/cuda/include/cuda_backend.h
@@ -64,62 +64,13 @@ extern void __checkCudaErrors(CUresult err, const char *file, const int line);
 
 #define checkCudaErrors(err)  __checkCudaErrors (err, __FILE__, __LINE__)
 
-struct Ptx {
+class Ptx {
+public:
     size_t len;
     char *text;
-
-    Ptx(size_t len)
-            : len(len), text(len > 0 ? new char[len] : nullptr) {}
-
-    Ptx() {
-        if (len > 0 && text != nullptr) {
-            delete[] text;
-        }
-    }
-
-    static Ptx *nvcc(const char *cudaSource, size_t len) {
-        Ptx *ptx = nullptr;
-        const char *cudaPath = "./tmp2.cu";
-        const char *ptxPath = "./tmp2.ptx";
-        const char *stderrPath = "./tmp2.stderr";
-        const char *stdoutPath = "./tmp2.stdout";
-        // we are going to fork exec nvcc
-        int pid;
-        if ((pid = fork()) == 0) {
-            std::ofstream cuda;
-            cuda.open(cudaPath);
-            cuda.write(cudaSource, len);
-            cuda.close();
-
-            const char *path = "/usr/local/cuda-12.2/bin/nvcc";
-            // const char *argv[]{"nvcc", "-v", "-ptx", cudaPath, "-o", ptxPath, nullptr};
-            const char *argv[]{"nvcc", "-ptx", cudaPath, "-o", ptxPath, nullptr};
-            // We are the child so exec nvcc.
-            //close(1); // stdout
-            //close(2); // stderr
-            //open(stderrPath, O_RDWR); // stdout
-            //open(stdoutPath, O_RDWR); // stderr
-            execvp(path, (char *const *) argv);
-        } else if (pid < 0) {
-            // fork failed.
-            std::cerr << "fork of nvcc failed" << std::endl;
-            std::exit(1);
-        } else {
-            std::cerr << "fork suceeded" << std::endl;
-            std::ifstream ptxStream(ptxPath);
-            ptxStream.seekg(0, ptxStream.end);
-            size_t ptxLen = ptxStream.tellg();
-            if (ptxLen > 0) {
-                ptx = new Ptx(ptxLen + 1);
-                ptxStream.seekg(0, ptxStream.beg);
-                ptxStream.read(ptx->text, ptx->len);
-                ptx->text[ptx->len] = '\0';
-            }
-            ptxStream.close();
-        }
-        std::cout << "returning PTX" << std::endl;
-        return ptx;
-    }
+    Ptx(size_t len);
+    ~Ptx();
+    static Ptx *nvcc(const char *cudaSource, size_t len);
 };
 
 class CudaBackend : public Backend {
@@ -131,14 +82,14 @@ public:
 
     class CudaProgram : public Backend::Program {
         class CudaKernel : public Backend::Program::Kernel {
-            class CudaBuffer {
+        class CudaBuffer: public Backend::Program::Kernel::Buffer {
             public:
-                void *ptr;
-                size_t sizeInBytes;
+
                 CUdeviceptr devicePtr;
 
                 CudaBuffer(void *ptr, size_t sizeInBytes);
-
+                void copyToDevice();
+                void copyFromDevice();
                 virtual ~CudaBuffer();
             };
 

--- a/hat/backends/cuda/java/hat/backend/CudaHatKernelBuilder.java
+++ b/hat/backends/cuda/java/hat/backend/CudaHatKernelBuilder.java
@@ -24,8 +24,11 @@
  */
 package hat.backend;
 
+import hat.backend.c99codebuilders.C99HatBuildContext;
 import hat.backend.c99codebuilders.C99HatKernelBuilder;
+import hat.optools.OpWrapper;
 
+import java.lang.reflect.code.Op;
 import java.lang.reflect.code.type.JavaType;
 
 public class CudaHatKernelBuilder extends C99HatKernelBuilder<CudaHatKernelBuilder> {
@@ -71,5 +74,14 @@ public class CudaHatKernelBuilder extends C99HatKernelBuilder<CudaHatKernelBuild
     @Override
     public CudaHatKernelBuilder globalPtrPrefix() {
         return self();
+    }
+
+
+    @Override
+    public CudaHatKernelBuilder atomicInc(C99HatBuildContext buildContext, Op.Result instanceResult, String name){
+        return identifier("atomicAdd").paren(_ -> {
+             ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
+             rarrow().identifier(name).comma().literal(1);
+        });
     }
 }

--- a/hat/backends/opencl/cpp/opencl_backend.cpp
+++ b/hat/backends/opencl/cpp/opencl_backend.cpp
@@ -24,7 +24,7 @@
  */
 #include "opencl_backend.h"
 
-OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLBuffer::OpenCLBuffer(cl_context context, void *ptr, size_t sizeInBytes)
+OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLBuffer::OpenCLBuffer(void *ptr, size_t sizeInBytes, cl_context context)
         : ptr(ptr), sizeInBytes(sizeInBytes) {
     cl_int status;
     clMem = clCreateBuffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeInBytes, ptr, &status);
@@ -58,9 +58,10 @@ long OpenCLBackend::OpenCLProgram::OpenCLKernel::ndrange(int range, void *argArr
         Arg_t *arg = argSled.arg(i);
 
         if (arg->variant == '&') {
-            arg->value.buffer.vendorPtr = new OpenCLBuffer(backend->context,
+            arg->value.buffer.vendorPtr = new OpenCLBuffer(
                     (void *) arg->value.buffer.memorySegment,
-                    (size_t) arg->value.buffer.sizeInBytes);
+                    (size_t) arg->value.buffer.sizeInBytes,
+                    backend->context);
             OpenCLBuffer *clbuf = ((OpenCLBuffer *) arg->value.buffer.vendorPtr);
             if ((status = clEnqueueWriteBuffer(backend->command_queue, clbuf->clMem, CL_FALSE, 0, clbuf->sizeInBytes, clbuf->ptr, backend->eventc, ((backend->eventc == 0) ? NULL : backend->events),
                     &(backend->events[backend->eventc]))) !=

--- a/hat/backends/opencl/include/opencl_backend.h
+++ b/hat/backends/opencl/include/opencl_backend.h
@@ -59,13 +59,15 @@ public:
 
     class OpenCLProgram : public Backend::Program {
         class OpenCLKernel : public Backend::Program::Kernel {
-        class OpenCLBuffer  {
+
+        class OpenCLBuffer : public Backend::Program::Kernel::Buffer {
             public:
                 void *ptr;
                 size_t sizeInBytes;
                 cl_mem clMem;
-
-                OpenCLBuffer(cl_context context, void *ptr, size_t sizeInBytes);
+                void copyToDevice();
+                void copyFromDevice();
+                OpenCLBuffer(void *ptr, size_t sizeInBytes, cl_context context);
 
                 virtual ~OpenCLBuffer();
             };

--- a/hat/backends/opencl/java/hat/backend/OpenCLHatKernelBuilder.java
+++ b/hat/backends/opencl/java/hat/backend/OpenCLHatKernelBuilder.java
@@ -24,8 +24,11 @@
  */
 package hat.backend;
 
+import hat.backend.c99codebuilders.C99HatBuildContext;
 import hat.backend.c99codebuilders.C99HatKernelBuilder;
+import hat.optools.OpWrapper;
 
+import java.lang.reflect.code.Op;
 import java.lang.reflect.code.type.JavaType;
 
 public class OpenCLHatKernelBuilder extends C99HatKernelBuilder<OpenCLHatKernelBuilder> {
@@ -71,5 +74,14 @@ public class OpenCLHatKernelBuilder extends C99HatKernelBuilder<OpenCLHatKernelB
     public OpenCLHatKernelBuilder globalPtrPrefix() {
         return keyword("__global");
     }
+
+    @Override
+    public OpenCLHatKernelBuilder atomicInc(C99HatBuildContext buildContext, Op.Result instanceResult, String name){
+          return identifier("atomic_inc").paren(_ -> {
+              ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
+              rarrow().identifier(name);
+          });
+    }
+
 
 }

--- a/hat/backends/shared/cpp/shared.cpp
+++ b/hat/backends/shared/cpp/shared.cpp
@@ -188,11 +188,13 @@ void hexdump(void *ptr, int buflen) {
 // We need to trampoline through the real backend
 
 extern "C" int getMaxComputeUnits(long backendHandle) {
+    std::cout << "trampolining through backendHandle to backend.getMaxComputeUnits()" <<std::endl;
     Backend *backend = (Backend *) backendHandle;
     return backend->getMaxComputeUnits();
 }
 
 extern "C" void info(long backendHandle) {
+    std::cout << "trampolining through backendHandle to backend.info()" <<std::endl;
     Backend *backend = (Backend *) backendHandle;
     backend->info();
 }
@@ -201,18 +203,18 @@ extern "C" void releaseBackend(long backendHandle) {
     delete backend;
 }
 extern "C" long compileProgram(long backendHandle, int len, char *source) {
-    //std::cout << "trampolining through backendHandle to compileProgram" <<std::endl;
+    std::cout << "trampolining through backendHandle to backend.compileProgram()" <<std::endl;
     Backend *backend = (Backend *) backendHandle;
     return backend->compileProgram(len, source);
 }
 extern "C" long getKernel(long programHandle, int nameLen, char *name) {
-    //std::cout << "trampolining through programHandle to get kernel" <<std::endl;
+    std::cout << "trampolining through programHandle to program.getKernel()" <<std::endl;
     Backend::Program *program = (Backend::Program *) programHandle;
     return program->getKernel(nameLen, name);
 }
 
 extern "C" long ndrange(long kernelHandle, int range, void *argArray) {
-    //std::cout << "trampolining through kernelHandle to dispatch " <<std::endl;
+    std::cout << "trampolining through kernelHandle to kernel.ndrange(...) " <<std::endl;
     Backend::Program::Kernel *kernel = (Backend::Program::Kernel *) kernelHandle;
     kernel->ndrange(range, argArray);
     return (long) 0;

--- a/hat/backends/shared/include/shared.h
+++ b/hat/backends/shared/include/shared.h
@@ -482,6 +482,17 @@ public:
     public:
         class Kernel {
         public:
+            class Buffer {
+            public:
+                void *ptr;
+                size_t sizeInBytes;
+                virtual void copyToDevice()=0;
+                virtual void copyFromDevice()=0;
+                Buffer(void *ptr, size_t sizeInBytes):ptr(ptr), sizeInBytes(sizeInBytes) {
+                }
+                virtual ~Buffer() {}
+            };
+
             Program *program;
 
             virtual long ndrange(int range, void *argArray) = 0;

--- a/hat/hat/src/java/hat/backend/c99codebuilders/C99HatBuilder.java
+++ b/hat/hat/src/java/hat/backend/c99codebuilders/C99HatBuilder.java
@@ -450,6 +450,10 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
         return self();
     }
 
+    public T atomicInc(C99HatBuildContext buildContext, Op.Result instanceResult, String name){
+         throw new IllegalStateException("atimicInc not implemented");
+    }
+
     @Override
     public T methodCall(C99HatBuildContext buildContext, InvokeOpWrapper invokeOpWrapper) {
         var name = invokeOpWrapper.name();
@@ -462,10 +466,11 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
                     && returnType instanceof PrimitiveType primitiveType && primitiveType.equals(JavaType.INT)) {
                 // this is a bit of a hack for atomics.
                 if (invokeOpWrapper.operandNAsResult(0) instanceof Op.Result instanceResult) {
-                    identifier("atomic_inc").paren(_ -> {
-                        ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
-                        rarrow().identifier(name.substring(0, name.length() - 3));
-                    });
+                    atomicInc(buildContext, instanceResult, name.substring(0, name.length() - 3));
+                    //identifier("atomic_inc").paren(_ -> {
+                    //    ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
+                    //    rarrow().identifier(name.substring(0, name.length() - 3));
+                    //});
                 } else {
                     throw new IllegalStateException("bad atomic");
                 }


### PR DESCRIPTION
Debugging ViolaJones on CUDA backend.  Discovered a race condition.  This fixes it. 

Also mapped atomicInc -> atomicAdd for CUDA C99 generatkion

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/babylon.git pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/86.diff">https://git.openjdk.org/babylon/pull/86.diff</a>

</details>
