### PR TITLE
Fixup babylon location property and remove spirv backend from default

### DIFF
--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -44,7 +44,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
      <module>cuda</module>
      <module>mock</module>
      <module>ptx</module>
-     <module>spirv</module>
+     <!--<module>spirv</module>-->
    </modules>
    <build>
      <plugins>

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -11,7 +11,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <maven.compiler.target>23</maven.compiler.target>
         <github.dir>${env.HOME}/github</github.dir>
         <beehive.spirv.toolkit.dir>${github.dir}/beehive-spirv-toolkit</beehive.spirv.toolkit.dir>
-        <babylon.repo.name>babylon-grfrost-fork</babylon.repo.name>
+        <babylon.repo.name>babylon</babylon.repo.name>
         <babylon.dir>${github.dir}/${babylon.repo.name}</babylon.dir>
         <hat.dir>${babylon.dir}/hat</hat.dir>
         <hat.target>${hat.dir}/maven-build</hat.target>


### PR DESCRIPTION
I mistakenly left my fork name as the babylon location. 

Also SPIRV backend removed from default build. 

See comment in hat/backends/pom.xml to allow SPIRV to build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/babylon.git pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/144.diff">https://git.openjdk.org/babylon/pull/144.diff</a>

</details>
