### PR TITLE
Updated code for dumping schema (debugging cuda violajones)

### DIFF
--- a/hat/backends/CMakeLists.txt
+++ b/hat/backends/CMakeLists.txt
@@ -82,3 +82,7 @@ if(CUDAToolkit_FOUND)
     add_custom_target(cuda_natives DEPENDS cuda_info cuda_backend)
 
 endif()
+add_executable(schemadump
+        ${CMAKE_SOURCE_DIR}/shared/cpp/shared.cpp
+        ${CMAKE_SOURCE_DIR}/shared/cpp/schemadump.cpp
+)

--- a/hat/backends/cuda/cpp/info.cpp
+++ b/hat/backends/cuda/cpp/info.cpp
@@ -25,7 +25,6 @@
 
 #include "cuda_backend.h"
 
-
 int main(int argc, char **argv) {
     CudaBackend cudaBackend;
     cudaBackend.info();

--- a/hat/backends/cuda/include/cuda_backend.h
+++ b/hat/backends/cuda/include/cuda_backend.h
@@ -101,7 +101,7 @@ public:
         private:
             CUfunction function;
         public:
-            CudaKernel(Backend::Program *program, CUfunction function);
+            CudaKernel(Backend::Program *program, std::string name, CUfunction function);
 
             ~CudaKernel();
 

--- a/hat/backends/opencl/cpp/info.cpp
+++ b/hat/backends/opencl/cpp/info.cpp
@@ -27,8 +27,5 @@
 int main(){
     OpenCLBackend backend;
     backend.info();
-  //  char *schema = (char*)"args:[1:?:4+S32Array:{length:s32,array:[*:?:s32]}]";
-   // std::cout << "schema = '"<<schema<<"'"<<std::endl;
-   // backend.dumpSchema(std::cout, 0, schema, nullptr);
 }
 

--- a/hat/backends/opencl/include/opencl_backend.h
+++ b/hat/backends/opencl/include/opencl_backend.h
@@ -87,7 +87,7 @@ public:
         protected:
             void showEvents(int width);
         public:
-            OpenCLKernel(Backend::Program *program, cl_kernel kernel);
+            OpenCLKernel(Backend::Program *program, std::string name,cl_kernel kernel);
 
             ~OpenCLKernel();
 

--- a/hat/backends/shared/cpp/schemadump.cpp
+++ b/hat/backends/shared/cpp/schemadump.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "shared.h"
+
+
+int main(int argc, char **argv) {
+    char *mandelSchema = (char *) "args:[5:?:8+S32Array2D:{width:s32,height:s32,array:[*:?:s32]},?:4+S32Array:{length:s32,array:[*:?:s32]},?:f32,?:f32,?:f32]";
+    char *squaresSchema = (char *) "args:[1:?:4+S32Array:{length:s32,array:[*:?:s32]}]";
+    char *colIntegralSchema = (char *)
+            "args:[2:"
+            "?:8+F32Array2D:{"
+            "width:s32,"
+            "height:s32,"
+            "array:[*:"
+            "?:f32"
+            "]"
+            "},"
+            "?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]}"
+            "]";
+    char *rowIntegralSchema = (char *) "args:[3:?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]},?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]},?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]}]";
+
+    char *cascadeSchema = (char *) "args:[5:!:163448!Cascade:{width:s32,height:s32,featureCount:s32,feature:[2913:Feature:{id:s32,threshold:f32,left:{hasValue:z8,?:x3,anon:<featureId:s32|value:f32>},right:{hasValue:z8,?:x3,anon:<featureId:s32|value:f32>},rect:[3:Rect:{x:s8,y:s8,width:s8,height:s8,weight:f32}]}],stageCount:s32,stage:[25:Stage:{id:s32,threshold:f32,firstTreeId:s16,treeCount:s16}],treeCount:s32,tree:[2913:Tree:{id:s32,firstFeatureId:s16,featureCount:s16}]},?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]},?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]},?:8+ScaleTable:{length:s32,multiScaleAccumulativeRange:s32,scale:[*:Scale:{scaleValue:f32,scaledXInc:f32,scaledYInc:f32,invArea:f32,scaledFeatureWidth:s32,scaledFeatureHeight:s32,gridWidth:s32,gridHeight:s32,gridSize:s32,accumGridSizeMin:s32,accumGridSizeMax:s32}]},?:8+ResultTable:{length:s32,atomicResultTableCount:s32,result:[*:Result:{x:f32,y:f32,width:f32,height:f32}]}]";
+    char *schema = cascadeSchema;
+    std::cout << "schema = '" << schema << "'" << std::endl;
+    Schema::dumpSchema(std::cout, schema);
+
+}
+

--- a/hat/backends/shared/cpp/shared.cpp
+++ b/hat/backends/shared/cpp/shared.cpp
@@ -185,16 +185,324 @@ void hexdump(void *ptr, int buflen) {
     }
 }
 
+char *Schema::strduprange(char *start, char *end) {
+    char *s = new char[end - start + 1];
+    std::memcpy(s, start, end - start);
+    s[end - start] = '\0';
+    return s;
+}
+
+std::ostream &Schema::dump(std::ostream &out, char *start, char *end) {
+    while (start < end) {
+        out << (char) *start;
+        start++;
+    }
+    return out;
+}
+
+std::ostream &Schema::indent(std::ostream &out, int depth) {
+    while (depth > 0) {
+        out << "  ";
+        depth++;
+    }
+    return out;
+}
+
+std::ostream &Schema::dump(std::ostream &out, char *label, char *start, char *end) {
+    out << label << " '";
+    dump(out, start, end) << "' " << std::endl;
+    return out;
+}
+
+
+static const int AWAITING_STATE = 0x00001;
+static const int IN_STATE = 0x00002;
+static const int HAVE_STATE = 0x00004;
+
+static const int NAME_STATE = 0x00010;
+static const int CAN_BE_ANON_STATE = 0x00020;
+static const int NUMERIC_STATE = 0x00040;
+static const int CAN_BE_FLEX_STATE = 0x00080;
+
+static const int ARGS_STATE = 0x00100;
+static const int ARRAY_STATE = 0x00200;
+static const int BUFFER_STATE = 0x00400;
+static const int FIELD_STATE = 0x01000;
+static const int TYPE_STATE = 0x02000;
+static const int STRUCT_STATE = 0x04000;
+static const int UNION_STATE = 0x08000;
+
+static const int awaitingArgsName = (ARGS_STATE | NAME_STATE | AWAITING_STATE);
+static const int awaitingArrayName = (ARRAY_STATE | NAME_STATE | AWAITING_STATE);
+static const int awaitingBufferName = (BUFFER_STATE | NAME_STATE | AWAITING_STATE);
+static const int awaitingArrayLen = (ARRAY_STATE | NUMERIC_STATE | AWAITING_STATE);
+static const int awaitingFieldName = (FIELD_STATE | NAME_STATE | AWAITING_STATE);
+static const int awaitingTypeName = (TYPE_STATE | NAME_STATE | AWAITING_STATE);
+
+static const int inArgsName = (ARGS_STATE | NAME_STATE | IN_STATE);
+static const int inArrayName = (ARRAY_STATE | CAN_BE_ANON_STATE | NAME_STATE | IN_STATE);
+static const int inBufferName = (BUFFER_STATE | NAME_STATE | IN_STATE);
+static const int inArrayLen = (ARRAY_STATE | CAN_BE_FLEX_STATE | NUMERIC_STATE | IN_STATE);
+static const int inBufferSize = (BUFFER_STATE | NUMERIC_STATE | IN_STATE);
+static const int inFieldName = (FIELD_STATE | CAN_BE_ANON_STATE | NAME_STATE | IN_STATE);
+static const int inTypeName = (TYPE_STATE | NAME_STATE | IN_STATE);
+
+static const int haveArrayName = (ARRAY_STATE | NAME_STATE | HAVE_STATE);
+static const int haveBufferName = (BUFFER_STATE | NAME_STATE | HAVE_STATE);
+static const int haveArgsName = (ARGS_STATE | NAME_STATE | HAVE_STATE);
+static const int haveFieldName = (FIELD_STATE | NAME_STATE | HAVE_STATE);
+static const int haveTypeName = (TYPE_STATE | NAME_STATE | HAVE_STATE);
+
+#define nameit(s) {s, #s}
+std::map<int, std::string> Schema::stateNameMap = {
+        nameit(awaitingArrayLen),
+        nameit(awaitingArrayName),
+        nameit(awaitingArgsName),
+        nameit(inArgsName),
+        nameit(inTypeName),
+        nameit(inArrayLen),
+        nameit(inArrayName),
+        nameit(inBufferName),
+        nameit(inBufferSize),
+        nameit(haveArrayName),
+        nameit(haveArgsName),
+        nameit(haveTypeName),
+        nameit(haveFieldName)
+};
+
+int Schema::replaceStateBit(int state, int remove, int set) {
+    state |= set;
+    state &= ~remove;
+    return state;
+}
+
+int Schema::newState(int state, int to) {
+    return to;
+}
+
+std::ostream &Schema::stateDescribe(std::ostream &out, int state) {
+    out << "(";
+    if (state & AWAITING_STATE) {
+        out << "Awaiting";
+    } else if (state & IN_STATE) {
+        out << "In";
+    } else if (state & HAVE_STATE) {
+        out << "Have";
+    }
+
+    if (state & FIELD_STATE) {
+        out << "Field";
+    } else if (state & TYPE_STATE) {
+        out << "Type";
+    } else if (state & BUFFER_STATE) {
+        out << "Buffer";
+    } else if (state & ARRAY_STATE) {
+        out << "Array";
+    } else if (state & ARGS_STATE) {
+        out << "Args";
+    }
+
+    if (state & NAME_STATE) {
+        out << "Name";
+    } else if (state & NUMERIC_STATE) {
+        out << "Numeric";
+    }
+
+    if (state & CAN_BE_ANON_STATE) {
+        out << "(? ok)";
+    } else if (state & CAN_BE_FLEX_STATE) {
+        out << "(* ok)";
+    }
+    out << ")";
+    return out;
+}
+
+std::ostream &Schema::stateType(std::ostream &out, int state) {
+    if (state & FIELD_STATE) {
+        out << "field";
+    } else if (state & TYPE_STATE) {
+        out << "type";
+    } else if (state & BUFFER_STATE) {
+        out << "buffer";
+    } else if (state & ARRAY_STATE) {
+        out << "array";
+    } else if (state & ARGS_STATE) {
+        out << "args";
+    } else {
+        out << "WTF";
+    }
+    return out;
+}
+
+char *Schema::dumpSchema(std::ostream &out, int state, int depth, char *ptr, void *data) {
+    char *start = nullptr;
+    indent(out, depth);
+    while (ptr != nullptr && *ptr != '\0') {
+        if (stateNameMap.count(state) == 0) {
+            std::cerr << "no key" << std::endl;
+            exit(1);
+        }
+        stateDescribe(out, state) << "> with '" << ((char) *ptr) << "'";
+        out.flush();
+        if (state & AWAITING_STATE) {
+            start = ptr;
+            if (
+                    (((state == awaitingArrayName) || (state == awaitingFieldName)) && (*ptr == '?'))
+                    || ((state & NAME_STATE) && (std::isalpha(*ptr)))
+                    || ((state & NUMERIC_STATE) && (std::isdigit(*ptr)))
+                    || ((state == awaitingArrayLen) && (*ptr == '*'))
+                    ) {
+                state = replaceStateBit(state, AWAITING_STATE, IN_STATE);
+                ptr++;
+            } else if (((*ptr == ',') || (*ptr == '}') || (*ptr == ']') || (*ptr == '>'))) {
+                ptr++;
+            } else {
+                std::cerr << "err " << "<" << stateNameMap[state] << "> with '" << ((char) *ptr) << "'" << ptr
+                          << std::endl;
+                exit(1);
+            }
+        } else if (state & IN_STATE) {
+            if (
+                    ((state & NAME_STATE) && (std::isalnum(*ptr) || *ptr == '_'))
+                    ||  ((state & NUMERIC_STATE) && std::isdigit(*ptr))
+                    || ((state == inBufferSize) && ((*ptr == '+') || (*ptr == '!')))
+                    ){
+                ptr++;
+            } else if (*ptr == ':') {
+                stateType(out, state);
+                dump(out, start, ptr++);
+                indent(out, depth);
+                state = replaceStateBit(state, IN_STATE, HAVE_STATE);
+            } else {
+                std::cerr << "err " << "<" << stateNameMap[state] << "> with '" << ((char) *ptr) << "'" << ptr
+                          << std::endl;
+                exit(1);
+            }
+        } else if ((state & HAVE_STATE)) {
+            switch (state) {
+                case haveArrayName: {
+                    // we expect a type
+                    if (std::isdigit(*ptr)) {
+                        start = ptr;
+                        ptr++;
+                        state = newState(state, inBufferSize);
+                    } else if (std::isalpha(*ptr)) {
+                        ptr++;
+                        state = newState(state, inTypeName);
+                    } else {
+                        std::cerr << "err " << "<" << stateNameMap[state] << "> with '" << ((char) *ptr) << "'" << ptr
+                                  << std::endl;
+                        exit(1);
+                    }
+                    break;
+                }
+                case haveArgsName: {
+                    // we expect a type name  or array, struct, union
+                    if (*ptr == '[') {
+                        ptr++;
+                        state = newState(state, awaitingArrayLen);
+                        // we expect a type
+                    } else if ((*ptr == '{') || (*ptr == '<')) {
+                        ptr++;
+                        state = newState(state, awaitingFieldName);
+                    } else if (std::isalnum(*ptr)) {
+                        ptr++;
+                        state =newState(state, inTypeName);
+                    } else {
+                        std::cerr << "err " << "<" << stateNameMap[state] << "> with '" << ((char) *ptr) << "'" << ptr
+                                  << std::endl;
+                        exit(1);
+                    }
+                    break;
+                }
+                default: {
+                    std::cerr << "err " << "<" << stateNameMap[state] << "> with '" << ((char) *ptr) << "'" << ptr
+                              << std::endl;
+                    exit(1);
+                }
+            }
+        } else {
+            std::cerr << "err " << "<" << stateNameMap[state] << "> with '" << ((char) *ptr) << "'" << ptr
+                      << std::endl;
+            exit(1);
+        }
+
+    }
+    return ptr;
+}
+
+char *Schema::dumpSchema(std::ostream &out, char *ptr, void *data) {
+    return dumpSchema(out, awaitingArgsName, 0, ptr, data);
+}
+
+char *Schema::dumpSchema(std::ostream &out, char *ptr) {
+    return dumpSchema(out, ptr, nullptr);
+}
+
+void Schema::dumpSled(std::ostream &out, void *argArray) {
+    ArgSled argSled(static_cast<ArgArray_t *>(argArray));
+    for (int i = 0; i < argSled.argc(); i++) {
+        Arg_t *arg = argSled.arg(i);
+        switch (arg->variant) {
+            case '&': {
+                out << "Buf: of " << arg->value.buffer.sizeInBytes << " bytes " << std::endl;
+                break;
+            }
+            case 'B': {
+                out << "S8:" << arg->value.s8 << std::endl;
+                break;
+            }
+            case 'Z': {
+                out << "Z:" << arg->value.z1 << std::endl;
+                break;
+            }
+            case 'C': {
+                out << "U16:" << arg->value.u16 << std::endl;
+                break;
+            }
+            case 'S': {
+                out << "S16:" << arg->value.s16 << std::endl;
+                break;
+            }
+            case 'I': {
+                out << "S32:" << arg->value.s32 << std::endl;
+                break;
+            }
+            case 'F': {
+                out << "F32:" << arg->value.s32 << std::endl;
+                break;
+            }
+            case 'J': {
+                out << "S64:" << arg->value.s64 << std::endl;
+                break;
+            }
+            case 'D': {
+                out << "F64:" << arg->value.f64 << std::endl;
+                break;
+            }
+            default: {
+                std::cerr << "unexpected variant '" << (char) arg->variant << "'" << std::endl;
+                exit(1);
+            }
+        }
+    }
+    out << "schema len = " << argSled.schemaLen() << std::endl;
+
+    out << "schema = " << argSled.schema() << std::endl;
+
+    // dumpSchema(out, argSled.schema()); not stable yet
+}
+
 // We need to trampoline through the real backend
 
 extern "C" int getMaxComputeUnits(long backendHandle) {
-    std::cout << "trampolining through backendHandle to backend.getMaxComputeUnits()" <<std::endl;
+    std::cout << "trampolining through backendHandle to backend.getMaxComputeUnits()" << std::endl;
     Backend *backend = (Backend *) backendHandle;
     return backend->getMaxComputeUnits();
 }
 
 extern "C" void info(long backendHandle) {
-    std::cout << "trampolining through backendHandle to backend.info()" <<std::endl;
+    std::cout << "trampolining through backendHandle to backend.info()" << std::endl;
     Backend *backend = (Backend *) backendHandle;
     backend->info();
 }
@@ -203,18 +511,18 @@ extern "C" void releaseBackend(long backendHandle) {
     delete backend;
 }
 extern "C" long compileProgram(long backendHandle, int len, char *source) {
-    std::cout << "trampolining through backendHandle to backend.compileProgram()" <<std::endl;
+    std::cout << "trampolining through backendHandle to backend.compileProgram()" << std::endl;
     Backend *backend = (Backend *) backendHandle;
     return backend->compileProgram(len, source);
 }
 extern "C" long getKernel(long programHandle, int nameLen, char *name) {
-    std::cout << "trampolining through programHandle to program.getKernel()" <<std::endl;
+    std::cout << "trampolining through programHandle to program.getKernel()" << std::endl;
     Backend::Program *program = (Backend::Program *) programHandle;
     return program->getKernel(nameLen, name);
 }
 
 extern "C" long ndrange(long kernelHandle, int range, void *argArray) {
-    std::cout << "trampolining through kernelHandle to kernel.ndrange(...) " <<std::endl;
+    std::cout << "trampolining through kernelHandle to kernel.ndrange(...) " << std::endl;
     Backend::Program::Kernel *kernel = (Backend::Program::Kernel *) kernelHandle;
     kernel->ndrange(range, argArray);
     return (long) 0;

--- a/hat/examples/violajones/src/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/java/violajones/ViolaJonesCompute.java
@@ -290,6 +290,7 @@ public class ViolaJonesCompute {
         cc.dispatchKernel(width * height, kc -> rgbToGreyKernel(kc, rgbS08x3Image, greyImage));
         F32Array2D integralImage = F32Array2D.create(accelerator, width, height);
         F32Array2D integralSqImage = F32Array2D.create(accelerator, width, height);
+        // createIntegralImage(greyImage, integralImage, integralSqImage);
 
         cc.dispatchKernel(width, kc -> integralColKernel(kc, greyImage, integralImage, integralSqImage));
         cc.dispatchKernel(height, kc -> integralRowKernel(kc, integralImage, integralSqImage));
@@ -311,7 +312,7 @@ public class ViolaJonesCompute {
         Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);
         Cascade cascade = Cascade.create(accelerator, haarCascade);
         RgbS08x3Image rgbImage = RgbS08x3Image.create(accelerator, nasa1996);
-        ResultTable resultTable = ResultTable.create(accelerator, 10000);
+        ResultTable resultTable = ResultTable.create(accelerator, 1000);
         HaarViewer harViz = new HaarViewer(accelerator, nasa1996, rgbImage, cascade, null, null);
 
         //System.out.println("Compute units "+((NativeBackend)accelerator.backend).getGetMaxComputeUnits());


### PR DESCRIPTION
Continuiing adding debugging support. 
Added Kernel Name to Kernel native class so we can dump the name. 
Continued (not complete) to expand schame dumps, to allow us to describe recieved native code buffers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/babylon.git pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/101.diff">https://git.openjdk.org/babylon/pull/101.diff</a>

</details>
