### PR TITLE
Introduced cuda error with last push.  This fixes it

### DIFF
--- a/hat/backends/cuda/include/cuda_backend.h
+++ b/hat/backends/cuda/include/cuda_backend.h
@@ -89,7 +89,7 @@ public:
             public:
                 CUdeviceptr devicePtr;
 
-                CudaBuffer(Backend::Program::Kernel *kernel, Arg_t *arg);
+                CudaBuffer(Backend::Program::Kernel *kernel, Arg_s *arg);
 
                 void copyToDevice();
 


### PR DESCRIPTION
Introduced 1 char CUDA typo in pash push. This is the fix.

Arg_t -> Arg_s

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.org/babylon.git pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/122.diff">https://git.openjdk.org/babylon/pull/122.diff</a>

</details>
