### PR TITLE
Switch to using maven as primary build

### DIFF
--- a/hat/.gitignore
+++ b/hat/.gitignore
@@ -1,2 +1,3 @@
 build/
 target/
+maven-build/

--- a/hat/README.md
+++ b/hat/README.md
@@ -63,13 +63,13 @@ cd hat
 . ./env.bash
 mvn clean  compile jar:jar install
 ls maven-build
-hat-1.0.jar			hat-example-heal-1.0.jar	libptx_backend.dylib
-hat-backend-cuda-1.0.jar	hat-example-mandel-1.0.jar	libspirv_backend.dylib
-hat-backend-mock-1.0.jar	hat-example-squares-1.0.jar	mock_info
-hat-backend-opencl-1.0.jar	hat-example-view-1.0.jar	opencl_info
-hat-backend-ptx-1.0.jar		hat-example-violajones-1.0.jar	ptx_info
-hat-backend-spirv-1.0.jar	libmock_backend.dylib		spirv_info
-hat-example-experiments-1.0.jar	libopencl_backend.dylib
+hat-1.0.jar                     hat-example-heal-1.0.jar        libptx_backend.dylib
+hat-backend-cuda-1.0.jar        hat-example-mandel-1.0.jar      libspirv_backend.dylib
+hat-backend-mock-1.0.jar        hat-example-squares-1.0.jar     mock_info
+hat-backend-opencl-1.0.jar      hat-example-view-1.0.jar        opencl_info
+hat-backend-ptx-1.0.jar         hat-example-violajones-1.0.jar  ptx_info
+hat-backend-spirv-1.0.jar       libmock_backend.dylib           spirv_info
+hat-example-experiments-1.0.jar libopencl_backend.dylib
 ```
 
 To run an example

--- a/hat/README.md
+++ b/hat/README.md
@@ -1,0 +1,146 @@
+# HAT Project
+
+This is a fairly large project with Java and Native artifacts.
+
+We rely on the `babylon` (JDK23+Babylon) project, and the project will initially be made available as a subproject
+called `hat` under [github.com/openjdk/babylon](https://github.com/openjdk/babylon)
+
+So this `README.md` should be under a checkout babylon repo which has been built.
+
+Here is how I prepare for babylon build babylon on an Ubuntu (x64) machine
+
+```
+mkdir -p ${HOME}/java
+cd ${HOME}/java
+wget https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/openjdk-22.0.1_linux-x64_bin.tar.gz
+export BOOT_JDK=${HOME}/java/jdk-22.0.1.jdk
+```
+
+Here is how I prepare for babylon build on my Mac (aarch64) machine.
+
+```
+mkdir -p ${HOME}/java
+cd ${HOME}/java
+wget https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/openjdk-22.0.1_linux-x64_bin.tar.gz
+export BOOT_JDK=${HOME}/java/jdk-22.0.1.jdk/Contents/Home
+```
+
+From now on the Mac and Ubuntu steps are the same
+
+```
+export GITHUB=${HOME}/github
+mkdir -p ${GITHUB}
+cd ${GITHUB}
+git clone https://github.com/openjdk/babylon.git
+cd ${GITHUB}/babylon
+bash configure  --with-boot-jdk=${BOOT_JDK}
+make clean
+make images
+```
+
+## Build notes
+
+HAT uses maven and cmake.
+
+Maven controls the build but delegates to cmake to build the native code for the various backends.
+
+Make sure that `JAVA_HOME` is setup to point to your babylon build and the `${JAVA_HOME}/bin` is in your PATH.
+
+The `env.bash` shell script can be 'dot included' in your build shell. It should detect the arch type and select the correct relative parent dir and inject that dir in your PATH.
+
+```bash
+cd hat
+. ./env.bash
+echo ${JAVA_HOME}
+/Users/grfrost/github/babylon/hat/../build/macosx-aarch64-server-release/jdk
+echo ${PATH}
+Users/grfrost/github/babylon/hat/../build/macosx-aarch64-server-release/jdk/bin:/usr/local/bin:......
+```
+
+Now we can just use maven to build, it will do its magic and place all jars and libs in `maven-build` dir
+```
+cd hat
+. ./env.bash
+mvn clean  compile jar:jar install
+ls maven-build
+hat-1.0.jar			hat-example-heal-1.0.jar	libptx_backend.dylib
+hat-backend-cuda-1.0.jar	hat-example-mandel-1.0.jar	libspirv_backend.dylib
+hat-backend-mock-1.0.jar	hat-example-squares-1.0.jar	mock_info
+hat-backend-opencl-1.0.jar	hat-example-view-1.0.jar	opencl_info
+hat-backend-ptx-1.0.jar		hat-example-violajones-1.0.jar	ptx_info
+hat-backend-spirv-1.0.jar	libmock_backend.dylib		spirv_info
+hat-example-experiments-1.0.jar	libopencl_backend.dylib
+```
+
+To run an example
+```
+${JAVA_HOME}/bin/java \
+   --enable-preview --enable-native-access=ALL-UNNAMED \
+   --class-path maven-build/hat-1.0.jar:maven-build/hat-example-mandel-1.0.jar:maven-build/hat-backend-opencl-1.0.jar \
+   --add-exports=java.base/jdk.internal=ALL-UNNAMED \
+   -Djava.library.path=maven-build\
+   mandel.MandelCompute
+```
+
+The `hatrun.bash` script simlifies this somewhat
+
+```
+bash hatrun.bash opencl mandel MandelCompute
+```
+
+### Intellij and Clion
+We can use JetBrains' `intelliJ` and `clion` but care must be taken as these tools
+do not play well together, specifically we cannot have `Clion` and `Intellij`
+project artifacts rooted under each other or in the same dir.
+
+The `intellij` subdir houses the various `*.iml` module files and the project `.idea` so
+just open that dir as an intellij project
+
+Thankfully `clion` uses cmake. So we can reuse the same `hat/backends/CMakeLists.txt` that
+maven uses to build the backends.
+
+### Initial Project Layout
+
+```
+${BABYLON_JDK}
+   └── hat
+        ├── maven-build (created by the build)
+        │
+        ├── intellij
+        │    ├── .idea
+        │    │    ├── compiler.xml
+        │    │    ├── misc.xml
+        │    │    ├── modules.xml
+        │    │    ├── uiDesigner.xml
+        │    │    ├── vcs.xml
+        │    │    └── workspace.xml
+        │    │
+        │    ├── hat.iml
+        │    ├── backend_(spirv|mock|cuda|ptx|opencl).iml
+        │    └── (mandel|violajones|experiments|heal|view).iml
+        │
+        ├── hat
+        │    ├── pom.xml
+        │    └── src
+        │         ├── src/main/java
+        │         └── src/main/resources
+        │
+        ├── backends
+        │    ├── pom.xml
+        │    ├── CMakeLists.txt
+        │    └── (opencl|cuda|ptx|mock|shared)
+        │          ├── pom.xml
+        │          ├── CMakeLists.txt
+        │          ├── cpp
+        │          ├── include
+        │          ├── src/main/java
+        │          └── src/main/resources
+        └── examples
+             ├── pom.xml
+             └── (mandel|violajones|squares|heal|view|experiments)
+                    ├── pom.xml
+                    ├── src/main/java
+                    └── src/main/resources
+```
+As you will note the `intellij` dir is somewhat self contained.  the various `*.iml`
+files refer to the source dirs using relative paths.

--- a/hat/backends/CMakeLists.txt
+++ b/hat/backends/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(backends)
 
+add_custom_target(copy_libs)
+
 if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
     set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/shared")
     message("SHARED_BACKEND=${SHARED_BACKEND}")

--- a/hat/backends/cuda/CMakeLists.txt
+++ b/hat/backends/cuda/CMakeLists.txt
@@ -48,4 +48,10 @@ if(CUDAToolkit_FOUND)
     )
     add_custom_target(cuda_natives DEPENDS cuda_info cuda_backend)
 
+    add_custom_target(copy_cuda_libs DEPENDS cuda_info cuda_backend
+        COMMAND echo cp ${CMAKE_BINARY_DIR}/cuda/libcuda_backend.* ${CMAKE_SOURCE_DIR}/../maven-build
+        COMMAND cp ${CMAKE_BINARY_DIR}/cuda/cuda_info ${CMAKE_SOURCE_DIR}/../maven-build
+   )
+add_dependencies(copy_libs copy_cuda_libs)
+
 endif()

--- a/hat/backends/cuda/pom.xml
+++ b/hat/backends/cuda/pom.xml
@@ -46,4 +46,27 @@ questions.
         <maven.compiler.target>23</maven.compiler.target>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-cuda-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/hat/backends/mock/CMakeLists.txt
+++ b/hat/backends/mock/CMakeLists.txt
@@ -39,6 +39,12 @@ target_link_libraries(mock_info
     mock_backend
 )
 add_custom_target(mock_natives DEPENDS mock_info mock_backend)
+add_custom_target(copy_mock_libs DEPENDS mock_info mock_backend
+    COMMAND cp ${CMAKE_BINARY_DIR}/mock/libmock_backend.* ${CMAKE_SOURCE_DIR}/../maven-build
+    COMMAND cp ${CMAKE_BINARY_DIR}/mock/mock_info ${CMAKE_SOURCE_DIR}/../maven-build
+)
+add_dependencies(copy_libs copy_mock_libs)
+
 
 
 

--- a/hat/backends/mock/pom.xml
+++ b/hat/backends/mock/pom.xml
@@ -46,4 +46,27 @@ questions.
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-mock-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/hat/backends/opencl/CMakeLists.txt
+++ b/hat/backends/opencl/CMakeLists.txt
@@ -49,4 +49,9 @@ if(OPENCL_FOUND)
         ${OPENCL_LIB}
     )
     add_custom_target(opencl_natives DEPENDS opencl_info opencl_backend)
+    add_custom_target(copy_opencl_libs DEPENDS opencl_info opencl_backend
+       COMMAND cp ${CMAKE_BINARY_DIR}/opencl/libopencl_backend.* ${CMAKE_SOURCE_DIR}/../maven-build
+       COMMAND cp ${CMAKE_BINARY_DIR}/opencl/opencl_info ${CMAKE_SOURCE_DIR}/../maven-build
+    )
+    add_dependencies(copy_libs copy_opencl_libs)
 endif()

--- a/hat/backends/opencl/pom.xml
+++ b/hat/backends/opencl/pom.xml
@@ -46,4 +46,31 @@ questions.
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-opencl-1.0.jar" todir="../../maven-build"/>
+
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
 </project>

--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -34,10 +34,83 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
    <packaging>pom</packaging>
    <modules>
      <module>opencl</module>
-     <module>cuda</module> 
+     <module>cuda</module>
      <module>mock</module>
      <module>ptx</module>
-     <!--<module>shared</module>-->
-     <!--<module>spirv</module> -->
+     <!--<module>spirv</module>-->
    </modules>
+   <build>
+     <plugins>
+        <plugin>
+           <groupId>org.codehaus.mojo</groupId>
+           <artifactId>exec-maven-plugin</artifactId>
+           <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>cmake_config</id>
+                <phase>install</phase>
+                <goals>
+                   <goal>exec</goal>
+                </goals>
+                <configuration>
+                   <executable>cmake</executable>
+                   <arguments>
+                      <argument>-B</argument>
+                      <argument>cmake-build-debug</argument>
+                   </arguments>
+                </configuration>
+             </execution>
+              <execution>
+                <id>cmake_build</id>
+                <phase>install</phase>
+                <goals>
+                   <goal>exec</goal>
+                </goals>
+                <configuration>
+                   <executable>cmake</executable>
+                   <arguments>
+                      <argument>--build</argument>
+                      <argument>cmake-build-debug</argument>
+                   </arguments>
+                </configuration>
+             </execution>
+              <execution>
+                <id>cmake_copy_libs</id>
+                <phase>install</phase>
+                <goals>
+                   <goal>exec</goal>
+                </goals>
+                <configuration>
+                   <executable>cmake</executable>
+                   <arguments>
+                      <argument>--build</argument>
+                      <argument>cmake-build-debug</argument>
+                      <argument>--target</argument>
+                      <argument>copy_libs</argument>
+                   </arguments>
+                </configuration>
+             </execution>
+
+              <execution>
+                <id>cmake_clean</id>
+                <phase>clean</phase>
+                <goals>
+                   <goal>exec</goal>
+                </goals>
+                <configuration>
+                   <executable>cmake</executable>
+                   <arguments>
+                      <argument>--build</argument>
+                      <argument>cmake-build-debug</argument>
+                      <argument>--target</argument>
+                      <argument>clean</argument>
+                   </arguments>
+                </configuration>
+             </execution>
+
+           </executions>
+        </plugin>
+     </plugins>
+   </build>
+
 </project>

--- a/hat/backends/ptx/CMakeLists.txt
+++ b/hat/backends/ptx/CMakeLists.txt
@@ -40,3 +40,9 @@ target_link_libraries(ptx_info
 )
 add_custom_target(ptx_natives DEPENDS ptx_info ptx_backend)
 
+add_custom_target(copy_ptx_libs DEPENDS ptx_info ptx_backend
+    COMMAND cp ${CMAKE_BINARY_DIR}/ptx/libptx_backend.* ${CMAKE_SOURCE_DIR}/../maven-build
+    COMMAND cp ${CMAKE_BINARY_DIR}/ptx/ptx_info ${CMAKE_SOURCE_DIR}/../maven-build
+)
+add_dependencies(copy_libs copy_ptx_libs)
+

--- a/hat/backends/ptx/pom.xml
+++ b/hat/backends/ptx/pom.xml
@@ -45,5 +45,27 @@ questions.
             <artifactId>hat</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-ptx-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/hat/backends/spirv/CMakeLists.txt
+++ b/hat/backends/spirv/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22.1)
-project(opencl_backend)
+project(spirv_backend)
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -39,5 +39,11 @@ target_link_libraries(spirv_info
 )
 
 add_custom_target(spirv_natives DEPENDS spirv_info spirv_backend)
+
+add_custom_target(copy_spirv_libs DEPENDS spirv_info spirv_backend
+   COMMAND cp ${CMAKE_BINARY_DIR}/spirv/libspirv_backend.* ${CMAKE_SOURCE_DIR}/../maven-build
+   COMMAND cp ${CMAKE_BINARY_DIR}/spirv/spirv_info ${CMAKE_SOURCE_DIR}/../maven-build
+)
+add_dependencies(copy_libs copy_spirv_libs)
 
 

--- a/hat/backends/spirv/pom.xml
+++ b/hat/backends/spirv/pom.xml
@@ -28,7 +28,7 @@ questions.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>oracle.code</groupId>
-    <artifactId>hat-backend-mock</artifactId>
+    <artifactId>hat-backend-spirv</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
 
@@ -38,12 +38,58 @@ questions.
         <maven.compiler.target>23</maven.compiler.target>
     </properties>
 
-     <dependencies>
+    <dependencies>
         <dependency>
-           <groupId>oracle.code</groupId>
-         <version>1.0</version>
-         <artifactId>hat</artifactId>
-       </dependency>
-     </dependencies>
-    
+            <groupId>oracle.code</groupId>
+            <version>1.0</version>
+            <artifactId>hat</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-spirv-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source1</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>
+                                    /Users/grfrost/github/grfrost/babylon-grfrost-fork/cr-examples/spirv/src/main/java
+                                </source>
+                                <source>/Users/grfrost/github/beehive-spirv-toolkit/lib/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
 </project>

--- a/hat/cmake.bash
+++ b/hat/cmake.bash
@@ -1,2 +1,2 @@
-cmake -B build 
+cmake -B build
 cmake --build build --target $1

--- a/hat/env.bash
+++ b/hat/env.bash
@@ -3,7 +3,7 @@ if [[ "$OS" == Linux ]]; then
   export ostype=linux
 elif  [[ "$OS" == Darwin ]]; then
   export ostype=macosx
-else 
+else
   echo "could not determine ostype uname -s returned ${OS}"
   exit 1
 fi
@@ -13,14 +13,14 @@ if [[ "$ARCH" == x86_64 ]]; then
   export archtype=${ARCH}
 elif  [[ "$ARCH" == arm64 ]]; then
   export archtype=aarch64
-else 
+else
   echo "could not determine aarchtype uname -m returned ${ARCH}"
   exit 1
 fi
 
 export JAVA_HOME=${PWD}/../build/${ostype}-${archtype}-server-release/jdk
 echo "exporting JAVA_HOME=${JAVA_HOME}"
-if echo ${PATH} | grep ${JAVA_HOME} >/dev/null ;then 
+if echo ${PATH} | grep ${JAVA_HOME} >/dev/null ;then
    echo 'path already contains ${JAVA_HOME}/bin'
 else
    export SAFE_PATH=${PATH}

--- a/hat/examples/experiments/pom.xml
+++ b/hat/examples/experiments/pom.xml
@@ -46,4 +46,27 @@ questions.
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-experiments-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/hat/examples/heal/pom.xml
+++ b/hat/examples/heal/pom.xml
@@ -45,4 +45,27 @@ questions.
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-heal-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/hat/examples/mandel/pom.xml
+++ b/hat/examples/mandel/pom.xml
@@ -45,4 +45,27 @@ questions.
             <artifactId>hat</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-mandel-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/hat/examples/squares/pom.xml
+++ b/hat/examples/squares/pom.xml
@@ -45,5 +45,28 @@ questions.
             <artifactId>hat</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-squares-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 
 </project>

--- a/hat/examples/view/pom.xml
+++ b/hat/examples/view/pom.xml
@@ -39,11 +39,34 @@ questions.
     </properties>
 
     <dependencies>
-       <dependency>
-          <groupId>oracle.code</groupId>
-          <version>1.0</version>
-          <artifactId>hat</artifactId>
-       </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <version>1.0</version>
+            <artifactId>hat</artifactId>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-view-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 
 </project>

--- a/hat/examples/violajones/pom.xml
+++ b/hat/examples/violajones/pom.xml
@@ -38,12 +38,35 @@ questions.
         <maven.compiler.target>23</maven.compiler.target>
     </properties>
 
-     <dependencies>
+    <dependencies>
         <dependency>
-           <groupId>oracle.code</groupId>
-         <version>1.0</version>
-         <artifactId>hat</artifactId>
-       </dependency>
-     </dependencies>
+            <groupId>oracle.code</groupId>
+            <version>1.0</version>
+            <artifactId>hat</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-violajones-1.0.jar" todir="../../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 
 </project>

--- a/hat/hat/pom.xml
+++ b/hat/hat/pom.xml
@@ -46,7 +46,6 @@ questions.
         </dependency>
     </dependencies>
     <build>
-    <!--<outputDirectory>../build/hat</outputDirectory>-->
     <pluginManagement>
         <plugins>
             <plugin>
@@ -78,16 +77,25 @@ questions.
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
-            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
-                <configuration>
-                    <outputDirectory>../build/hat</outputDirectory>
-                </configuration>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <copy file="target/${project.artifactId}-1.0.jar" todir="../maven-build"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
-            -->
-        </plugins> 
+       </plugins>
     </build>
+
 </project>

--- a/hat/hatrun.bash
+++ b/hat/hatrun.bash
@@ -2,21 +2,21 @@ function example(){
    backend=$1
    example=$2
    example_class=$3
-   if test "${backend}" =  "java"; then 
+   if test "${backend}" =  "java"; then
        backend_jar=backends/shared/src/main/resources
    else
-       backend_jar=backends/${backend}/target/hat-backend-${backend}-1.0.jar 
+       backend_jar=maven-build/hat-backend-${backend}-1.0.jar
    fi
    echo checking backend_jar = ${backend_jar}
-   if test -f ${backend_jar} -o -d ${backend_jar} ;then 
-      example_jar=examples/${example}/target/hat-example-${example}-1.0.jar
+   if test -f ${backend_jar} -o -d ${backend_jar} ;then
+      example_jar=maven-build/hat-example-${example}-1.0.jar
       echo checking example_jar = ${example_jar}
-      if test -f ${example_jar} ; then 
+      if test -f ${example_jar} ; then
          ${JAVA_HOME}/bin/java \
             --enable-preview --enable-native-access=ALL-UNNAMED \
             --class-path hat/target/hat-1.0.jar:${example_jar}:${backend_jar} \
             --add-exports=java.base/jdk.internal=ALL-UNNAMED \
-            -Djava.library.path=build/backends/${backend}\
+            -Djava.library.path=maven-build\
             -Dheadless=true \
             ${example}.${example_class}
       else
@@ -27,6 +27,6 @@ function example(){
    fi
 }
 
-example $* 
+example $*
 
 

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
    <version>1.0</version>
    <artifactId>parent</artifactId>
    <packaging>pom</packaging>
-         <dependencies>
+   <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
@@ -13,10 +13,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <scope>test</scope>
         </dependency>
    </dependencies>
-    <modules>
+
+   <modules>
      <module>hat</module>
      <module>backends</module>
      <module>examples</module>
    </modules>
-
 </project>

--- a/hat/run.bash
+++ b/hat/run.bash
@@ -1,36 +1,7 @@
-function example(){
-   backend=$1
-   example=$2
-   example_class=$3
-   if test "${backend}" =  "java"; then 
-       backend_jar=backends/shared/src/main/resources
-   else
-       backend_jar=backends/${backend}/target/hat-backend-${backend}-1.0.jar 
-   fi
-   echo checking backend_jar = ${backend_jar}
-   if test -f ${backend_jar} -o -d ${backend_jar} ;then 
-      example_jar=examples/${example}/target/hat-example-${example}-1.0.jar
-      echo checking example_jar = ${example_jar}
-      if test -f ${example_jar} ; then 
-         ${JAVA_HOME}/bin/java \
-            --enable-preview --enable-native-access=ALL-UNNAMED \
-            --class-path hat/target/hat-1.0.jar:${example_jar}:${backend_jar} \
-            --add-exports=java.base/jdk.internal=ALL-UNNAMED \
-            -Djava.library.path=build/backends/${backend}\
-            -Dheadless=true \
-            ${example}.${example_class}
-      else
-         echo no such example example_jar = ${example_jar}
-      fi
-   else
-      echo no such backend backend_jar = ${backend_jar}
-   fi
-}
-
-#example java violajones ViolaJonesCompute 
-#example opencl violajones ViolaJonesCompute 
-example java squares Squares
-#example opencl squares Squares
-example java mandel MandelCompute
-#example opencl mandel MandelCompute
+bash ./hatrun.bash java violajones ViolaJonesCompute
+bash ./hatrun.bash violajones ViolaJonesCompute
+bash ./hatrun.bash java squares Squares
+bash ./hatrun.bash opencl squares Squares
+bash ./hatrun.bash java mandel MandelCompute
+bash ./hatrun.bash opencl mandel MandelCompute
 

--- a/hat/whitespacecheck.bash
+++ b/hat/whitespacecheck.bash
@@ -1,0 +1,12 @@
+find . \
+   -name "*.iml" \
+   -o -name "*.bash" \
+   -o -name "*.xml" \
+   -o -name "*.java" \
+   -o -name "*.h" \
+   -o -name "*.md" \
+   -o -name "*.cpp" \
+   -o -name CMakeFiles.list \
+   | xargs grep "  *$" \
+   | cut -d: -f1 \
+   | sort -u

--- a/hat/whitespacecheck.bash
+++ b/hat/whitespacecheck.bash
@@ -1,3 +1,4 @@
+echo spaces at end of lines
 find . \
    -name "*.iml" \
    -o -name "*.bash" \
@@ -10,3 +11,18 @@ find . \
    | xargs grep "  *$" \
    | cut -d: -f1 \
    | sort -u
+
+echo tabs
+find . \
+   -name "*.iml" \
+   -o -name "*.bash" \
+   -o -name "*.xml" \
+   -o -name "*.java" \
+   -o -name "*.h" \
+   -o -name "*.md" \
+   -o -name "*.cpp" \
+   -o -name CMakeFiles.list \
+   | xargs grep "\t" \
+   | cut -d: -f1 \
+   | sort -u
+


### PR DESCRIPTION
Here we switch to using maven as the primary build.

So hopefully 
```
cd hat
. ./env.bash
mvn clean compile jar:jar install
```
Will work for all. 

Some supporting scripts added too.   
Specifically `hatrun.bash`

```
bash ./hatrun.bash opencl violajones ViolaJonesCompute
```

Some cmake top level artifacts remain in case something is missing..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/babylon.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/128.diff">https://git.openjdk.org/babylon/pull/128.diff</a>

</details>
