### PR TITLE
Bump version check in sanity.java to 24

### DIFF
--- a/hat/sanity.java
+++ b/hat/sanity.java
@@ -76,7 +76,7 @@ public class PomChecker {
       var javaHome = System.getProperty("java.home");
       var pwd = new File(System.getProperty("user.dir"));
 
-      if (javaVersion.startsWith("23")){
+      if (javaVersion.startsWith("24")){
          out.println("javaVersion "+javaVersion+" looks OK");
 
          var props = new LinkedHashMap<String,String>();


### PR DESCRIPTION
A one char change ;) 

sanity.java now checks for JDK 24.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/babylon.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/159.diff">https://git.openjdk.org/babylon/pull/159.diff</a>

</details>
