### PR TITLE
Concat Transform Optimizations

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/StringConcatTransformer.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/StringConcatTransformer.java
@@ -40,130 +40,82 @@ import java.util.*;
  */
 public class StringConcatTransformer implements OpTransformer {
 
-    private static final JavaType J_L_BYTESTRING = JavaType.type(StringBuilder.class);
-    private static final JavaType J_L_CHARSEQUENCE = JavaType.type(CharSequence.class);
     private static final JavaType J_L_OBJECT = JavaType.type(Object.class);
-    private static final MethodRef SB_TO_STRING = MethodRef.method(J_L_BYTESTRING, "toString", JavaType.J_L_STRING);
+    private static final JavaType J_L_STRING_BUILDER = JavaType.type(StringBuilder.class);
 
-    final private Set<Value> StringBuilders = new HashSet<>();
-    final private Map<Integer, Value> IntConstants = new HashMap<>();
+    private static final MethodRef SB_TO_STRING_REF = MethodRef.method(
+            J_L_STRING_BUILDER, "toString", JavaType.J_L_STRING);
 
-    public StringConcatTransformer() {
-    }
+    public StringConcatTransformer() {}
 
-    private static boolean reusableResult(Op.Result r) {
-        if (r.uses().size() == 1) {
-            return r.uses().stream().allMatch((use) -> use.op() instanceof CoreOp.ConcatOp);
-        }
-        return false;
-    }
-
-    @Override public Block.Builder apply(Block.Builder builder, Op op) {
-        if (op instanceof CoreOp.ConcatOp cz) {
-
-            Value left = builder.context().getValue(cz.operands().get(0));
-            Value right = builder.context().getValue(cz.operands().get(1));
-            Op.Result result = cz.result();
-            if (reusableResult(result)) {
-                Value sb = stringBuilder(builder, left, right);
-                builder.context().mapValue(result, sb);
-            } else {
-                Value sb = stringBuilder(builder, left, right);
-                Value str = buildString(builder, sb);
-                builder.context().mapValue(result, str);
+    @Override
+    public Block.Builder apply(Block.Builder block, Op op) {
+        switch (op) {
+            case CoreOp.ConcatOp cz when isRootConcat(cz) -> {
+                // Create a string builder and build by traversing tree of operands
+                Op.Result builder = block.apply(CoreOp._new(FunctionType.functionType(J_L_STRING_BUILDER)));
+                buildFromTree(block, builder, cz);
+                // Convert to string
+                Value s = block.op(CoreOp.invoke(SB_TO_STRING_REF, builder));
+                block.context().mapValue(cz.result(), s);
             }
+            case CoreOp.ConcatOp cz -> {
+                // Process later when building from root concat
+            }
+            default -> block.op(op);
+        }
+        return block;
+    }
+
+    static boolean isRootConcat(CoreOp.ConcatOp cz) {
+        // Root of concat tree, zero uses, two or more uses,
+        // or one use that is not a subsequent concat op
+        Set<Op.Result> uses = cz.result().uses();
+        return uses.size() != 1 || !(uses.iterator().next().op() instanceof CoreOp.ConcatOp);
+    }
+
+    static void buildFromTree(Block.Builder block, Op.Result builder, CoreOp.ConcatOp cz) {
+        // Process concat op's operands from left to right
+        buildFromTree(block, builder, cz.operands().get(0));
+        buildFromTree(block, builder, cz.operands().get(1));
+    }
+
+    static void buildFromTree(Block.Builder block, Op.Result builder, Value v) {
+        if (v instanceof Op.Result r &&
+                r.op() instanceof CoreOp.ConcatOp cz &&
+                r.uses().size() == 1) {
+            // Node of tree, recursively traverse the operands
+            buildFromTree(block, builder, cz);
         } else {
-            builder.op(op);
+            // Leaf of tree, append value to builder
+            // Note leaf can be the result of a ConcatOp with multiple uses
+            block.op(append(block, builder, block.context().getValue(v)));
         }
-        return builder;
     }
 
-    //Uses StringBuilder and Immediate String Value
-    private Value buildString(Block.Builder builder, Value sb){
-        var toStringInvoke = CoreOp.invoke(SB_TO_STRING, sb);
-        return builder.apply(toStringInvoke);
+    private static Op append(Block.Builder block, Value builder, Value arg) {
+        return append(block, builder, arg, arg.type());
     }
 
-    private Value stringBuilder(Block.Builder builder, Value left, Value right) {
-        if (left.type().equals(J_L_BYTESTRING) && StringBuilders.contains(left)
-                || right.type().equals(J_L_BYTESTRING) && StringBuilders.contains(right)) {
-            var res = builder.op(append(builder, left, right));
-            StringBuilders.add(res);
-            return res;
+    private static Op append(Block.Builder block, Value builder, Value arg, TypeElement type) {
+        // Check if we need to widen unsupported integer types in the StringBuilder API
+        // Strings are fed in as-is, everything else given as an Object.
+        if (type instanceof PrimitiveType) {
+            if (List.of(JavaType.BYTE, JavaType.SHORT).contains(type)) {
+                Value widened = block.op(CoreOp.conv(JavaType.INT, arg));
+                MethodRef methodDesc = MethodRef.method(J_L_STRING_BUILDER, "append", J_L_STRING_BUILDER, JavaType.INT);
+                return CoreOp.invoke(methodDesc, builder, widened);
+            } else {
+                MethodRef methodDesc = MethodRef.method(J_L_STRING_BUILDER, "append", J_L_STRING_BUILDER, type);
+                return CoreOp.invoke(methodDesc, builder, arg);
+            }
+        } else if (type.equals(JavaType.J_L_STRING)) {
+            MethodRef methodDesc = MethodRef.method(J_L_STRING_BUILDER, "append", J_L_STRING_BUILDER, type);
+            return CoreOp.invoke(methodDesc, builder, arg);
         } else {
-            CoreOp.NewOp newBuilder = CoreOp._new(FunctionType.functionType(J_L_BYTESTRING));
-            Value sb = builder.op(newBuilder);
-            StringBuilders.add(sb);
-            var res = builder.op(append(builder, sb, left));
-            StringBuilders.add(res);
-            var res2 = builder.op(append(builder, res, right));
-            StringBuilders.add(res2);
-            return res2;
+            MethodRef methodDesc = MethodRef.method(J_L_STRING_BUILDER, "append", J_L_STRING_BUILDER, J_L_OBJECT);
+            return CoreOp.invoke(methodDesc, builder, arg);
         }
-    }
-
-    private Op append(Block.Builder builder, Value left, Value right) {
-        //Left argument is a blessed stringbuilder
-        if (left.type().equals(J_L_BYTESTRING) && StringBuilders.contains(left)) {
-            var rightType = right.type();
-            if (rightType.equals(J_L_BYTESTRING)) {
-                rightType = J_L_CHARSEQUENCE;
-                MethodRef leftMethodDesc = MethodRef.method(J_L_BYTESTRING, "append", J_L_BYTESTRING, rightType);
-                return CoreOp.invoke(leftMethodDesc, left, right);
-            }
-
-            if (rightType instanceof PrimitiveType) {
-                if (List.of(JavaType.BYTE, JavaType.SHORT).contains(rightType)) {
-                    Value widened = builder.op(CoreOp.conv(JavaType.INT, right));
-                    MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "append", J_L_BYTESTRING, JavaType.INT);
-                    return CoreOp.invoke(methodDesc, left, widened);
-                } else {
-                    MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "append", J_L_BYTESTRING, rightType);
-                    return CoreOp.invoke(methodDesc, left, right);
-                }
-            } else if (rightType.equals(JavaType.J_L_STRING)) {
-                MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "append", J_L_BYTESTRING, rightType);
-                return CoreOp.invoke(methodDesc, left, right);
-            } else {
-                MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "append", J_L_BYTESTRING, J_L_OBJECT);
-                return CoreOp.invoke(methodDesc, left, right);
-            }
-        } else if (right.type().equals(J_L_BYTESTRING) && StringBuilders.contains(right)) {
-            var leftType = left.type();
-            var zero = getConstant(builder, 0);
-            if (leftType.equals(J_L_BYTESTRING)) {
-                leftType = J_L_CHARSEQUENCE;
-                MethodRef leftMethodDesc = MethodRef.method(J_L_BYTESTRING, "insert", J_L_BYTESTRING, JavaType.INT, leftType);
-                return CoreOp.invoke(leftMethodDesc, right, zero, left);
-            }
-            if (leftType instanceof PrimitiveType) {
-                if (List.of(JavaType.BYTE, JavaType.SHORT).contains(leftType)) {
-                    Value widened = builder.op(CoreOp.conv(JavaType.INT, left));
-                    MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "insert", J_L_BYTESTRING, JavaType.INT, JavaType.INT);
-                    return CoreOp.invoke(methodDesc, right, zero, widened);
-                } else {
-                    MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "insert", J_L_BYTESTRING, JavaType.INT, leftType);
-                    return CoreOp.invoke(methodDesc, right, zero, left);
-                }
-            } else if (leftType.equals(JavaType.J_L_STRING)) {
-                MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "insert", J_L_BYTESTRING, JavaType.INT, leftType);
-                return CoreOp.invoke(methodDesc, right, zero, left);
-            } else {
-                MethodRef methodDesc = MethodRef.method(J_L_BYTESTRING, "insert", J_L_BYTESTRING, JavaType.INT, J_L_OBJECT);
-                return CoreOp.invoke(methodDesc, right, zero, left);
-            }
-        }
-        throw new RuntimeException("append requires a blessed StringBuilder as one Value argument");
-    }
-
-    private Value getConstant(Block.Builder builder, int con) {
-        var val = IntConstants.get(con);
-        if (val == null) {
-            var constOp = CoreOp.constant(JavaType.INT, con);
-            val = builder.op(constOp);
-            IntConstants.put(0, val);
-        }
-        return val;
     }
 
 }

--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/StringConcatTransformer.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/StringConcatTransformer.java
@@ -42,11 +42,9 @@ public class StringConcatTransformer implements OpTransformer {
     private static final JavaType CHAR_SEQ_TYPE = JavaType.type(CharSequence.class);
     private static final MethodRef SB_TO_STRING = MethodRef.method(SBC_TYPE, "toString", JavaType.J_L_STRING);
 
-    record StringAndBuilder(Value string, Value stringBuilder) { }
-
     public StringConcatTransformer() {}
 
-    private static boolean resusableResult(Op.Result r) {
+    private static boolean reusableResult(Op.Result r) {
         if (r.uses().size() == 1) {
             return r.uses().stream().noneMatch((use) -> use.op() instanceof CoreOp.ReturnOp ||
                     use.op() instanceof CoreOp.VarOp);
@@ -60,8 +58,8 @@ public class StringConcatTransformer implements OpTransformer {
 
             Value left = builder.context().getValue(cz.operands().get(0));
             Value right = builder.context().getValue(cz.operands().get(1));
-            Value result = cz.result();
-            if (resusableResult((Op.Result) result)) {
+            Op.Result result = cz.result();
+            if (reusableResult(result)) {
                 Value sb = stringBuilder(builder, left, right);
                 builder.context().mapValue(result, sb);
             } else {
@@ -78,8 +76,7 @@ public class StringConcatTransformer implements OpTransformer {
     //Uses StringBuilder and Immediate String Value
     private static Value buildString(Block.Builder builder, Value sb){
         var toStringInvoke = CoreOp.invoke(SB_TO_STRING, sb);
-        Value newString = builder.apply(toStringInvoke);
-        return newString;
+        return builder.apply(toStringInvoke);
     }
 
     private static Value stringBuilder(Block.Builder builder, Value left, Value right) {
@@ -89,8 +86,7 @@ public class StringConcatTransformer implements OpTransformer {
             CoreOp.NewOp newBuilder = CoreOp._new(FunctionType.functionType(SBC_TYPE));
             Value sb = builder.apply(newBuilder);
             var res = builder.op(append(sb, left));
-            var res2 = builder.op(append(res, right));
-            return res2;
+            return builder.op(append(res, right));
         }
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/StringConcatTransformer.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/StringConcatTransformer.java
@@ -46,8 +46,7 @@ public class StringConcatTransformer implements OpTransformer {
 
     private static boolean reusableResult(Op.Result r) {
         if (r.uses().size() == 1) {
-            return r.uses().stream().noneMatch((use) -> use.op() instanceof CoreOp.ReturnOp ||
-                    use.op() instanceof CoreOp.VarOp);
+            return r.uses().stream().allMatch((use) -> use.op() instanceof CoreOp.ConcatOp);
         }
         return false;
     }

--- a/test/jdk/java/lang/reflect/code/TestStringConcatTransform.java
+++ b/test/jdk/java/lang/reflect/code/TestStringConcatTransform.java
@@ -97,6 +97,7 @@ public class TestStringConcatTransform {
         CoreOp.FuncOp f_transformed = model.transform(new StringConcatTransformer());
         Object[] args = prepArgs(method);
 
+        model.writeTo(System.out);
         f_transformed.writeTo(System.out);
 
         var interpreted = Interpreter.invoke(model, args);
@@ -113,6 +114,10 @@ public class TestStringConcatTransform {
         CoreOp.FuncOp ssa_model = generateSSA(model);
         CoreOp.FuncOp ssa_transformed_model = ssa_model.transform(new StringConcatTransformer());
         Object[] args = prepArgs(method);
+
+        model.writeTo(System.out);
+        ssa_model.writeTo(System.out);
+        ssa_transformed_model.writeTo(System.out);
 
         var model_interpreted = Interpreter.invoke(model, args);
         var transformed_model_interpreted = Interpreter.invoke(transformed_model, args);
@@ -193,10 +198,44 @@ public class TestStringConcatTransform {
     }
 
     @CodeReflection
-    public static String intConcatNestedSplit(int i, String s){
+    public static String intConcatNestedSplit(int i, String s) {
         String q, r;
         String inter = i + (q = r = s + "hello") + 52;
         return q + r + inter;
     }
 
+    @CodeReflection
+    public static String degenerateTree(String a, String b, String c, String d) {
+        String s = (a + b) + (c + d);
+        return s;
+    }
+
+    //This String Builder is getting tweaked, check for side effects
+    @CodeReflection
+    public static String degenerateTree2(String a, String d) {
+        StringBuilder sb = new StringBuilder("test");
+        String s = sb + a;
+        String t = s + d;
+        System.out.println(sb);
+        return t;
+    }
+
+    @CodeReflection
+    public static String degenerateTree4(String a, String b, String c, String d) {
+        String s = ((a + b) + c) + d;
+        return s;
+    }
+
+    @CodeReflection
+    public static String degenerateTree5(String a, String b, String c, String d) {
+        String s = (a + (b + (c + d)));
+        return s;
+    }
+
+    @CodeReflection
+    public static String widenPrimitives(short a, byte b, int c, int d) {
+        String s = (a + (b + (c + d + "hi")));
+        return s;
+    }
 }
+


### PR DESCRIPTION
Updates to the transformation on Concats to StringBuilder that reduce redundant "new" StringBuilders while respecting correctness.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/babylon.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/149.diff">https://git.openjdk.org/babylon/pull/149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/149#issuecomment-2174999426)