### PR TITLE
ComputeContext can now implement BufferAllocator

### DIFF
--- a/hat/examples/mandel/src/main/java/mandel/buffers/RgbaS32Image.java
+++ b/hat/examples/mandel/src/main/java/mandel/buffers/RgbaS32Image.java
@@ -24,7 +24,7 @@
  */
 package mandel.buffers;
 
-import hat.Accelerator;
+import hat.buffer.BufferAllocator;
 import hat.buffer.ImageBuffer;
 
 import java.awt.image.BufferedImage;
@@ -34,12 +34,12 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 public interface RgbaS32Image extends ImageBuffer {
     StructLayout layout =  ImageBuffer.createLayout(RgbaS32Image.class,JAVA_SHORT);
-    private static RgbaS32Image create(Accelerator accelerator, int width, int height) {
-        return ImageBuffer.create(accelerator, RgbaS32Image.class, layout,width, height, BufferedImage.TYPE_INT_ARGB, 1);
+    private static RgbaS32Image create(BufferAllocator bufferAllocator, int width, int height) {
+        return ImageBuffer.create(bufferAllocator, RgbaS32Image.class, layout,width, height, BufferedImage.TYPE_INT_ARGB, 1);
     }
 
-    static RgbaS32Image create(Accelerator accelerator, BufferedImage bufferedImage) {
-        return create(accelerator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
+    static RgbaS32Image create(BufferAllocator bufferAllocator, BufferedImage bufferedImage) {
+        return create(bufferAllocator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
 
     }
 

--- a/hat/examples/violajones/src/main/java/violajones/HaarViewer.java
+++ b/hat/examples/violajones/src/main/java/violajones/HaarViewer.java
@@ -26,6 +26,7 @@ package violajones;
 
 
 import hat.Accelerator;
+import hat.buffer.BufferAllocator;
 import hat.buffer.F32Array2D;
 import hat.buffer.S32Array;
 import violajones.buffers.GreyU16Image;
@@ -64,7 +65,7 @@ public class HaarViewer extends JFrame {
         final F32Array2D integralImageF32;
         final F32Array2D integralSqImageF32;
 
-        public IntegralWindow(Container container, Accelerator accelerator, F32Array2D integralImageF32, F32Array2D integralSqImageF32) {
+        public IntegralWindow(Container container, BufferAllocator bufferAllocator, F32Array2D integralImageF32, F32Array2D integralSqImageF32) {
             this.integralImageF32 = integralImageF32;
             this.integralSqImageF32 = integralSqImageF32;
 
@@ -73,8 +74,8 @@ public class HaarViewer extends JFrame {
                 int height = this.integralImageF32.height();
                 this.integral = new BufferedImage(width, height, BufferedImage.TYPE_USHORT_GRAY);
                 this.integralSq = new BufferedImage(width, height, BufferedImage.TYPE_USHORT_GRAY);
-                this.integralImageU16 = GreyU16Image.create(accelerator, integral);
-                this.integralSqImageU16 = GreyU16Image.create(accelerator, integralSq);
+                this.integralImageU16 = GreyU16Image.create(bufferAllocator, integral);
+                this.integralSqImageU16 = GreyU16Image.create(bufferAllocator, integralSq);
                 this.integralImageView = new JComponent() {
                     @Override
                     public void paint(Graphics g) {
@@ -169,7 +170,7 @@ public class HaarViewer extends JFrame {
     final double imageScale = .5;
 
 
-    public HaarViewer(Accelerator accelerator,
+    public HaarViewer(BufferAllocator bufferAllocator,
                       BufferedImage image,
                       RgbS08x3Image rgbS08x3Image,
                       Cascade cascade,
@@ -245,7 +246,7 @@ public class HaarViewer extends JFrame {
         gridPanel.add(imageView);
         add(gridPanel, BorderLayout.CENTER);
         add(imagePanel, BorderLayout.EAST);
-        this.integralWindow = new IntegralWindow(this, accelerator, integralImageF32, integralSqImageF32);
+        this.integralWindow = new IntegralWindow(this, bufferAllocator, integralImageF32, integralSqImageF32);
         this.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         pack();
         setVisible(true);

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
@@ -316,17 +316,13 @@ public class ViolaJonesCoreCompute {
         long start = System.currentTimeMillis();
         int width = rgbS08x3Image.width();
 
-
-
-
         int height = rgbS08x3Image.height();
-        Accelerator accelerator = cc.accelerator;
-        F32Array2D greyImage = F32Array2D.create(accelerator, width, height);
+        F32Array2D greyImage = F32Array2D.create(cc, width, height);
         //javaRgbToGreyScale(rgbS08x3Image, greyImage);
 
         cc.dispatchKernel(width * height, kc -> rgbToGreyKernel(kc, rgbS08x3Image, greyImage));
-        F32Array2D integralImage = F32Array2D.create(accelerator, width, height);
-        F32Array2D integralSqImage = F32Array2D.create(accelerator, width, height);
+        F32Array2D integralImage = F32Array2D.create(cc, width, height);
+        F32Array2D integralSqImage = F32Array2D.create(cc, width, height);
 
         //javaCreateIntegralImage(greyImage, integralImage, integralSqImage);
 
@@ -335,7 +331,7 @@ public class ViolaJonesCoreCompute {
         cc.dispatchKernel(width, kc -> integralColKernel(kc, greyImage, integralImage, integralSqImage));
         cc.dispatchKernel(height, kc -> integralRowKernel(kc, integralImage, integralSqImage));
         // harViz.showIntegrals();
-        ScaleTable scaleTable = ScaleTable.create(accelerator, cascade, width, height);
+        ScaleTable scaleTable = ScaleTable.create(cc, cascade, width, height);
         System.out.print("range requested=");
         System.out.print(scaleTable.multiScaleAccumulativeRange());
         System.out.println();

--- a/hat/examples/violajones/src/main/java/violajones/buffers/GreyU16Image.java
+++ b/hat/examples/violajones/src/main/java/violajones/buffers/GreyU16Image.java
@@ -25,6 +25,7 @@
 package violajones.buffers;
 
 import hat.Accelerator;
+import hat.buffer.BufferAllocator;
 import hat.buffer.ImageBuffer;
 
 import java.awt.image.BufferedImage;
@@ -35,12 +36,12 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 public interface GreyU16Image extends ImageBuffer {
 
     StructLayout layout =  ImageBuffer.createLayout(GreyU16Image.class,JAVA_SHORT);
-    private static GreyU16Image create(Accelerator accelerator, int width, int height) {
-        return ImageBuffer.create(accelerator, GreyU16Image.class, layout,width, height, BufferedImage.TYPE_USHORT_GRAY, 1);
+    private static GreyU16Image create(BufferAllocator bufferAllocator, int width, int height) {
+        return ImageBuffer.create(bufferAllocator, GreyU16Image.class, layout,width, height, BufferedImage.TYPE_USHORT_GRAY, 1);
     }
 
-    static GreyU16Image create(Accelerator accelerator, BufferedImage bufferedImage) {
-        return create(accelerator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
+    static GreyU16Image create(BufferAllocator bufferAllocator, BufferedImage bufferedImage) {
+        return create(bufferAllocator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
     }
 
     short data(long idx);

--- a/hat/examples/violajones/src/main/java/violajones/buffers/RgbS08x3Image.java
+++ b/hat/examples/violajones/src/main/java/violajones/buffers/RgbS08x3Image.java
@@ -25,6 +25,7 @@
 package violajones.buffers;
 
 import hat.Accelerator;
+import hat.buffer.BufferAllocator;
 import hat.buffer.ImageBuffer;
 
 import java.awt.image.BufferedImage;
@@ -36,12 +37,12 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 public interface RgbS08x3Image extends ImageBuffer {
     StructLayout layout =  ImageBuffer.createLayout(RgbS08x3Image.class,JAVA_BYTE);
 
-    private static RgbS08x3Image create(Accelerator accelerator, int width, int height) {
-        return ImageBuffer.create(accelerator, RgbS08x3Image.class,layout, width, height, BufferedImage.TYPE_INT_RGB, 3);
+    private static RgbS08x3Image create(BufferAllocator bufferAllocator, int width, int height) {
+        return ImageBuffer.create(bufferAllocator, RgbS08x3Image.class,layout, width, height, BufferedImage.TYPE_INT_RGB, 3);
     }
 
-    static RgbS08x3Image create(Accelerator accelerator, BufferedImage bufferedImage) {
-        return create(accelerator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
+    static RgbS08x3Image create(BufferAllocator bufferAllocator, BufferedImage bufferedImage) {
+        return create(bufferAllocator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
 
     }
 

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
@@ -126,7 +126,7 @@ public interface ScaleTable extends Table<ScaleTable.Scale> {
                 bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(),ScaleTable.class,layout,length)),length);
     }
 
-    static ScaleTable create(Accelerator accelerator, Cascade cascade, int imageWidth, int imageHeight) {
+    static ScaleTable create(BufferAllocator bufferAllocator, Cascade cascade, int imageWidth, int imageHeight) {
 
         final float startScale = 1f;
         final float scaleMultiplier = 2f;
@@ -147,7 +147,7 @@ public interface ScaleTable extends Table<ScaleTable.Scale> {
             multiScaleCountVar++;
         }
 
-        ScaleTable scaleTable = ScaleTable.create(accelerator, multiScaleCountVar);
+        ScaleTable scaleTable = ScaleTable.create(bufferAllocator, multiScaleCountVar);
 
         // now we know the size
 

--- a/hat/hat/src/main/java/hat/ComputeContext.java
+++ b/hat/hat/src/main/java/hat/ComputeContext.java
@@ -1,8 +1,10 @@
 package hat;
 
 import hat.buffer.Buffer;
+import hat.buffer.BufferAllocator;
 import hat.callgraph.ComputeCallGraph;
 import hat.callgraph.KernelCallGraph;
+import hat.ifacemapper.SegmentMapper;
 import hat.optools.FuncOpWrapper;
 import hat.optools.LambdaOpWrapper;
 import hat.optools.OpWrapper;
@@ -33,7 +35,7 @@ import java.util.function.Consumer;
  *
  * @author Gary Frost
  */
-public class ComputeContext {
+public class ComputeContext implements BufferAllocator {
     public static final MethodRef M_CC_PRE_MUTATE = MethodRef.method(ComputeContext.class, "preMutate",
             void.class, Buffer.class);
     public static final MethodRef M_CC_POST_MUTATE = MethodRef.method(ComputeContext.class, "postMutate",
@@ -116,6 +118,11 @@ public class ComputeContext {
 
     public void postAccess(Buffer b) {
         /*System.out.println("postAccess " + b);*/
+    }
+
+    @Override
+    public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper) {
+        return accelerator.allocate(segmentMapper);
     }
 
     public interface QuotableKernelContextConsumer extends Quotable, Consumer<KernelContext> {

--- a/hat/hat/src/main/java/hat/buffer/F32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array.java
@@ -33,12 +33,12 @@ import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 
 public interface F32Array extends Array1D {
     StructLayout layout  = Array1D.getLayout(F32Array.class, JAVA_FLOAT);
-    static F32Array create(Accelerator accelerator, int length) {
-        return Array1D.create(accelerator, F32Array.class,layout, length);
+    static F32Array create(BufferAllocator bufferAllocator, int length) {
+        return Array1D.create(bufferAllocator, F32Array.class,layout, length);
     }
 
-    static F32Array create(Accelerator accelerator, float[] source) {
-        return create(accelerator, source.length).copyFrom(source);
+    static F32Array create(BufferAllocator bufferAllocator, float[] source) {
+        return create(bufferAllocator, source.length).copyFrom(source);
     }
 
     float array(long idx);

--- a/hat/hat/src/main/java/hat/buffer/F32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array2D.java
@@ -33,8 +33,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface F32Array2D extends Array2D {
     StructLayout layout  = Array2D.getLayout(F32Array2D.class, JAVA_FLOAT);
-    static F32Array2D create(Accelerator accelerator, int width, int height) {
-        return Array2D.create(accelerator, F32Array2D.class, layout, width, height);
+    static F32Array2D create(BufferAllocator bufferAllocator, int width, int height) {
+        return Array2D.create(bufferAllocator, F32Array2D.class, layout, width, height);
     }
     float array(long idx);
 

--- a/hat/hat/src/main/java/hat/buffer/S32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array.java
@@ -34,12 +34,12 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface S32Array extends Array1D {
     StructLayout layout  = Array1D.getLayout(S32Array.class, JAVA_INT);
-    static S32Array create(Accelerator accelerator, int length) {
-        return Array1D.create(accelerator, S32Array.class,layout, length);
+    static S32Array create(BufferAllocator bufferAllocator, int length) {
+        return Array1D.create(bufferAllocator, S32Array.class,layout, length);
     }
 
-    static S32Array create(Accelerator accelerator, int[] source) {
-        return create(accelerator, source.length).copyfrom(source);
+    static S32Array create(BufferAllocator bufferAllocator, int[] source) {
+        return create(bufferAllocator, source.length).copyfrom(source);
     }
 
     int array(long idx);

--- a/hat/hat/src/main/java/hat/buffer/S32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array2D.java
@@ -32,8 +32,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface S32Array2D extends Array2D {
     StructLayout layout  = Array2D.getLayout(S32Array2D.class, JAVA_INT);
-    static S32Array2D create(Accelerator accelerator, int width, int height) {
-        return Array2D.create(accelerator, S32Array2D.class, layout, width, height);
+    static S32Array2D create(BufferAllocator bufferAllocator, int width, int height) {
+        return Array2D.create(bufferAllocator, S32Array2D.class, layout, width, height);
     }
 
     int array(long idx);


### PR DESCRIPTION
By making ComputeContext implement BufferAllocate.  We can simplify this code. 
```
S32Array arr = S32Array.create(cc.accelerator, len);
```
to just 
```
S32Array arr = S32Array.create(cc, len);
```

It still delegates to accelerator, which delegates to the baclend.  Allowing for example the backend to allocate on a GPU.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/babylon.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/139.diff">https://git.openjdk.org/babylon/pull/139.diff</a>

</details>
