### PR TITLE
cmake tidyup and access with maven build

### DIFF
--- a/hat/.gitignore
+++ b/hat/.gitignore
@@ -1,1 +1,2 @@
 build/
+target/

--- a/hat/CMakeLists.txt
+++ b/hat/CMakeLists.txt
@@ -59,13 +59,10 @@ endif()
 
 ## We have JAVA_HOME so now setup clean targets
 
-set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
-   ${CMAKE_BINARY_DIR}/hat ${CMAKE_BINARY_DIR}/mandel ${CMAKE_BINARY_DIR}/violajones ${CMAKE_BINARY_DIR}/experiments
-   ${CMAKE_BINARY_DIR}/opencl_info ${CMAKE_BINARY_DIR}/cuda_info ${CMAKE_BINARY_DIR}/mock_info ${CMAKE_BINARY_DIR}/spirv_info
-   ${CMAKE_BINARY_DIR}/ptx_backend ${CMAKE_BINARY_DIR}/mock_backend ${CMAKE_BINARY_DIR}/opencl_backend ${CMAKE_BINARY_DIR}/cuda_backend ${CMAKE_BINARY_DIR}/spirv_backend
-   ${CMAKE_BINARY_DIR}/libmock_backend.dylib ${CMAKE_BINARY_DIR}/libptx_backend.dylib ${CMAKE_BINARY_DIR}/libopencl_backend.dylib ${CMAKE_BINARY_DIR}/libspirv_backend.dylib ${CMAKE_BINARY_DIR}/libcuda_backend.dylib
-   ${CMAKE_BINARY_DIR}/libspirv_backend.so ${CMAKE_BINARY_DIR}/libmock_backend.so ${CMAKE_BINARY_DIR}/libptx_backend.so ${CMAKE_BINARY_DIR}/libcuda_backend.so ${CMAKE_BINARY_DIR}/libopencl_backend.so
-)
+#set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+#   ${CMAKE_BINARY_DIR}/hat ${CMAKE_BINARY_DIR}/mandel ${CMAKE_BINARY_DIR}/violajones ${CMAKE_BINARY_DIR}/experiments ${CMAKE_BINARY_DIR}/heal ${CMAKE_BINARY_DIR}/view 
+#   ${CMAKE_BINARY_DIR}/backends
+#)
 
 add_custom_target(backend_jars)
 add_custom_target(backend_libs)
@@ -275,6 +272,15 @@ add_custom_target(violajones.jar DEPENDS violajones.javac
 )
 add_dependencies(example_jars violajones.jar)
 
+#### We delegate to the cmake config for backends which is clion compatible. 
+
+set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/backends/shared")
+set (PTX_BACKEND "${CMAKE_SOURCE_DIR}/backends/ptx")
+set (OPENCL_BACKEND "${CMAKE_SOURCE_DIR}/backends/opencl")
+set (CUDA_BACKEND "${CMAKE_SOURCE_DIR}/backends/opencl")
+set (SPIRV_BACKEND "${CMAKE_SOURCE_DIR}/backends/spirv")
+set (MOCK_BACKEND "${CMAKE_SOURCE_DIR}/backends/mock")
+add_subdirectory("backends")
 
 #### We can always build the Java artifacts for all of our backends
 #### we do need to guard the building of native artifacts
@@ -311,118 +317,14 @@ add_custom_target(opencl_backend.jar DEPENDS opencl_backend.javac
        -C ${OPENCL_BACKEND_CLASS_DIR} .
 )
 add_dependencies(backend_jars opencl_backend.jar)
-
-### libopencl_backend.so/.dylib
-
-if(OPENCL_FOUND)
-  message("OPENCL")
-  if (APPLE)
-     include_directories(
-        ${CMAKE_SOURCE_DIR}/backends/shared/include
-        ${CMAKE_SOURCE_DIR}/backends/opencl/include
-        "-framework OpenCL"
-     )
-     link_directories(
-        ${CMAKE_BINARY_DIR}
-     )
-
-     add_library(opencl_backend SHARED
-        ${CMAKE_SOURCE_DIR}/backends/shared/cpp/shared.cpp
-        ${CMAKE_SOURCE_DIR}/backends/opencl/cpp/opencl_backend.cpp
-     )
-
-     target_link_libraries(opencl_backend
-        "-framework OpenCL"
-     )
-
-     add_executable(opencl_info
-        ${CMAKE_SOURCE_DIR}/backends/opencl/cpp/info.cpp
-     )
-
-     target_link_libraries(opencl_info
-        opencl_backend
-        "-framework OpenCL"
-     )
-     target_link_libraries(opencl_info
-          "-framework OpenCL"
-     )
-
-     add_custom_target(opencl_info_exec DEPENDS opencl_backend.jar opencl_backend
-        COMMAND  ${DOIT}
-          ${JAVA_HOME}/bin/java
-            --enable-preview --enable-native-access=ALL-UNNAMED
-            --add-exports=java.base/jdk.internal=ALL-UNNAMED
-            -classpath ${OPENCL_BACKEND_JAR}:${HAT_JAR}
-            -Djava.library.path=${CMAKE_BINARY_DIR}
-            hat.backend.OpenCLDeviceInfo
-     )
-     add_dependencies(info_executables opencl_info)
-     add_dependencies(backend_libs opencl_backend)
-
-     set(AVAILABLE_BACKEND_JAR ${OPENCL_BACKEND_JAR})
-  else()
-     message("OPENCL but not on APPLE")
-     include_directories(
-        ${CMAKE_SOURCE_DIR}/backends/shared/include
-        ${CMAKE_SOURCE_DIR}/backends/opencl/include
-        ${OPENCL_INCLUDE_DIR}
-     )
-     link_directories(
-        ${CMAKE_BINARY_DIR}
-     )
-
-     add_library(opencl_backend SHARED
-        ${CMAKE_SOURCE_DIR}/backends/shared/cpp/shared.cpp
-        ${CMAKE_SOURCE_DIR}/backends/opencl/cpp/opencl_backend.cpp
-     )
-
-     target_link_libraries(opencl_backend
-        "OpenCL"
-     )
-
-     add_executable(opencl_info
-        ${CMAKE_SOURCE_DIR}/backends/opencl/cpp/info.cpp
-     )
-
-     target_link_libraries(opencl_info
-        opencl_backend
-        "OpenCL"
-     )
-     target_link_libraries(opencl_info
-        "OpenCL"
-     )
-
-     add_custom_target(opencl_info_exec DEPENDS opencl_backend.jar opencl_backend
-        COMMAND  ${DOIT}
-          ${JAVA_HOME}/bin/java
-            --enable-preview --enable-native-access=ALL-UNNAMED
-            --add-exports=java.base/jdk.internal=ALL-UNNAMED
-            -classpath ${OPENCL_BACKEND_JAR}:${HAT_JAR}
-            -Djava.library.path=${CMAKE_BINARY_DIR}
-            hat.backend.OpenCLDeviceInfo
-     )
-     add_dependencies(info_executables opencl_info)
-     add_dependencies(backend_libs opencl_backend)
-
-     set(AVAILABLE_BACKEND_JAR ${OPENCL_BACKEND_JAR})
-  endif()
-
-  if(is$ENV{ECHO_ONLY} STREQUAL isON )
-     add_custom_target(echo_only DEPENDS opencl_backend add--with-jtreg=${JTREG_HOME}
-      COMMAND
-         sed -n '/.command.:/ s/.command.: *.\(.*\)./\\\\1/p' ${CMAKE_BINARY_DIR}/compile_commands.json
-      COMMAND
-         cat ${CMAKE_BINARY_DIR}/CMakeFiles/opencl_info.dir/link.txt
-      COMMAND
-         cat ${CMAKE_BINARY_DIR}/CMakeFiles/opencl_backend.dir/link.txt
-   )
-  endif()
+find_package(OpenCL)
+if(OPENCL_FOUND)  
+    add_dependencies(info_executables opencl_info)
+    add_dependencies(backend_libs opencl_backend)
 endif()
-##End of OpenCL Backend
+
 
 ##CUDA Backend
-###cuda_backend.jar
-
 set(CUDA_BACKEND_JAVA_SOURCE_ROOT ${CMAKE_SOURCE_DIR}/backends/cuda/java)
 file(GLOB_RECURSE CUDA_BACKEND_JAVA_SOURCE_FILES ${CUDA_BACKEND_JAVA_SOURCE_ROOT}/*.java)
 set(CUDA_BACKEND_CLASS_DIR ${CMAKE_BINARY_DIR}/cuda_backend/classes)
@@ -449,65 +351,12 @@ add_custom_target(cuda_backend.jar DEPENDS cuda_backend.javac
         -C ${CUDA_BACKEND_CLASS_DIR} .
 )
 add_dependencies(backend_jars cuda_backend.jar)
+find_package(CUDAToolkit)
 
-### libcuda_backend.so/.dylib
 if(CUDAToolkit_FOUND)
-  message("CUDA")
-
-  include_directories(
-      ${CUDAToolkit_INCLUDE_DIR}
-      ${CMAKE_SOURCE_DIR}/backends/shared/include
-      ${CMAKE_SOURCE_DIR}/backends/cuda/include
-  )
-
-  link_directories(
-      ${CMAKE_BINARY_DIR}
-      ${CUDAToolkit_LIBRARY_DIR}
-  )
-
-  add_library(cuda_backend SHARED
-     ${CMAKE_SOURCE_DIR}/backends/shared/cpp/shared.cpp
-     ${CMAKE_SOURCE_DIR}/backends/cuda/cpp/cuda_backend.cpp
-  )
-
-  target_link_libraries(cuda_backend
-     -lcudart
-     -lcuda
-  )
-
-  add_executable(cuda_info
-     ${CMAKE_SOURCE_DIR}/backends/cuda/cpp/info.cpp
-  )
-
-  target_link_libraries(cuda_info
-     cuda_backend
-     -lcudart -lcuda
-  )
-
-  add_custom_target(cuda_info_exec DEPENDS cuda_backend.jar cuda_backend
-      COMMAND  ${DOIT}
-        ${JAVA_HOME}/bin/java
-            --enable-preview --enable-native-access=ALL-UNNAMED
-            --add-exports=java.base/jdk.internal=ALL-UNNAMED
-            -classpath ${CUDA_BACKEND_JAR}:${HAT_JAR}
-            -Djava.library.path=${CMAKE_BINARY_DIR}
-            hat.backend.CudaDeviceInfo
-  )
-  set(AVAILABLE_BACKEND_JAR ${CUDA_BACKEND_JAR})
-  add_dependencies(info_executables cuda_info)
-  add_dependencies(backend_libs cuda_backend)
-
-  if(is$ENV{ECHO_ONLY} STREQUAL isON )
-   add_custom_target(echo_only DEPENDS cuda_backend
-      COMMAND
-         cat ${CMAKE_BINARY_DIR}/CMakeFiles/cuda_info.dir/link.txt
-      COMMAND
-         cat ${CMAKE_BINARY_DIR}/CMakeFiles/cuda_backend.dir/link.txt
-   )
-  endif()
-
+    add_dependencies(info_executables cuda_info)
+    add_dependencies(backend_libs cuda_backend)
 endif()
-
 ##End of CUDA Backend
 
 if (EXISTS ${BEEHIVE})
@@ -548,49 +397,18 @@ add_custom_target(spirv_backend.jar DEPENDS spirv_backend.javac
 add_dependencies(backend_jars spirv_backend.jar)
 
 
-## SPIRV binaries.
-## We dont need to guard this yet because we don't need SPIRV headers or libs to link to
-## if(SPIRV_FOUND)
 
-### libspirv_backend.so/.dylib
-
-include_directories(
-    ${CMAKE_SOURCE_DIR}/backends/shared/include
-    ${CMAKE_SOURCE_DIR}/backends/spirv/include
+add_custom_target(spirv_info_exec DEPENDS spirv_backend.jar spirv_backend
+   COMMAND  ${DOIT}
+      ${JAVA_HOME}/bin/java
+        --enable-preview --enable-native-access=ALL-UNNAMED
+        --add-exports=java.base/jdk.internal=ALL-UNNAMED
+        -classpath ${SPIRV_BACKEND_JAR}:${HAT_JAR}
+        -Djava.library.path=${CMAKE_BINARY_DIR}
+        hat.backend.SpirvDeviceInfo
   )
-  link_directories(
-     ${CMAKE_BINARY_DIR}
-  )
-
-  add_library(spirv_backend SHARED
-    ${CMAKE_SOURCE_DIR}/backends/shared/cpp/shared.cpp
-    ${CMAKE_SOURCE_DIR}/backends/spirv/cpp/spirv_backend.cpp
-  )
-
-  target_link_libraries(spirv_backend
-  )
-
-  add_executable(spirv_info
-      ${CMAKE_SOURCE_DIR}/backends/spirv/cpp/info.cpp
-  )
-
-  target_link_libraries(spirv_info
-       spirv_backend
-  )
-
-  add_custom_target(spirv_info_exec DEPENDS spirv_backend.jar spirv_backend
-      COMMAND  ${DOIT}
-        ${JAVA_HOME}/bin/java
-          --enable-preview --enable-native-access=ALL-UNNAMED
-          --add-exports=java.base/jdk.internal=ALL-UNNAMED
-          -classpath ${SPIRV_BACKEND_JAR}:${HAT_JAR}
-          -Djava.library.path=${CMAKE_BINARY_DIR}
-          hat.backend.SpirvDeviceInfo
-  )
-  add_dependencies(info_executables spirv_info)
-  add_dependencies(backend_libs spirv_backend)
-#endif()
-
+add_dependencies(info_executables spirv_info)
+add_dependencies(backend_libs spirv_backend)
 ## end of SPIRV
 else()
    message("BEEHIVE! not found")
@@ -625,37 +443,6 @@ add_custom_target(ptx_backend.jar DEPENDS ptx_backend.javac
         -C ${PTX_BACKEND_CLASS_DIR} .
 )
 add_dependencies(backend_jars ptx_backend.jar)
-
-
-## PTX binaries.
-## We dont need to guard these during initial development because we don't need CUDA headers or libs to link to
-## if(CUDAToolkit_FOUND)
-### libptx_backend.so/.dylib
-
-include_directories(
-    ${CMAKE_SOURCE_DIR}/backends/shared/include
-    ${CMAKE_SOURCE_DIR}/backends/ptx/include
-  )
-  link_directories(
-     ${CMAKE_BINARY_DIR}
-  )
-
-  add_library(ptx_backend SHARED
-    ${CMAKE_SOURCE_DIR}/backends/shared/cpp/shared.cpp
-    ${CMAKE_SOURCE_DIR}/backends/ptx/cpp/ptx_backend.cpp
-  )
-
-  target_link_libraries(ptx_backend
-  )
-
-  add_executable(ptx_info
-      ${CMAKE_SOURCE_DIR}/backends/ptx/cpp/info.cpp
-  )
-
-  target_link_libraries(ptx_info
-       ptx_backend
-  )
-
   add_custom_target(ptx_info_exec DEPENDS ptx_backend.jar ptx_backend
       COMMAND  ${DOIT}
         ${JAVA_HOME}/bin/java
@@ -665,8 +452,8 @@ include_directories(
           -Djava.library.path=${CMAKE_BINARY_DIR}
           hat.backend.SpirvDeviceInfo
   )
-  add_dependencies(info_executables ptx_info)
-  add_dependencies(backend_libs ptx_backend)
+add_dependencies(info_executables ptx_info)   
+add_dependencies(backend_libs ptx_backend)    
 #endif()
 
 ## end of PTX
@@ -702,34 +489,6 @@ add_custom_target(mock_backend.jar DEPENDS mock_backend.javac
 add_dependencies(backend_jars mock_backend.jar)
 
 
-## MOCK binaries.
-## We dont need to guard these because we don't have headers or libs to link to
-### libmock_backend.so/.dylib
-
-include_directories(
-    ${CMAKE_SOURCE_DIR}/backends/shared/include
-    ${CMAKE_SOURCE_DIR}/backends/mock/include
-  )
-  link_directories(
-     ${CMAKE_BINARY_DIR}
-  )
-
-  add_library(mock_backend SHARED
-    ${CMAKE_SOURCE_DIR}/backends/shared/cpp/shared.cpp
-    ${CMAKE_SOURCE_DIR}/backends/mock/cpp/mock_backend.cpp
-  )
-
-  target_link_libraries(mock_backend
-  )
-
-  add_executable(mock_info
-      ${CMAKE_SOURCE_DIR}/backends/mock/cpp/info.cpp
-  )
-
-  target_link_libraries(mock_info
-       mock_backend
-  )
-
   add_custom_target(mock_info_exec DEPENDS mock_backend.jar mock_backend
       COMMAND  ${DOIT}
         ${JAVA_HOME}/bin/java
@@ -739,8 +498,9 @@ include_directories(
           -Djava.library.path=${CMAKE_BINARY_DIR}
           hat.backend.MockDeviceInfo
   )
-  add_dependencies(info_executables mock_info)
-  add_dependencies(backend_libs mock_backend)
+
+add_dependencies(info_executables mock_info) 
+add_dependencies(backend_libs mock_backend)  
 #endif()
 
 ## end of MOCK
@@ -764,7 +524,7 @@ add_custom_target(squares_opencl DEPENDS squares.jar opencl_backend.jar opencl_b
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${SQUARES_JAR}:${OPENCL_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/opencl
        squares.Squares
 )
 
@@ -774,7 +534,7 @@ add_custom_target(squares_cuda DEPENDS squares.jar cuda_backend.jar cuda_backend
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${SQUARES_JAR}:${CUDA_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/cuda
        squares.Squares
 )
 add_custom_target(squares_ptx DEPENDS squares.jar ptx_backend.jar ptx_backend
@@ -783,7 +543,7 @@ add_custom_target(squares_ptx DEPENDS squares.jar ptx_backend.jar ptx_backend
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${SQUARES_JAR}:${PTX_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/ptx
        squares.Squares
 )
 
@@ -825,7 +585,7 @@ add_custom_target(mandel_opencl DEPENDS mandel.jar opencl_backend.jar opencl_bac
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${MANDEL_JAR}:${OPENCL_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/opencl
        mandel.MandelCompute
 )
 
@@ -835,7 +595,7 @@ add_custom_target(mandel_cuda DEPENDS mandel.jar cuda_backend.jar cuda_backend
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${MANDEL_JAR}:${CUDA_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/cuda
        mandel.MandelCompute
 )
 
@@ -856,7 +616,7 @@ add_custom_target(violajones_opencl DEPENDS violajones.jar opencl_backend.jar op
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${VIOLAJONES_JAR}:${OPENCL_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/opencl
        violajones.ViolaJonesCompute
 )
 
@@ -866,7 +626,7 @@ add_custom_target(violajones_cuda DEPENDS violajones.jar cuda_backend.jar cuda_b
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${VIOLAJONES_JAR}:${CUDA_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/cuda
        violajones.ViolaJonesCompute
 )
 
@@ -876,7 +636,6 @@ add_custom_target(violajones_headless_java DEPENDS violajones.jar
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${VIOLAJONES_JAR}:${CMAKE_SOURCE_DIR}/backends/shared/services
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
        -Dheadless=true
        violajones.ViolaJonesCompute
 )
@@ -887,7 +646,7 @@ add_custom_target(violajones_headless_opencl DEPENDS violajones.jar opencl_backe
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${VIOLAJONES_JAR}:${OPENCL_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/opencl
        -Dheadless=true
        violajones.ViolaJonesCompute
 )
@@ -898,7 +657,7 @@ add_custom_target(violajones_headless_cuda DEPENDS violajones.jar cuda_backend.j
        --enable-preview --enable-native-access=ALL-UNNAMED
        --class-path ${HAT_JAR}:${VIOLAJONES_JAR}:${CUDA_BACKEND_JAR}
        --add-exports=java.base/jdk.internal=ALL-UNNAMED
-       -Djava.library.path=${CMAKE_BINARY_DIR}
+       -Djava.library.path=${CMAKE_BINARY_DIR}/backends/cuda
        -Dheadless=true
        violajones.ViolaJonesCompute
 )

--- a/hat/backends/.gitignore
+++ b/hat/backends/.gitignore
@@ -1,1 +1,3 @@
 cmake-build-debug
+opencl/build
+cuda/build

--- a/hat/backends/CMakeLists.txt
+++ b/hat/backends/CMakeLists.txt
@@ -1,92 +1,43 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(backends)
 
+if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/shared")
+    message("SHARED_BACKEND=${SHARED_BACKEND}")
+endif()
+
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(OpenCL)
-find_package(CUDAToolkit)
-
-if(OPENCL_FOUND)
-    message("OPENCL")
-    if (APPLE)
-       set(OPENCL_INCLUDE_DIR "-framework OpenCL")
-       set(OPENCL_LIB "-framework OpenCL")
-    else()
-       #set(OPENCL_INCLUDE_DIR "-framework OpenCL")  
-       set(OPENCL_LIB "OpenCL")
-    endif()
-
-    include_directories(
-        ${CMAKE_SOURCE_DIR}/opencl/shared/include
-        ${CMAKE_SOURCE_DIR}/opencl/include
-        ${CMAKE_SOURCE_DIR}/shared/include
-        ${OPENCL_INCLUDE_DIR}
-    )
-    link_directories(
-        ${CMAKE_BINARY_DIR}
-    )
-
-    add_library(opencl_backend SHARED
-        ${CMAKE_SOURCE_DIR}/shared/cpp/shared.cpp
-        ${CMAKE_SOURCE_DIR}/opencl/cpp/opencl_backend.cpp
-    )
-
-    target_link_libraries(opencl_backend
-        ${OPENCL_LIB}
-    )
-
-    add_executable(opencl_info
-        ${CMAKE_SOURCE_DIR}/opencl/cpp/info.cpp
-    )
-
-    target_link_libraries(opencl_info
-        opencl_backend
-        ${OPENCL_LIB}
-    )
-    add_custom_target(opencl_natives DEPENDS opencl_info opencl_backend)
+include_directories(
+    ${SHARED_BACKEND}/include
+)
+if ("${OPENCL_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (OPENCL_BACKEND "${CMAKE_SOURCE_DIR}/opencl")
+    message("OPENCL_BACKEND=${OPENCL_BACKEND}")
 endif()
-
-if(CUDAToolkit_FOUND)
-    message("CUDA")
-
-    include_directories(
-            ${CUDAToolkit_INCLUDE_DIR}
-            ${CMAKE_SOURCE_DIR}/shared/include
-            ${CMAKE_SOURCE_DIR}/cuda/include
-    )
-
-    link_directories(
-            ${CMAKE_BINARY_DIR}
-            ${CUDAToolkit_LIBRARY_DIR}
-    )
-
-    add_library(cuda_backend SHARED
-            ${CMAKE_SOURCE_DIR}/shared/cpp/shared.cpp
-            ${CMAKE_SOURCE_DIR}/cuda/cpp/cuda_backend.cpp
-    )
-
-    target_link_libraries(cuda_backend
-            -lcudart
-            -lcuda
-    )
-
-    add_executable(cuda_info
-            ${CMAKE_SOURCE_DIR}/cuda/cpp/info.cpp
-    )
-
-    target_link_libraries(cuda_info
-            cuda_backend
-            -lcudart
-            -lcuda
-    )
-    add_custom_target(cuda_natives DEPENDS cuda_info cuda_backend)
-
+add_subdirectory(opencl)
+if ("${CUDA_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (CUDA_BACKEND "${CMAKE_SOURCE_DIR}/cuda")
+    message("CUDA_BACKEND=${CUDA_BACKEND}")
 endif()
+add_subdirectory(cuda)
+if ("${SPIRV_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (SPIRV_BACKEND "${CMAKE_SOURCE_DIR}/spirv")
+    message("SPIRV_BACKEND=${SPIRV_BACKEND}")
+endif()
+add_subdirectory(spirv)
+if ("${PTX_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (PTX_BACKEND "${CMAKE_SOURCE_DIR}/ptx")
+    message("PTX_BACKEND=${PTX_BACKEND}")
+endif()
+add_subdirectory(ptx)
+if ("${MOCK_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (MOCK_BACKEND "${CMAKE_SOURCE_DIR}/mock")
+    message("MOCK_BACKEND=${MOCK_BACKEND}")
+endif()
+add_subdirectory(mock)
 add_executable(schemadump
-        ${CMAKE_SOURCE_DIR}/shared/cpp/shared.cpp
-        ${CMAKE_SOURCE_DIR}/shared/cpp/schemadump.cpp
+        ${SHARED_BACKEND}/cpp/shared.cpp
+        ${SHARED_BACKEND}/cpp/schemadump.cpp
 )
-add_library(ptx_backend SHARED
-        ${CMAKE_SOURCE_DIR}/shared/cpp/shared.cpp
-        ${CMAKE_SOURCE_DIR}/ptx/cpp/ptx_backend.cpp
-)
+

--- a/hat/backends/cuda/CMakeLists.txt
+++ b/hat/backends/cuda/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(cuda_backend)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(CUDAToolkit)
+if(CUDAToolkit_FOUND)
+    message("CUDA")
+
+    include_directories(
+            ${CUDAToolkit_INCLUDE_DIR}
+            ${CMAKE_SOURCE_DIR}/${SHARED_PATH_ADJUST}/shared/include
+            ${CMAKE_SOURCE_DIR}/${CUDA_PATH_ADJUST}/include
+    )
+
+    link_directories(
+            ${CMAKE_BINARY_DIR}
+            ${CUDAToolkit_LIBRARY_DIR}
+    )
+
+    add_library(cuda_backend SHARED
+            ${CMAKE_SOURCE_DIR}/${SHARED_PATH_ADJUST}/cpp/shared.cpp
+            ${CMAKE_SOURCE_DIR}/${CUDA_PATH_ADJUST}/cpp/cuda_backend.cpp
+    )
+
+    target_link_libraries(cuda_backend
+            -lcudart
+            -lcuda
+    )
+
+    add_executable(cuda_info
+            ${CMAKE_SOURCE_DIR}/${CUDA_PATH_ADJUST}/cpp/info.cpp
+    )
+
+    target_link_libraries(cuda_info
+            cuda_backend
+            -lcudart
+            -lcuda
+    )
+    add_custom_target(cuda_natives DEPENDS cuda_info cuda_backend)
+
+
+endif()

--- a/hat/backends/mock/CMakeLists.txt
+++ b/hat/backends/mock/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(opencl_backend)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(OpenCL)
+if ("${MOCK_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (MOCK_BACKEND "${CMAKE_SOURCE_DIR}")
+    message("MOCK_BACKEND=${MOCK_BACKEND}")
+endif()
+if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
+    message("SHARED_BACKEND=${SHARED_BACKEND}")
+endif()
+
+
+message("MOCK")
+
+include_directories(
+    ${MOCK_BACKEND}/include
+    ${SHARED_BACKEND}/include
+    ${MOCK_INCLUDE_DIR}
+)
+link_directories(
+    ${CMAKE_BINARY_DIR}
+)
+
+add_library(mock_backend SHARED
+    ${SHARED_BACKEND}/cpp/shared.cpp
+    ${MOCK_BACKEND}/cpp/mock_backend.cpp
+)
+
+
+add_executable(mock_info
+    ${MOCK_BACKEND}/cpp/info.cpp
+)
+
+target_link_libraries(mock_info
+    mock_backend
+)
+add_custom_target(mock_natives DEPENDS mock_info mock_backend)
+
+
+

--- a/hat/backends/mock/cpp/mock_backend.cpp
+++ b/hat/backends/mock/cpp/mock_backend.cpp
@@ -33,15 +33,15 @@ public:
     class MockProgram : public Backend::Program {
         class MockKernel : public Backend::Program::Kernel {
         public:
-            MockKernel(Backend::Program *program)
-                    : Backend::Program::Kernel(program) {
+            MockKernel(Backend::Program *program, char *name)
+                    : Backend::Program::Kernel(program, name) {
             }
 
             ~MockKernel() {
             }
 
-            long ndrange(int range, void *argArray) {
-                std::cout << "mock ndrange(" << range << ") " << std::endl;
+            long ndrange(void *argArray) {
+                std::cout << "mock ndrange() " << std::endl;
                 return 0;
             }
         };
@@ -55,7 +55,7 @@ public:
         }
 
         long getKernel(int nameLen, char *name) {
-            return (long) new MockKernel(this);
+            return (long) new MockKernel(this, name);
         }
 
         bool programOK() {

--- a/hat/backends/opencl/CMakeLists.txt
+++ b/hat/backends/opencl/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(opencl_backend)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(OpenCL)
+if(OPENCL_FOUND)
+    message("OPENCL")
+    if ("${OPENCL_BACKEND}EMPTY" STREQUAL "EMPTY")
+        set (OPENCL_BACKEND "${CMAKE_SOURCE_DIR}")
+        message("OPENCL_BACKEND=${OPENCL_BACKEND}")
+    endif()
+    if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
+        set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
+        message("SHARED_BACKEND=${SHARED_BACKEND}")
+    endif()
+
+    if (APPLE)
+       set(OPENCL_INCLUDE_DIR "-framework OpenCL")
+       set(OPENCL_LIB "-framework OpenCL")
+    else()
+       set(OPENCL_LIB "OpenCL")
+    endif()
+
+    include_directories(
+        ${OPENCL_BACKEND}/include
+        ${SHARED_BACKEND}/include
+        ${OPENCL_INCLUDE_DIR}
+    )
+    link_directories(
+        ${CMAKE_BINARY_DIR}
+    )
+
+    add_library(opencl_backend SHARED
+        ${SHARED_BACKEND}/cpp/shared.cpp
+        ${OPENCL_BACKEND}/cpp/opencl_backend.cpp
+    )
+
+    target_link_libraries(opencl_backend
+        ${OPENCL_LIB}
+    )
+
+    add_executable(opencl_info
+        ${OPENCL_BACKEND}/cpp/info.cpp
+    )
+
+    target_link_libraries(opencl_info
+        opencl_backend
+        ${OPENCL_LIB}
+    )
+    add_custom_target(opencl_natives DEPENDS opencl_info opencl_backend)
+endif()

--- a/hat/backends/ptx/CMakeLists.txt
+++ b/hat/backends/ptx/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(opencl_backend)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(OpenCL)
+if ("${PTX_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (PTX_BACKEND "${CMAKE_SOURCE_DIR}")
+    message("PTX_BACKEND=${PTX_BACKEND}")
+endif()
+if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
+    message("SHARED_BACKEND=${SHARED_BACKEND}")
+endif()
+
+
+message("PTX")
+
+include_directories(
+    ${PTX_BACKEND}/include
+    ${SHARED_BACKEND}/include
+    ${PTX_INCLUDE_DIR}
+)
+link_directories(
+    ${CMAKE_BINARY_DIR}
+)
+
+add_library(ptx_backend SHARED
+    ${SHARED_BACKEND}/cpp/shared.cpp
+    ${PTX_BACKEND}/cpp/ptx_backend.cpp
+)
+
+
+add_executable(ptx_info
+    ${PTX_BACKEND}/cpp/info.cpp
+)
+
+target_link_libraries(ptx_info
+    ptx_backend
+)
+add_custom_target(ptx_natives DEPENDS ptx_info ptx_backend)
+

--- a/hat/backends/spirv/CMakeLists.txt
+++ b/hat/backends/spirv/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(opencl_backend)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(OpenCL)
+if ("${SPIRV_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (SPIRV_BACKEND "${CMAKE_SOURCE_DIR}")
+    message("SPIRV_BACKEND=${SPIRV_BACKEND}")
+endif()
+if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
+    set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
+    message("SHARED_BACKEND=${SHARED_BACKEND}")
+endif()
+
+message("SPIRV")
+
+include_directories(
+    ${SPIRV_BACKEND}/include
+    ${SHARED_BACKEND}/include
+    ${SPIRV_INCLUDE_DIR}
+)
+link_directories(
+    ${CMAKE_BINARY_DIR}
+)
+
+add_library(spirv_backend SHARED
+    ${SHARED_BACKEND}/cpp/shared.cpp
+    ${SPIRV_BACKEND}/cpp/spirv_backend.cpp
+)
+
+
+add_executable(spirv_info
+    ${SPIRV_BACKEND}/cpp/info.cpp
+)
+
+target_link_libraries(spirv_info
+    spirv_backend
+)
+
+add_custom_target(spirv_natives DEPENDS spirv_info spirv_backend)
+
+

--- a/hat/backends/spirv/cpp/spirv_backend.cpp
+++ b/hat/backends/spirv/cpp/spirv_backend.cpp
@@ -33,15 +33,15 @@ public:
     class SpirvProgram : public Backend::Program {
         class SpirvKernel : public Backend::Program::Kernel {
         public:
-            SpirvKernel(Backend::Program *program)
-                    : Backend::Program::Kernel(program) {
+            SpirvKernel(Backend::Program *program, char *name)
+                    : Backend::Program::Kernel(program, name) {
             }
 
             ~SpirvKernel() {
             }
 
-            long ndrange(int range, void *argArray) {
-                std::cout << "spirv ndrange(" << range << ") " << std::endl;
+            long ndrange(void *argArray) {
+                std::cout << "spirv ndrange() " << std::endl;
                 return 0;
             }
         };
@@ -55,7 +55,7 @@ public:
         }
 
         long getKernel(int nameLen, char *name) {
-            return (long) new SpirvKernel(this);
+            return (long) new SpirvKernel(this, name);
         }
 
         bool programOK() {

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -117,6 +117,37 @@ questions.
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>
                 <executions>
+
+                  <execution>
+                     <id>cmake1</id>
+                     <phase>test</phase>
+                     <goals>
+                        <goal>exec</goal>
+                     </goals>
+                     <configuration>
+                        <executable>cmake</executable>
+                        <arguments>
+                            <argument>-B</argument> <argument>build</argument>
+                        </arguments>
+                     </configuration>
+                  </execution>
+
+                  <execution>
+                     <id>cmake2</id>
+                     <phase>test</phase>
+                     <goals>
+                        <goal>exec</goal>
+                     </goals>
+                     <configuration>
+                        <executable>cmake</executable>
+                        <arguments>
+                            <argument>--build</argument> <argument>build</argument>
+                            <argument>--target</argument> <argument>opencl_backend</argument>
+                        </arguments>
+                     </configuration>
+                  </execution>
+
+
                   <execution>
                      <id>squares</id>
                      <phase>test</phase>
@@ -129,7 +160,7 @@ questions.
                             <argument>--enable-preview</argument>
                             <argument>--enable-native-access=ALL-UNNAMED</argument>
                             <argument>--add-exports=java.base/jdk.internal=ALL-UNNAMED</argument>
-                            <argument>-Djava.library.path=build</argument>
+                            <argument>-Djava.library.path=build/backends/opencl</argument>
                             <argument>--class-path=target/hat-1.0-SNAPSHOT-jar-with-dependencies.jar</argument>
                             <argument>squares.Squares</argument>
                         </arguments>
@@ -149,7 +180,7 @@ questions.
                             <argument>--enable-preview</argument>
                             <argument>--enable-native-access=ALL-UNNAMED</argument>
                             <argument>--add-exports=java.base/jdk.internal=ALL-UNNAMED</argument>
-                            <argument>-Djava.library.path=build</argument>
+                            <argument>-Djava.library.path=build/backends/opencl</argument>
                             <argument>-Dheadless=true</argument>
                             <argument>--class-path=target/hat-1.0-SNAPSHOT-jar-with-dependencies.jar</argument>
                             <argument>violajones.ViolaJonesCompute</argument>
@@ -169,7 +200,7 @@ questions.
                             <argument>--enable-preview</argument>
                             <argument>--enable-native-access=ALL-UNNAMED</argument>
                             <argument>--add-exports=java.base/jdk.internal=ALL-UNNAMED</argument>
-                            <argument>-Djava.library.path=build</argument>
+                            <argument>-Djava.library.path=build/backends/opencl</argument>
                             <argument>--class-path=target/hat-1.0-SNAPSHOT-jar-with-dependencies.jar</argument>
                             <argument>mandel.MandelCompute</argument>
                         </arguments>


### PR DESCRIPTION
cmake from hat root now delegates to backend/CMakeLists.txt, which delegates to the appropriate baclend/*/CMakeLists.txt

This has two advantages one. 
 1) The hat root cmake is way less complicated. 
 2) The backends/CMakeLists.txt is clion compatible. 
 
 I also worked out how to build cmake from inside maven.  Working for OpenCL at least. 
 
 This means that the root level cmake may well become unnecessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.org/babylon.git pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/115.diff">https://git.openjdk.org/babylon/pull/115.diff</a>

</details>
