### PR TITLE
Computes the VarOp's result type from its operand type, if not overridden

### DIFF
--- a/cr-examples/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
+++ b/cr-examples/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
@@ -82,8 +82,8 @@ public class TranslateToSpirvModel  {
         // Emit all SPIR-V Variable ops first and emit initializing stores afterward, at the CR model VarOp position.
         for (int i = 0; i < paramCount; i++) {
             CoreOp.VarOp jvop = (CoreOp.VarOp)entryBlock.ops().get(i);
-            TypeElement resultType = new PointerType(jvop.varType(), StorageType.CROSSWORKGROUP);
-            SpirvOps.VariableOp svop = new SpirvOps.VariableOp((String)jvop.attributes().get(""), resultType, jvop.varType());
+            TypeElement resultType = new PointerType(jvop.varValueType(), StorageType.CROSSWORKGROUP);
+            SpirvOps.VariableOp svop = new SpirvOps.VariableOp((String)jvop.attributes().get(""), resultType, jvop.varValueType());
             spirvBlock.op(svop);
             valueMap.put(jvop.result(), svop.result());
             varOps.add(svop);
@@ -97,8 +97,8 @@ public class TranslateToSpirvModel  {
                 if (bi > 0) spirvBlock = blockMap.get(block);
                 Op op = ops.get(i);
                 if (op instanceof CoreOp.VarOp jvop) {
-                    TypeElement resultType = new PointerType(jvop.varType(), StorageType.CROSSWORKGROUP);
-                    SpirvOps.VariableOp svop = new SpirvOps.VariableOp((String)jvop.attributes().get(""), resultType, jvop.varType());
+                    TypeElement resultType = new PointerType(jvop.varValueType(), StorageType.CROSSWORKGROUP);
+                    SpirvOps.VariableOp svop = new SpirvOps.VariableOp((String)jvop.attributes().get(""), resultType, jvop.varValueType());
                     bodyBuilder.entryBlock().op(svop);
                     valueMap.put(jvop.result(), svop.result());
                     varOps.add(svop);

--- a/hat/hat/src/main/java/hat/optools/VarOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/VarOpWrapper.java
@@ -9,7 +9,7 @@ public abstract class VarOpWrapper extends OpWrapper<CoreOp.VarOp> {
     }
 
     public JavaType javaType() {
-        return (JavaType) op().varType();
+        return (JavaType) op().varValueType();
     }
 
     public String varName() {

--- a/src/java.base/share/classes/java/lang/reflect/code/Block.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Block.java
@@ -692,7 +692,7 @@ public final class Block implements CodeElement<Block, Op> {
          * Transforms a body into this block, with this block builder's context.
          *
          * @param bodyToTransform the body to transform
-         * @param args        the list of values to map to the parameters of the body's entry block
+         * @param args        the list of output values to map to the input parameters of the body's entry block
          * @param ot          the operation transformer
          * @see #transformBody(Body, List, CopyContext, OpTransformer)
          */
@@ -721,7 +721,7 @@ public final class Block implements CodeElement<Block, Op> {
          * When the parent body is built any empty non-entry blocks that have no successors will be removed.
          *
          * @param bodyToTransform the body to transform
-         * @param args            the list of values to map to the parameters of the body's entry block
+         * @param args            the list of output values to map to the input parameters of the body's entry block
          * @param cc              the copy context, for values captured in the body
          * @param ot              the operation transformer
          */

--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
@@ -100,7 +100,7 @@ public final class SSA {
                             Block.Builder bb = cc.getBlock(b);
                             return joinPoints.get(b).stream().collect(Collectors.toMap(
                                     varOp -> varOp,
-                                    varOp -> bb.parameter(varOp.varType())));
+                                    varOp -> bb.parameter(varOp.varValueType())));
                         });
 
                         // Append successor arguments

--- a/src/java.base/share/classes/java/lang/reflect/code/type/VarType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/VarType.java
@@ -10,22 +10,22 @@ import java.util.Objects;
 public final class VarType implements TypeElement {
     static final String NAME = "Var";
 
-    final TypeElement variableType;
+    final TypeElement valueType;
 
-    VarType(TypeElement variableType) {
-        this.variableType = variableType;
+    VarType(TypeElement valueType) {
+        this.valueType = valueType;
     }
 
     /**
      * {@return the variable type's value type}
      */
     public TypeElement valueType() {
-        return variableType;
+        return valueType;
     }
 
     @Override
     public ExternalizedTypeElement externalize() {
-        return new ExternalizedTypeElement(NAME, List.of(variableType.externalize()));
+        return new ExternalizedTypeElement(NAME, List.of(valueType.externalize()));
     }
 
     @Override
@@ -37,12 +37,12 @@ public final class VarType implements TypeElement {
     public boolean equals(Object o) {
         if (this == o) return true;
         return o instanceof VarType that &&
-                variableType.equals(that.variableType);
+                valueType.equals(that.valueType);
     }
 
     @Override
     public int hashCode() {
-        return variableType.hashCode();
+        return valueType.hashCode();
     }
 
     /**

--- a/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
+++ b/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
@@ -270,19 +270,8 @@ public class CoreBinaryOpsTest {
                     ? type
                     : functionType.returnType();
             return CoreOp.func(original.funcName(), FunctionType.functionType(retType, type, type))
-                    .body(builder -> builder.transformBody(original.body(), builder.parameters(), (block, op) -> {
-                                block.context().mapValue(op.result(), block.op(retype(block.context(), op)));
-                                return block;
-                            })
+                    .body(builder -> builder.transformBody(original.body(), builder.parameters(), OpTransformer.COPYING_TRANSFORMER)
                     );
-        }
-
-        private static Op retype(CopyContext context, Op op) {
-            return switch (op) {
-                case CoreOp.VarOp varOp ->
-                        CoreOp.var(varOp.varName(), context.getValueOrDefault(varOp.operands().getFirst(), varOp.operands().getFirst()));
-                default -> op;
-            };
         }
 
         private static Stream<Arguments> argumentsForMethod(CoreOp.FuncOp funcOp, Method testMethod) {

--- a/test/jdk/java/lang/reflect/code/TestVarOp.java
+++ b/test/jdk/java/lang/reflect/code/TestVarOp.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestVarOp
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.type.FunctionType;
+import java.lang.reflect.code.type.JavaType;
+import java.lang.runtime.CodeReflection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class TestVarOp {
+
+    @CodeReflection
+    static Object f(String s) {
+        Object o = s;
+        return o;
+    }
+
+    @Test
+    public void testTypeSubstitutionAndPreserve() {
+        CoreOp.FuncOp f = getFuncOp("f");
+        CoreOp.FuncOp ft = CoreOp.func("f", FunctionType.functionType(JavaType.J_L_OBJECT, JavaType.type(CharSequence.class)))
+                .body(fb -> {
+                    fb.transformBody(f.body(), fb.parameters(), OpTransformer.COPYING_TRANSFORMER);
+                });
+
+        List<CoreOp.VarOp> vops = ft.elements()
+                .flatMap(ce -> ce instanceof CoreOp.VarOp vop ? Stream.of(vop) : null)
+                .toList();
+        // VarOp for block parameter, translate from String to CharSequence
+        Assert.assertEquals(vops.get(0).resultType().valueType(), JavaType.type(CharSequence.class));
+        // VarOp for local variable, preserve Object
+        Assert.assertEquals(vops.get(1).resultType().valueType(), JavaType.J_L_OBJECT);
+    }
+
+    static CoreOp.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestVarOp.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}


### PR DESCRIPTION
It's currently hard to apply a simple retyping transformation to a code model since the variable operation, `VarOp`, fixes its result type when copying. `VarOp` now supports a fixed result type only when the init operand's type, `T` say, is not equal to the value type of the VarOp's result type, `U` say for `Var<U>`. 

This works but we might need to revisit and remove any notion of a fixed result type when copying. (We can behave differently when constructing from an externalized operation.)

Also renamed some methods and added some helper methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/babylon.git pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/148.diff">https://git.openjdk.org/babylon/pull/148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/148#issuecomment-2174506189)