### PR TITLE
Decouple iface segment mapper allocation from Acclerator

### DIFF
--- a/hat/backends/mock/src/main/java/hat/backend/MockBackend.java
+++ b/hat/backends/mock/src/main/java/hat/backend/MockBackend.java
@@ -28,6 +28,7 @@ package hat.backend;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.buffer.BackendConfig;
+import hat.buffer.BufferAllocator;
 import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.SegmentMapper;
 
@@ -45,11 +46,11 @@ public class MockBackend extends NativeBackend {
         //         boolean gpu;
         //         boolean junk;
         //   };
-        static MockConfig create(Arena arena, MethodHandles.Lookup lookup, boolean gpu) {
-            MockConfig config = SegmentMapper.of(lookup, MockConfig.class,
+        static MockConfig create(BufferAllocator bufferAllocator, MethodHandles.Lookup lookup, boolean gpu) {
+            MockConfig config = bufferAllocator.allocate(SegmentMapper.of(lookup, MockConfig.class,
                     JAVA_BOOLEAN.withName("gpu"),
                     JAVA_BOOLEAN.withName("junk")
-            ).allocate(arena);
+            ));
             config.gpu(gpu);
             return config;
         }
@@ -65,7 +66,7 @@ public class MockBackend extends NativeBackend {
 
     public MockBackend() {
         super("mock_backend");
-        getBackend(MockConfig.create(arena(), MethodHandles.lookup(), true));
+        getBackend(MockConfig.create(this, MethodHandles.lookup(), true));
     }
 
     @Override

--- a/hat/backends/opencl/src/main/java/hat/backend/OpenCLBackend.java
+++ b/hat/backends/opencl/src/main/java/hat/backend/OpenCLBackend.java
@@ -28,6 +28,7 @@ package hat.backend;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.buffer.BackendConfig;
+import hat.buffer.BufferAllocator;
 import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.SegmentMapper;
 
@@ -45,11 +46,11 @@ public class OpenCLBackend extends C99NativeBackend {
         //         boolean gpu;
         //         boolean junk;
         //   };
-        static OpenCLConfig create(Arena arena, MethodHandles.Lookup lookup, boolean gpu) {
-            OpenCLConfig config = SegmentMapper.of(lookup, OpenCLConfig.class,
+        static OpenCLConfig create(BufferAllocator bufferAllocator, MethodHandles.Lookup lookup, boolean gpu) {
+            OpenCLConfig config = bufferAllocator.allocate(SegmentMapper.of(lookup, OpenCLConfig.class,
                     JAVA_BOOLEAN.withName("gpu"),
                     JAVA_BOOLEAN.withName("junk")
-            ).allocate(arena);
+            ));
             config.gpu(gpu);
             return config;
         }
@@ -65,7 +66,7 @@ public class OpenCLBackend extends C99NativeBackend {
 
     public OpenCLBackend() {
         super("opencl_backend");
-        getBackend(OpenCLConfig.create(arena(), MethodHandles.lookup(), true));
+        getBackend(OpenCLConfig.create(this, MethodHandles.lookup(), true));
         info();
     }
 

--- a/hat/examples/heal/src/main/java/heal/S32RGBTable.java
+++ b/hat/examples/heal/src/main/java/heal/S32RGBTable.java
@@ -26,11 +26,13 @@ package heal;
 
 import hat.Accelerator;
 import hat.buffer.Buffer;
+import hat.buffer.BufferAllocator;
 import hat.buffer.Table;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
@@ -57,8 +59,9 @@ public interface S32RGBTable extends Table<S32RGBTable.RGB> {
 
             MemoryLayout.sequenceLayout(0, S32RGBTable.RGB.layout).withName("rgb")).withName(S32XYTable.class.getSimpleName());
 
-    static S32RGBTable create(Accelerator accelerator, int length) {
-        S32RGBTable table = SegmentMapper.ofIncomplete(accelerator.lookup, S32RGBTable.class,layout,length).allocate(accelerator.backend.arena());
+    static S32RGBTable create(BufferAllocator bufferAllocator, int length) {
+        S32RGBTable table = bufferAllocator.allocate(
+                SegmentMapper.ofIncomplete(MethodHandles.lookup(), S32RGBTable.class,layout,length));
         Buffer.setLength(table,length);
         return table;
     }

--- a/hat/examples/heal/src/main/java/heal/S32XYTable.java
+++ b/hat/examples/heal/src/main/java/heal/S32XYTable.java
@@ -26,11 +26,13 @@ package heal;
 
 import hat.Accelerator;
 import hat.buffer.Buffer;
+import hat.buffer.BufferAllocator;
 import hat.buffer.Table;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -54,8 +56,8 @@ public interface S32XYTable extends Table<S32XYTable.XY> {
             MemoryLayout.sequenceLayout(0, S32XYTable.XY.layout).withName("xy")
     ).withName("XY");
 
-    static S32XYTable create(Accelerator accelerator, int length) {
-        S32XYTable table = SegmentMapper.ofIncomplete(accelerator.lookup, S32XYTable.class,layout, length).allocate(accelerator.backend.arena());
+    static S32XYTable create(BufferAllocator bufferAllocator, int length) {
+        S32XYTable table = bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(), S32XYTable.class,layout, length));
         Buffer.setLength(table, length);
         return table;
     }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -25,12 +25,14 @@
 package violajones.ifaces;
 
 import hat.Accelerator;
+import hat.buffer.BufferAllocator;
 import hat.buffer.CompleteBuffer;
 import hat.ifacemapper.SegmentMapper;
 import violajones.XMLHaarCascadeModel;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.MemoryLayout.sequenceLayout;
 import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
@@ -175,9 +177,9 @@ public interface Cascade extends CompleteBuffer {
         short featureCount();
     }
 
-    static Cascade create(Accelerator accelerator, XMLHaarCascadeModel haarCascade) {
+    static Cascade create(BufferAllocator bufferAllocator, XMLHaarCascadeModel haarCascade) {
 
-        Cascade cascade = SegmentMapper.of(accelerator.lookup, Cascade.class,
+        Cascade cascade = bufferAllocator.allocate(SegmentMapper.of(MethodHandles.lookup(), Cascade.class,
                 JAVA_INT.withName("width"),
                 JAVA_INT.withName("height"),
                 JAVA_INT.withName("featureCount"),
@@ -186,7 +188,7 @@ public interface Cascade extends CompleteBuffer {
                 sequenceLayout(haarCascade.stages.size(), Stage.layout.withName(Stage.class.getSimpleName())).withName("stage"),
                 JAVA_INT.withName("treeCount"),
                 sequenceLayout(haarCascade.trees.size(), Tree.layout.withName(Tree.class.getSimpleName())).withName("tree")
-        ).allocate(accelerator.backend.arena());
+        ));
         cascade.width(haarCascade.width());
         cascade.height(haarCascade.height());
         cascade.featureCount(haarCascade.features.size());

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
@@ -26,11 +26,13 @@ package violajones.ifaces;
 
 import hat.Accelerator;
 import hat.buffer.Buffer;
+import hat.buffer.BufferAllocator;
 import hat.buffer.Table;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -69,10 +71,9 @@ public interface ResultTable extends Table<ResultTable.Result> {
             MemoryLayout.sequenceLayout(0, ResultTable.Result.layout).withName("result")
     );
 
-    static ResultTable create(Accelerator accelerator, int length) {
+    static ResultTable create(BufferAllocator bufferAllocator, int length) {
         return Buffer.setLength(
-                SegmentMapper.ofIncomplete(accelerator.lookup,ResultTable.class,layout,length)
-                        .allocate(accelerator.backend.arena()),length);
+                bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(),ResultTable.class,layout,length)),length);
     }
 
     default Result get(int i) {

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
@@ -27,6 +27,7 @@ package violajones.ifaces;
 
 import hat.Accelerator;
 import hat.buffer.Buffer;
+import hat.buffer.BufferAllocator;
 import hat.buffer.Table;
 import hat.ifacemapper.SegmentMapper;
 
@@ -34,6 +35,7 @@ import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -119,10 +121,9 @@ public interface ScaleTable extends Table<ScaleTable.Scale> {
             JAVA_INT.withName("multiScaleAccumulativeRange"),
             MemoryLayout.sequenceLayout(0, ScaleTable.Scale.layout).withName("scale")
     ).withName(ScaleTable.class.getSimpleName());
-    private static ScaleTable create(Accelerator accelerator, int length) {
+    private static ScaleTable create(BufferAllocator bufferAllocator, int length) {
         return Buffer.setLength(
-                SegmentMapper.ofIncomplete(accelerator.lookup,ScaleTable.class,layout,length)
-                        .allocate(accelerator.backend.arena()),length);
+                bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(),ScaleTable.class,layout,length)),length);
     }
 
     static ScaleTable create(Accelerator accelerator, Cascade cascade, int imageWidth, int imageHeight) {

--- a/hat/hat/src/main/java/hat/Accelerator.java
+++ b/hat/hat/src/main/java/hat/Accelerator.java
@@ -26,6 +26,9 @@ package hat;
 
 
 import hat.backend.Backend;
+import hat.buffer.Buffer;
+import hat.buffer.BufferAllocator;
+import hat.ifacemapper.SegmentMapper;
 import hat.optools.LambdaOpWrapper;
 import hat.optools.OpWrapper;
 
@@ -64,10 +67,12 @@ import java.util.function.Predicate;
  *
  * @author Gary Frost
  */
-public class Accelerator {
+public class Accelerator implements BufferAllocator {
     public final MethodHandles.Lookup lookup;
     public final Backend backend;
     private final Map<Method, hat.ComputeContext> cache = new HashMap<>();
+
+
 
     public NDRange range(int max) {
         NDRange ndRange = new NDRange(this);
@@ -94,6 +99,13 @@ public class Accelerator {
      */
     public Accelerator(MethodHandles.Lookup lookup, Predicate<Backend> backendPredicate) {
         this(lookup, Backend.getBackend(backendPredicate));
+    }
+
+
+
+    @Override
+    public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper) {
+        return backend.allocate(segmentMapper);
     }
 
     /**

--- a/hat/hat/src/main/java/hat/backend/Backend.java
+++ b/hat/hat/src/main/java/hat/backend/Backend.java
@@ -27,14 +27,18 @@ package hat.backend;
 
 import hat.ComputeContext;
 import hat.NDRange;
+import hat.buffer.Buffer;
+import hat.buffer.BufferAllocator;
 import hat.callgraph.KernelCallGraph;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.util.ServiceLoader;
 import java.util.function.Predicate;
 
-public interface Backend {
-    Arena arena();
+public interface Backend extends BufferAllocator {
+
+   // Arena arena();
 
     default String getName() {
         return this.getClass().getName();

--- a/hat/hat/src/main/java/hat/backend/JavaBackend.java
+++ b/hat/hat/src/main/java/hat/backend/JavaBackend.java
@@ -26,6 +26,8 @@
 package hat.backend;
 
 import hat.ComputeContext;
+import hat.buffer.Buffer;
+import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
 import java.lang.reflect.InvocationTargetException;
@@ -36,10 +38,9 @@ public abstract class JavaBackend implements Backend {
     public final Arena arena = Arena.global();
 
     @Override
-    public Arena arena() {
-        return arena;
+    public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper){
+        return segmentMapper.allocate(arena);
     }
-
     @Override
     public void computeContextHandoff(ComputeContext computeContext) {
         System.out.println("Java backend received computeContext ");

--- a/hat/hat/src/main/java/hat/backend/NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/NativeBackend.java
@@ -26,7 +26,9 @@
 package hat.backend;
 
 import hat.ComputeContext;
+import hat.buffer.Buffer;
 import hat.callgraph.CallGraph;
+import hat.ifacemapper.SegmentMapper;
 import hat.optools.FuncOpWrapper;
 
 import java.lang.foreign.Arena;
@@ -40,11 +42,11 @@ public abstract class NativeBackend extends NativeBackendDriver {
 
     public final Arena arena = Arena.global();
 
-    @Override
-    public Arena arena() {
-        return arena;
-    }
 
+    @Override
+    public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper){
+        return segmentMapper.allocate(arena);
+    }
     public NativeBackend(String libName) {
         super(libName);
     }

--- a/hat/hat/src/main/java/hat/buffer/Array1D.java
+++ b/hat/hat/src/main/java/hat/buffer/Array1D.java
@@ -30,6 +30,7 @@ import hat.ifacemapper.SegmentMapper;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
@@ -41,9 +42,9 @@ public interface Array1D extends Array {
         ).withName(clazz.getSimpleName());
     }
 
-    static <T extends Array1D> T create(Accelerator accelerator, Class<T> clazz, StructLayout structLayout, int length) {
+    static <T extends Array1D> T create(BufferAllocator bufferAllocator, Class<T> clazz, StructLayout structLayout, int length) {
 
-        T buffer = SegmentMapper.ofIncomplete(accelerator.lookup, clazz, structLayout,length).allocate(accelerator.backend.arena());
+        T buffer = bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(), clazz, structLayout,length));
         Buffer.setLength(buffer,length);
         return buffer;
     }

--- a/hat/hat/src/main/java/hat/buffer/Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/Array2D.java
@@ -30,6 +30,7 @@ import hat.ifacemapper.SegmentMapper;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
@@ -42,10 +43,9 @@ public interface Array2D extends Array {
         ).withName(iface.getSimpleName());
     }
 
-    static <T extends Array2D> T create(Accelerator accelerator, Class<T> clazz, StructLayout structLayout,int width, int height) {
+    static <T extends Array2D> T create(BufferAllocator bufferAllocator, Class<T> clazz, StructLayout structLayout,int width, int height) {
 
-        T buffer = SegmentMapper.ofIncomplete(accelerator.lookup, clazz, structLayout, (long) width * height)
-                .allocate(accelerator.backend.arena());
+        T buffer = bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(), clazz, structLayout, (long) width * height));
         MemorySegment segment = Buffer.getMemorySegment(buffer);
         segment.set(JAVA_INT, structLayout.byteOffset(MemoryLayout.PathElement.groupElement("width")), width);
         segment.set(JAVA_INT, structLayout.byteOffset(MemoryLayout.PathElement.groupElement("height")), height);

--- a/hat/hat/src/main/java/hat/buffer/BufferAllocator.java
+++ b/hat/hat/src/main/java/hat/buffer/BufferAllocator.java
@@ -1,0 +1,9 @@
+package hat.buffer;
+
+import hat.ifacemapper.SegmentMapper;
+
+import java.lang.foreign.MemorySegment;
+
+public interface BufferAllocator {
+    <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper);
+}

--- a/hat/hat/src/main/java/hat/buffer/ImageBuffer.java
+++ b/hat/hat/src/main/java/hat/buffer/ImageBuffer.java
@@ -36,6 +36,7 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
 import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandles;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -58,8 +59,8 @@ public interface ImageBuffer extends IncompleteBuffer {
                     TYPE_USHORT_565_RGB, TYPE_USHORT_555_RGB, TYPE_CUSTOM
 
      */
-    static <T extends ImageBuffer> T create(Accelerator accelerator, Class<T> iface,StructLayout structLayout, int width, int height, int bufferedImageType, int elementsPerPixel) {
-        T rgba = SegmentMapper.ofIncomplete(accelerator.lookup, iface, structLayout, width * height * elementsPerPixel).allocate(accelerator.backend.arena());
+    static <T extends ImageBuffer> T create(BufferAllocator bufferAllocator, Class<T> iface,StructLayout structLayout, int width, int height, int bufferedImageType, int elementsPerPixel) {
+        T rgba = bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(), iface, structLayout, width * height * elementsPerPixel));
         MemorySegment segment = Buffer.getMemorySegment(rgba);
         segment.set(JAVA_INT, structLayout.byteOffset(MemoryLayout.PathElement.groupElement("width")), width);
         segment.set(JAVA_INT, structLayout.byteOffset(MemoryLayout.PathElement.groupElement("height")), height);


### PR DESCRIPTION
Currently we must pass an accelerator to create an iface buffer mapping

This does not make sense.  The allocation probably needs to come from the backend. 

So we decouple by creating a BufferAllocator interface which performs the task.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/babylon.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/138.diff">https://git.openjdk.org/babylon/pull/138.diff</a>

</details>
