### PR TITLE
fix std::string to char * for kernel names

### DIFF
--- a/hat/backends/opencl/cpp/opencl_backend.cpp
+++ b/hat/backends/opencl/cpp/opencl_backend.cpp
@@ -97,7 +97,7 @@ OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLBuffer::~OpenCLBuffer() {
     clReleaseMemObject(clMem);
 }
 
-OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLKernel(Backend::Program *program, std::string name, cl_kernel kernel)
+OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLKernel(Backend::Program *program, char* name, cl_kernel kernel)
         : Backend::Program::Kernel(program, name), kernel(kernel), eventMax(0), events(nullptr),
           eventc(0) {
 }
@@ -241,7 +241,7 @@ OpenCLBackend::OpenCLProgram::~OpenCLProgram() {
 long OpenCLBackend::OpenCLProgram::getKernel(int nameLen, char *name) {
     cl_int status;
     cl_kernel kernel = clCreateKernel(program, name, &status);
-    return (long) new OpenCLKernel(this,std::string(name), kernel);
+    return (long) new OpenCLKernel(this,name, kernel);
 }
 
 bool OpenCLBackend::OpenCLProgram::programOK() {

--- a/hat/backends/ptx/cpp/ptx_backend.cpp
+++ b/hat/backends/ptx/cpp/ptx_backend.cpp
@@ -34,7 +34,7 @@ public:
     class PTXProgram : public Backend::Program {
         class PTXKernel : public Backend::Program::Kernel {
         public:
-            PTXKernel(Backend::Program *program, std::string name)
+            PTXKernel(Backend::Program *program, char * name)
                     : Backend::Program::Kernel(program, name) {
             }
 
@@ -56,7 +56,7 @@ public:
         }
 
         long getKernel(int nameLen, char *name) {
-            return (long) new PTXKernel(this, std::string(name));
+            return (long) new PTXKernel(this, name);
         }
 
         bool programOK() {


### PR DESCRIPTION
Opencl and PTX backends now aligned with CUDA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/babylon.git pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/106.diff">https://git.openjdk.org/babylon/pull/106.diff</a>

</details>
