### PR TITLE
fix opencl buffer created by last cuda fix..

### DIFF
--- a/hat/backends/opencl/cpp/opencl_backend.cpp
+++ b/hat/backends/opencl/cpp/opencl_backend.cpp
@@ -25,11 +25,16 @@
 #include "opencl_backend.h"
 
 OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLBuffer::OpenCLBuffer(void *ptr, size_t sizeInBytes, cl_context context)
-        : ptr(ptr), sizeInBytes(sizeInBytes) {
+        : Backend::Program::Kernel::Buffer(ptr, sizeInBytes) {
     cl_int status;
     clMem = clCreateBuffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeInBytes, ptr, &status);
 }
+void OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLBuffer::copyToDevice() {
 
+}
+void OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLBuffer::copyFromDevice() {
+
+}
 OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLBuffer::~OpenCLBuffer() {
     clReleaseMemObject(clMem);
 }

--- a/hat/backends/opencl/include/opencl_backend.h
+++ b/hat/backends/opencl/include/opencl_backend.h
@@ -62,8 +62,7 @@ public:
 
         class OpenCLBuffer : public Backend::Program::Kernel::Buffer {
             public:
-                void *ptr;
-                size_t sizeInBytes;
+
                 cl_mem clMem;
                 void copyToDevice();
                 void copyFromDevice();


### PR DESCRIPTION
I introduced an opencl bug in  last commit. This fixes that bug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.org/babylon.git pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/87.diff">https://git.openjdk.org/babylon/pull/87.diff</a>

</details>
