### PR TITLE
Experiments with HatPtrOp

### DIFF
--- a/hat/backends/shared/cpp/schema.cpp
+++ b/hat/backends/shared/cpp/schema.cpp
@@ -147,19 +147,23 @@ Schema::ArgNode *Schema::ArgNode::parse(Cursor *cursor) {
     cursor->expectEither('!', '?', &actual, __LINE__);
 
     cursor->expect(':', __LINE__);
-    cursor->expectDigit("long byteCount of buffer", __LINE__);
-    long bytes = cursor->getLong();
-    if (cursor->isEither('#', '+', &actual)) {
-        bool complete = (actual == '#');
-        cursor->expectAlpha("identifier", __LINE__);
-        char *identifier = cursor->getIdentifier();
-        cursor->expect(':', "after identifier ", __LINE__);
-        cursor->expect('{', "top level arg struct", __LINE__);
-        addChild(cursor, new ArgStructNode(this, complete, identifier));
-    } else if (cursor->peekAlpha()) {
-        addChild(cursor, new FieldNode(this, cursor->getIdentifier()));
-    } else {
-        cursor->error(std::cerr, __FILE__, __LINE__, "expecting '#' ");
+    if (cursor->peekAlpha()) {
+        addChild(cursor, new FieldNode(this, nullptr));
+    }else{
+        cursor->expectDigit("long byteCount of buffer", __LINE__);
+        long bytes = cursor->getLong();
+        if (cursor->isEither('#', '+', &actual)) {
+            bool complete = (actual == '#');
+            cursor->expectAlpha("identifier", __LINE__);
+            char *identifier = cursor->getIdentifier();
+            cursor->expect(':', "after identifier ", __LINE__);
+            cursor->expect('{', "top level arg struct", __LINE__);
+            addChild(cursor, new ArgStructNode(this, complete, identifier));
+        } else if (cursor->peekAlpha()) {
+            addChild(cursor, new FieldNode(this, cursor->getIdentifier()));
+        } else {
+            cursor->error(std::cerr, __FILE__, __LINE__, "expecting '#' ");
+        }
     }
     cursor->expect(')', "at end of NamedStructOrUnion", __LINE__);
     cursor->out();

--- a/hat/backends/shared/cpp/schemadump.cpp
+++ b/hat/backends/shared/cpp/schemadump.cpp
@@ -38,7 +38,8 @@ int main(int argc, char **argv) {
     char *gradientRow = (char *) "4(!:32#KernelContext:{x:s32,maxX:s32}),(?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]}),(?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]}),(?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]})";
     char *gradientCol = (char *)
             "3(!:32#KernelContext:{x:s32,maxX:s32}),(?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]}),(?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]})";
-
+    char* squares = (char*)"2(!:32#KernelContext:{x:s32,maxX:s32}),(?:4+S32Array:{length:s32,array:[*:?:s32]})";
+    char *suaresadd=(char*)"3(!:32#KernelContext:{x:s32,maxX:s32}),(?:4+S32Array:{length:s32,array:[*:?:s32]}),(?:s32)";
     char *cascadeSchema = (char *) R"(6
         (!:32#KernelContext:{x:s32,maxX:s32}),
         (!:163472#Cascade:{
@@ -99,7 +100,7 @@ int main(int argc, char **argv) {
         (?:8+F32Array2D:{width:s32,height:s32,array:[*:?:f32]}),
         (?:8+ScaleTable:{length:s32,multiScaleAccumulativeRange:s32,scale:[*:Scale:{scaleValue:f32,scaledXInc:f32,scaledYInc:f32,invArea:f32,scaledFeatureWidth:s32,scaledFeatureHeight:s32,gridWidth:s32,gridHeight:s32,gridSize:s32,accumGridSizeMin:s32,accumGridSizeMax:s32}]}),
         (?:8+ResultTable:{length:s32,atomicResultTableCount:s32,result:[*:Result:{x:f32,y:f32,width:f32,height:f32}]}))";
-    char *schema = cascadeSchema;
+    char *schema = suaresadd;
     std::cout << "schema = '" << schema << "'" << std::endl;
     Cursor cursor(schema);
     Schema::SchemaNode schemaNode;

--- a/hat/intellij/experiments.iml
+++ b/hat/intellij/experiments.iml
@@ -9,5 +9,8 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="hat" />
     <orderEntry type="module" module-name="backend_spirv" />
+    <orderEntry type="module" module-name="backend_opencl" />
+    <orderEntry type="module" module-name="backend_ptx" />
+    <orderEntry type="module" module-name="backend_mock" />
   </component>
 </module>


### PR DESCRIPTION
Experiments with HatPtrOp to simplify accessing iface mappings when lowering code. 

Also a schema parse fix for simple types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/babylon.git pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/124.diff">https://git.openjdk.org/babylon/pull/124.diff</a>

</details>
