### PR TITLE
Conflicting code reflection fields for method overrides

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -43,6 +43,7 @@ import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.scope.MethodScope;
 import sun.reflect.annotation.AnnotationType;
 import sun.reflect.annotation.AnnotationParser;
+import java.io.CharArrayWriter;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.AnnotationFormatError;
 import java.lang.reflect.code.op.ExtendedOp;
@@ -277,7 +278,17 @@ public final class Method extends Executable {
 
     private Optional<FuncOp> createCodeModel() {
         Class<?> dc = getDeclaringClass();
-        String fieldName = getName() + "$" + "op";
+        CharArrayWriter sigB = new CharArrayWriter();
+        for (var p : parameterTypes) {
+            sigB.append(p.descriptorString());
+        }
+        char[] sig = sigB.toCharArray();
+        for (int i = 0; i < sig.length; i++) {
+            switch (sig[i]) {
+                case '.', ';', '[', '/': sig[i] = '$';
+            }
+        }
+        String fieldName = getName() + "$" + new String(sig) + "$" + "op";
         Field f;
         try {
             f = dc.getDeclaredField(fieldName);

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -43,7 +43,6 @@ import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.scope.MethodScope;
 import sun.reflect.annotation.AnnotationType;
 import sun.reflect.annotation.AnnotationParser;
-import java.io.CharArrayWriter;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.AnnotationFormatError;
 import java.lang.reflect.code.op.ExtendedOp;
@@ -55,6 +54,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 
 import static java.lang.reflect.code.op.CoreOp.*;
+import java.lang.reflect.code.type.MethodRef;
 
 /**
  * A {@code Method} provides information about, and access to, a single method
@@ -278,17 +278,13 @@ public final class Method extends Executable {
 
     private Optional<FuncOp> createCodeModel() {
         Class<?> dc = getDeclaringClass();
-        CharArrayWriter sigB = new CharArrayWriter();
-        for (var p : parameterTypes) {
-            sigB.append(p.descriptorString());
-        }
-        char[] sig = sigB.toCharArray();
+        char[] sig = MethodRef.method(this).toString().toCharArray();
         for (int i = 0; i < sig.length; i++) {
             switch (sig[i]) {
                 case '.', ';', '[', '/': sig[i] = '$';
             }
         }
-        String fieldName = getName() + "$" + new String(sig) + "$" + "op";
+        String fieldName = new String(sig) + "$" + "op";
         Field f;
         try {
             f = dc.getDeclaredField(fieldName);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -371,8 +371,8 @@ public class ReflectMethods extends TreeTranslator {
                 sig.append(name.toString());
             }
         };
-        for (var p : method.params) {
-            sigGen.assembleSig(types.erasure(p.type));
+        for (var pt : method.sym.externalType(types).getParameterTypes()) {
+            sigGen.assembleSig(types.erasure(pt));
         }
         char[] sigCh = sig.toCharArray();
         for (int i = 0; i < sigCh.length; i++) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -88,6 +88,7 @@ import jdk.internal.java.lang.reflect.code.type.*;
 import jdk.internal.java.lang.reflect.code.type.WildcardType.BoundKind;
 
 import javax.lang.model.element.Modifier;
+import java.io.CharArrayWriter;
 import java.lang.constant.ClassDesc;
 import java.util.*;
 import java.util.function.Function;
@@ -191,7 +192,7 @@ public class ReflectMethods extends TreeTranslator {
                 }
                 // create a static final field holding the op' string text.
                 // The name of the field is foo$op, where 'foo' is the name of the corresponding method.
-                classOps.add(opFieldDecl(tree.name, tree.getModifiers().flags, funcOp));
+                classOps.add(opFieldDecl(methodName(tree), tree.getModifiers().flags, funcOp));
             } catch (UnsupportedASTException ex) {
                 // whoops, some AST node inside the method body were not supported. Log it and move on.
                 log.note(ex.tree, Notes.MethodIrSkip(tree.sym.enclClass(), tree.sym, ex.tree.getTag().toString()));
@@ -352,6 +353,34 @@ public class ReflectMethods extends TreeTranslator {
 
     Name lambdaName() {
         return names.fromString("lambda").append('$', names.fromString(String.valueOf(lambdaCount++)));
+    }
+
+    Name methodName(JCMethodDecl method) {
+        CharArrayWriter sig = new CharArrayWriter();
+        var sigGen = new Types.SignatureGenerator(types) {
+            @Override
+            protected void append(char ch) {
+                sig.append(ch);
+            }
+            @Override
+            protected void append(byte[] ba) {
+                sig.append(new String(ba));
+            }
+            @Override
+            protected void append(Name name) {
+                sig.append(name.toString());
+            }
+        };
+        for (var p : method.params) {
+            sigGen.assembleSig(types.erasure(p.type));
+        }
+        char[] sigCh = sig.toCharArray();
+        for (int i = 0; i < sigCh.length; i++) {
+            switch (sigCh[i]) {
+                case '.', ';', '[', '/' -> sigCh[i] = '$';
+            }
+        }
+        return method.name.append('$', names.fromChars(sigCh, 0, sigCh.length));
     }
 
     private JCVariableDecl opFieldDecl(Name prefix, long flags, CoreOp.FuncOp op) {

--- a/test/jdk/java/lang/reflect/code/TestOverloads.java
+++ b/test/jdk/java/lang/reflect/code/TestOverloads.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.runtime.CodeReflection;
+import java.util.*;
+import java.util.stream.Stream;
+
+/*
+ * @test
+ * @run testng TestOverloads
+ */
+
+public class TestOverloads {
+
+    @CodeReflection
+    static int f() {
+       return 0;
+    }
+
+    @CodeReflection
+    static int f(int i) {
+       return 1;
+    }
+
+    @CodeReflection
+    static int f(Integer i) {
+       return 2;
+    }
+
+    @CodeReflection
+    static int f(Object o) {
+       return 3;
+    }
+
+    @CodeReflection
+    static int f(List<Integer> l) {
+       return 4;
+    }
+
+    @CodeReflection
+    static int f(List<Integer> l, Object o) {
+       return 5;
+    }
+
+    @DataProvider(name = "testData")
+    public static Object[][]  testData() {
+        return new Object[][]{
+            new Object[] {new Class[]{}, new Object[]{}},
+            new Object[] {new Class[]{int.class}, new Object[]{-1}},
+            new Object[] {new Class[]{Integer.class}, new Object[]{-1}},
+            new Object[] {new Class[]{Object.class}, new Object[]{"hello"}},
+            new Object[] {new Class[]{List.class}, new Object[]{List.of()}},
+            new Object[] {new Class[]{List.class, Object.class}, new Object[]{List.of(), -1}}
+        };
+    }
+
+    @Test(dataProvider = "testData")
+    public static void testOverloads(Class<?>[] paramTypes, Object[] params) {
+        try {
+            Class<TestOverloads> clazz = TestOverloads.class;
+            Method method = clazz.getDeclaredMethod("f", paramTypes);
+            CoreOp.FuncOp f = method.getCodeModel().orElseThrow();
+            var res1 = Interpreter.invoke(MethodHandles.lookup(), f, params);
+            var res2 = method.invoke(null, params);
+
+            Assert.assertEquals(res1, res2);
+
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/jdk/java/lang/reflect/code/TestTryFinally.java
+++ b/test/jdk/java/lang/reflect/code/TestTryFinally.java
@@ -168,7 +168,7 @@ public class TestTryFinally {
     }
 
     @Test
-    public void finallyReturn() {
+    public void testFinallyReturn() {
         CoreOp.FuncOp f = getFuncOp("finallyReturn");
 
         f.writeTo(System.out);

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
@@ -158,7 +158,7 @@ public class TestTryFinally {
     }
 
     @Test
-    public void finallyReturn() {
+    public void testFinallyReturn() {
         CoreOp.FuncOp f = getFuncOp("finallyReturn");
 
         MethodHandle mh = generate(f);


### PR DESCRIPTION
This patch constructs code reflection fields from method name and $-escaped method parameters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/babylon.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/162.diff">https://git.openjdk.org/babylon/pull/162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/162#issuecomment-2196742995)