### PR TITLE
Fix JavaDoc typos

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/TypeElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/TypeElement.java
@@ -31,9 +31,6 @@ public non-sealed interface TypeElement extends CodeItem {
      */
     record ExternalizedTypeElement(String identifier, List<ExternalizedTypeElement> arguments) {
 
-        /**
-         * {@inheritDoc}
-         */
         public ExternalizedTypeElement {
             arguments = List.copyOf(arguments);
         }
@@ -94,7 +91,7 @@ public non-sealed interface TypeElement extends CodeItem {
          * <p>
          * For any given externalized type element, {@code te}, the following
          * expression returns {@code true}.
-         * {@snippet lang=java
+         * {@snippet lang=java :
          * te.equals(ExternalizedTypeElement.ofString(te.toString()));
          * }
          * @param s the string


### PR DESCRIPTION
Fix JavaDoc typos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/babylon.git pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/157.diff">https://git.openjdk.org/babylon/pull/157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/157#issuecomment-2187501860)