### PR TITLE
Null check only when selector expression of switch expression is of reference type

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -27,15 +27,8 @@ package java.lang.reflect.code.op;
 
 import java.lang.constant.ClassDesc;
 import java.lang.reflect.code.*;
-import java.lang.reflect.code.type.ArrayType;
-import java.lang.reflect.code.type.ClassType;
-import java.lang.reflect.code.type.MethodRef;
-import java.lang.reflect.code.type.RecordTypeRef;
-import java.lang.reflect.code.type.FunctionType;
-import java.lang.reflect.code.type.JavaType;
-import java.lang.reflect.code.type.TupleType;
+import java.lang.reflect.code.type.*;
 import java.lang.reflect.code.TypeElement;
-import java.lang.reflect.code.type.VarType;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -821,12 +814,16 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             return false;
         }
 
+        private boolean isSelectorOfTypePrimitive() {
+            return List.of(CHAR, BYTE, SHORT, INT).contains(operands().get(0).type());
+        }
+
         @Override
         public Block.Builder lower(Block.Builder b, OpTransformer opT) {
 
             Value selectorExpression = b.context().getValue(operands().get(0));
 
-            if (!haveNullCase()) {
+            if (!isSelectorOfTypePrimitive() && !haveNullCase()) {
                 Block.Builder throwBlock = b.block();
                 throwBlock.op(_throw(
                         throwBlock.op(_new(FunctionType.functionType(JavaType.type(NullPointerException.class))))

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -28,7 +28,6 @@ package java.lang.reflect.code.op;
 import java.lang.constant.ClassDesc;
 import java.lang.reflect.code.*;
 import java.lang.reflect.code.type.*;
-import java.lang.reflect.code.TypeElement;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -814,16 +814,12 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             return false;
         }
 
-        private boolean isSelectorOfTypePrimitive() {
-            return List.of(CHAR, BYTE, SHORT, INT).contains(operands().get(0).type());
-        }
-
         @Override
         public Block.Builder lower(Block.Builder b, OpTransformer opT) {
 
             Value selectorExpression = b.context().getValue(operands().get(0));
 
-            if (!isSelectorOfTypePrimitive() && !haveNullCase()) {
+            if (!(selectorExpression.type() instanceof PrimitiveType) && !haveNullCase()) {
                 Block.Builder throwBlock = b.block();
                 throwBlock.op(_throw(
                         throwBlock.op(_new(FunctionType.functionType(JavaType.type(NullPointerException.class))))

--- a/test/jdk/java/lang/reflect/code/TestSwitchExpressionOp.java
+++ b/test/jdk/java/lang/reflect/code/TestSwitchExpressionOp.java
@@ -93,6 +93,24 @@ public class TestSwitchExpressionOp {
         Assert.assertThrows(NullPointerException.class, () -> Interpreter.invoke(lf, new Object[]{null}));
     }
 
+    @CodeReflection
+    private static String f5(int i) {
+        return switch (i) {
+            case 1 -> "1";
+            case 2 -> "2";
+            default -> "default";
+        };
+    }
+
+    @Test
+    public void test5() {
+        CoreOp.FuncOp lf = lower("f5");
+
+        Assert.assertEquals(Interpreter.invoke(lf, 1), f5(1));
+        Assert.assertEquals(Interpreter.invoke(lf, 2), f5(2));
+        Assert.assertEquals(Interpreter.invoke(lf, 99), f5(99));
+    }
+
     static CoreOp.FuncOp getFuncOp(String name) {
         Optional<Method> om = Stream.of(TestSwitchExpressionOp.class.getDeclaredMethods())
                 .filter(m -> m.getName().equals(name))

--- a/test/jdk/java/lang/reflect/code/TestSwitchExpressionOp.java
+++ b/test/jdk/java/lang/reflect/code/TestSwitchExpressionOp.java
@@ -2,7 +2,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.code.Op;
+import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.runtime.CodeReflection;


### PR DESCRIPTION
Generate lowered form of switch expression that check if the selector expression is null only when the selector expression has type reference.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/babylon.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/112.diff">https://git.openjdk.org/babylon/pull/112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/112#issuecomment-2148209443)