### PR TITLE
Remove need for manual initial creation of backends/cmake-debug-build

### DIFF
--- a/hat/README.md
+++ b/hat/README.md
@@ -56,15 +56,8 @@ echo ${JAVA_HOME}
 echo ${PATH}
 Users/grfrost/github/babylon/hat/../build/macosx-aarch64-server-release/jdk/bin:/usr/local/bin:......
 ```
-
-Before a first build we need to create the `backends/cmake-build-debug` dir.
-```
-cd hat/backends
-mkdir cmake-build-debug
-cmake -B cmake-build-debug
-```
-
 Now we can just use maven to build, it will do its magic and place all jars and libs in `maven-build` dir
+
 ```
 cd hat
 . ./env.bash

--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -47,8 +47,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
            <version>3.1.0</version>
             <executions>
               <execution>
-                <id>cmake_config</id>
-                <phase>install</phase>
+                <id>cmake_compile</id>
+                <phase>compile</phase>
                 <goals>
                    <goal>exec</goal>
                 </goals>
@@ -61,7 +61,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 </configuration>
              </execution>
               <execution>
-                <id>cmake_build</id>
+                <id>cmake_install_build</id>
                 <phase>install</phase>
                 <goals>
                    <goal>exec</goal>
@@ -75,7 +75,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 </configuration>
              </execution>
               <execution>
-                <id>cmake_copy_libs</id>
+                <id>cmake_install_copy_libs</id>
                 <phase>install</phase>
                 <goals>
                    <goal>exec</goal>
@@ -91,19 +91,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 </configuration>
              </execution>
 
-              <execution>
+             <execution>
                 <id>cmake_clean</id>
                 <phase>clean</phase>
                 <goals>
                    <goal>exec</goal>
                 </goals>
                 <configuration>
-                   <executable>cmake</executable>
+                   <executable>rm </executable>
                    <arguments>
-                      <argument>--build</argument>
+                      <argument>-rf</argument>
                       <argument>cmake-build-debug</argument>
-                      <argument>--target</argument>
-                      <argument>clean</argument>
                    </arguments>
                 </configuration>
              </execution>


### PR DESCRIPTION
Found out how to get maven to create the baclends/cmake-debug-build dir. 

So now we don't need the extra step on initial build. 

Fixes up README.md accordingly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/babylon.git pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/131.diff">https://git.openjdk.org/babylon/pull/131.diff</a>

</details>
