### PR TITLE
Add support for enclosing class types

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/parser/impl/DescParser.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/parser/impl/DescParser.java
@@ -97,14 +97,17 @@ public final class DescParser {
                 t = l.token();
             }
         } else {
-            // Qualified identifier
+            // type element identifier
             Tokens.Token t = l.accept(TokenKind.IDENTIFIER,
-                    TokenKind.PLUS, TokenKind.SUB);
+                    TokenKind.PLUS, TokenKind.SUB, TokenKind.DOT);
             identifier.append(t.kind == TokenKind.IDENTIFIER ? t.name() : t.kind.name);
-            while (l.acceptIf(Tokens.TokenKind.DOT)) {
-                identifier.append(Tokens.TokenKind.DOT.name);
-                t = l.accept(Tokens.TokenKind.IDENTIFIER);
-                identifier.append(t.name());
+            if (t.kind == TokenKind.IDENTIFIER) {
+                // keep going if we see "."
+                while (l.acceptIf(Tokens.TokenKind.DOT)) {
+                    identifier.append(Tokens.TokenKind.DOT.name);
+                    t = l.accept(Tokens.TokenKind.IDENTIFIER);
+                    identifier.append(t.name());
+                }
             }
         }
 
@@ -121,8 +124,6 @@ public final class DescParser {
         } else {
             args = List.of();
         }
-
-        // @@@ Enclosed/inner classes, separated by $ which may also be parameterized
 
         // Parse array-like syntax []+
         int dims = 0;

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -127,11 +127,13 @@ public final class CoreTypeFactory {
                     return JavaType.typeVarRef(parts[1],
                             (ClassType)constructType(parseExTypeElem(parts[0])),
                             constructTypeArgument(tree, 0, NO_WILDCARDS));
-                } else {
+                } else if (parts.length == 3) {
                     // method type-var
                     return JavaType.typeVarRef(parts[2],
                             parseMethodRef(String.format("%s::%s", parts[0], parts[1])),
                             constructTypeArgument(tree, 0, NO_WILDCARDS));
+                } else {
+                    throw badType(tree, "type variable");
                 }
             } else if (identifier.equals(".")) {
                 // qualified type

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -2,9 +2,11 @@ package java.lang.reflect.code.type;
 
 import java.lang.constant.ClassDesc;
 import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.TypeElement.ExternalizedTypeElement;
 import java.lang.reflect.code.type.WildcardType.BoundKind;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 public final class CoreTypeFactory {
 
@@ -90,85 +92,103 @@ public final class CoreTypeFactory {
      */
     public static final TypeElementFactory JAVA_TYPE_FACTORY = new TypeElementFactory() {
         @Override
-        public TypeElement constructType(TypeElement.ExternalizedTypeElement tree) {
+        public JavaType constructType(TypeElement.ExternalizedTypeElement tree) {
             String identifier = tree.identifier();
-            int dimensions = 0;
+
             if (identifier.startsWith("[")) {
+                // Array types are "flattened". Skip over '[', but keep track of them in 'dimensions'
                 if (tree.arguments().size() != 1) {
-                    throw new IllegalArgumentException("Bad type: " + tree);
+                    throw badType(tree, "array type");
                 }
                 for (int i = 1; i < identifier.length(); i++) {
                     if (identifier.charAt(i) != '[') {
-                        throw new IllegalArgumentException("Bad type: " + tree);
+                        throw badType(tree, "array type");
                     }
                 }
-                dimensions = identifier.length();
-                tree = tree.arguments().getFirst();
-                identifier = tree.identifier();
-            }
-
-            List<JavaType> typeArguments = new ArrayList<>(tree.arguments().size());
-            for (TypeElement.ExternalizedTypeElement child : tree.arguments()) {
-                TypeElement t = JAVA_TYPE_FACTORY.constructType(child);
-                if (!(t instanceof JavaType a)) {
-                    throw new IllegalArgumentException("Bad type: " + tree);
-                }
-                typeArguments.add(a);
-            }
-            if (identifier.equals("+") || identifier.equals("-")) {
+                JavaType elemType = constructType(tree.arguments().getFirst());
+                return JavaType.array(elemType, identifier.length());
+            } else if (identifier.equals("+") || identifier.equals("-")) {
                 // wildcard type
+                if (tree.arguments().size() != 1) {
+                    throw badType(tree, "wildcard type argument");
+                }
                 BoundKind kind = identifier.equals("+") ?
                         BoundKind.EXTENDS : BoundKind.SUPER;
-                return JavaType.wildcard(kind, typeArguments.get(0));
+                return JavaType.wildcard(kind,
+                        constructTypeArgument(tree, 0, NO_WILDCARDS));
             } else if (identifier.startsWith("#")) {
                 // type-var
-                if (typeArguments.size() != 1) {
-                    throw new IllegalArgumentException("Bad type-variable bounds: " + tree);
+                if (tree.arguments().size() != 1) {
+                    throw badType(tree, "type variable");
                 }
                 String[] parts = identifier.substring(1).split("::");
                 if (parts.length == 2) {
                     // class type-var
                     return JavaType.typeVarRef(parts[1],
                             (ClassType)constructType(parseExTypeElem(parts[0])),
-                            typeArguments.get(0));
+                            constructTypeArgument(tree, 0, NO_WILDCARDS));
                 } else {
                     // method type-var
                     return JavaType.typeVarRef(parts[2],
                             parseMethodRef(String.format("%s::%s", parts[0], parts[1])),
-                            typeArguments.get(0));
+                            constructTypeArgument(tree, 0, NO_WILDCARDS));
                 }
             } else if (identifier.equals(".")) {
                 // qualified type
-                ClassType enclType = (ClassType)typeArguments.get(0);
-                ClassType innerType = (ClassType)typeArguments.get(1);
+                if (tree.arguments().size() != 2) {
+                    throw badType(tree, "qualified type");
+                }
+                ClassType enclType = (ClassType)constructTypeArgument(tree, 0, CLASS);
+                ClassType innerType = (ClassType)constructTypeArgument(tree, 1, CLASS);
                 // the inner class name is obtained by subtracting the name of the enclosing type
                 // from the name of the inner type (and also dropping an extra '$')
                 String innerName = innerType.toNominalDescriptor().displayName()
                         .substring(enclType.toNominalDescriptor().displayName().length() + 1);
                 JavaType qual = JavaType.qualified(enclType, innerName);
-                if (innerType.hasTypeArguments()) {
-                    qual = JavaType.parameterized(qual, innerType.typeArguments());
+                return (innerType.hasTypeArguments()) ?
+                    JavaType.parameterized(qual, innerType.typeArguments()) : qual;
+            } else {
+                // primitive or reference
+                JavaType t = switch (identifier) {
+                    case "boolean" -> JavaType.BOOLEAN;
+                    case "byte" -> JavaType.BYTE;
+                    case "char" -> JavaType.CHAR;
+                    case "short" -> JavaType.SHORT;
+                    case "int" -> JavaType.INT;
+                    case "long" -> JavaType.LONG;
+                    case "float" -> JavaType.FLOAT;
+                    case "double" -> JavaType.DOUBLE;
+                    case "void" -> JavaType.VOID;
+                    default -> JavaType.type(ClassDesc.of(identifier));
+                };
+                if (!tree.arguments().isEmpty()) {
+                    if (t instanceof PrimitiveType) {
+                        throw new IllegalArgumentException("primitive type: " + tree);
+                    }
+                    return JavaType.parameterized(t,
+                            tree.arguments().stream().map(this::constructType).toList());
+                } else {
+                    return t;
                 }
-                return qual;
             }
-            JavaType t = switch (identifier) {
-                case "boolean" -> JavaType.BOOLEAN;
-                case "byte" -> JavaType.BYTE;
-                case "char" -> JavaType.CHAR;
-                case "short" -> JavaType.SHORT;
-                case "int" -> JavaType.INT;
-                case "long" -> JavaType.LONG;
-                case "float" -> JavaType.FLOAT;
-                case "double" -> JavaType.DOUBLE;
-                case "void" -> JavaType.VOID;
-                default -> JavaType.type(ClassDesc.of(identifier));
-            };
-            if (!typeArguments.isEmpty()) {
-                t = JavaType.parameterized(t, typeArguments);
-            }
-            return dimensions == 0 ?
-                    t : JavaType.array(t, dimensions);
         }
+
+        static IllegalArgumentException badType(ExternalizedTypeElement tree, String str) {
+            return new IllegalArgumentException(String.format("Bad %s: %s", str, tree));
+        }
+
+        private JavaType constructTypeArgument(ExternalizedTypeElement element, int index, Predicate<JavaType> filter) {
+            ExternalizedTypeElement arg = element.arguments().get(index);
+            JavaType type = constructType(arg);
+            if (!filter.test(type)) {
+                throw new IllegalArgumentException(String.format("Unexpected argument %s", element));
+            } else {
+                return type;
+            }
+        }
+
+        private static Predicate<JavaType> NO_WILDCARDS = t -> !(t instanceof WildcardType);
+        private static Predicate<JavaType> CLASS = t -> t instanceof ClassType;
     };
 
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -137,6 +137,19 @@ public final class CoreTypeFactory {
                             parseMethodRef(String.format("%s::%s", parts[0], parts[1])),
                             typeArguments.get(0));
                 }
+            } else if (identifier.equals(".")) {
+                // qualified type
+                ClassType enclType = (ClassType)typeArguments.get(0);
+                ClassType innerType = (ClassType)typeArguments.get(1);
+                // the inner class name is obtained by subtracting the name of the enclosing type
+                // from the name of the inner type (and also dropping an extra '$')
+                String innerName = innerType.toNominalDescriptor().displayName()
+                        .substring(enclType.toNominalDescriptor().displayName().length() + 1);
+                JavaType qual = JavaType.qualified(enclType, innerName);
+                if (innerType.hasTypeArguments()) {
+                    qual = JavaType.parameterized(qual, innerType.typeArguments());
+                }
+                return qual;
             }
             JavaType t = switch (identifier) {
                 case "boolean" -> JavaType.BOOLEAN;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -2271,8 +2271,14 @@ public class ReflectMethods extends TreeTranslator {
                                 typeToTypeElement(t.getUpperBound()));
                 case CLASS -> {
                     Assert.check(!t.isIntersection() && !t.isUnion());
-                    // @@@ Need to clean this up, probably does not work inner generic classes
-                    // whose enclosing class is also generic
+                    JavaType typ;
+                    if (t.getEnclosingType() != Type.noType) {
+                        Name innerName = t.tsym.flatName().subName(t.getEnclosingType().tsym.flatName().length() + 1);
+                        typ = JavaType.qualified(typeToTypeElement(t.getEnclosingType()), innerName.toString());
+                    } else {
+                        typ = JavaType.type(ClassDesc.of(t.tsym.flatName().toString()));
+                    }
+
                     List<JavaType> typeArguments;
                     if (t.getTypeArguments().nonEmpty()) {
                         typeArguments = new ArrayList<>();
@@ -2284,7 +2290,7 @@ public class ReflectMethods extends TreeTranslator {
                     }
 
                     // Use flat name to ensure demarcation of nested classes
-                    yield JavaType.parameterized(JavaType.type(ClassDesc.of(t.tsym.flatName().toString())), typeArguments);
+                    yield JavaType.parameterized(typ, typeArguments);
                 }
                 default -> {
                     throw new UnsupportedOperationException("Unsupported type: kind=" + t.getKind() + " type=" + t);

--- a/test/jdk/java/lang/reflect/code/type/TestErasure.java
+++ b/test/jdk/java/lang/reflect/code/type/TestErasure.java
@@ -95,12 +95,12 @@ public class TestErasure {
 
     static List<TypeAndErasure<ClassType>> nestedReferences() {
         List<TypeAndErasure<ClassType>> nestedTypes = new ArrayList<>();
-        ClassType rawCase = JavaType.qualified(Outer.TYPE, "Inner");
+        ClassType rawCase = JavaType.qualified(JavaType.type(Outer.class), "Inner");
         nestedTypes.add(new TypeAndErasure<>(rawCase, rawCase));
         BoundKind[] kinds = new BoundKind[] { null, BoundKind.EXTENDS, BoundKind.SUPER };
         for (JavaType argOuter : typeArguments()) {
             for (JavaType argInner : typeArguments()) {
-                ClassType t = JavaType.parameterized(Outer.TYPE, argOuter);
+                ClassType t = JavaType.parameterized(JavaType.type(Outer.class), argOuter);
                 t = JavaType.qualified(t, "Inner");
                 t = JavaType.parameterized(t, argInner);
                 nestedTypes.add(new TypeAndErasure<>(t, rawCase));
@@ -175,7 +175,5 @@ public class TestErasure {
     // used for the test
     static class Outer<X> {
         class Inner<X> { }
-
-        static final JavaType TYPE = JavaType.type(Outer.class.describeConstable().get());
     }
 }

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.lang.reflect.code.type.ArrayType;
 import java.lang.reflect.code.type.ClassType;
+import java.lang.reflect.code.type.CoreTypeFactory;
 import java.lang.reflect.code.type.JavaType;
 import java.util.ArrayList;
 import java.util.List;
@@ -170,7 +171,9 @@ public class TestJavaType {
 
     @Test(dataProvider = "types")
     public void testTypeRoundTrip(Type type) throws ReflectiveOperationException {
-        Assert.assertEquals(type, JavaType.type(type).resolve(MethodHandles.lookup()));
+        JavaType javaType = JavaType.type(type);
+        Assert.assertEquals(type, javaType.resolve(MethodHandles.lookup()));
+        Assert.assertEquals(javaType, CoreTypeFactory.JAVA_TYPE_FACTORY.constructType(javaType.externalize()));
     }
 
     @DataProvider

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -288,7 +288,7 @@ public class TestJavaType {
         static class Outer<X> {
             class Inner<X> { }
         }
-        
+
         Outer<String>.Inner<String> o1;
         Outer<? extends String>.Inner<String> o2;
         Outer<String>.Inner<? extends String> o3;
@@ -299,7 +299,7 @@ public class TestJavaType {
         Outer<?>.Inner<String> o8;
         Outer<String>.Inner<?> o9;
         Outer<?>.Inner<?> o10;
-        
+
         Outer<int[]>.Inner<int[]> oa1;
         Outer<? extends int[]>.Inner<int[]> oa2;
         Outer<int[]>.Inner<? extends int[]> oa3;

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -284,5 +284,75 @@ public class TestJavaType {
         Map<? extends List<? extends X>, ? super List<? extends X>>[][] aax6;
         Map<? extends List<? extends X>[], ? super List<? extends X>[]>[][] aax7;
         List<X[]>[][] aax8;
+
+        static class Outer<X> {
+            class Inner<X> { }
+        }
+        
+        Outer<String>.Inner<String> o1;
+        Outer<? extends String>.Inner<String> o2;
+        Outer<String>.Inner<? extends String> o3;
+        Outer<? extends String>.Inner<? extends String> o4;
+        Outer<? super String>.Inner<String> o5;
+        Outer<String>.Inner<? super String> o6;
+        Outer<? super String>.Inner<? super String> o7;
+        Outer<?>.Inner<String> o8;
+        Outer<String>.Inner<?> o9;
+        Outer<?>.Inner<?> o10;
+        
+        Outer<int[]>.Inner<int[]> oa1;
+        Outer<? extends int[]>.Inner<int[]> oa2;
+        Outer<int[]>.Inner<? extends int[]> oa3;
+        Outer<? extends int[]>.Inner<? extends int[]> oa4;
+        Outer<? super int[]>.Inner<int[]> oa5;
+        Outer<int[]>.Inner<? super int[]> oa6;
+        Outer<? super int[]>.Inner<? super int[]> oa7;
+        Outer<?>.Inner<int[]> oa8;
+        Outer<int[]>.Inner<?> oa9;
+        Outer<?>.Inner<?> oa10;
+
+        Outer<String>.Inner<String>[] ao1;
+        Outer<? extends String>.Inner<String>[] ao2;
+        Outer<String>.Inner<? extends String>[] ao3;
+        Outer<? extends String>.Inner<? extends String>[] ao4;
+        Outer<? super String>.Inner<String>[] ao5;
+        Outer<String>.Inner<? super String>[] ao6;
+        Outer<? super String>.Inner<? super String>[] ao7;
+        Outer<?>.Inner<String>[] ao8;
+        Outer<String>.Inner<?>[] ao9;
+        Outer<?>.Inner<?>[] ao10;
+
+        Outer<int[]>.Inner<int[]>[] aoa1;
+        Outer<? extends int[]>.Inner<int[]>[] aoa2;
+        Outer<int[]>.Inner<? extends int[]>[] aoa3;
+        Outer<? extends int[]>.Inner<? extends int[]>[] aoa4;
+        Outer<? super int[]>.Inner<int[]>[] aoa5;
+        Outer<int[]>.Inner<? super int[]>[] aoa6;
+        Outer<? super int[]>.Inner<? super int[]>[] aoa7;
+        Outer<?>.Inner<int[]>[] aoa8;
+        Outer<int[]>.Inner<?>[] aoa9;
+        Outer<?>.Inner<?>[] aoa10;
+
+        Outer<String>.Inner<String>[][] aao1;
+        Outer<? extends String>.Inner<String>[][] aao2;
+        Outer<String>.Inner<? extends String>[][] aao3;
+        Outer<? extends String>.Inner<? extends String>[][] aao4;
+        Outer<? super String>.Inner<String>[][] aao5;
+        Outer<String>.Inner<? super String>[][] aao6;
+        Outer<? super String>.Inner<? super String>[][] aao7;
+        Outer<?>.Inner<String>[][] aao8;
+        Outer<String>.Inner<?>[][] aao9;
+        Outer<?>.Inner<?>[][] aao10;
+
+        Outer<int[]>.Inner<int[]>[][] aaoa1;
+        Outer<? extends int[]>.Inner<int[]>[][] aaoa2;
+        Outer<int[]>.Inner<? extends int[]>[][] aaoa3;
+        Outer<? extends int[]>.Inner<? extends int[]>[][] aaoa4;
+        Outer<? super int[]>.Inner<int[]>[][] aaoa5;
+        Outer<int[]>.Inner<? super int[]>[][] aaoa6;
+        Outer<? super int[]>.Inner<? super int[]>[][] aaoa7;
+        Outer<?>.Inner<int[]>[][] aaoa8;
+        Outer<int[]>.Inner<?>[][] aaoa9;
+        Outer<?>.Inner<?>[][] aaoa10;
     }
 }

--- a/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
+++ b/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
@@ -158,7 +158,7 @@ class IntersectionTypeTest {
         return null;
     }
 
-    class E1 implements A, B, C {
+    static class E1 implements A, B, C {
         @Override
         public void m_A() { }
         @Override
@@ -167,7 +167,7 @@ class IntersectionTypeTest {
         public void m_C() { }
     }
 
-    class E2 implements A, B, C {
+    static class E2 implements A, B, C {
         @Override
         public void m_A() { }
         @Override

--- a/test/langtools/tools/javac/reflect/MethodReferenceTest.java
+++ b/test/langtools/tools/javac/reflect/MethodReferenceTest.java
@@ -105,13 +105,13 @@ public class MethodReferenceTest {
     @IR("""
             func @"test4" (%0 : MethodReferenceTest)void -> {
                 %1 : java.lang.String = constant @"s";
-                %2 : MethodReferenceTest$A<java.lang.String> = invoke %0 %1 @"MethodReferenceTest::a(java.lang.Object)MethodReferenceTest$A";
-                %3 : Var<MethodReferenceTest$A<java.lang.String>> = var %2 @"rec$";
+                %2 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = invoke %0 %1 @"MethodReferenceTest::a(java.lang.Object).<MethodReferenceTest, MethodReferenceTest$A>";
+                %3 : Var<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>> = var %2 @"rec$";
                 %4 : java.util.function.Function<java.lang.String, java.lang.String> = lambda (%5 : java.lang.String)java.lang.String -> {
                     %6 : Var<java.lang.String> = var %5 @"x$0";
-                    %7 : MethodReferenceTest$A<java.lang.String> = var.load %3;
+                    %7 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = var.load %3;
                     %8 : java.lang.String = var.load %6;
-                    %9 : java.lang.String = invoke %7 %8 @"MethodReferenceTest$A::m(java.lang.Object)java.lang.Object";
+                    %9 : java.lang.String = invoke %7 %8 @".<MethodReferenceTest, MethodReferenceTest$A>::m(java.lang.Object)java.lang.Object";
                     return %9;
                 };
                 %10 : Var<java.util.function.Function<java.lang.String, java.lang.String>> = var %4 @"f";
@@ -167,11 +167,11 @@ public class MethodReferenceTest {
     @CodeReflection
     @IR("""
             func @"test7" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>> = lambda ()MethodReferenceTest$A<java.lang.String> -> {
-                    %2 : MethodReferenceTest$A<java.lang.String> = new %0 @"func<MethodReferenceTest$A>";
+                %1 : java.util.function.Supplier<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>> = lambda ().<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> -> {
+                    %2 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = new %0 @"func<.<MethodReferenceTest, MethodReferenceTest$A>>";
                     return %2;
                 };
-                %3 : Var<java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>>> = var %1 @"aNew";
+                %3 : Var<java.util.function.Supplier<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>>> = var %1 @"aNew";
                 return;
             };
             """)
@@ -182,13 +182,13 @@ public class MethodReferenceTest {
     @CodeReflection
     @IR("""
             func @"test8" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]> = lambda (%2 : int)MethodReferenceTest$A<java.lang.String>[] -> {
+                %1 : java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>> = lambda (%2 : int).<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> -> {
                     %3 : Var<int> = var %2 @"x$0";
                     %4 : int = var.load %3;
-                    %5 : MethodReferenceTest$A[] = new %4 @"func<MethodReferenceTest$A[], int>";
+                    %5 : .<MethodReferenceTest, MethodReferenceTest$A> = new %4 @"func<.<MethodReferenceTest, MethodReferenceTest$A>, int>";
                     return %5;
                 };
-                %6 : Var<java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]>> = var %1 @"aNewArray";
+                %6 : Var<java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>>> = var %1 @"aNewArray";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/MethodReferenceTest.java
+++ b/test/langtools/tools/javac/reflect/MethodReferenceTest.java
@@ -182,13 +182,13 @@ public class MethodReferenceTest {
     @CodeReflection
     @IR("""
             func @"test8" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>> = lambda (%2 : int).<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> -> {
+                %1 : java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>[]> = lambda (%2 : int).<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>[] -> {
                     %3 : Var<int> = var %2 @"x$0";
                     %4 : int = var.load %3;
-                    %5 : .<MethodReferenceTest, MethodReferenceTest$A> = new %4 @"func<.<MethodReferenceTest, MethodReferenceTest$A>, int>";
+                    %5 : .<MethodReferenceTest, MethodReferenceTest$A>[] = new %4 @"func<.<MethodReferenceTest, MethodReferenceTest$A>[], int>";
                     return %5;
                 };
-                %6 : Var<java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>>> = var %1 @"aNewArray";
+                %6 : Var<java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>[]>> = var %1 @"aNewArray";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -96,8 +96,8 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test3" (%0 : NewTest)void -> {
-                %1 : NewTest$B = new %0 @"func<NewTest$B>";
-                %2 : Var<NewTest$B> = var %1 @"b";
+                %1 : .<NewTest, NewTest$B> = new %0 @"func<.<NewTest, NewTest$B>>";
+                %2 : Var<.<NewTest, NewTest$B>> = var %1 @"b";
                 return;
             };
             """)
@@ -110,8 +110,8 @@ public class NewTest {
             func @"test4" (%0 : NewTest)void -> {
                 %1 : int = constant @"1";
                 %2 : int = constant @"2";
-                %3 : NewTest$B = new %0 %1 %2 @"func<NewTest$B, int, int>";
-                %4 : Var<NewTest$B> = var %3 @"b";
+                %3 : .<NewTest, NewTest$B> = new %0 %1 %2 @"func<.<NewTest, NewTest$B>, int, int>";
+                %4 : Var<.<NewTest, NewTest$B>> = var %3 @"b";
                 return;
             };
             """)
@@ -122,8 +122,8 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test5" (%0 : NewTest)void -> {
-                %1 : NewTest$B = new %0 @"func<NewTest$B>";
-                %2 : Var<NewTest$B> = var %1 @"b";
+                %1 : .<NewTest, NewTest$B> = new %0 @"func<.<NewTest, NewTest$B>>";
+                %2 : Var<.<NewTest, NewTest$B>> = var %1 @"b";
                 return;
             };
             """)
@@ -134,9 +134,9 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test6" (%0 : NewTest)void -> {
-                %1 : NewTest$B = field.load %0 @"NewTest::f()NewTest$B";
-                %2 : NewTest$B$C = new %1 @"func<NewTest$B$C>";
-                %3 : Var<NewTest$B$C> = var %2 @"c";
+                %1 : .<NewTest, NewTest$B> = field.load %0 @"NewTest::f().<NewTest, NewTest$B>";
+                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @"func<.<.<NewTest, NewTest$B>, NewTest$B$C>>";
+                %3 : Var<.<.<NewTest, NewTest$B>, NewTest$B$C>> = var %2 @"c";
                 return;
             };
             """)
@@ -147,9 +147,9 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test7" (%0 : NewTest)void -> {
-                %1 : NewTest$B = invoke %0 @"NewTest::b()NewTest$B";
-                %2 : NewTest$B$C = new %1 @"func<NewTest$B$C>";
-                %3 : Var<NewTest$B$C> = var %2 @"c";
+                %1 : .<NewTest, NewTest$B> = invoke %0 @"NewTest::b().<NewTest, NewTest$B>";
+                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @"func<.<.<NewTest, NewTest$B>, NewTest$B$C>>";
+                %3 : Var<.<.<NewTest, NewTest$B>, NewTest$B$C>> = var %2 @"c";
                 return;
             };
             """)
@@ -183,18 +183,16 @@ public class NewTest {
         }
     }
 
-    // @@@ This produces incorrect type descriptors for generic inner classes
-    // the type argument for type BG is not preserved
-//    @CodeReflection
+    @CodeReflection
     @IR("""
             func @"test9" (%0 : NewTest, %1 : java.util.List<java.lang.String>, %2 : java.util.List<java.lang.Number>)void -> {
                 %3 : Var<java.util.List<java.lang.String>> = var %1 @"l1";
                 %4 : Var<java.util.List<java.lang.Number>> = var %2 @"l2";
                 %5 : java.util.List<java.lang.String> = var.load %3;
-                %6 : NewTest$BG<java.lang.String> = new %0 %5 @"func<NewTest$BG, java.util.List>";
+                %6 : .<NewTest, NewTest$BG<java.lang.String>> = new %0 %5 @"func<.<NewTest, NewTest$BG>, java.util.List>";
                 %7 : java.util.List<java.lang.Number> = var.load %4;
-                %8 : NewTest$BG$CG<java.lang.Number> = new %6 %7 @"func<NewTest$BG$CG, java.util.List>";
-                %9 : Var<NewTest$BG$CG<java.lang.Number>> = var %8 @"numberCG";
+                %8 : .<.<NewTest, NewTest$BG<java.lang.String>>, NewTest$BG$CG<java.lang.Number>> = new %6 %7 @"func<.<.<NewTest, NewTest$BG>, NewTest$BG$CG>, java.util.List>";
+                %9 : Var<.<.<NewTest, NewTest$BG<java.lang.String>>, NewTest$BG$CG<java.lang.Number>>> = var %8 @"numberCG";
                 return;
             };
             """)


### PR DESCRIPTION
`ReflectMethod` can already handle references to inner classes. There is, however, an issue as the code model currently does not allow to represents inner class types. That is, inner classes are "flattened" into a single class type. As a result, only one parameterization can be specified (the one for the innermost type).

This means that if we have a class declaration like this:

```
class Outer<X> {
   class Inner<X> { }
}
```

We can represent types like `Outer.Inner` and `Outer.Inner<String>` (note that this is called a *rare type*, and is disallowed by the spec) but not types like `Outer<String>.Inner<Integer>`.

The solution is for `ClassType` to capture the enclosing type information. This solves not only the problem of parameterization of the enclosing class, but a more subtle problem: given a type like `Foo$Bar`, how to tell if this is an inner class with an enclosing `Foo`, or just a class with a weird name? The structural type info is impossible to reconstruct given only the binary name.

We now have a new `ExternalizedTypeElement`, whose identifier is `.` which is used to denote qualified types. That is, a type like `Outer<String>.Inner<Integer>` is expressed in the serialized form as follows:

```
.<Outer<java.lang.String>, Outer$Inner<java.lang.Integer>>
```

This Java type can be constructed as follows (note the new `JavaType::qualified` factory):

```java
JavaType outer = parameterized(type(Outer.class), J_L_STRING);
JavaType inner = parameterized(qualified(outer, "Inner"), J_L_INTEGER);
```

The parser and factory code is relatively straightforward. The only subtle bit is that when we have an inner type in javac (or, equivalently, when parsing external type elements in the factory), we need to "infer" the inner class name given the flat names of the inner vs. outer types. This is done by removing the "enclosing part" from the inner type flat name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/babylon.git pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/107.diff">https://git.openjdk.org/babylon/pull/107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/107#issuecomment-2139715748)