### PR TITLE
cuda fixes for violajones

### DIFF
--- a/hat/backends/cuda/cpp/cuda_backend.cpp
+++ b/hat/backends/cuda/cpp/cuda_backend.cpp
@@ -29,10 +29,13 @@
 #include "cuda_backend.h"
 
 Ptx::Ptx(size_t len)
-        : len(len), text(len > 0 ? new char[len] : nullptr) {}
+        : len(len), text(len > 0 ? new char[len] : nullptr) {
+    std::cout << "in Ptx with buffer allocated "<<len << std::endl;
+}
 
 Ptx::~Ptx() {
     if (len > 0 && text != nullptr) {
+        std::cout << "in ~Ptx with deleting allocated "<<len << std::endl;
         delete[] text;
     }
 }
@@ -43,56 +46,67 @@ uint64_t timeSinceEpochMillisec() {
 }
 
 Ptx *Ptx::nvcc(const char *cudaSource, size_t len) {
-
+    Ptx *ptx = nullptr;
     uint64_t time = timeSinceEpochMillisec();
-    std::stringstream timestampCuda;
-    timestampCuda << "./tmp" << time << ".cu";
     std::stringstream timestampPtx;
     timestampPtx << "./tmp" << time << ".ptx";
-    Ptx *ptx = nullptr;
-    const char *cudaPath = strdup(timestampCuda.str().c_str());
     const char *ptxPath = strdup(timestampPtx.str().c_str());
- //   std::cout << "cuda " << cudaPath << std::endl;
- //   std::cout << "ptx " << ptxPath << std::endl;
+   // std::cout << "ptx " << ptxPath << std::endl;
     // we are going to fork exec nvcc
     int pid;
     if ((pid = fork()) == 0) {
         std::ofstream cuda;
+        std::stringstream timestampCuda;
+        timestampCuda << "./tmp" << time << ".cu";
+        const char *cudaPath = strdup(timestampCuda.str().c_str());
+        std::cout << "cuda " << cudaPath << std::endl;
         cuda.open(cudaPath, std::ofstream::trunc);
         cuda.write(cudaSource, len);
         cuda.close();
-
         const char *path = "/usr/local/cuda-12.2/bin/nvcc";
-        // const char *argv[]{"nvcc", "-v", "-ptx", cudaPath, "-o", ptxPath, nullptr};
         const char *argv[]{"nvcc", "-ptx", cudaPath, "-o", ptxPath, nullptr};
-        // We are the child so exec nvcc.
-        //close(1); // stdout
-        //close(2); // stderr
-        //open(stderrPath, O_RDWR); // stdout
-        //open(stdoutPath, O_RDWR); // stderr
+        // we can't free cudaPath or ptxpath in child because we need them in exec, no prob through
+        // because we get a new proc so they are released to os
         execvp(path, (char *const *) argv);
+
     } else if (pid < 0) {
         // fork failed.
         std::cerr << "fork of nvcc failed" << std::endl;
         std::exit(1);
     } else {
         int status;
-     //   std::cerr << "fork suceeded waitikbng for child" << std::endl;
+     //   std::cerr << "fork suceeded waiting for child" << std::endl;
         pid_t result = wait(&status);
-      //  std::cerr << "child finished" << std::endl;
-        std::ifstream ptxStream(ptxPath);
-        ptxStream.seekg(0, ptxStream.end);
-        size_t ptxLen = ptxStream.tellg();
-        if (ptxLen > 0) {
-            ptx = new Ptx(ptxLen + 1);
-            ptxStream.seekg(0, ptxStream.beg);
-            ptxStream.read(ptx->text, ptx->len);
-            ptx->text[ptx->len] = '\0';
-            ptx->text[ptx->len - 1] = '\0';
-        }
-        ptxStream.close();
+        std::cerr << "child finished" << std::endl;
+        std::ifstream ptxStream;
+        ptxStream.open(ptxPath);
+      //  if (ptxStream.is_open()) {
+            ptxStream.seekg(0, std::ios::end);
+            size_t ptxLen = ptxStream.tellg();
+            ptxStream.close();
+            ptxStream.open(ptxPath);
+            free((void *) ptxPath);
+            ptxPath = nullptr;
+            if (ptxLen > 0) {
+                std::cerr << "ptx len "<< ptxLen << std::endl;
+                ptx = new Ptx(ptxLen + 1);
+                std::cerr << "about to read  "<< ptx->len << std::endl;
+                ptxStream.read(ptx->text, ptx->len);
+                ptxStream.close();
+                std::cerr << "about to read  "<< ptx->len << std::endl;
+                ptx->text[ptx->len - 1] = '\0';
+                std::cerr << "read text "<< ptx->text << std::endl;
+
+            } else {
+                std::cerr << "no ptx! ptxLen == 0?";
+                exit(1);
+            }
+      //  }else{
+        //    std::cerr << "no ptx!";
+       //     exit(1);
+      //  }
     }
-  //  std::cout << "returning PTX" << std::endl;
+    std::cout << "returning PTX" << std::endl;
     return ptx;
 }
 
@@ -100,13 +114,19 @@ Ptx *Ptx::nvcc(const char *cudaSource, size_t len) {
 //http://mercury.pr.erau.edu/~siewerts/extra/code/digital-media/CUDA/cuda_work/samples/0_Simple/matrixMulDrv/matrixMulDrv.cpp
  */
 CudaBackend::CudaProgram::CudaKernel::CudaBuffer::CudaBuffer(Backend::Program::Kernel *kernel, Arg_t *arg)
-        : Buffer(kernel, arg) {
+        : Buffer(kernel, arg), devicePtr() {
     /*
      *   (void *) arg->value.buffer.memorySegment,
      *   (size_t) arg->value.buffer.sizeInBytes);
      */
   //  std::cout << "cuMemAlloc()" << std::endl;
-    checkCudaErrors(cuMemAlloc(&devicePtr, (size_t) arg->value.buffer.sizeInBytes));
+    CUresult status = cuMemAlloc(&devicePtr, (size_t) arg->value.buffer.sizeInBytes);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cuMemFree() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
+                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
+        exit(-1);
+    }
   //  std::cout << "devptr " << std::hex<<  (long)devicePtr <<std::dec <<std::endl;
     arg->value.buffer.vendorPtr = static_cast<void *>(this);
 }
@@ -116,12 +136,18 @@ CudaBackend::CudaProgram::CudaKernel::CudaBuffer::~CudaBuffer() {
  //   std::cout << "cuMemFree()"
   //          << "devptr " << std::hex<<  (long)devicePtr <<std::dec
    //         << std::endl;
-    checkCudaErrors(cuMemFree(devicePtr));
+    CUresult  status = cuMemFree(devicePtr);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cuMemFree() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
+                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
+        exit(-1);
+    }
     arg->value.buffer.vendorPtr = nullptr;
 }
 
 void CudaBackend::CudaProgram::CudaKernel::CudaBuffer::copyToDevice() {
-    CudaKernel * cudaKernel = dynamic_cast<CudaKernel*>(kernel);
+    auto cudaKernel = dynamic_cast<CudaKernel*>(kernel);
  //   std::cout << "copyToDevice() 0x"   << std::hex<<arg->value.buffer.sizeInBytes<<std::dec << " "<< arg->value.buffer.sizeInBytes << " "
  //             << "devptr " << std::hex<<  (long)devicePtr <<std::dec
  //             << std::endl;
@@ -137,18 +163,24 @@ void CudaBackend::CudaProgram::CudaKernel::CudaBuffer::copyToDevice() {
     }
 
 
-    checkCudaErrors(cuMemcpyHtoDAsync(devicePtr, arg->value.buffer.memorySegment, arg->value.buffer.sizeInBytes,cudaKernel->cudaStream));
-    cudaError_t t1 = cudaStreamSynchronize(cudaKernel->cudaStream);
-    if (CUDA_SUCCESS != t1) {
-        std::cerr << "CUDA error = " << t1
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(t1))
+    CUresult status = cuMemcpyHtoDAsync(devicePtr, arg->value.buffer.memorySegment, arg->value.buffer.sizeInBytes,cudaKernel->cudaStream);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cuMemcpyHtoDAsync() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
+                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
+        exit(-1);
+    }
+    status = static_cast<CUresult >(cudaStreamSynchronize(cudaKernel->cudaStream));
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cudaStreamSynchronize() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);
     }
 }
 
 void CudaBackend::CudaProgram::CudaKernel::CudaBuffer::copyFromDevice() {
-    CudaKernel * cudaKernel = dynamic_cast<CudaKernel*>(kernel);
+    auto cudaKernel = dynamic_cast<CudaKernel*>(kernel);
  //   std::cout << "copyFromDevice() 0x" << std::hex<<arg->value.buffer.sizeInBytes<<std::dec << " "<< arg->value.buffer.sizeInBytes << " "
  //             << "devptr " << std::hex<<  (long)devicePtr <<std::dec
   //            << std::endl;
@@ -162,9 +194,15 @@ void CudaBackend::CudaProgram::CudaKernel::CudaBuffer::copyFromDevice() {
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);
     }
-    checkCudaErrors(cuMemcpyDtoHAsync(arg->value.buffer.memorySegment, devicePtr, arg->value.buffer.sizeInBytes,cudaKernel->cudaStream));
+    CUresult status =cuMemcpyDtoHAsync(arg->value.buffer.memorySegment, devicePtr, arg->value.buffer.sizeInBytes,cudaKernel->cudaStream);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cudaStreamSynchronize() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
+                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
+        exit(-1);
+    }
     cudaError_t t1 = cudaStreamSynchronize(cudaKernel->cudaStream);
-    if (CUDA_SUCCESS != t1) {
+    if (static_cast<cudaError_t>(CUDA_SUCCESS) != t1) {
         std::cerr << "CUDA error = " << t1
                   <<" " << cudaGetErrorString(static_cast<cudaError_t>(t1))
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
@@ -180,21 +218,20 @@ void CudaBackend::CudaProgram::CudaKernel::CudaBuffer::copyFromDevice() {
     }
 }
 
-CudaBackend::CudaProgram::CudaKernel::CudaKernel(Backend::Program *program,std::string name, CUfunction function)
-        : Backend::Program::Kernel(program, name), function(function) {
+CudaBackend::CudaProgram::CudaKernel::CudaKernel(Backend::Program *program,char * name, CUfunction function)
+        : Backend::Program::Kernel(program, name), function(function),cudaStream() {
 }
 
-CudaBackend::CudaProgram::CudaKernel::~CudaKernel() {
+CudaBackend::CudaProgram::CudaKernel::~CudaKernel() = default;
 
-    // releaseCUfunction function
-}
-
-long CudaBackend::CudaProgram::CudaKernel::ndrange(int range, void *argArray) {
+long CudaBackend::CudaProgram::CudaKernel::ndrange(void *argArray) {
   //  std::cout << "ndrange(" << range << ") " << name << std::endl;
+
     cudaStreamCreate(&cudaStream);
     ArgSled argSled(static_cast<ArgArray_t *>(argArray));
  //   Schema::dumpSled(std::cout, argArray);
     void *argslist[argSled.argc()];
+    NDRange *ndrange = nullptr;
 #ifdef VERBOSE
     std::cerr << "there are " << argSled.argc() << "args " << std::endl;
 #endif
@@ -202,6 +239,9 @@ long CudaBackend::CudaProgram::CudaKernel::ndrange(int range, void *argArray) {
         Arg_t *arg = argSled.arg(i);
         switch (arg->variant) {
             case '&': {
+                if (arg->idx == 0){
+                    ndrange = static_cast<NDRange *>(arg->value.buffer.memorySegment);
+                }
                 auto cudaBuffer = new CudaBuffer(this, arg);
                 cudaBuffer->copyToDevice();
                 argslist[arg->idx] = static_cast<void *>(&cudaBuffer->devicePtr);
@@ -223,7 +263,7 @@ long CudaBackend::CudaProgram::CudaKernel::ndrange(int range, void *argArray) {
         }
     }
 
-
+    int range = ndrange->maxX;
     int rangediv1024 = range / 1024;
     int rangemod1024 = range % 1024;
     if (rangemod1024 > 0) {
@@ -233,25 +273,29 @@ long CudaBackend::CudaProgram::CudaKernel::ndrange(int range, void *argArray) {
   //  std::cout << "   Requested range   = " << range << std::endl;
   //  std::cout << "   Range mod 1024    = " << rangemod1024 << std::endl;
    // std::cout << "   Actual range 1024 = " << (rangediv1024 * 1024) << std::endl;
-
-    cudaError_t t0 = cudaStreamSynchronize(cudaStream);
-    if (CUDA_SUCCESS != t0) {
-        std::cerr << "CUDA error = " << t0
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(t0))
+    auto status= static_cast<CUresult>(cudaStreamSynchronize(cudaStream));
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cudaStreamSynchronize() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);
     }
 
-    checkCudaErrors(cuLaunchKernel(function,
+    status= cuLaunchKernel(function,
                                    rangediv1024, 1, 1,
                                    1024, 1, 1,
                                    0, cudaStream,
-                    argslist, 0));
-
-    cudaError_t t1 = cudaStreamSynchronize(cudaStream);
-    if (CUDA_SUCCESS != t1) {
-        std::cerr << "CUDA error = " << t1
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(t1))
+                    argslist, 0);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cuLaunchKernel() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
+                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
+        exit(-1);
+    }
+    status= static_cast<CUresult>(cudaStreamSynchronize(cudaStream));
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cudaStreamSynchronize() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);
     }
@@ -265,10 +309,10 @@ long CudaBackend::CudaProgram::CudaKernel::ndrange(int range, void *argArray) {
 
         }
     }
-    cudaError_t t2 =   cudaStreamSynchronize(cudaStream);
-    if (CUDA_SUCCESS != t2) {
-        std::cerr << "CUDA error = " << t2
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(t2))
+    status=   static_cast<CUresult>(cudaStreamSynchronize(cudaStream));
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cudaStreamSynchronize() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);
     }
@@ -289,16 +333,19 @@ CudaBackend::CudaProgram::CudaProgram(Backend *backend, BuildInfo *buildInfo, Pt
         : Backend::Program(backend, buildInfo), ptx(ptx), module(module) {
 }
 
-CudaBackend::CudaProgram::~CudaProgram() {
-}
+CudaBackend::CudaProgram::~CudaProgram() = default;
 
 long CudaBackend::CudaProgram::getKernel(int nameLen, char *name) {
     CUfunction function;
-  //  std::cout << "trying to get kernelFunction " << name << std::endl;
-    checkCudaErrors(
-            cuModuleGetFunction(&function, module, name)
-    );
-    return reinterpret_cast<long>(new CudaKernel(this, std::string(name), function));
+    CUresult status= cuModuleGetFunction(&function, module, name);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cuModuleGetFunction() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
+                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
+        exit(-1);
+    }
+    long kernelHandle =  reinterpret_cast<long>(new CudaKernel(this, name, function));
+    return kernelHandle;
 }
 
 bool CudaBackend::CudaProgram::programOK() {
@@ -307,18 +354,17 @@ bool CudaBackend::CudaProgram::programOK() {
 
 CudaBackend::CudaBackend(CudaBackend::CudaConfig *cudaConfig, int
 configSchemaLen, char *configSchema)
-        : Backend((Backend::Config
-*) cudaConfig, configSchemaLen, configSchema) {
+        : Backend((Backend::Config*) cudaConfig, configSchemaLen, configSchema), device(),context()  {
   //  std::cout << "CudaBackend constructor " << ((cudaConfig == nullptr) ? "cudaConfig== null" : "got cudaConfig")
     //          << std::endl;
     int deviceCount = 0;
     CUresult err = cuInit(0);
     if (err == CUDA_SUCCESS) {
-        checkCudaErrors(cuDeviceGetCount(&deviceCount));
+        cuDeviceGetCount(&deviceCount);
         std::cout << "CudaBackend device count" << std::endl;
-        checkCudaErrors(cuDeviceGet(&device, 0));
+        cuDeviceGet(&device, 0);
         std::cout << "CudaBackend device ok" << std::endl;
-        checkCudaErrors(cuCtxCreate(&context, 0, device));
+        cuCtxCreate(&context, 0, device);
         std::cout << "CudaBackend context created ok" << std::endl;
     } else {
         std::cout << "CudaBackend failed, we seem to have the runtime library but no device, no context, nada "
@@ -333,7 +379,13 @@ CudaBackend::CudaBackend() : CudaBackend(nullptr, 0, nullptr) {
 
 CudaBackend::~CudaBackend() {
     std::cout << "freeing context" << std::endl;
-    checkCudaErrors(cuCtxDestroy(context));
+    CUresult status = cuCtxDestroy(context);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cuCtxDestroy(() CUDA error = " << status
+                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
+                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
+        exit(-1);
+    }
 }
 
 int CudaBackend::getMaxComputeUnits() {
@@ -349,24 +401,24 @@ void CudaBackend::info() {
 
     // get compute capabilities and the devicename
     int major = 0, minor = 0;
-    checkCudaErrors(cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
-    checkCudaErrors(cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
+    cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device);
+    cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device);
     std::cout << "> GPU Device has major=" << major << " minor=" << minor << " compute capability" << std::endl;
 
     int warpSize;
-    checkCudaErrors(cuDeviceGetAttribute(&warpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, device));
+    cuDeviceGetAttribute(&warpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, device);
     std::cout << "> GPU Device has warpSize " << warpSize << std::endl;
 
     int threadsPerBlock;
-    checkCudaErrors(cuDeviceGetAttribute(&threadsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK, device));
+    cuDeviceGetAttribute(&threadsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK, device);
     std::cout << "> GPU Device has threadsPerBlock " << threadsPerBlock << std::endl;
 
     int cores;
-    checkCudaErrors(cuDeviceGetAttribute(&cores, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device));
+    cuDeviceGetAttribute(&cores, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device);
     std::cout << "> GPU Cores " << cores << std::endl;
 
     size_t totalGlobalMem;
-    checkCudaErrors(cuDeviceTotalMem(&totalGlobalMem, device));
+    cuDeviceTotalMem(&totalGlobalMem, device);
     std::cout << "  Total amount of global memory:   " << (unsigned long long) totalGlobalMem << std::endl;
     std::cout << "  64-bit Memory Address:           " <<
               ((totalGlobalMem > (unsigned long long) 4 * 1024 * 1024 * 1024L) ? "YES" : "NO") << std::endl;
@@ -375,7 +427,6 @@ void CudaBackend::info() {
 
 long CudaBackend::compileProgram(int len, char *source) {
     Ptx *ptx = Ptx::nvcc(source, len);
-
     CUmodule module;
     std::cout << "inside compileProgram" << std::endl;
     std::cout << "cuda " << source << std::endl;
@@ -403,90 +454,18 @@ long CudaBackend::compileProgram(int len, char *source) {
 
         //delete ptx;
     } else {
-        std::cout << "no ptx content!/" << std::endl;
+        std::cout << "no ptx content!" << std::endl;
         exit(1);
     }
 }
 
 long getBackend(void *config, int configSchemaLen, char *configSchema) {
-    return reinterpret_cast<long>(new CudaBackend(static_cast<CudaBackend::CudaConfig *>(config), configSchemaLen,
-                                                  configSchema));
+    long backendHandle= reinterpret_cast<long>(
+            new CudaBackend(static_cast<CudaBackend::CudaConfig *>(config), configSchemaLen,
+                            configSchema));
+    std::cout << "getBackend() -> backendHandle=" << std::hex << backendHandle << std::dec << std::endl;
+    return backendHandle;
 }
 
 
-void __checkCudaErrors(CUresult err, const char *file, const int line) {
-    if (CUDA_SUCCESS != err) {
-        std::cerr << "CUDA error = " << err
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(err))
-                  <<" " << file << " line " << line << std::endl;
-        exit(-1);
-    }
-}
-
-const char *CudaBackend::errorMsg(CUresult status) {
-    static struct {
-        CUresult code;
-        const char *msg;
-    } error_table[] = {
-            {CUDA_SUCCESS, "success"},
-            // {CL_DEVICE_NOT_FOUND,                "device not found",},
-            //   {CL_DEVICE_NOT_AVAILABLE,            "device not available",},
-            //   {CL_COMPILER_NOT_AVAILABLE,          "compiler not available",},
-            //   {CL_MEM_OBJECT_ALLOCATION_FAILURE,   "mem object allocation failure",},
-            //   {CL_OUT_OF_RESOURCES,                "out of resources",},
-            //   {CL_OUT_OF_HOST_MEMORY,              "out of host memory",},
-            //   {CL_PROFILING_INFO_NOT_AVAILABLE,    "profiling not available",},
-            //   {CL_MEM_COPY_OVERLAP,                "memcopy overlaps",},
-            //   {CL_IMAGE_FORMAT_MISMATCH,           "image format mismatch",},
-            //   {CL_IMAGE_FORMAT_NOT_SUPPORTED,      "image format not supported",},
-            //   {CL_BUILD_PROGRAM_FAILURE,           "build program failed",},
-            //   {CL_MAP_FAILURE,                     "map failed",},
-            //   {CL_INVALID_VALUE,                   "invalid value",},
-            //   {CL_INVALID_DEVICE_TYPE,             "invalid device type",},
-            //   {CL_INVALID_PLATFORM,                "invlaid platform",},
-            //   {CL_INVALID_DEVICE,                  "invalid device",},
-            //   {CL_INVALID_CONTEXT,                 "invalid context",},
-            //   {CL_INVALID_QUEUE_PROPERTIES,        "invalid queue properties",},
-            //   {CL_INVALID_COMMAND_QUEUE,           "invalid command queue",},
-            //   {CL_INVALID_HOST_PTR,                "invalid host ptr",},
-            //   {CL_INVALID_MEM_OBJECT,              "invalid mem object",},
-            //   {CL_INVALID_IMAGE_FORMAT_DESCRIPTOR, "invalid image format descriptor ",},
-            //   {CL_INVALID_IMAGE_SIZE,              "invalid image size",},
-            //   {CL_INVALID_SAMPLER,                 "invalid sampler",},
-            //   {CL_INVALID_BINARY,                  "invalid binary",},
-            //   {CL_INVALID_BUILD_OPTIONS,           "invalid build options",},
-            //   {CL_INVALID_PROGRAM,                 "invalid program ",},
-            //   {CL_INVALID_PROGRAM_EXECUTABLE,      "invalid program executable",},
-            //   {CL_INVALID_KERNEL_NAME,             "invalid kernel name",},
-            //   {CL_INVALID_KERNEL_DEFINITION,       "invalid definition",},
-            //   {CL_INVALID_KERNEL,                  "invalid kernel",},
-            //   {CL_INVALID_ARG_INDEX,               "invalid arg index",},
-            //   {CL_INVALID_ARG_VALUE,               "invalid arg value",},
-            //   {CL_INVALID_ARG_SIZE,                "invalid arg size",},
-            //   {CL_INVALID_KERNEL_ARGS,             "invalid kernel args",},
-            //   {CL_INVALID_WORK_DIMENSION,          "invalid work dimension",},
-            //   {CL_INVALID_WORK_GROUP_SIZE,         "invalid work group size",},
-            //   {CL_INVALID_WORK_ITEM_SIZE,          "invalid work item size",},
-            //   {CL_INVALID_GLOBAL_OFFSET,           "invalid global offset",},
-            //   {CL_INVALID_EVENT_WAIT_LIST,         "invalid event wait list",},
-            //   {CL_INVALID_EVENT,                   "invalid event",},
-            //   {CL_INVALID_OPERATION,               "invalid operation",},
-            //   {CL_INVALID_GL_OBJECT,               "invalid gl object",},
-            //   {CL_INVALID_BUFFER_SIZE,             "invalid buffer size",},
-            //  {CL_INVALID_MIP_LEVEL,               "invalid mip level",},
-            //   {CL_INVALID_GLOBAL_WORK_SIZE,        "invalid global work size",},
-            {(CUresult) 0, nullptr},
-    };
-    static char unknown[256];
-    int ii;
-
-    for (ii = 0; error_table[ii].msg != NULL; ii++) {
-        if (error_table[ii].code == status) {
-            //std::cerr << " clerror '" << error_table[ii].msg << "'" << std::endl;
-            return error_table[ii].msg;
-        }
-    }
-    SNPRINTF(unknown, sizeof(unknown), "unknown error %d", status);
-    return unknown;
-}
 

--- a/hat/backends/cuda/include/cuda_backend.h
+++ b/hat/backends/cuda/include/cuda_backend.h
@@ -60,9 +60,9 @@
 
 #include<vector>
 
-extern void __checkCudaErrors(CUresult err, const char *file, const int line);
+//extern void __checkCudaErrors(CUresult err, const char *file, const int line);
 
-#define checkCudaErrors(err)  __checkCudaErrors (err, __FILE__, __LINE__)
+//#define checkCudaErrors(err)  __checkCudaErrors (err, __FILE__, __LINE__)
 
 class Ptx {
 public:
@@ -102,11 +102,11 @@ public:
             CUfunction function;
             cudaStream_t cudaStream;
         public:
-            CudaKernel(Backend::Program *program, std::string name, CUfunction function);
+            CudaKernel(Backend::Program *program, char* name, CUfunction function);
 
-            ~CudaKernel();
+            ~CudaKernel() override;
 
-            long ndrange(int range, void *argArray);
+            long ndrange( void *argArray);
         };
 
     private:
@@ -140,7 +140,7 @@ public:
 
     long compileProgram(int len, char *source);
 
-    static const char *errorMsg(CUresult status);
+    //static const char *errorMsg(CUresult status);
 
 };
 

--- a/hat/backends/opencl/include/opencl_backend.h
+++ b/hat/backends/opencl/include/opencl_backend.h
@@ -87,7 +87,7 @@ public:
         protected:
             void showEvents(int width);
         public:
-            OpenCLKernel(Backend::Program *program, std::string name,cl_kernel kernel);
+            OpenCLKernel(Backend::Program *program, char* name,cl_kernel kernel);
 
             ~OpenCLKernel();
 

--- a/hat/backends/shared/cpp/shared.cpp
+++ b/hat/backends/shared/cpp/shared.cpp
@@ -497,48 +497,51 @@ void Schema::dumpSled(std::ostream &out, void *argArray) {
 
 extern "C" int getMaxComputeUnits(long backendHandle) {
    // std::cout << "trampolining through backendHandle to backend.getMaxComputeUnits()" << std::endl;
-    Backend *backend = (Backend *) backendHandle;
+    auto *backend = reinterpret_cast<Backend*>(backendHandle);
     return backend->getMaxComputeUnits();
 }
 
 extern "C" void info(long backendHandle) {
   //  std::cout << "trampolining through backendHandle to backend.info()" << std::endl;
-    Backend *backend = (Backend *) backendHandle;
+    auto *backend = reinterpret_cast<Backend*>(backendHandle);
     backend->info();
 }
 extern "C" void releaseBackend(long backendHandle) {
-    Backend *backend = (Backend *) backendHandle;
+    auto *backend = reinterpret_cast<Backend*>(backendHandle);
     delete backend;
 }
 extern "C" long compileProgram(long backendHandle, int len, char *source) {
-    std::cout << "trampolining through backendHandle to backend.compileProgram()" << std::endl;
-    Backend *backend = (Backend *) backendHandle;
-    return backend->compileProgram(len, source);
+    std::cout << "trampolining through backendHandle to backend.compileProgram() "
+        <<std::hex<<backendHandle<< std::dec <<std::endl;
+    auto *backend = reinterpret_cast<Backend*>(backendHandle);
+    auto programHandle = backend->compileProgram(len, source);
+    std::cout << "programHandle = "<<std::hex<<backendHandle<< std::dec <<std::endl;
+    return programHandle;
 }
 extern "C" long getKernel(long programHandle, int nameLen, char *name) {
-  //  std::cout << "trampolining through programHandle to program.getKernel()" << std::endl;
-    Backend::Program *program = (Backend::Program *) programHandle;
+    std::cout << "trampolining through programHandle to program.getKernel()"
+            <<std::hex<<programHandle<< std::dec <<std::endl;
+    auto program = reinterpret_cast<Backend::Program *>(programHandle);
     return program->getKernel(nameLen, name);
 }
 
 extern "C" long ndrange(long kernelHandle, void *argArray) {
     std::cout << "trampolining through kernelHandle to kernel.ndrange(...) " << std::endl;
-
-    Backend::Program::Kernel *kernel = (Backend::Program::Kernel *) kernelHandle;
+    auto kernel = reinterpret_cast<Backend::Program::Kernel *>(kernelHandle);
     kernel->ndrange( argArray);
     return (long) 0;
 }
 extern "C" void releaseKernel(long kernelHandle) {
-    Backend::Program::Kernel *kernel = (Backend::Program::Kernel *) kernelHandle;
+    auto kernel = reinterpret_cast<Backend::Program::Kernel *>(kernelHandle);
     delete kernel;
 }
 
 extern "C" void releaseProgram(long programHandle) {
-    Backend::Program *program = (Backend::Program *) programHandle;
+    auto program = reinterpret_cast<Backend::Program *>(programHandle);
     delete program;
 }
 extern "C" bool programOK(long programHandle) {
-    Backend::Program *program = (Backend::Program *) programHandle;
+    auto program = reinterpret_cast<Backend::Program *>(programHandle);
     return program->programOK();
 }
 

--- a/hat/backends/shared/include/shared.h
+++ b/hat/backends/shared/include/shared.h
@@ -455,17 +455,21 @@ public:
                 virtual ~Buffer() {}
             };
 
-            std::string name;
+            char *name;// strduped!
 
             Program *program;
 
             virtual long ndrange( void *argArray) = 0;
 
-            Kernel(Program *program, std::string name)
-                    : program(program), name(name) {
+            Kernel(Program *program, char * name)
+                    : program(program), name(strdup(name)) {
             }
 
-            virtual ~Kernel() {}
+            virtual ~Kernel(){
+                if (name){
+                    free(name);
+                }
+            }
         };
 
     public:

--- a/hat/examples/squares/src/java/squares/Squares.java
+++ b/hat/examples/squares/src/java/squares/Squares.java
@@ -35,8 +35,8 @@ import java.lang.runtime.CodeReflection;
 public class Squares {
     @CodeReflection
     public static void squareKernel(KernelContext kc, S32Array s32Array) {
-        if (kc.x<s32Array.length()){
-           int value = s32Array.array(kc.x);        // arr[cc.x]
+        if (kc.x<kc.maxX){
+           int value = s32Array.array(kc.x);     // arr[cc.x]
            s32Array.array(kc.x, value * value);  // arr[cc.x]=value*value
         }
     }
@@ -57,7 +57,7 @@ public class Squares {
         }
         accelerator.compute(
                 cc -> Squares.square(cc, arr)  //QuotableComputeContextConsumer
-        );                                  //   extends Quotable, Consumer<ComputeContext>
+        );                                     //   extends Quotable, Consumer<ComputeContext>
         for (int i = 0; i < arr.length(); i++) {
             System.out.println(i + " " + arr.array(i));
         }

--- a/hat/hat/src/java/hat/backend/c99codebuilders/C99HatKernelBuilder.java
+++ b/hat/hat/src/java/hat/backend/c99codebuilders/C99HatKernelBuilder.java
@@ -71,8 +71,8 @@ public abstract class C99HatKernelBuilder<T extends C99HatKernelBuilder<T>> exte
 
     public final T scope() {
         return
-                identifier("kc").rarrow().identifier("x").equals().globalId().semicolon().nl()
-                .identifier("kc").rarrow().identifier("maxX").equals().globalSize().semicolon().nl();
+                identifier("kc").rarrow().identifier("x").equals().globalId().semicolon().nl();
+                //.identifier("kc").rarrow().identifier("maxX").equals().globalSize().semicolon().nl();
     }
 
     public abstract T globalPtrPrefix();


### PR DESCRIPTION
Found source of access violation in CUDA backend.

Also a bug in the algorithm itself (causing to walk off array).

Violajones still does not work for larger Nasa image.  But does for other three image types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/babylon.git pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/105.diff">https://git.openjdk.org/babylon/pull/105.diff</a>

</details>
