### PR TITLE
Schema builder seems to recreate simple layouts, close with Cascade

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/Cascade.java
+++ b/hat/examples/experiments/src/main/java/experiments/Cascade.java
@@ -65,7 +65,7 @@ public interface Cascade extends CompleteBuffer {
         Rect rect(long idx);
     }
     int featureCount();
-    void featureCount(int featureCount);
+    //void featureCount(int featureCount);
     Feature feature(long idx);
     interface Stage extends Buffer.StructChild {
         float threshold();
@@ -78,7 +78,7 @@ public interface Cascade extends CompleteBuffer {
         void treeCount(short treeCount);
     }
     int stageCount();
-    void stageCount(int stageCount);
+   // void stageCount(int stageCount);
     Stage stage(long idx);
     interface Tree extends Buffer.StructChild {
         void id(int id);
@@ -89,7 +89,7 @@ public interface Cascade extends CompleteBuffer {
         short featureCount();
     }
     int treeCount();
-    void treeCount(int treeCount);
+ //   void treeCount(int treeCount);
     Tree tree(long idx);
 
 
@@ -99,6 +99,7 @@ public interface Cascade extends CompleteBuffer {
                     .fields("id","threshold")
                     .fields("left","right",linkOrValue->linkOrValue
                             .field("hasValue")
+                            .pad(3)
                             .field("anon", anon->anon.fields("featureId","value"))
                     )
                     .array("rect", 3 , rect->rect.fields("x","y","width","height","weight"))

--- a/hat/examples/experiments/src/main/java/experiments/ResultTable.java
+++ b/hat/examples/experiments/src/main/java/experiments/ResultTable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package experiments;
+
+import hat.buffer.Buffer;
+
+public interface ResultTable extends Buffer{
+    interface Result extends Buffer.StructChild {
+        float x();
+        void x(float x);
+        float y();
+        void y(float y);
+        float width();
+        void width(float width);
+        float height();
+        void height(float height);
+    }
+    void atomicResultTableCount(int atomicResultTableCount);
+    int atomicResultTableCount();
+    int length();
+    Result result(long idx);
+    Schema<ResultTable> schema = Schema.of(ResultTable.class, resultTable->resultTable
+            .field("atomicResultTableCount")
+            .arrayLen("length").array("result", array->array.fields("x","y","width","height"))
+    );
+    default int atomicResultTableCountInc() {
+        int index = atomicResultTableCount();
+        atomicResultTableCount(index + 1);
+        return index;
+    }
+}

--- a/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
@@ -36,22 +36,27 @@ import java.lang.foreign.Arena;
 public class SchemaLayoutTest {
 
     public static void main(String[] args) {
-        Cascade.schema.toText(t->System.out.print(t));
-        S32Array.schema.toText(t->System.out.print(t));
-
         BufferAllocator bufferAllocator= new BufferAllocator() {
             public <T extends Buffer> T allocate(SegmentMapper<T> s) {return s.allocate(Arena.global());}
         };
         hat.buffer.S32Array os32  = hat.buffer.S32Array.create(bufferAllocator,100);
-        System.out.println();
-        System.out.println(Buffer.getLayout(os32));
+        System.out.println("Layout from hat S32Array "+ Buffer.getLayout(os32));
 
-
-      //  Function<SegmentMapper<S32Array>,S32Array> allocator = s->s.allocate(Arena.global());
         var s32Array = S32Array.schema.allocate(bufferAllocator, 100).instance;
-        int i = s32Array.length();
-       // var cascade = Cascade.schema.allocate(bufferAllocator,10,10,10).instance;
+        int s23ArrayLen = s32Array.length();
+        System.out.println("Layout from schema "+Buffer.getLayout(s32Array));
+        ResultTable.schema.toText(t->System.out.print(t));
 
+        var resultTable = ResultTable.schema.allocate(bufferAllocator, 100).instance;
+        int resultTableLen = resultTable.length();
+        System.out.println(Buffer.getLayout(resultTable));
+
+
+        Cascade.schema.toText(t->System.out.print(t));
+        var cascadelayout = Cascade.schema.layout(10,10,10);
+        System.out.println(cascadelayout);
+        var cascade = Cascade.schema.allocate(bufferAllocator,10,10,10).instance;
+        System.out.println(Buffer.getLayout(cascade));
         //var layout = Cascade.schema.field.layout();
 
    //     System.out.println(layout);


### PR DESCRIPTION
More success using Schema builder to replace manually defining layouts. 
Simple layouts (S32Array and ResultTable) seem stable and consistant.
Cascade is close, but need to set 'unbound arrays'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/babylon.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/153.diff">https://git.openjdk.org/babylon/pull/153.diff</a>

</details>
