### PR TITLE
Bytecode round 6 - lifting lambdas

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
@@ -75,6 +75,9 @@ import java.util.function.BiFunction;
 public final class BytecodeLift {
 
     private static final ClassDesc CD_LambdaMetafactory = ClassDesc.ofDescriptor("Ljava/lang/invoke/LambdaMetafactory;");
+    private static final MethodRef LCMP = MethodRef.method(JavaType.J_L_LONG, "compare", JavaType.INT, JavaType.LONG, JavaType.LONG);
+    private static final MethodRef FCMP = MethodRef.method(JavaType.J_L_FLOAT, "compare", JavaType.INT, JavaType.FLOAT, JavaType.FLOAT);
+    private static final MethodRef DCMP = MethodRef.method(JavaType.J_L_DOUBLE, "compare", JavaType.INT, JavaType.DOUBLE, JavaType.DOUBLE);
 
     private final Block.Builder entryBlock;
     private final CodeModel codeModel;
@@ -356,6 +359,12 @@ public final class BytecodeLift {
                                 CoreOp.ashr(stack.pop(), toInt(operand));
                         case IUSHR, LUSHR ->
                                 CoreOp.lshr(stack.pop(), toInt(operand));
+                        case LCMP ->
+                                CoreOp.invoke(LCMP, stack.pop(), operand);
+                        case FCMPL, FCMPG ->
+                                CoreOp.invoke(FCMP, stack.pop(), operand);
+                        case DCMPL, DCMPG ->
+                                CoreOp.invoke(DCMP, stack.pop(), operand);
                         default ->
                             throw new IllegalArgumentException("Unsupported operator opcode: " + inst.opcode());
                     }));

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -410,6 +410,21 @@ public class TestBytecode {
         return consume(i, Math::negateExact);
     }
 
+    @CodeReflection
+    static boolean compareLong(long i, long j) {
+        return i > j;
+    }
+
+    @CodeReflection
+    static boolean compareFloat(float i, float j) {
+        return i > j;
+    }
+
+    @CodeReflection
+    static boolean compareDouble(double i, double j) {
+        return i > j;
+    }
+
     record TestData(Method testMethod) {
         @Override
         public String toString() {

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -518,13 +518,16 @@ public class TestBytecode {
             permutateAllArgs(d.testMethod.getParameterTypes(), args ->
                 Assert.assertEquals(invokeAndConvert(flift, args), d.testMethod.invoke(null, args)));
         } catch (Throwable e) {
+            System.out.println("Compiled model:");
+            d.testMethod.getCodeModel().ifPresent(f -> f.writeTo(System.out));
+            System.out.println("Lifted model:");
             flift.writeTo(System.out);
             throw e;
         }
     }
 
     private static Object invokeAndConvert(CoreOp.FuncOp func, Object[] args) {
-        Object ret = Interpreter.invoke(func, args);
+        Object ret = Interpreter.invoke(MethodHandles.lookup(), func, args);
         if (ret instanceof Integer i) {
             TypeElement rt = func.invokableType().returnType();
             if (rt.equals(JavaType.BOOLEAN)) {

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -70,7 +70,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static byte byteNumOps(byte i, byte j, byte k) {
         k++;
         i = (byte) ((i + j) / k - i % j);
@@ -79,7 +78,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static short shortNumOps(short i, short j, short k) {
         k++;
         i = (short) ((i + j) / k - i % j);
@@ -88,7 +86,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static char charNumOps(char i, char j, char k) {
         k++;
         i = (char) ((i + j) / k - i % j);
@@ -126,19 +123,16 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static byte byteBitOps(byte i, byte j, byte k) {
         return (byte) (i & j | k ^ j);
     }
 
     @CodeReflection
-    @SkipLift
     static short shortBitOps(short i, short j, short k) {
         return (short) (i & j | k ^ j);
     }
 
     @CodeReflection
-    @SkipLift
     static char charBitOps(char i, char j, char k) {
         return (char) (i & j | k ^ j);
     }
@@ -154,37 +148,31 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int intShiftOps(int i, int j, int k) {
         return ((-1 >> i) << (j << k)) >>> (k - j);
     }
 
     @CodeReflection
-    @SkipLift
     static byte byteShiftOps(byte i, byte j, byte k) {
         return (byte) (((-1 >> i) << (j << k)) >>> (k - j));
     }
 
     @CodeReflection
-    @SkipLift
     static short shortShiftOps(short i, short j, short k) {
         return (short) (((-1 >> i) << (j << k)) >>> (k - j));
     }
 
     @CodeReflection
-    @SkipLift
     static char charShiftOps(char i, char j, char k) {
         return (char) (((-1 >> i) << (j << k)) >>> (k - j));
     }
 
     @CodeReflection
-    @SkipLift
     static long longShiftOps(long i, long j, long k) {
         return ((-1 >> i) << (j << k)) >>> (k - j);
     }
 
     @CodeReflection
-    @SkipLift
     static Object[] boxingAndUnboxing(int i, byte b, short s, char c, Integer ii, Byte bb, Short ss, Character cc) {
         ii += i; ii += b; ii += s; ii += c;
         i += ii; i += bb; i += ss; i += cc;
@@ -338,7 +326,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static boolean not(boolean b) {
         return !b;
     }
@@ -516,9 +503,7 @@ public class TestBytecode {
 
     @Test(dataProvider = "testMethods")
     public void testLift(TestData d) throws Throwable {
-        if (d.testMethod.getAnnotation(SkipLift.class) != null) {
-            throw new SkipException("skipped");
-        }
+        if (d.testMethod.getAnnotation(SkipLift.class) != null) return;
         CoreOp.FuncOp flift;
         try {
             flift = BytecodeLift.lift(CLASS_DATA, d.testMethod.getName(), toMethodTypeDesc(d.testMethod));

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -31,7 +31,6 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import org.testng.Assert;
-import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -384,7 +383,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int quotableLambda(int i) {
         return consumeQuotable(i, a -> -a);
     }
@@ -395,7 +393,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int quotableLambdaWithCapture(int i, String s) {
         return consumeQuotable(i, a -> a + s.length());
     }
@@ -406,7 +403,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int nestedQuotableLambdasWithCaptures(int i, int j, String s) {
         return consumeQuotable(i, a -> consumeQuotable(a, b -> a + b + j - s.length()) + s.length());
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -22,8 +22,6 @@
  */
 
 import java.io.IOException;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.components.ClassPrinter;
@@ -408,13 +406,9 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int methodHandle(int i) {
         return consume(i, Math::negateExact);
     }
-
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface SkipLift {}
 
     record TestData(Method testMethod) {
         @Override
@@ -496,7 +490,6 @@ public class TestBytecode {
 
     @Test(dataProvider = "testMethods")
     public void testLift(TestData d) throws Throwable {
-        if (d.testMethod.getAnnotation(SkipLift.class) != null) return;
         CoreOp.FuncOp flift;
         try {
             flift = BytecodeLift.lift(CLASS_DATA, d.testMethod.getName(), toMethodTypeDesc(d.testMethod));

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -390,7 +390,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int lambdaWithCapture(int i, String s) {
         return consume(i, a -> a + s.length());
     }
@@ -402,15 +401,14 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int nestedLambdasWithCaptures(int i, int j, String s) {
-        return consume(i, a -> consume(a, b -> a + b + j) + s.length());
+        return consume(i, a -> consume(a, b -> a + b + j - s.length()) + s.length());
     }
 
     @CodeReflection
     @SkipLift
     static int nestedQuotableLambdasWithCaptures(int i, int j, String s) {
-        return consumeQuotable(i, a -> consumeQuotable(a, b -> a + b + j) + s.length());
+        return consumeQuotable(i, a -> consumeQuotable(a, b -> a + b + j - s.length()) + s.length());
     }
 
     @CodeReflection
@@ -464,15 +462,15 @@ public class TestBytecode {
         for (var argType : argTypes) TEST_ARGS.put(argType, values);
     }
     static {
-        initTestArgs(values(1, 2, 3, 4), int.class, Integer.class);
-        initTestArgs(values((byte)1, (byte)2, (byte)3, (byte)4), byte.class, Byte.class);
-        initTestArgs(values((short)1, (short)2, (short)3, (short)4), short.class, Short.class);
-        initTestArgs(values((char)1, (char)2, (char)3, (char)4), char.class, Character.class);
+        initTestArgs(values(1, 2, 4), int.class, Integer.class);
+        initTestArgs(values((byte)1, (byte)3, (byte)4), byte.class, Byte.class);
+        initTestArgs(values((short)1, (short)2, (short)3), short.class, Short.class);
+        initTestArgs(values((char)2, (char)3, (char)4), char.class, Character.class);
         initTestArgs(values(false, true), boolean.class, Boolean.class);
         initTestArgs(values("Hello World"), String.class);
-        initTestArgs(values(1l, 2l, 3l, 4l), long.class, Long.class);
-        initTestArgs(values(1f, 2f, 3f, 4f), float.class, Float.class);
-        initTestArgs(values(1d, 2d, 3d, 4d), double.class, Double.class);
+        initTestArgs(values(1l, 2l, 4l), long.class, Long.class);
+        initTestArgs(values(1f, 3f, 4f), float.class, Float.class);
+        initTestArgs(values(1d, 2d, 3d), double.class, Double.class);
     }
 
     interface Executor {

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -379,7 +379,6 @@ public class TestBytecode {
     }
 
     @CodeReflection
-    @SkipLift
     static int lambda(int i) {
         return consume(i, a -> -a);
     }
@@ -508,7 +507,10 @@ public class TestBytecode {
         try {
             flift = BytecodeLift.lift(CLASS_DATA, d.testMethod.getName(), toMethodTypeDesc(d.testMethod));
         } catch (Throwable e) {
-            System.out.println("Lift failed, expected:");
+            ClassPrinter.toYaml(ClassFile.of().parse(TestBytecode.class.getResourceAsStream("TestBytecode.class").readAllBytes())
+                    .methods().stream().filter(m -> m.methodName().equalsString(d.testMethod().getName())).findAny().get(),
+                    ClassPrinter.Verbosity.CRITICAL_ATTRIBUTES, System.out::print);
+            System.out.println("Lift failed, compiled model:");
             d.testMethod.getCodeModel().ifPresent(f -> f.writeTo(System.out));
             throw e;
         }


### PR DESCRIPTION
- lifting lambdas (local impl methods) as inlined functions
- lifting method handles (external methods) as lambdas with invocation
- improved lifting of byte, short, char, boolean and int operands
- lifting LCMP, FCMP and DCMP to `::compare` method calls
- lifting LOOKUPSWITCH and TABLESWITCH to chain of conditional branches

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/babylon.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/109.diff">https://git.openjdk.org/babylon/pull/109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/109#issuecomment-2141693198)