### PR TITLE
Use more generic location for nvcc

### DIFF
--- a/hat/backends/cuda/cpp/cuda_backend.cpp
+++ b/hat/backends/cuda/cpp/cuda_backend.cpp
@@ -63,7 +63,8 @@ Ptx *Ptx::nvcc(const char *cudaSource, size_t len) {
         cuda.open(cudaPath, std::ofstream::trunc);
         cuda.write(cudaSource, len);
         cuda.close();
-        const char *path = "/usr/local/cuda-12.2/bin/nvcc";
+        const char *path = "/usr/bin/nvcc";
+        //const char *path = "/usr/local/cuda-12.2/bin/nvcc";
         const char *argv[]{"nvcc", "-ptx", cudaPath, "-o", ptxPath, nullptr};
         // we can't free cudaPath or ptxpath in child because we need them in exec, no prob through
         // because we get a new proc so they are released to os

--- a/hat/examples/violajones/src/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/java/violajones/ViolaJonesCompute.java
@@ -50,8 +50,8 @@ public class ViolaJonesCompute {
         BufferedImage nasa1996 = ImageIO.read(ViolaJones.class.getResourceAsStream(
                //"/images/team.jpg"
               // "/images/eggheads.jpg"
-              // "/images/highett.jpg"
-             "/images/Nasa1996.jpg"
+              "/images/highett.jpg"
+            // "/images/Nasa1996.jpg"
         ));
         XMLHaarCascadeModel haarCascade = XMLHaarCascadeModel.load(
                 ViolaJonesRaw.class.getResourceAsStream("/cascades/haarcascade_frontalface_default.xml"));


### PR DESCRIPTION
Select smaller default image and use generic nvcc location for cuda to ptx

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/117/head:pull/117` \
`$ git checkout pull/117`

Update a local copy of the PR: \
`$ git checkout pull/117` \
`$ git pull https://git.openjdk.org/babylon.git pull/117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 117`

View PR using the GUI difftool: \
`$ git pr show -t 117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/117.diff">https://git.openjdk.org/babylon/pull/117.diff</a>

</details>
