### PR TITLE
Allow us to bind arbitary data to iface mapping.

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/Cascade.java
+++ b/hat/examples/experiments/src/main/java/experiments/Cascade.java
@@ -32,7 +32,7 @@ import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
 
-public interface Cascade extends CompleteBuffer {
+public interface Cascade extends Buffer {
     int width();
 
     void width(int width);
@@ -169,7 +169,7 @@ public interface Cascade extends CompleteBuffer {
         Cascade.schema.toText(t -> System.out.print(t));
         var cascadelayout = Cascade.schema.layout(10, 10, 10);
         System.out.println(cascadelayout);
-        var cascade = Cascade.schema.allocate(bufferAllocator, 10, 10, 10).instance;
+        var cascade = Cascade.schema.allocate(bufferAllocator, 10, 10, 10);
         System.out.println(Buffer.getLayout(cascade));
     }
 }

--- a/hat/examples/experiments/src/main/java/experiments/S32Array.java
+++ b/hat/examples/experiments/src/main/java/experiments/S32Array.java
@@ -46,7 +46,8 @@ public interface S32Array extends Buffer {
         hat.buffer.S32Array os32  = hat.buffer.S32Array.create(bufferAllocator,100);
         System.out.println("Layout from hat S32Array "+ Buffer.getLayout(os32));
 
-        var s32Array = S32Array.schema.allocate(bufferAllocator, 100).instance;
+        var s32Array = S32Array.schema.allocate(bufferAllocator, 100);
+        Schema.BoundSchema boundSchema = (Schema.BoundSchema)Buffer.getHatData(s32Array);
         int s23ArrayLen = s32Array.length();
         System.out.println("Layout from schema "+Buffer.getLayout(s32Array));
         ResultTable.schema.toText(t->System.out.print(t));

--- a/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
@@ -42,12 +42,12 @@ public class SchemaLayoutTest {
         hat.buffer.S32Array os32  = hat.buffer.S32Array.create(bufferAllocator,100);
         System.out.println("Layout from hat S32Array "+ Buffer.getLayout(os32));
 
-        var s32Array = S32Array.schema.allocate(bufferAllocator, 100).instance;
+        var s32Array = S32Array.schema.allocate(bufferAllocator, 100);
         int s23ArrayLen = s32Array.length();
         System.out.println("Layout from schema "+Buffer.getLayout(s32Array));
         ResultTable.schema.toText(t->System.out.print(t));
 
-        var resultTable = ResultTable.schema.allocate(bufferAllocator, 100).instance;
+        var resultTable = ResultTable.schema.allocate(bufferAllocator, 100);
         int resultTableLen = resultTable.length();
         System.out.println(Buffer.getLayout(resultTable));
 
@@ -55,7 +55,8 @@ public class SchemaLayoutTest {
         Cascade.schema.toText(t->System.out.print(t));
         var cascadelayout = Cascade.schema.layout(10,10,10);
         System.out.println(cascadelayout);
-        var cascade = Cascade.schema.allocate(bufferAllocator,10,10,10).instance;
+        var cascade = Cascade.schema.allocate(bufferAllocator,10,10,10);
+
         System.out.println(Buffer.getLayout(cascade));
         //var layout = Cascade.schema.field.layout();
 

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
@@ -69,8 +69,8 @@ public class ViolaJonesCompute {
         );
         Cascade cascade = Cascade.create(accelerator, haarCascade);
 
-       var boundSchema = Cascade.schema.allocate(accelerator,haarCascade.featureCount(),haarCascade.stageCount(),haarCascade.treeCount());
-       var cascade2 = boundSchema.instance;
+       var cascade2 = Cascade.schema.allocate(accelerator,haarCascade.featureCount(),haarCascade.stageCount(),haarCascade.treeCount());
+
 
        System.out.println("Original   "+Buffer.getLayout(cascade));
         System.out.println("Schema     "+Buffer.getLayout(cascade2));

--- a/hat/hat/src/main/java/hat/buffer/Buffer.java
+++ b/hat/hat/src/main/java/hat/buffer/Buffer.java
@@ -24,6 +24,9 @@
  */
 package hat.buffer;
 
+import hat.Schema;
+import hat.ifacemapper.HatData;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -32,6 +35,7 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.reflect.InvocationTargetException;
 
+import static hat.ifacemapper.MapperUtil.SECRET_HAT_DATA_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_LAYOUT_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_OFFSET_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_SEGMENT_METHOD_NAME;
@@ -66,6 +70,15 @@ public interface Buffer {
             throw new RuntimeException(e);
         }
     }
+
+    static <T extends Buffer>HatData getHatData(T buffer) {
+        try {
+            return (HatData) buffer.getClass().getDeclaredMethod(SECRET_HAT_DATA_METHOD_NAME).invoke(buffer);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
     static <T extends Buffer> MemoryLayout getLayout(T buffer) {
         try {

--- a/hat/hat/src/main/java/hat/ifacemapper/AbstractSegmentMapper.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/AbstractSegmentMapper.java
@@ -25,7 +25,6 @@
 
 package hat.ifacemapper;
 
-
 import hat.ifacemapper.accessor.Accessors;
 import hat.ifacemapper.accessor.ValueType;
 import hat.ifacemapper.accessor.AccessorInfo;
@@ -47,19 +46,23 @@ abstract class AbstractSegmentMapper<T> implements SegmentMapper<T> {
     private final Class<T> type;
     @Stable
     private final GroupLayout layout;
+    private final HatData hatData;
     private final boolean leaf;
     private final MapperCache mapperCache;
     protected Accessors accessors;
 
     protected AbstractSegmentMapper(MethodHandles.Lookup lookup,
                                     Class<T> type,
+
                                     GroupLayout layout,
+                                    HatData hatData,
                                     boolean leaf,
                                     ValueType valueType, // This is always ValueType.Interface... !
                                     UnaryOperator<Class<T>> typeInvariantChecker,
                                     BiFunction<Class<?>, GroupLayout, Accessors> accessorFactory) {
         this.lookup = lookup;
         this.type = typeInvariantChecker.apply(type);
+        this.hatData = hatData;
         this.layout = layout;
         this.leaf = leaf;
         this.mapperCache = MapperCache.of(lookup);
@@ -84,14 +87,19 @@ abstract class AbstractSegmentMapper<T> implements SegmentMapper<T> {
     public final GroupLayout layout() {
         return layout;
     }
-
+    @Override
+    public final HatData hatData() {
+        return hatData;
+    }
 
     @Override
     public final String toString() {
         return getClass().getSimpleName() + "[" +
                 "lookup=" + lookup + ", " +
                 "type=" + type + ", " +
-                "layout=" + layout + "]";
+                "layout=" + layout +
+                "hatData=" + ((hatData==null)?"null":hatData) + ", " +
+                "]";
     }
 
     // Protected methods

--- a/hat/hat/src/main/java/hat/ifacemapper/HatData.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/HatData.java
@@ -1,0 +1,4 @@
+package hat.ifacemapper;
+
+public interface HatData {
+}

--- a/hat/hat/src/main/java/hat/ifacemapper/MapperUtil.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/MapperUtil.java
@@ -52,8 +52,8 @@ public final class MapperUtil {
             Boolean.getBoolean("hat.ifacemapper.debug");
 
     public static final String SECRET_SEGMENT_METHOD_NAME = "$_$_$sEgMeNt$_$_$";
-
     public static final String SECRET_LAYOUT_METHOD_NAME = "$_$_$lAyOuT$_$_$";
+    public static final String SECRET_HAT_DATA_METHOD_NAME = "$_$_$hAtDaTa$_$_$";
     public static final String SECRET_OFFSET_METHOD_NAME = "$_$_$oFfSeT$_$_$";
 
     public static boolean isDebug() {

--- a/hat/intellij/.idea/vcs.xml
+++ b/hat/intellij/.idea/vcs.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
     <mapping directory="$PROJECT_DIR$/../../../beehive-spirv-toolkit" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
Iface mapping modiried to alllow us to bind arbitary data to the iface to layout to segment mapping. 

Specifically as BoundSchema implements HatData we can now bind the schema to iface mapping so the schema can be recovered at runtime.

Initially HatData is a marker interface. 

We could also add setDirty/isDirty methods to HatData.  Allowing babylon modified compute code to mark buffers as 'dirty', forcing the backend to copy to device. 
