### PR TITLE
Ubuntu opencl cmake fix for opencl shared libs and execs

### DIFF
--- a/hat/CMakeLists.txt
+++ b/hat/CMakeLists.txt
@@ -302,10 +302,10 @@ if(OPENCL_FOUND)
 
      target_link_libraries(opencl_info
         opencl_backend
-        "-framework OpenCL"
+        "OpenCL"
      )
      target_link_libraries(opencl_info
-          "-framework OpenCL"
+        "OpenCL"
      )
 
      add_custom_target(opencl_info_exec DEPENDS opencl_backend.jar opencl_backend


### PR DESCRIPTION
Ubuntu opencl target does not use -framework.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/babylon.git pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/89.diff">https://git.openjdk.org/babylon/pull/89.diff</a>

</details>
