### PR TITLE
Add support for local classes

### DIFF
--- a/test/langtools/tools/javac/reflect/LocalClassTest.java
+++ b/test/langtools/tools/javac/reflect/LocalClassTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Smoke test for code reflection with local class creation expressions.
+ * @build LocalClassTest
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester LocalClassTest
+ */
+
+import java.lang.runtime.CodeReflection;
+
+public class LocalClassTest {
+
+    final static String CONST_STRING = "Hello!";
+    String nonConstString = "Hello!";
+
+    @CodeReflection
+    @IR("""
+            func @"testLocalNoCapture" (%0 : LocalClassTest)void -> {
+                %1 : .<LocalClassTest, LocalClassTest$1Foo> = new %0 @"func<.<LocalClassTest, LocalClassTest$1Foo>, LocalClassTest>";
+                invoke %1 @".<LocalClassTest, LocalClassTest$1Foo>::m()void";
+                return;
+            };
+            """)
+    void testLocalNoCapture() {
+        class Foo {
+            void m() { }
+        }
+        new Foo().m();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"testAnonNoCapture" (%0 : LocalClassTest)void -> {
+                %1 : .<LocalClassTest, LocalClassTest$1> = new %0 @"func<.<LocalClassTest, LocalClassTest$1>, LocalClassTest>";
+                invoke %1 @".<LocalClassTest, LocalClassTest$1>::m()void";
+                return;
+            };
+            """)
+    void testAnonNoCapture() {
+        new Object() {
+            void m() { }
+        }.m();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"testLocalCaptureParam" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
+                %2 : Var<java.lang.String> = var %1 @"s";
+                %3 : java.lang.String = var.load %2;
+                %4 : .<LocalClassTest, LocalClassTest$2Foo> = new %0 %3 @"func<.<LocalClassTest, LocalClassTest$2Foo>, LocalClassTest, java.lang.String>";
+                %5 : java.lang.String = invoke %4 @".<LocalClassTest, LocalClassTest$2Foo>::m()java.lang.String";
+                return %5;
+            };
+            """)
+    String testLocalCaptureParam(String s) {
+        class Foo {
+            String m() { return s; }
+        }
+        return new Foo().m();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"testAnonCaptureParam" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
+                %2 : Var<java.lang.String> = var %1 @"s";
+                %3 : java.lang.String = var.load %2;
+                %4 : .<LocalClassTest, LocalClassTest$2> = new %0 %3 @"func<.<LocalClassTest, LocalClassTest$2>, LocalClassTest, java.lang.String>";
+                %5 : java.lang.String = invoke %4 @".<LocalClassTest, LocalClassTest$2>::m()java.lang.String";
+                return %5;
+            };
+            """)
+    String testAnonCaptureParam(String s) {
+        return new Object() {
+            String m() { return s; }
+        }.m();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"testLocalCaptureParamAndField" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
+                %2 : Var<java.lang.String> = var %1 @"s";
+                %3 : java.lang.String = constant @"Hello!";
+                %4 : Var<java.lang.String> = var %3 @"localConst";
+                %5 : java.lang.String = var.load %2;
+                %6 : .<LocalClassTest, LocalClassTest$3Foo> = new %0 %5 @"func<.<LocalClassTest, LocalClassTest$3Foo>, LocalClassTest, java.lang.String>";
+                %7 : java.lang.String = invoke %6 @".<LocalClassTest, LocalClassTest$3Foo>::m()java.lang.String";
+                return %7;
+            };
+            """)
+    String testLocalCaptureParamAndField(String s) {
+        final String localConst = "Hello!";
+        class Foo {
+            String m() { return localConst + s + nonConstString + CONST_STRING; }
+        }
+        return new Foo().m();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"testAnonCaptureParamAndField" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
+                %2 : Var<java.lang.String> = var %1 @"s";
+                %3 : java.lang.String = constant @"Hello!";
+                %4 : Var<java.lang.String> = var %3 @"localConst";
+                %5 : java.lang.String = var.load %2;
+                %6 : .<LocalClassTest, LocalClassTest$3> = new %0 %5 @"func<.<LocalClassTest, LocalClassTest$3>, LocalClassTest, java.lang.String>";
+                %7 : java.lang.String = invoke %6 @".<LocalClassTest, LocalClassTest$3>::m()java.lang.String";
+                return %7;
+            };
+            """)
+    String testAnonCaptureParamAndField(String s) {
+        final String localConst = "Hello!";
+        return new Object() {
+            String m() { return localConst + s + nonConstString + CONST_STRING; }
+        }.m();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"testLocalDependency" (%0 : LocalClassTest, %1 : int, %2 : int)void -> {
+                %3 : Var<int> = var %1 @"s";
+                %4 : Var<int> = var %2 @"i";
+                %5 : int = var.load %3;
+                %6 : int = var.load %4;
+                %7 : .<LocalClassTest, LocalClassTest$1Bar> = new %0 %5 %6 @"func<.<LocalClassTest, LocalClassTest$1Bar>, LocalClassTest, int, int>";
+                return;
+            };
+            """)
+    void testLocalDependency(int s, int i) {
+        class Foo {
+            int i() { return i; }
+        }
+        class Bar {
+            int s() { return s; }
+            Foo foo() { return new Foo(); }
+        }
+        new Bar();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"testAnonDependency" (%0 : LocalClassTest, %1 : int, %2 : int)void -> {
+                %3 : Var<int> = var %1 @"s";
+                %4 : Var<int> = var %2 @"i";
+                %5 : int = var.load %3;
+                %6 : int = var.load %4;
+                %7 : .<LocalClassTest, LocalClassTest$4> = new %0 %5 %6 @"func<.<LocalClassTest, LocalClassTest$4>, LocalClassTest, int, int>";
+                return;
+            };
+            """)
+    void testAnonDependency(int s, int i) {
+        class Foo {
+            int i() { return i; }
+        }
+        new Object() {
+            int s() { return s; }
+            Foo foo() { return new Foo(); }
+        };
+    }
+}

--- a/test/langtools/tools/javac/reflect/MethodReferenceTest.java
+++ b/test/langtools/tools/javac/reflect/MethodReferenceTest.java
@@ -168,7 +168,7 @@ public class MethodReferenceTest {
     @IR("""
             func @"test7" (%0 : MethodReferenceTest)void -> {
                 %1 : java.util.function.Supplier<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>> = lambda ().<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> -> {
-                    %2 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = new %0 @"func<.<MethodReferenceTest, MethodReferenceTest$A>>";
+                    %2 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = new %0 @"func<.<MethodReferenceTest, MethodReferenceTest$A>, MethodReferenceTest>";
                     return %2;
                 };
                 %3 : Var<java.util.function.Supplier<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>>> = var %1 @"aNew";

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -96,7 +96,7 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test3" (%0 : NewTest)void -> {
-                %1 : .<NewTest, NewTest$B> = new %0 @"func<.<NewTest, NewTest$B>>";
+                %1 : .<NewTest, NewTest$B> = new %0 @"func<.<NewTest, NewTest$B>, NewTest>";
                 %2 : Var<.<NewTest, NewTest$B>> = var %1 @"b";
                 return;
             };
@@ -110,7 +110,7 @@ public class NewTest {
             func @"test4" (%0 : NewTest)void -> {
                 %1 : int = constant @"1";
                 %2 : int = constant @"2";
-                %3 : .<NewTest, NewTest$B> = new %0 %1 %2 @"func<.<NewTest, NewTest$B>, int, int>";
+                %3 : .<NewTest, NewTest$B> = new %0 %1 %2 @"func<.<NewTest, NewTest$B>, NewTest, int, int>";
                 %4 : Var<.<NewTest, NewTest$B>> = var %3 @"b";
                 return;
             };
@@ -122,7 +122,7 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test5" (%0 : NewTest)void -> {
-                %1 : .<NewTest, NewTest$B> = new %0 @"func<.<NewTest, NewTest$B>>";
+                %1 : .<NewTest, NewTest$B> = new %0 @"func<.<NewTest, NewTest$B>, NewTest>";
                 %2 : Var<.<NewTest, NewTest$B>> = var %1 @"b";
                 return;
             };
@@ -135,7 +135,7 @@ public class NewTest {
     @IR("""
             func @"test6" (%0 : NewTest)void -> {
                 %1 : .<NewTest, NewTest$B> = field.load %0 @"NewTest::f().<NewTest, NewTest$B>";
-                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @"func<.<.<NewTest, NewTest$B>, NewTest$B$C>>";
+                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @"func<.<.<NewTest, NewTest$B>, NewTest$B$C>, .<NewTest, NewTest$B>>";
                 %3 : Var<.<.<NewTest, NewTest$B>, NewTest$B$C>> = var %2 @"c";
                 return;
             };
@@ -148,7 +148,7 @@ public class NewTest {
     @IR("""
             func @"test7" (%0 : NewTest)void -> {
                 %1 : .<NewTest, NewTest$B> = invoke %0 @"NewTest::b().<NewTest, NewTest$B>";
-                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @"func<.<.<NewTest, NewTest$B>, NewTest$B$C>>";
+                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @"func<.<.<NewTest, NewTest$B>, NewTest$B$C>, .<NewTest, NewTest$B>>";
                 %3 : Var<.<.<NewTest, NewTest$B>, NewTest$B$C>> = var %2 @"c";
                 return;
             };
@@ -189,9 +189,9 @@ public class NewTest {
                 %3 : Var<java.util.List<java.lang.String>> = var %1 @"l1";
                 %4 : Var<java.util.List<java.lang.Number>> = var %2 @"l2";
                 %5 : java.util.List<java.lang.String> = var.load %3;
-                %6 : .<NewTest, NewTest$BG<java.lang.String>> = new %0 %5 @"func<.<NewTest, NewTest$BG>, java.util.List>";
+                %6 : .<NewTest, NewTest$BG<java.lang.String>> = new %0 %5 @"func<.<NewTest, NewTest$BG>, NewTest, java.util.List>";
                 %7 : java.util.List<java.lang.Number> = var.load %4;
-                %8 : .<.<NewTest, NewTest$BG<java.lang.String>>, NewTest$BG$CG<java.lang.Number>> = new %6 %7 @"func<.<.<NewTest, NewTest$BG>, NewTest$BG$CG>, java.util.List>";
+                %8 : .<.<NewTest, NewTest$BG<java.lang.String>>, NewTest$BG$CG<java.lang.Number>> = new %6 %7 @"func<.<.<NewTest, NewTest$BG>, NewTest$BG$CG>, .<NewTest, NewTest$BG<java.lang.String>>, java.util.List>";
                 %9 : Var<.<.<NewTest, NewTest$BG<java.lang.String>>, NewTest$BG$CG<java.lang.Number>>> = var %8 @"numberCG";
                 return;
             };

--- a/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
+++ b/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
@@ -55,11 +55,19 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
-import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
 public class TestIRFromAnnotation {
+
+    static final Set<String> EXCLUDED_TEST = Set.of(
+            "LocalClassTest.java",              // name of local classes is not stable at annotation processing time
+            "TestLocalCapture.java",            // plain testng test
+            "TestCaptureQuoted.java",           // plain testng test
+            "TestCaptureQuotable.java",         // plain testng test
+            "QuotedSameInstanceTest.java",      // plain testng test
+            "CodeModelSameInstanceTest.java"    // plain testng test
+    );
 
     public static void main(String... args) throws Exception {
         String testSrc = System.getProperty("test.src");
@@ -69,11 +77,15 @@ public class TestIRFromAnnotation {
 
     void run(File baseDir) throws Exception {
         for (File file : getAllFiles(List.of(baseDir))) {
-            if (!file.exists() || !file.getName().endsWith(".java")) {
+            if (!file.exists() || !file.getName().endsWith(".java") || isExcluded(file)) {
                 continue;
             }
             analyze(file);
         }
+    }
+
+    boolean isExcluded(File file) {
+        return EXCLUDED_TEST.contains(file.getName());
     }
 
     void analyze(File source) {

--- a/test/langtools/tools/javac/reflect/TestLocalCapture.java
+++ b/test/langtools/tools/javac/reflect/TestLocalCapture.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Smoke test for captured values in local classes.
+ * @run testng TestLocalCapture
+ */
+
+import org.testng.annotations.*;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.code.op.CoreOp.FuncOp;
+import java.lang.runtime.CodeReflection;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.*;
+
+public class TestLocalCapture {
+
+    int x = 13;
+    final int CONST = 1;
+
+    @CodeReflection
+    public int sum(int y, int z) {
+        final int localConst = 2;
+        class Foo {
+            int sum(int z) { return localConst + x + y + z + CONST; };
+        }
+        return new Foo().sum(z);
+    }
+
+    @Test(dataProvider = "ints")
+    public void testLocalCapture(int y) throws ReflectiveOperationException {
+        Method sum = TestLocalCapture.class.getDeclaredMethod("sum", int.class, int.class);
+        FuncOp model = sum.getCodeModel().get();
+        int found = (int)Interpreter.invoke(MethodHandles.lookup(), model, this, y, 17);
+        int expected = sum(y, 17);
+        assertEquals(found, expected);
+    }
+
+    @DataProvider(name = "ints")
+    public Object[][] ints() {
+        return IntStream.range(0, 50)
+                .mapToObj(i -> new Object[] { i })
+                .toArray(Object[][]::new);
+    }
+}


### PR DESCRIPTION
This PR adds support for local and anonymous instance class creation in the code model.

This is a bit trickier than inner classes in that local classes can also capture local variables from enclosing scopes. And, to make things even trickier, some local classes can be used in a *pre-construction* environment, that is in a location where `this` is not available yet (e.g. because we're in the middle of a `super` constructor call).

In this PR, we only add support for local and anonymous class that do **not** appear in a pre-construction context. The logic to compute the set of captured local is shared with `Lower` (as part of Java 8 that logic has been somewhat generalized to accommodate different clients, as lambda generation also needs to know the set of variables captured by a local class). The resulting captures are then added as arguments of the `new` operation, and the constructor signature is tweaked accordingly.

For instance, given this:

```java
    String testLocalCaptureParam(String s) {
        class Foo {
            String m() { return s; }
        }
        return new Foo().m();
    }
```

The following model is now generated:

```
func @"testLocalCaptureParam" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
                %2 : Var<java.lang.String> = var %1 @"s";
                %3 : java.lang.String = var.load %2;
                %4 : .<LocalClassTest, LocalClassTest$2Foo> = new %0 %3 @"func<.<LocalClassTest, LocalClassTest$2Foo>, LocalClassTest, java.lang.String>";
                %5 : java.lang.String = invoke %4 @".<LocalClassTest, LocalClassTest$2Foo>::m()java.lang.String";
                return %5;
            };
```

I've added a bunch of tests to check the shape of the resulting code model, plus a dynamic test to make sure that we can indeed build local classes by interpreting said model.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.org/babylon.git pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/111.diff">https://git.openjdk.org/babylon/pull/111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/111#issuecomment-2148068218)