### PR TITLE
Found the violajones off by one error

### DIFF
--- a/hat/backends/opencl/cpp/opencl_backend.cpp
+++ b/hat/backends/opencl/cpp/opencl_backend.cpp
@@ -612,6 +612,7 @@ const char *OpenCLBackend::errorMsg(cl_int status) {
             {CL_INVALID_BUFFER_SIZE,             "invalid buffer size",},
             {CL_INVALID_MIP_LEVEL,               "invalid mip level",},
             {CL_INVALID_GLOBAL_WORK_SIZE,        "invalid global work size",},
+            {-9999,                              "enqueueNdRangeKernel Illegal read or write to a buffer",},
             {0,                                  NULL},
     };
     static char unknown[256];
@@ -623,7 +624,7 @@ const char *OpenCLBackend::errorMsg(cl_int status) {
             return error_table[ii].msg;
         }
     }
-    SNPRINTF(unknown, sizeof(unknown), "awaitingName error %d", status);
+    SNPRINTF(unknown, sizeof(unknown), "unmapped string for  error %d", status);
     return unknown;
 }
 

--- a/hat/examples/violajones/src/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/java/violajones/ViolaJonesCompute.java
@@ -50,8 +50,8 @@ public class ViolaJonesCompute {
         BufferedImage nasa1996 = ImageIO.read(ViolaJones.class.getResourceAsStream(
                //"/images/team.jpg"
               // "/images/eggheads.jpg"
-              "/images/highett.jpg"
-            // "/images/Nasa1996.jpg"
+             // "/images/highett.jpg"
+             "/images/Nasa1996.jpg"
         ));
         XMLHaarCascadeModel haarCascade = XMLHaarCascadeModel.load(
                 ViolaJonesRaw.class.getResourceAsStream("/cascades/haarcascade_frontalface_default.xml"));

--- a/hat/examples/violajones/src/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/java/violajones/ViolaJonesCoreCompute.java
@@ -196,7 +196,7 @@ public class ViolaJonesCoreCompute {
             F32Array2D integral,
             Cascade.Stage stage,
             Cascade cascade
-	    ) {
+        ) {
         float sumOfThisStage = 0;
         int startTreeIdx = stage.firstTreeId();
         int endTreeIdx = startTreeIdx + stage.treeCount();
@@ -255,7 +255,7 @@ public class ViolaJonesCoreCompute {
             // covered by the scale.
             int scalc = 0;
             ScaleTable.Scale scale = scaleTable.scale(scalc);
-	    scalc++;
+            scalc++;
             while (kc.x >= scale.accumGridSizeMax() && scalc<scaleTable.length()) {
                 scale = scaleTable.scale(scalc);
                 scalc++;

--- a/hat/examples/violajones/src/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/java/violajones/ViolaJonesCoreCompute.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
 import hat.backend.Backend;
+import hat.buffer.S32Array;
 import hat.buffer.F32Array2D;
 import org.xml.sax.SAXException;
 import violajones.attic.ViolaJones;
@@ -194,7 +195,8 @@ public class ViolaJonesCoreCompute {
             float vnorm,
             F32Array2D integral,
             Cascade.Stage stage,
-            Cascade cascade) {
+            Cascade cascade
+	    ) {
         float sumOfThisStage = 0;
         int startTreeIdx = stage.firstTreeId();
         int endTreeIdx = startTreeIdx + stage.treeCount();
@@ -234,7 +236,6 @@ public class ViolaJonesCoreCompute {
                 }
             }
         }
-
         return sumOfThisStage > stage.threshold(); // true if this looks like a face
     }
 
@@ -248,14 +249,16 @@ public class ViolaJonesCoreCompute {
 
     ) {
 
-        if (kc.x < scaleTable.multiScaleAccumulativeRange()) {
+        if (kc.x < kc.maxX){//;scaleTable.multiScaleAccumulativeRange()) {
             // We need to determine the scale information for a given gid.
             // we check each scale in the scale table and check if our gid is
             // covered by the scale.
             int scalc = 0;
-            ScaleTable.Scale scale = scaleTable.scale(scalc++);
-            while (kc.x >= scale.accumGridSizeMax()) {
-                scale = scaleTable.scale(scalc++);
+            ScaleTable.Scale scale = scaleTable.scale(scalc);
+	    scalc++;
+            while (kc.x >= scale.accumGridSizeMax() && scalc<scaleTable.length()) {
+                scale = scaleTable.scale(scalc);
+                scalc++;
             }
 
             // Now we need to convert our scale relative git to an x,y,w,h
@@ -306,6 +309,9 @@ public class ViolaJonesCoreCompute {
         long start = System.currentTimeMillis();
         int width = rgbS08x3Image.width();
 
+
+
+
         int height = rgbS08x3Image.height();
         Accelerator accelerator = cc.accelerator;
         F32Array2D greyImage = F32Array2D.create(accelerator, width, height);
@@ -323,6 +329,9 @@ public class ViolaJonesCoreCompute {
         cc.dispatchKernel(height, kc -> integralRowKernel(kc, integralImage, integralSqImage));
         // harViz.showIntegrals();
         ScaleTable scaleTable = ScaleTable.create(accelerator, cascade, width, height);
+        System.out.print("range requested=");
+        System.out.print(scaleTable.multiScaleAccumulativeRange());
+        System.out.println();
 
         cc.dispatchKernel(scaleTable.multiScaleAccumulativeRange(), kc ->
                 findFeaturesKernel(kc, cascade, integralImage, integralSqImage, scaleTable, resultTable));


### PR DESCRIPTION
Tracked down the 'access violation' 

Turned out to be. an 'off by one' error as a result of a C99 code gen error.

This patch gets around it.  Now Violajones Nasa image works on CUDA + OpenCL on Nvidia platform

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/babylon.git pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/118.diff">https://git.openjdk.org/babylon/pull/118.diff</a>

</details>
