### PR TITLE
Allow static access to layouts of iface mapped segments

### DIFF
--- a/hat/examples/heal/src/main/java/heal/RGBList.java
+++ b/hat/examples/heal/src/main/java/heal/RGBList.java
@@ -66,11 +66,6 @@ class RGBList implements S32RGBTable{
         return length;
     }
 
-    @Override
-    public void length(int length) {
-        this.length = length;
-    }
-
     static public class RGB implements S32RGBTable.RGB{
         RGBList rgbList;
         int idx=-1;

--- a/hat/examples/heal/src/main/java/heal/S32RGBTable.java
+++ b/hat/examples/heal/src/main/java/heal/S32RGBTable.java
@@ -25,6 +25,7 @@
 package heal;
 
 import hat.Accelerator;
+import hat.buffer.Buffer;
 import hat.buffer.Table;
 import hat.ifacemapper.SegmentMapper;
 
@@ -52,14 +53,13 @@ public interface S32RGBTable extends Table<S32RGBTable.RGB> {
 
         void b(int b);
     }
+    StructLayout layout = MemoryLayout.structLayout(  JAVA_INT.withName("length"),
+
+            MemoryLayout.sequenceLayout(0, S32RGBTable.RGB.layout).withName("rgb")).withName(S32XYTable.class.getSimpleName());
 
     static S32RGBTable create(Accelerator accelerator, int length) {
-        S32RGBTable table = SegmentMapper.of(accelerator.lookup, S32RGBTable.class,
-                JAVA_INT.withName("length"),
-
-                MemoryLayout.sequenceLayout(length, S32RGBTable.RGB.layout).withName("rgb")
-        ).allocate(accelerator.backend.arena());
-        table.length(length);
+        S32RGBTable table = SegmentMapper.ofIncomplete(accelerator.lookup, S32RGBTable.class,layout,length).allocate(accelerator.backend.arena());
+        Buffer.setLength(table,length);
         return table;
     }
 

--- a/hat/examples/heal/src/main/java/heal/S32XYTable.java
+++ b/hat/examples/heal/src/main/java/heal/S32XYTable.java
@@ -25,6 +25,7 @@
 package heal;
 
 import hat.Accelerator;
+import hat.buffer.Buffer;
 import hat.buffer.Table;
 import hat.ifacemapper.SegmentMapper;
 
@@ -48,13 +49,14 @@ public interface S32XYTable extends Table<S32XYTable.XY> {
         void x(int x);
         void idx(int idx);
     }
+    StructLayout layout = MemoryLayout.structLayout(
+            JAVA_INT.withName("length"),
+            MemoryLayout.sequenceLayout(0, S32XYTable.XY.layout).withName("xy")
+    ).withName("XY");
 
     static S32XYTable create(Accelerator accelerator, int length) {
-        S32XYTable table = SegmentMapper.of(accelerator.lookup, S32XYTable.class,
-                JAVA_INT.withName("length"),
-                MemoryLayout.sequenceLayout(length, S32XYTable.XY.layout).withName("xy")
-        ).allocate(accelerator.backend.arena());
-        table.length(length);
+        S32XYTable table = SegmentMapper.ofIncomplete(accelerator.lookup, S32XYTable.class,layout, length).allocate(accelerator.backend.arena());
+        Buffer.setLength(table, length);
         return table;
     }
 

--- a/hat/examples/heal/src/main/java/heal/XYList.java
+++ b/hat/examples/heal/src/main/java/heal/XYList.java
@@ -64,11 +64,6 @@ class XYList implements S32XYTable {
         return length;
     }
 
-    @Override
-    public void length(int length) {
-        this.length=length;
-    }
-
     public static class XY implements S32XYTable.XY{
         XYList xyList;
         private int idx=-1;

--- a/hat/examples/mandel/src/main/java/mandel/MandelViewer.java
+++ b/hat/examples/mandel/src/main/java/mandel/MandelViewer.java
@@ -25,6 +25,7 @@
 package mandel;
 
 
+import hat.buffer.Buffer;
 import hat.buffer.S32Array2D;
 
 import javax.swing.JComponent;
@@ -112,8 +113,8 @@ public class MandelViewer extends JFrame {
         }
 
         public void syncWithRGB(S32Array2D s32Array2D) {
-            long offset = s32Array2D.layout().byteOffset(MemoryLayout.PathElement.groupElement("array"));
-            MemorySegment.copy(s32Array2D.memorySegment(), JAVA_INT, offset, ((DataBufferInt) image.getRaster().getDataBuffer()).getData(), 0, s32Array2D.size());
+            long offset = Buffer.getLayout(s32Array2D).byteOffset(MemoryLayout.PathElement.groupElement("array"));
+            MemorySegment.copy(Buffer.getMemorySegment(s32Array2D), JAVA_INT, offset, ((DataBufferInt) image.getRaster().getDataBuffer()).getData(), 0, s32Array2D.size());
             this.repaint();
         }
 

--- a/hat/examples/mandel/src/main/java/mandel/buffers/RgbaS32Image.java
+++ b/hat/examples/mandel/src/main/java/mandel/buffers/RgbaS32Image.java
@@ -28,12 +28,14 @@ import hat.Accelerator;
 import hat.buffer.ImageBuffer;
 
 import java.awt.image.BufferedImage;
+import java.lang.foreign.StructLayout;
 
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 public interface RgbaS32Image extends ImageBuffer {
+    StructLayout layout =  ImageBuffer.createLayout(RgbaS32Image.class,JAVA_SHORT);
     private static RgbaS32Image create(Accelerator accelerator, int width, int height) {
-        return ImageBuffer.create(accelerator, RgbaS32Image.class, width, height, BufferedImage.TYPE_INT_ARGB, 1, JAVA_SHORT);
+        return ImageBuffer.create(accelerator, RgbaS32Image.class, layout,width, height, BufferedImage.TYPE_INT_ARGB, 1);
     }
 
     static RgbaS32Image create(Accelerator accelerator, BufferedImage bufferedImage) {

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
@@ -28,6 +28,8 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
 import hat.backend.Backend;
+import hat.backend.JavaMultiThreadedBackend;
+import hat.backend.JavaSequentialBackend;
 import hat.buffer.F32Array2D;
 import org.xml.sax.SAXException;
 import violajones.attic.ViolaJones;
@@ -55,7 +57,10 @@ public class ViolaJonesCompute {
         ));
         XMLHaarCascadeModel haarCascade = XMLHaarCascadeModel.load(
                 ViolaJonesRaw.class.getResourceAsStream("/cascades/haarcascade_frontalface_default.xml"));
-        Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(),
+              //  new JavaSequentialBackend()
+                Backend.FIRST
+        );
         Cascade cascade = Cascade.create(accelerator, haarCascade);
         RgbS08x3Image rgbImage = RgbS08x3Image.create(accelerator, nasa1996);
         ResultTable resultTable = ResultTable.create(accelerator, 1000);

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
@@ -204,7 +204,7 @@ public class ViolaJonesCoreCompute {
             // Todo: Find a way to iterate which is interface mapped segment friendly.
             Cascade.Tree tree = cascade.tree(treeIdx);
             Cascade.Feature feature = cascade.feature(tree.firstFeatureId());
-
+           // long featureOffset = feature.offset();
             while (feature != null) {
                 float featureGradientSum = .0f;
                 // features have 1, 2 or 3 rects to scan  we might be best to unroll
@@ -255,9 +255,14 @@ public class ViolaJonesCoreCompute {
             // covered by the scale.
             int scalc = 0;
             ScaleTable.Scale scale = scaleTable.scale(scalc);
+          //  var offset=scale.offset();
+           // System.out.println("scale offset "+offset);
             scalc++;
             while (kc.x >= scale.accumGridSizeMax() && scalc<scaleTable.length()) {
                 scale = scaleTable.scale(scalc);
+             //   var layout =scale.layout();
+              //  offset=scale.offset();
+              //  System.out.println("scale offset "+offset);
                 scalc++;
             }
 
@@ -288,6 +293,8 @@ public class ViolaJonesCoreCompute {
             int stageCount = cascade.stageCount();
             for (int stagec = 0; stagec < stageCount && stillLooksLikeAFace; stagec++) {
                 Cascade.Stage stage = cascade.stage(stagec);
+              //  Class stageClass = stage.getClass();
+               // long stageOffset = stage.offset();
                 stillLooksLikeAFace = isAFaceStage(kc.x, scale.scaleValue(), scale.invArea(), x, y, vnorm, integral, stage, cascade);
             }
 

--- a/hat/examples/violajones/src/main/java/violajones/buffers/GreyU16Image.java
+++ b/hat/examples/violajones/src/main/java/violajones/buffers/GreyU16Image.java
@@ -28,17 +28,19 @@ import hat.Accelerator;
 import hat.buffer.ImageBuffer;
 
 import java.awt.image.BufferedImage;
+import java.lang.foreign.StructLayout;
 
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 public interface GreyU16Image extends ImageBuffer {
+
+    StructLayout layout =  ImageBuffer.createLayout(GreyU16Image.class,JAVA_SHORT);
     private static GreyU16Image create(Accelerator accelerator, int width, int height) {
-        return ImageBuffer.create(accelerator, GreyU16Image.class, width, height, BufferedImage.TYPE_USHORT_GRAY, 1, JAVA_SHORT);
+        return ImageBuffer.create(accelerator, GreyU16Image.class, layout,width, height, BufferedImage.TYPE_USHORT_GRAY, 1);
     }
 
     static GreyU16Image create(Accelerator accelerator, BufferedImage bufferedImage) {
         return create(accelerator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
-
     }
 
     short data(long idx);

--- a/hat/examples/violajones/src/main/java/violajones/buffers/RgbS08x3Image.java
+++ b/hat/examples/violajones/src/main/java/violajones/buffers/RgbS08x3Image.java
@@ -28,13 +28,16 @@ import hat.Accelerator;
 import hat.buffer.ImageBuffer;
 
 import java.awt.image.BufferedImage;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 
 public interface RgbS08x3Image extends ImageBuffer {
+    StructLayout layout =  ImageBuffer.createLayout(RgbS08x3Image.class,JAVA_BYTE);
 
     private static RgbS08x3Image create(Accelerator accelerator, int width, int height) {
-        return ImageBuffer.create(accelerator, RgbS08x3Image.class, width, height, BufferedImage.TYPE_INT_RGB, 3, JAVA_BYTE);
+        return ImageBuffer.create(accelerator, RgbS08x3Image.class,layout, width, height, BufferedImage.TYPE_INT_RGB, 3);
     }
 
     static RgbS08x3Image create(Accelerator accelerator, BufferedImage bufferedImage) {

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -40,9 +40,9 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 public interface Cascade extends CompleteBuffer {
-    interface Feature {
+    interface Feature extends CompleteBuffer{
 
-        interface Rect {
+        interface Rect extends CompleteBuffer{
             StructLayout layout = MemoryLayout.structLayout(
                     JAVA_BYTE.withName("x"),
                     JAVA_BYTE.withName("y"),
@@ -73,7 +73,7 @@ public interface Cascade extends CompleteBuffer {
         }
 
 
-        interface LinkOrValue {
+        interface LinkOrValue extends CompleteBuffer {
             interface Anon {
                 MemoryLayout layout = MemoryLayout.unionLayout(
                         JAVA_INT.withName("featureId"),
@@ -108,7 +108,7 @@ public interface Cascade extends CompleteBuffer {
                 Feature.LinkOrValue.layout.withName("left"),
                 Feature.LinkOrValue.layout.withName("right"),
                 MemoryLayout.sequenceLayout(3, Feature.Rect.layout).withName("rect")
-        );
+        ).withName(Feature.class.getSimpleName());
 
         int id();
 
@@ -128,13 +128,13 @@ public interface Cascade extends CompleteBuffer {
         Feature.Rect rect(long idx);
     }
 
-    interface Stage {
+    interface Stage extends CompleteBuffer{
         StructLayout layout = MemoryLayout.structLayout(
                 JAVA_INT.withName("id"),
                 JAVA_FLOAT.withName("threshold"),
                 JAVA_SHORT.withName("firstTreeId"),
                 JAVA_SHORT.withName("treeCount")
-        ).withName("Stage");
+        ).withName(Stage.class.getSimpleName());
 
         float threshold();
 
@@ -153,12 +153,12 @@ public interface Cascade extends CompleteBuffer {
         void treeCount(short treeCount);
     }
 
-    interface Tree {
+    interface Tree extends CompleteBuffer{
         StructLayout layout = MemoryLayout.structLayout(
                 JAVA_INT.withName("id"),
                 JAVA_SHORT.withName("firstFeatureId"),
                 JAVA_SHORT.withName("featureCount")
-        ).withName("Tree");
+        ).withName(Tree.class.getSimpleName());
 
         void id(int id);
 

--- a/hat/hat/src/main/java/hat/backend/NativeBackendDriver.java
+++ b/hat/hat/src/main/java/hat/backend/NativeBackendDriver.java
@@ -27,6 +27,7 @@ package hat.backend;
 
 import hat.buffer.ArgArray;
 import hat.buffer.BackendConfig;
+import hat.buffer.Buffer;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -91,7 +92,7 @@ public abstract class NativeBackendDriver implements Backend {
                 String schema = backendConfig.schema();
                 var arena = Arena.global();
                 var cstr = arena.allocateFrom(schema);
-                backendHandle = (long) getBackend_MH.invoke(backendConfig.memorySegment(), schema.length(), cstr);
+                backendHandle = (long) getBackend_MH.invoke(Buffer.getMemorySegment(backendConfig), schema.length(), cstr);
             }
         } catch (Throwable throwable) {
             throw new IllegalStateException(throwable);
@@ -123,7 +124,7 @@ public abstract class NativeBackendDriver implements Backend {
 
     public void dumpArgArray(ArgArray argArray) {
         try {
-            dumpArgArray_MH.invoke(argArray.memorySegment());
+            dumpArgArray_MH.invoke(Buffer.getMemorySegment(argArray));
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
@@ -145,7 +146,7 @@ public abstract class NativeBackendDriver implements Backend {
 
     public void ndRange(long kernelHandle,  ArgArray argArray) {
         try {
-            this.ndrange_MH.invoke(kernelHandle, argArray.memorySegment());
+            this.ndrange_MH.invoke(kernelHandle, Buffer.getMemorySegment(argArray));
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }

--- a/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatKernelBuilder.java
+++ b/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatKernelBuilder.java
@@ -33,6 +33,7 @@ import hat.optools.FuncOpWrapper;
 import hat.optools.StructuralOpWrapper;
 import hat.util.StreamCounter;
 
+import java.lang.foreign.GroupLayout;
 import java.lang.reflect.code.type.ClassType;
 import java.lang.reflect.code.type.JavaType;
 import java.util.function.Consumer;
@@ -130,7 +131,7 @@ public abstract class C99HatKernelBuilder<T extends C99HatKernelBuilder<T>> exte
             for (int arg = 1; arg < args.length; arg++) {
                 if (args[arg] instanceof Buffer buffer) {
                     FuncOpWrapper.ParamTable.Info info = list.get(arg);
-                    info.setLayout(buffer.layout());
+                    info.setLayout((GroupLayout) Buffer.getLayout(buffer));
                     info.setClass(args[arg].getClass());
                 }
             }

--- a/hat/hat/src/main/java/hat/backend/c99codebuilders/Typedef.java
+++ b/hat/hat/src/main/java/hat/backend/c99codebuilders/Typedef.java
@@ -180,7 +180,7 @@ public class Typedef {
     }
 
     Typedef(Buffer instance) {
-        this(instance.getClass().getInterfaces()[0], instance.layout());
+        this(instance.getClass().getInterfaces()[0], Buffer.getLayout(instance));
     }
 
     public boolean isIncomplete() {

--- a/hat/hat/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/hat/src/main/java/hat/buffer/ArgArray.java
@@ -55,7 +55,7 @@ public interface ArgArray extends IncompleteBuffer {
                         JAVA_BYTE.withName("access"), //0=??/1=RO/2=WO/3=RW
                         JAVA_BYTE.withName("state"), //0=UNKNOWN/1=GPUDIRTY/2=JAVADIRTY
                         MemoryLayout.paddingLayout(16 - JAVA_BYTE.byteSize() - JAVA_BYTE.byteSize())
-                ).withName("buf");
+                ).withName(Buf.class.getSimpleName());
 
                 MemorySegment address();
 
@@ -91,7 +91,7 @@ public interface ArgArray extends IncompleteBuffer {
                     JAVA_LONG.withName("u64"),
                     JAVA_DOUBLE.withName("f64"),
                     Buf.layout.withName("buf")
-            ).withName("value");
+            ).withName(Value.class.getSimpleName());
 
             boolean z1();
 
@@ -141,7 +141,7 @@ public interface ArgArray extends IncompleteBuffer {
                 JAVA_BYTE.withName("variant"), //5
                 MemoryLayout.paddingLayout(16 - JAVA_INT.byteSize() - JAVA_BYTE.byteSize()),
                 Value.layout.withName("value")
-        );
+        ).withName(Arg.class.getSimpleName());
 
         int idx();
 
@@ -327,7 +327,7 @@ public interface ArgArray extends IncompleteBuffer {
                 case Long s64 -> arg.s64(s64);
                 case Double f64 -> arg.f64(f64);
                 case Buffer buffer -> {
-                    MemorySegment segment = buffer.memorySegment();
+                    MemorySegment segment = Buffer.getMemorySegment(buffer);
                     arg.variant((byte) '&');
                     Arg.Value value = arg.value();
                     Arg.Value.Buf buf = value.buf();
@@ -390,7 +390,7 @@ public interface ArgArray extends IncompleteBuffer {
                 case Long s64 -> arg.s64(s64);
                 case Double f64 -> arg.f64(f64);
                 case Buffer buffer -> {
-                    MemorySegment segment = buffer.memorySegment();
+                    MemorySegment segment = Buffer.getMemorySegment(buffer);
                     arg.variant((byte) '&');
                     Arg.Value value = arg.value();
                     Arg.Value.Buf buf = value.buf();

--- a/hat/hat/src/main/java/hat/buffer/Array1D.java
+++ b/hat/hat/src/main/java/hat/buffer/Array1D.java
@@ -34,18 +34,17 @@ import java.lang.foreign.StructLayout;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface Array1D extends Array {
-    static <T extends Array1D> StructLayout layout(Class<T> clazz, MemoryLayout memoryLayout, int length) {
+    static <T extends Array1D> StructLayout getLayout(Class<T> clazz, MemoryLayout memoryLayout) {
         return MemoryLayout.structLayout(
                 JAVA_INT.withName("length"),
-                MemoryLayout.sequenceLayout(length, memoryLayout).withName("array")
+                MemoryLayout.sequenceLayout(0, memoryLayout).withName("array")
         ).withName(clazz.getSimpleName());
     }
 
-    static <T extends Array1D> T create(Accelerator accelerator, Class<T> clazz, int length, MemoryLayout memoryLayout) {
-        StructLayout structLayout = Array1D.layout(clazz, memoryLayout, length);
-        T buffer = SegmentMapper.of(accelerator.lookup, clazz, structLayout).allocate(accelerator.backend.arena());
-        MemorySegment segment = buffer.memorySegment();
-        segment.set(JAVA_INT, structLayout.byteOffset(MemoryLayout.PathElement.groupElement("length")), length);
+    static <T extends Array1D> T create(Accelerator accelerator, Class<T> clazz, StructLayout structLayout, int length) {
+
+        T buffer = SegmentMapper.ofIncomplete(accelerator.lookup, clazz, structLayout,length).allocate(accelerator.backend.arena());
+        Buffer.setLength(buffer,length);
         return buffer;
     }
 

--- a/hat/hat/src/main/java/hat/buffer/Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/Array2D.java
@@ -34,19 +34,19 @@ import java.lang.foreign.StructLayout;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface Array2D extends Array {
-    static <T extends Array2D> StructLayout layout(Class<T> clazz, MemoryLayout memoryLayout, int length) {
+    static <T extends Array2D> StructLayout getLayout(Class<T> iface, MemoryLayout memoryLayout) {
         return MemoryLayout.structLayout(
                 JAVA_INT.withName("width"),
                 JAVA_INT.withName("height"),
-                MemoryLayout.sequenceLayout(length, memoryLayout).withName("array")
-        ).withName(clazz.getSimpleName());
+                MemoryLayout.sequenceLayout(0, memoryLayout).withName("array")
+        ).withName(iface.getSimpleName());
     }
 
-    static <T extends Array2D> T create(Accelerator accelerator, Class<T> clazz, int width, int height, MemoryLayout memoryLayout) {
-        StructLayout structLayout = Array2D.layout(clazz, memoryLayout, width * height);
-        T buffer = SegmentMapper.of(accelerator.lookup, clazz, Array2D.layout(clazz, memoryLayout, width * height))
+    static <T extends Array2D> T create(Accelerator accelerator, Class<T> clazz, StructLayout structLayout,int width, int height) {
+
+        T buffer = SegmentMapper.ofIncomplete(accelerator.lookup, clazz, structLayout, (long) width * height)
                 .allocate(accelerator.backend.arena());
-        MemorySegment segment = buffer.memorySegment();
+        MemorySegment segment = Buffer.getMemorySegment(buffer);
         segment.set(JAVA_INT, structLayout.byteOffset(MemoryLayout.PathElement.groupElement("width")), width);
         segment.set(JAVA_INT, structLayout.byteOffset(MemoryLayout.PathElement.groupElement("height")), height);
         return buffer;

--- a/hat/hat/src/main/java/hat/buffer/Buffer.java
+++ b/hat/hat/src/main/java/hat/buffer/Buffer.java
@@ -36,20 +36,39 @@ import java.lang.foreign.UnionLayout;
 import java.lang.foreign.ValueLayout;
 import java.lang.reflect.InvocationTargetException;
 
+import static hat.ifacemapper.MapperUtil.SECRET_LAYOUT_METHOD_NAME;
+import static hat.ifacemapper.MapperUtil.SECRET_OFFSET_METHOD_NAME;
+import static hat.ifacemapper.MapperUtil.SECRET_SEGMENT_METHOD_NAME;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
 public interface Buffer {
-    default MemorySegment memorySegment() {
+    static <T extends Buffer>MemorySegment getMemorySegment(T buffer){
         try {
-            return (MemorySegment) getClass().getDeclaredMethod("$_$_$sEgMeNt$_$_$").invoke(this);
+            return (MemorySegment) buffer.getClass().getDeclaredMethod(SECRET_SEGMENT_METHOD_NAME).invoke(buffer);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }
 
-    default GroupLayout layout() {
+   static <T extends Buffer>MemoryLayout getLayout(T buffer){
+       try {
+           return (MemoryLayout) buffer.getClass().getDeclaredMethod(SECRET_LAYOUT_METHOD_NAME).invoke(buffer);
+       } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+           throw new RuntimeException(e);
+       }
+   }
+
+    static <T extends Buffer>long getOffset(T buffer){
         try {
-            return (GroupLayout) getClass().getDeclaredMethod("$_$_$lAyOuT$_$_$").invoke(this);
+            return (long) buffer.getClass().getDeclaredMethod(SECRET_OFFSET_METHOD_NAME).invoke(buffer);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }
+
+    static <T extends Buffer> T setLength(T buffer, int length){
+        Buffer.getMemorySegment(buffer).set(JAVA_INT, Buffer.getLayout(buffer).byteOffset(MemoryLayout.PathElement.groupElement("length")), length);
+        return buffer;
+    }
+
 }

--- a/hat/hat/src/main/java/hat/buffer/CompleteBuffer.java
+++ b/hat/hat/src/main/java/hat/buffer/CompleteBuffer.java
@@ -6,9 +6,9 @@ import java.lang.foreign.MemorySegment;
 public interface CompleteBuffer extends Buffer {
     default String schema() {
         return new SchemaBuilder()
-                .literal(memorySegment().byteSize())
+                .literal(Buffer.getMemorySegment(this).byteSize())
                 .hash()
-                .layout(layout(),null, false)
+                .layout(Buffer.getLayout(this),null, false)
                 .toString();
     }
 }

--- a/hat/hat/src/main/java/hat/buffer/F32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array.java
@@ -27,12 +27,14 @@ package hat.buffer;
 import hat.Accelerator;
 
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 
 public interface F32Array extends Array1D {
+    StructLayout layout  = Array1D.getLayout(F32Array.class, JAVA_FLOAT);
     static F32Array create(Accelerator accelerator, int length) {
-        return Array1D.create(accelerator, F32Array.class, length, JAVA_FLOAT);
+        return Array1D.create(accelerator, F32Array.class,layout, length);
     }
 
     static F32Array create(Accelerator accelerator, float[] source) {
@@ -44,12 +46,12 @@ public interface F32Array extends Array1D {
     void array(long idx, float f);
 
     default F32Array copyFrom(float[] floats) {
-        MemorySegment.copy(floats, 0, memorySegment(), JAVA_FLOAT, 4, length());
+        MemorySegment.copy(floats, 0, Buffer.getMemorySegment(this), JAVA_FLOAT, 4, length());
         return this;
     }
 
     default F32Array copyTo(float[] floats) {
-        MemorySegment.copy(memorySegment(), JAVA_FLOAT, 4, floats, 0, length());
+        MemorySegment.copy(Buffer.getMemorySegment(this), JAVA_FLOAT, 4, floats, 0, length());
         return this;
     }
 

--- a/hat/hat/src/main/java/hat/buffer/F32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array2D.java
@@ -26,13 +26,16 @@ package hat.buffer;
 
 import hat.Accelerator;
 
+import java.lang.foreign.StructLayout;
+
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface F32Array2D extends Array2D {
+    StructLayout layout  = Array2D.getLayout(F32Array2D.class, JAVA_FLOAT);
     static F32Array2D create(Accelerator accelerator, int width, int height) {
-        return Array2D.create(accelerator, F32Array2D.class, width, height, JAVA_FLOAT);
+        return Array2D.create(accelerator, F32Array2D.class, layout, width, height);
     }
-
     float array(long idx);
 
     void array(long idx, float v);

--- a/hat/hat/src/main/java/hat/buffer/IncompleteBuffer.java
+++ b/hat/hat/src/main/java/hat/buffer/IncompleteBuffer.java
@@ -6,7 +6,7 @@ import java.lang.foreign.StructLayout;
 
 public interface IncompleteBuffer extends Buffer {
     default String schema() {
-        MemoryLayout memoryLayout = layout();
+        MemoryLayout memoryLayout = Buffer.getLayout(this);
         if (memoryLayout instanceof StructLayout structLayout) {
             var memberLayouts = structLayout.memberLayouts();
             if (memberLayouts.getLast() instanceof SequenceLayout tailSequenceLayout) {
@@ -14,7 +14,7 @@ public interface IncompleteBuffer extends Buffer {
                         .literal(memoryLayout.byteOffset(
                                 MemoryLayout.PathElement.groupElement(memberLayouts.size() - 1)))
                         .plus()
-                        .layout(layout(),tailSequenceLayout,true)
+                        .layout(Buffer.getLayout(this),tailSequenceLayout,true)
                         .toString();
             } else {
                 throw new IllegalStateException("IncompleteBuffer last layout is not SequenceLayout!");

--- a/hat/hat/src/main/java/hat/buffer/KernelContext.java
+++ b/hat/hat/src/main/java/hat/buffer/KernelContext.java
@@ -3,26 +3,26 @@ package hat.buffer;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
 import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface KernelContext extends CompleteBuffer {
+    StructLayout layout = MemoryLayout.structLayout(
+            JAVA_INT.withName("x"),
+            JAVA_INT.withName("maxX")
+    ).withName(KernelContext.class.getSimpleName());
+
     static KernelContext create(Arena arena, MethodHandles.Lookup lookup, int x, int maxX) {
-        KernelContext kernelContext = SegmentMapper.of(lookup, KernelContext.class,
-                JAVA_INT.withName("x"),
-                JAVA_INT.withName("maxX")
-        ).allocate(arena);
+        KernelContext kernelContext = SegmentMapper.of(lookup, KernelContext.class,layout).allocate(arena);
         kernelContext.x(x);
-        kernelContext.maxX(x);
+        kernelContext.maxX(maxX);
         return kernelContext;
     }
-
     int x();
-
     void x(int x);
-
     int maxX();
-
     void maxX(int maxX);
 }

--- a/hat/hat/src/main/java/hat/buffer/S32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array.java
@@ -27,12 +27,15 @@ package hat.buffer;
 import hat.Accelerator;
 
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
 
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface S32Array extends Array1D {
+    StructLayout layout  = Array1D.getLayout(S32Array.class, JAVA_INT);
     static S32Array create(Accelerator accelerator, int length) {
-        return Array1D.create(accelerator, S32Array.class, length, JAVA_INT);
+        return Array1D.create(accelerator, S32Array.class,layout, length);
     }
 
     static S32Array create(Accelerator accelerator, int[] source) {
@@ -44,12 +47,12 @@ public interface S32Array extends Array1D {
     void array(long idx, int f);
 
     default S32Array copyfrom(int[] floats) {
-        MemorySegment.copy(floats, 0, memorySegment(), JAVA_INT, 4, length());
+        MemorySegment.copy(floats, 0, Buffer.getMemorySegment(this), JAVA_INT, 4, length());
         return this;
     }
 
     default S32Array copyTo(int[] floats) {
-        MemorySegment.copy(memorySegment(), JAVA_INT, 4, floats, 0, length());
+        MemorySegment.copy(Buffer.getMemorySegment(this), JAVA_INT, 4, floats, 0, length());
         return this;
     }
 }

--- a/hat/hat/src/main/java/hat/buffer/S32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array2D.java
@@ -26,11 +26,14 @@ package hat.buffer;
 
 import hat.Accelerator;
 
+import java.lang.foreign.StructLayout;
+
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface S32Array2D extends Array2D {
+    StructLayout layout  = Array2D.getLayout(S32Array2D.class, JAVA_INT);
     static S32Array2D create(Accelerator accelerator, int width, int height) {
-        return Array2D.create(accelerator, S32Array2D.class, width, height, JAVA_INT);
+        return Array2D.create(accelerator, S32Array2D.class, layout, width, height);
     }
 
     int array(long idx);

--- a/hat/hat/src/main/java/hat/buffer/Table.java
+++ b/hat/hat/src/main/java/hat/buffer/Table.java
@@ -23,19 +23,6 @@
  * questions.
  */
 package hat.buffer;
-
-import java.util.function.Consumer;
-
 public interface Table<T> extends IncompleteBuffer {
-
-   // default void with(int i, Consumer<T> consumer) {
-     //   T t = get(i);
-       // consumer.accept(t);
-   // }
-
     int length();
-
-    void length(int length);
-
-   // T get(int i);
 }

--- a/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -53,7 +53,12 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
         Optional<Method> nonDeclaredMethod = Stream.of(declaringClass.getMethods())
                 .filter(method -> method.getName().equals(methodRef().name()))
                 .findFirst();
-        return nonDeclaredMethod.get();
+        if (nonDeclaredMethod.isPresent()){
+            return nonDeclaredMethod.get();
+        }else {
+            throw new IllegalStateException("what were we looking for ?"); // getClass causes this
+            //return nonDeclaredMethod.get();
+        }
     }
 
 

--- a/hat/intellij/.idea/vcs.xml
+++ b/hat/intellij/.idea/vcs.xml
@@ -3,5 +3,6 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../../../beehive-spirv-toolkit" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
Previously we needed an instance of an iface mapped segment in order to access it's layout. 

Moving towards a pattern that allows us to access this information from the iface interface class.  

We will need this to allow us to capture offsets when lowereing to SSA form.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/babylon.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/137.diff">https://git.openjdk.org/babylon/pull/137.diff</a>

</details>
