### PR TITLE
Allow FuncOpWrapper to wrap SSA lowered funcOps

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/DNA.java
+++ b/hat/examples/experiments/src/main/java/experiments/DNA.java
@@ -1,0 +1,73 @@
+
+package experiments;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.code.CopyContext;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.Value;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.type.JavaType;
+import java.lang.runtime.CodeReflection;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DNA {
+    static int myFunc(int i) {
+        return 0;
+    }
+
+    @CodeReflection
+    public static void addMul(int add, int mul) {
+        int len = myFunc(add);
+    }
+
+    public static class DNAOp extends Op { // externalized
+        private final TypeElement type;
+
+        DNAOp(String opName, TypeElement type, List<Value> operands) {
+            super(opName, operands);
+            this.type = type;
+        }
+
+        @Override
+        public Op transform(CopyContext copyContext, OpTransformer opTransformer) {
+            throw new IllegalStateException("in transform");
+            //  return null;
+        }
+
+
+        @Override
+        public TypeElement resultType() {
+            System.out.println("in result type");
+            return type;
+        }
+    }
+
+
+    static public void main(String[] args) throws Exception {
+        Method method = DNA.class.getDeclaredMethod("addMul", int.class, int.class);
+        var funcOp = method.getCodeModel().get();
+        var transformed = funcOp.transform((builder, op) -> {
+            CopyContext cc = builder.context();
+            if (op instanceof CoreOp.InvokeOp invokeOp) {
+               // List<Value> operands = new ArrayList<>();
+                //builder.op(new DNAOp("dna", JavaType.INT, operands));
+                List<Value> inputOperands = invokeOp.operands();
+                List<Value> outputOperands = cc.getValues(inputOperands);
+                Op.Result inputResult = invokeOp.result();
+                Op.Result outputResult = builder.op(new DNAOp("dna", JavaType.INT, outputOperands));
+                cc.mapValue(inputResult, outputResult);
+            } else {
+                builder.op(op);
+            }
+            return builder;
+        });
+
+
+        System.out.println(transformed.toText());
+
+    }
+}
+

--- a/hat/hat/pom.xml
+++ b/hat/hat/pom.xml
@@ -46,18 +46,18 @@ questions.
         </dependency>
     </dependencies>
     <build>
-    <pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
-                <configuration>
-                   <argLine> -enable-preview</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </pluginManagement>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.1.2</version>
+                    <configuration>
+                        <argLine>-enable-preview</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -95,7 +95,7 @@ questions.
                     </execution>
                 </executions>
             </plugin>
-       </plugins>
+        </plugins>
     </build>
 
 </project>

--- a/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuildContext.java
+++ b/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuildContext.java
@@ -44,8 +44,8 @@ public class C99HatBuildContext {
         @Override
         public CoreOp.VarOp resolve(Value value) {
             if (value instanceof Block.Parameter blockParameter) {
-                if (opWrapper.parameterToVarOpMap.containsKey(blockParameter)) {
-                    return opWrapper.parameterToVarOpMap.get(blockParameter);
+                if (opWrapper.parameterVarOpMap.containsKey(blockParameter)) {
+                    return opWrapper.parameterVarOpMap.get(blockParameter);
                 } else {
                     throw new IllegalStateException("what ?");
                 }

--- a/hat/hat/src/main/java/hat/ops/HatOp.java
+++ b/hat/hat/src/main/java/hat/ops/HatOp.java
@@ -1,0 +1,26 @@
+package hat.ops;
+
+import java.lang.reflect.code.CopyContext;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.Value;
+import java.util.List;
+
+public abstract class HatOp extends Op {
+    private final TypeElement type;
+
+    HatOp(String opName, TypeElement type, List<Value> operands) {
+        super(opName, operands);
+        this.type = type;
+    }
+
+    HatOp(HatOp that, CopyContext cc) {
+        super(that, cc);
+        this.type = that.type;
+    }
+
+    @Override
+    public TypeElement resultType() {
+        return type;
+    }
+}

--- a/hat/hat/src/main/java/hat/ops/HatPtrOp.java
+++ b/hat/hat/src/main/java/hat/ops/HatPtrOp.java
@@ -1,0 +1,24 @@
+package hat.ops;
+
+import java.lang.reflect.code.CopyContext;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.Value;
+import java.util.List;
+
+public class HatPtrOp extends HatOp {
+
+    public HatPtrOp(TypeElement typeElement, List<Value> operands) {
+        super("hat.ptr", typeElement, operands);
+    }
+
+    public HatPtrOp(HatOp that, CopyContext cc) {
+        super(that, cc);
+    }
+
+    @Override
+    public Op transform(CopyContext cc, OpTransformer ot) {
+        return new HatPtrOp(this, cc);
+    }
+}

--- a/hat/hat/src/main/java/hat/optools/OpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/OpWrapper.java
@@ -229,4 +229,8 @@ public class OpWrapper<T extends Op> {
         }
         return list.stream();
     }
+
+    public Op.Result result() {
+        return op.result();
+    }
 }

--- a/hat/intellij/hat.iml
+++ b/hat/intellij/hat.iml
@@ -2,7 +2,7 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$/../hat/src/main/java">
+    <content url="file://$MODULE_DIR$/../hat/">
       <sourceFolder url="file://$MODULE_DIR$/../hat/src/main/java" isTestSource="false" />
     </content>
     <content url="file://$MODULE_DIR$" />


### PR DESCRIPTION
Issue was reported wrapping (FuncOpWrapper) FuncOp after lowering to SSA form. 

Also introduced HatPtrOp which will allow us to track layout information while lowering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.org/babylon.git pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/130.diff">https://git.openjdk.org/babylon/pull/130.diff</a>

</details>
