### PR TITLE
OpWriter block naming align with block indexes

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -61,7 +61,7 @@ public final class OpWriter {
         @Override
         public String apply(CodeItem codeItem) {
             return switch (codeItem) {
-                case Block block -> gn.computeIfAbsent(block, _b -> name(block));
+                case Block block -> gn.computeIfAbsent(block, _b -> name(_b));
                 case Value value -> gn.computeIfAbsent(value, _v -> String.valueOf(valueOrdinal++));
                 default -> throw new IllegalStateException("Unexpected code item: " + codeItem);
             };

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -48,25 +48,20 @@ public final class OpWriter {
     static final class GlobalValueBlockNaming implements Function<CodeItem, String> {
         final Map<CodeItem, String> gn;
         int valueOrdinal = 0;
-        int blockOrdinal = 0;
 
         GlobalValueBlockNaming() {
             this.gn = new HashMap<>();
         }
 
-        private String blockId(Block b) {
-            if (b.index() < 0) return "__" + blockOrdinal++;
-            Op po;
-            Block pb;
-            return (((po = b.parentBody().parentOp()) != null
-                    && (pb = po.parentBlock()) != null)
-                    ? blockId(pb) : "") + "_" + b.index();
+        private String name(Block b) {
+            Block p = b.parentBody().parentOp().parentBlock();
+            return (p == null ? "block_" : name(p) + "_") + b.index();
         }
 
         @Override
         public String apply(CodeItem codeItem) {
             return switch (codeItem) {
-                case Block block -> gn.computeIfAbsent(block, _b -> "block" + blockId(block));
+                case Block block -> gn.computeIfAbsent(block, _b -> name(block));
                 case Value value -> gn.computeIfAbsent(value, _v -> String.valueOf(valueOrdinal++));
                 default -> throw new IllegalStateException("Unexpected code item: " + codeItem);
             };

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -61,7 +61,7 @@ public final class OpWriter {
         @Override
         public String apply(CodeItem codeItem) {
             return switch (codeItem) {
-                case Block block -> gn.computeIfAbsent(block, _b -> name(_b));
+                case Block block -> gn.computeIfAbsent(block, _b -> name(block));
                 case Value value -> gn.computeIfAbsent(value, _v -> String.valueOf(valueOrdinal++));
                 default -> throw new IllegalStateException("Unexpected code item: " + codeItem);
             };

--- a/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/writer/OpWriter.java
@@ -54,10 +54,19 @@ public final class OpWriter {
             this.gn = new HashMap<>();
         }
 
+        private String blockId(Block b) {
+            if (b.index() < 0) return "__" + blockOrdinal++;
+            Op po;
+            Block pb;
+            return (((po = b.parentBody().parentOp()) != null
+                    && (pb = po.parentBlock()) != null)
+                    ? blockId(pb) : "") + "_" + b.index();
+        }
+
         @Override
         public String apply(CodeItem codeItem) {
             return switch (codeItem) {
-                case Block block -> gn.computeIfAbsent(block, _b -> "block_" + blockOrdinal++);
+                case Block block -> gn.computeIfAbsent(block, _b -> "block" + blockId(block));
                 case Value value -> gn.computeIfAbsent(value, _v -> String.valueOf(valueOrdinal++));
                 default -> throw new IllegalStateException("Unexpected code item: " + codeItem);
             };


### PR DESCRIPTION
I propose to change OpWriter block naming conventions to be aligned with block indexes.

It is very hard to debug when there is no connection between debugged body and available prints provided by OpWriter.
This patch composes block name as composition of block indexes from super-parent-body block index down the actual block index. With fallback to the `block__<counter>` In case the block is not a part of a body.

This is and example of such print:
```
    %0 : java.util.function.IntUnaryOperator = lambda @loc="88:31" (%1 : int)int -> {
        %2 : Var<int> = var %1 @"i" @loc="88:31";
        %3 : int = var.load %2 @loc="89:17";
        %4 : int = constant @"0" @loc="89:21";
        %5 : boolean = gt %3 %4 @loc="89:17";
        cbranch %5 ^block_0_1 ^block_0_2;
      
      ^block_0_1:
        %6 : java.util.function.IntUnaryOperator = lambda @loc="90:38" (%7 : int)int -> {
            %8 : Var<int> = var %7 @"ii" @loc="90:38";
            %9 : int = var.load %8 @loc="91:25";
            %10 : int = constant @"0" @loc="91:30";
            %11 : boolean = lt %9 %10 @loc="91:25";
            cbranch %11 ^block_0_1_1 ^block_0_1_2;
          
          ^block_0_1_1:
            %12 : int = constant @"2" @loc="92:32";
            %13 : int = var.load %8 @loc="92:36";
            %14 : int = mul %12 %13 @loc="92:32";
            %15 : int = constant @"1" @loc="92:41";
            %16 : int = sub %14 %15 @loc="92:32";
            return %16 @loc="92:25";
          
          ^block_0_1_2:
            %17 : int = var.load %8 @loc="94:32";
            return %17 @loc="94:25";
          
          ^block_0_1_3:
            return @loc="90:38";
        };
        %18 : Var<java.util.function.IntUnaryOperator> = var %6 @"o" @loc="90:17";
        %19 : java.util.function.IntUnaryOperator = var.load %18 @loc="97:24";
        %20 : int = constant @"2" @loc="97:37";
        %21 : int = var.load %2 @loc="97:41";
        %22 : int = mul %20 %21 @loc="97:37";
        %23 : int = invoke %19 %22 @"java.util.function.IntUnaryOperator::applyAsInt(int)int" @loc="97:24";
        return %23 @loc="97:17";
      
      ^block_0_2:
        %24 : java.util.function.IntUnaryOperator = lambda @loc="99:38" (%25 : int)int -> {
            %26 : Var<int> = var %25 @"ii" @loc="99:38";
            %27 : int = var.load %26 @loc="100:25";
            %28 : int = constant @"0" @loc="100:30";
            %29 : boolean = lt %27 %28 @loc="100:25";
            cbranch %29 ^block_0_2_1 ^block_0_2_2;
          
          ^block_0_2_1:
            %30 : int = constant @"2" @loc="101:32";
            %31 : int = var.load %26 @loc="101:36";
            %32 : int = mul %30 %31 @loc="101:32";
            %33 : int = constant @"1" @loc="101:41";
            %34 : int = sub %32 %33 @loc="101:32";
            return %34 @loc="101:25";
          
          ^block_0_2_2:
            %35 : int = var.load %26 @loc="103:32";
            return %35 @loc="103:25";
          
          ^block_0_2_3:
            return @loc="99:38";
        };
        %36 : Var<java.util.function.IntUnaryOperator> = var %24 @"o" @loc="99:17";
        %37 : java.util.function.IntUnaryOperator = var.load %36 @loc="106:24";
        %38 : int = constant @"3" @loc="106:37";
        %39 : int = var.load %2 @loc="106:41";
        %40 : int = mul %38 %39 @loc="106:37";
        %41 : int = invoke %37 %40 @"java.util.function.IntUnaryOperator::applyAsInt(int)int" @loc="106:24";
        return %41 @loc="106:17";
      
      ^block_0_3:
        return @loc="88:31";
    };
    %42 : Var<java.util.function.IntUnaryOperator> = var %0 @"o1" @loc="88:9";
    %43 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream" @loc="109:9";
    %44 : java.util.function.IntUnaryOperator = var.load %42 @loc="109:28";
    %45 : int = constant @"10" @loc="109:42";
    %46 : int = invoke %44 %45 @"java.util.function.IntUnaryOperator::applyAsInt(int)int" @loc="109:28";
    invoke %43 %46 @"java.io.PrintStream::println(int)void" @loc="109:9";
    return @loc="86:5";
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/babylon.git pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/91.diff">https://git.openjdk.org/babylon/pull/91.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/91#issuecomment-2129643798)