### PR TITLE
Fixed up ptx backend (native) so that PTX work can begin

### DIFF
--- a/hat/CMakeLists.txt
+++ b/hat/CMakeLists.txt
@@ -777,6 +777,15 @@ add_custom_target(squares_cuda DEPENDS squares.jar cuda_backend.jar cuda_backend
        -Djava.library.path=${CMAKE_BINARY_DIR}
        squares.Squares
 )
+add_custom_target(squares_ptx DEPENDS squares.jar ptx_backend.jar ptx_backend
+   COMMAND  ${DOIT}
+     ${JAVA_HOME}/bin/java
+       --enable-preview --enable-native-access=ALL-UNNAMED
+       --class-path ${HAT_JAR}:${SQUARES_JAR}:${PTX_BACKEND_JAR}
+       --add-exports=java.base/jdk.internal=ALL-UNNAMED
+       -Djava.library.path=${CMAKE_BINARY_DIR}
+       squares.Squares
+)
 
 #  heal executable
 add_custom_target(heal_java DEPENDS heal.jar

--- a/hat/backends/CMakeLists.txt
+++ b/hat/backends/CMakeLists.txt
@@ -86,3 +86,7 @@ add_executable(schemadump
         ${CMAKE_SOURCE_DIR}/shared/cpp/shared.cpp
         ${CMAKE_SOURCE_DIR}/shared/cpp/schemadump.cpp
 )
+add_library(ptx_backend SHARED
+        ${CMAKE_SOURCE_DIR}/shared/cpp/shared.cpp
+        ${CMAKE_SOURCE_DIR}/ptx/cpp/ptx_backend.cpp
+)

--- a/hat/backends/ptx/cpp/ptx_backend.cpp
+++ b/hat/backends/ptx/cpp/ptx_backend.cpp
@@ -34,15 +34,15 @@ public:
     class PTXProgram : public Backend::Program {
         class PTXKernel : public Backend::Program::Kernel {
         public:
-            PTXKernel(Backend::Program *program)
-                    : Backend::Program::Kernel(program) {
+            PTXKernel(Backend::Program *program, std::string name)
+                    : Backend::Program::Kernel(program, name) {
             }
 
             ~PTXKernel() {
             }
 
-            long ndrange(int range, void *argArray) {
-                std::cout << "ptx ndrange(" << range << ") " << std::endl;
+            long ndrange(void *argArray) {
+                std::cout << "ptx ndrange() " << std::endl;
                 return 0;
             }
         };
@@ -56,7 +56,7 @@ public:
         }
 
         long getKernel(int nameLen, char *name) {
-            return (long) new PTXKernel(this);
+            return (long) new PTXKernel(this, std::string(name));
         }
 
         bool programOK() {

--- a/hat/backends/ptx/java/hat/backend/PTXBackend.java
+++ b/hat/backends/ptx/java/hat/backend/PTXBackend.java
@@ -48,8 +48,18 @@ public class PTXBackend extends NativeBackend {
         // Here we recieve a callgraph from the kernel entrypoint
         // The first time we see this we need to convert the kernel entrypoint
         // and rechable methods to PTX.
-        kernelCallGraph.kernelReachableResolvedStream().forEach(kr -> {
 
-        });
+        // sort the dag by rank means that we get the methods called by the entrypoint in dependency order
+        // of course there may not be any of these
+        kernelCallGraph.kernelReachableResolvedStream()
+                .sorted((lhs, rhs) -> rhs.rank - lhs.rank)
+                .forEach(kernelReachableResolvedMethod ->
+                        System.out.println(" call to -> "+kernelReachableResolvedMethod.method.getName())
+                );
+
+        System.out.println("Entrypoint ->"+kernelCallGraph.entrypoint.method.getName());
+        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().toText());
+        System.out.println("Add your code to "+PTXBackend.class.getName()+".dispatchKernel() to actually run! :)");
+        System.exit(1);
     }
 }

--- a/hat/examples/squares/src/java/squares/Squares.java
+++ b/hat/examples/squares/src/java/squares/Squares.java
@@ -36,14 +36,16 @@ public class Squares {
     @CodeReflection
     public static void squareKernel(KernelContext kc, S32Array s32Array) {
         if (kc.x<s32Array.length()){
-           int value = s32Array.array(kc.x);     // arr[cc.x]
+           int value = s32Array.array(kc.x);        // arr[cc.x]
            s32Array.array(kc.x, value * value);  // arr[cc.x]=value*value
         }
     }
 
     @CodeReflection
     public static void square(ComputeContext cc, S32Array s32Array) {
-        cc.dispatchKernel(s32Array.length(), kc -> squareKernel(kc, s32Array));
+        cc.dispatchKernel(s32Array.length(),
+                kc -> squareKernel(kc, s32Array)
+        );
     }
 
     public static void main(String[] args) {

--- a/hat/intellij/squares.iml
+++ b/hat/intellij/squares.iml
@@ -12,5 +12,6 @@
     <orderEntry type="module" module-name="backend_opencl" />
     <orderEntry type="module" module-name="backend_cuda" />
     <orderEntry type="module" module-name="backend_spirv" />
+    <orderEntry type="module" module-name="backend_ptx" />
   </component>
 </module>


### PR DESCRIPTION
Synced ptx native code to changes made for OpenCL+CUDA. 

This allows PTX java backend work to commence.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/babylon.git pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/104.diff">https://git.openjdk.org/babylon/pull/104.diff</a>

</details>
