### PR TITLE
Improve JavaType::toString

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/TypeElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/TypeElement.java
@@ -114,6 +114,9 @@ public non-sealed interface TypeElement extends CodeItem {
      */
     ExternalizedTypeElement externalize();
 
+    /**
+     * Return a string representation of this Java type.
+     */
     @Override
     String toString();
 

--- a/src/java.base/share/classes/java/lang/reflect/code/type/ArrayType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/ArrayType.java
@@ -92,7 +92,7 @@ public final class ArrayType implements JavaType {
 
     @Override
     public String toString() {
-        return externalize().toString();
+        return componentType.toString() + "[]";
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/ClassType.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * A class type.
@@ -98,7 +99,18 @@ public final class ClassType implements TypeVarRef.Owner, JavaType {
 
     @Override
     public String toString() {
-        return externalize().toString();
+        String prefix = enclosing != null ?
+                enclosing + "$":
+                (!type.packageName().isEmpty() ?
+                        type.packageName() + "." : "");
+        String name = enclosing == null ?
+                type.displayName() :
+                type.displayName().substring(enclosing.type.displayName().length() + 1);
+        String typeArgs = hasTypeArguments() ?
+                typeArguments().stream().map(JavaType::toString)
+                        .collect(Collectors.joining(", ", "<", ">")) :
+                "";
+        return String.format("%s%s%s", prefix, name, typeArgs);
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/PrimitiveType.java
@@ -55,7 +55,7 @@ public final class PrimitiveType implements JavaType {
 
     @Override
     public String toString() {
-        return externalize().toString();
+        return type.displayName();
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
@@ -101,7 +101,7 @@ public final class TypeVarRef implements JavaType {
 
     @Override
     public String toString() {
-        return externalize().toString();
+        return name;
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/type/WildcardType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/WildcardType.java
@@ -80,7 +80,9 @@ public final class WildcardType implements JavaType {
 
     @Override
     public String toString() {
-        return externalize().toString();
+        return boundKind() == BoundKind.EXTENDS &&
+                boundType.equals(J_L_OBJECT) ?
+                "?" : boundKind().boundStr + boundType.toString();
     }
 
     @Override
@@ -116,8 +118,14 @@ public final class WildcardType implements JavaType {
      */
     public enum BoundKind {
         /** A bound kind representing a {@code ? extends} wildcard type*/
-        EXTENDS,
+        EXTENDS("? extends "),
         /** A bound kind representing a {@code ? super} wildcard type*/
-        SUPER
+        SUPER("? super ");
+
+        final String boundStr;
+
+        BoundKind(String boundStr) {
+            this.boundStr = boundStr;
+        }
     }
 }

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -176,6 +176,12 @@ public class TestJavaType {
         Assert.assertEquals(javaType, CoreTypeFactory.JAVA_TYPE_FACTORY.constructType(javaType.externalize()));
     }
 
+    @Test(dataProvider = "types")
+    public void testTypeString(Type type) throws ReflectiveOperationException {
+        JavaType javaType = JavaType.type(type);
+        Assert.assertEquals(type.getTypeName(), javaType.toString());
+    }
+
     @DataProvider
     public Object[][] types() throws ReflectiveOperationException {
         List<Object[]> types = new ArrayList<>();


### PR DESCRIPTION
The string representation of `JavaType` is automatically derived from the type's externalized form. This PR tweaks the implementation of `toString` so that a more meaningful representation is generated, namely one that is consistent with `java.lang.reflect.Type::getTypeName`.

For instance, instead of this:

```java
 .<Outer<java.lang.String>, Outer$Inner<java.lang.Integer>>
```

This is now generated:

```java
Outer<java.lang.String>$Inner<java.lang.Integer>
```

I've added another combinatorial test which checks that `Type::getTypeName` of the resolved reflective type matches the string representation of the original `JavaType`.

The main question is around `ClassType::toClassName`. This method is effectively attempting to generate a user-friendly type string from the `JavaType` (note that this method doesn't take into account enclosing types). Should we update this to call `toString` ? Or should we perhaps remove it, and ask clients to use `toString` instead (which now works on all types) ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/babylon.git pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/110.diff">https://git.openjdk.org/babylon/pull/110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/110#issuecomment-2142977823)