### PR TITLE
Report no attribute present when extracting attribute value from externalized op

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
@@ -408,7 +408,7 @@ public class ArithMathOps {
                     v -> switch (v) {
                         case String s -> CompareKind.valueOf(s);
                         case CompareKind k -> k;
-                        default -> throw new UnsupportedOperationException("Unsupported start value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported start value:" + v);
                     });
             return new CompareOp(def, ck);
         }

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -165,7 +165,7 @@ public class TritonOps {
             String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
-                        default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
                     });
             return new FuncOp(def, funcName);
         }
@@ -255,7 +255,7 @@ public class TritonOps {
             String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
-                        default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
                     });
 
             return new CallOp(def, funcName);
@@ -332,7 +332,7 @@ public class TritonOps {
                     v -> switch (v) {
                         case String s -> Integer.valueOf(s);
                         case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
                     });
             return new ReduceOp(def, axis);
         }
@@ -418,7 +418,7 @@ public class TritonOps {
                     v -> switch (v) {
                         case String s -> Integer.valueOf(s);
                         case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
                     });
             return new GetProgramIdOp(def, axis);
         }
@@ -472,13 +472,13 @@ public class TritonOps {
                     v -> switch (v) {
                         case String s -> Integer.valueOf(s);
                         case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported start value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported start value:" + v);
                     });
             int end = def.extractAttributeValue(ATTRIBUTE_END, false,
                     v -> switch (v) {
                         case String s -> Integer.valueOf(s);
                         case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported end value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported end value:" + v);
                     });
             return new MakeRangeOp(def, start, end);
         }
@@ -534,7 +534,7 @@ public class TritonOps {
                     v -> switch (v) {
                         case String s -> Integer.valueOf(s);
                         case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
                     });
             return new ExpandOp(def, axis);
         }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/SlotOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/SlotOp.java
@@ -58,7 +58,7 @@ public abstract class SlotOp extends ExternalizableOp {
                 v -> switch (v) {
                     case String s -> Integer.parseInt(s);
                     case Integer i -> i;
-                    default -> throw new UnsupportedOperationException("Unsupported slot value:" + v);
+                    case null, default -> throw new UnsupportedOperationException("Unsupported slot value:" + v);
                 });
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
@@ -152,7 +152,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
             String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
-                        default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
                     });
             return new FuncOp(def, funcName);
         }
@@ -252,7 +252,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
             String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
-                        default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
                     });
 
             return new FuncCallOp(def, funcName);
@@ -1328,7 +1328,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                     true, v -> switch (v) {
                         case String s -> MethodRef.ofString(s);
                         case MethodRef md -> md;
-                        default -> throw new UnsupportedOperationException("Unsupported invoke descriptor value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported invoke descriptor value:" + v);
                     });
 
             return new InvokeOp(def, invokeDescriptor);
@@ -1449,7 +1449,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                             yield ft;
                         }
                         case FunctionType ct -> ct;
-                        default -> throw new UnsupportedOperationException("Unsupported new descriptor value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported new descriptor value:" + v);
                     });
             return new NewOp(def, constructorType);
         }
@@ -1570,7 +1570,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                         v -> switch (v) {
                             case String s -> FieldRef.ofString(s);
                             case FieldRef fd -> fd;
-                            default ->
+                            case null, default ->
                                     throw new UnsupportedOperationException("Unsupported field descriptor value:" + v);
                         });
                 return new FieldLoadOp(def, fieldDescriptor);
@@ -1631,7 +1631,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                         v -> switch (v) {
                             case String s -> FieldRef.ofString(s);
                             case FieldRef fd -> fd;
-                            default ->
+                            case null, default ->
                                     throw new UnsupportedOperationException("Unsupported field descriptor value:" + v);
                         });
                 return new FieldStoreOp(def, fieldDescriptor);
@@ -1837,7 +1837,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                     v -> switch (v) {
                         case String s -> JavaType.ofString(s);
                         case JavaType td -> td;
-                        default -> throw new UnsupportedOperationException("Unsupported type descriptor value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported type descriptor value:" + v);
                     });
             return new InstanceOfOp(def, typeDescriptor);
         }
@@ -1904,7 +1904,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                     v -> switch (v) {
                         case String s -> JavaType.ofString(s);
                         case JavaType td -> td;
-                        default -> throw new UnsupportedOperationException("Unsupported type descriptor value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported type descriptor value:" + v);
                     });
             return new CastOp(def, type);
         }
@@ -1999,6 +1999,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
             String name = def.extractAttributeValue(ATTRIBUTE_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
+                        case null -> null;
                         default -> throw new UnsupportedOperationException("Unsupported var name value:" + v);
                     });
             return new VarOp(def, name);
@@ -2251,7 +2252,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                     v -> switch (v) {
                         case String s -> Integer.valueOf(s);
                         case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported tuple index value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported tuple index value:" + v);
                     });
             return new TupleLoadOp(def, index);
         }
@@ -2322,7 +2323,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
                     v -> switch (v) {
                         case String s -> Integer.valueOf(s);
                         case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported tuple index value:" + v);
+                        case null, default -> throw new UnsupportedOperationException("Unsupported tuple index value:" + v);
                     });
             return new TupleWithOp(def, index);
         }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -2622,7 +2622,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 String name = def.extractAttributeValue(ATTRIBUTE_BINDING_NAME, true,
                         v -> switch (v) {
                             case String s -> s;
-                            default ->
+                            case null, default ->
                                     throw new UnsupportedOperationException("Unsupported pattern binding name value:" + v);
                         });
                 return new BindingPatternOp(def, name);
@@ -2691,7 +2691,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                         v -> switch (v) {
                             case String s -> RecordTypeRef.ofString(s);
                             case RecordTypeRef rtd -> rtd;
-                            default ->
+                            case null, default ->
                                     throw new UnsupportedOperationException("Unsupported record type descriptor value:" + v);
                         });
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExternalizableOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExternalizableOp.java
@@ -77,23 +77,26 @@ public abstract class ExternalizableOp extends Op {
          * attempts to remove the attribute with the given name.
          *
          * <p>On successful removal of the attribute its value is converted by applying the value
-         * to the mapping function.
+         * to the mapping function. A {@code null} value is represented the instance
+         * {@link #NULL_ATTRIBUTE_VALUE}.
+         *
+         * <p>If no attribute is present the {@code null} value is applied to the mapping function.
          *
          * @param name      the attribute name.
          * @param isDefault true if the attribute is a default attribute
          * @param <T>       the converted attribute value type
          * @return the converted attribute value
-         * @throws IllegalArgumentException if there is no attribute present
          */
         public <T> T extractAttributeValue(String name, boolean isDefault, Function<Object, T> mapper) {
-            Object value = attributes.remove(isDefault ? "" : name);
-            if (value == null) {
-                if (!isDefault) {
-                    throw new IllegalArgumentException("Required attribute not present: "
-                            + name);
-                }
+            Object value = null;
+            if (isDefault && attributes.containsKey("")) {
+                value = attributes.remove("");
+                assert value != null;
+            }
 
+            if (value == null && attributes.containsKey(name)) {
                 value = attributes.remove(name);
+                assert value != null;
             }
 
             return mapper.apply(value);

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExternalizableOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExternalizableOp.java
@@ -77,7 +77,7 @@ public abstract class ExternalizableOp extends Op {
          * attempts to remove the attribute with the given name.
          *
          * <p>On successful removal of the attribute its value is converted by applying the value
-         * to the mapping function. A {@code null} value is represented the instance
+         * to the mapping function. A {@code null} value is represented by the value
          * {@link #NULL_ATTRIBUTE_VALUE}.
          *
          * <p>If no attribute is present the {@code null} value is applied to the mapping function.


### PR DESCRIPTION
`ExternalizedOp.extractAttributeValue` is changed to report `null` to the mapping function if no attribute is present in the attribute map (a `null` value is represented by the value `ExternalizedOp.NULL_ATTRIBUTE_VALUE`) . This enables the caller to support a default value when no attribute is present.

Variable operations (`VarOp`) now correctly support variables with no names when instantiating from an externalized op.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/babylon.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/150.diff">https://git.openjdk.org/babylon/pull/150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/150#issuecomment-2176952178)