### PR TITLE
SPIRV backend needs extra dependencies make it optional

### DIFF
--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -37,7 +37,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
      <module>cuda</module>
      <module>mock</module>
      <module>ptx</module>
-     <module>spirv</module>
+     <!--<module>spirv</module>-->
    </modules>
    <build>
      <plugins>


### PR DESCRIPTION
SPIRV requires Tornado spirv lib.  So we will make it optional.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/babylon.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/134.diff">https://git.openjdk.org/babylon/pull/134.diff</a>

</details>
