### PR TITLE
Simplify creation of BoundSchema from Schema

### DIFF
--- a/hat/docs/hat-notes-and-links.md
+++ b/hat/docs/hat-notes-and-links.md
@@ -1,0 +1,37 @@
+
+
+# Notes and Links
+
+----
+
+* [Contents](hat-00.md)
+* House Keeping
+    * [Project Layout](hat-01-01-project-layout.md)
+    * [Building Babylon](hat-01-02-building-babylon.md)
+    * [Maven and CMake](hat-01-03-maven-cmake.md)
+* Programming Model
+    * [Programming Model](hat-03-programming-model.md)
+* Interface Mapping
+    * [Interface Mapping Overview](hat-04-01-interface-mapping.md)
+    * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
+* Implementation Detail
+    * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+
+---
+
+# Notes and Links
+
+### Deep Learning
+* [Amazons Deep Learning Java](http://djl.ai/)
+
+### Manchester University TornadoVM
+* [Tornado VM](https://github.com/beehive-lab/TornadoVM)
+* [SPIRV Toolkit]()https://github.com/beehive-lab/beehive-spirv-toolkit
+
+### Other JAVA GPU
+* [Aparapi](https://github.com/Syncleus/aparapi)
+
+### Github repos
+* [Babylon OpenJDK](https://github.com/openjdk/babylon)
+* [JTREG](https://github.com/openjdk/jtreg)
+* [jexctract](https://github.com/openjdk/jextract)

--- a/hat/examples/experiments/src/main/java/experiments/Mesh.java
+++ b/hat/examples/experiments/src/main/java/experiments/Mesh.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package experiments;
+
+import hat.Schema;
+import hat.buffer.Buffer;
+
+import java.util.Random;
+
+public interface Mesh extends Buffer {
+    interface Point3D extends StructChild {
+        int x();void x(int x);
+        int y();void y(int y);
+        int z();void z(int z);
+    }
+
+    int points();void points(int points);
+    Point3D point(long idx);
+
+    interface Vertex3D extends StructChild {
+        int from();void from(int id);
+        int to();void to(int id);
+    }
+
+    int vertices(); void vertices(int vertices);
+    Vertex3D vertex(long idx);
+
+    Schema<Mesh> schema = Schema.of(Mesh.class, cascade -> cascade
+            .arrayLen("points").array("point", p -> p.fields("x","y","z"))
+            .arrayLen("vertices").array("vertex", v -> v.fields("from","to"))
+    );
+
+    public static void main(String[] args) {
+        Mesh.schema.toText(t -> System.out.print(t));
+        var mesh = Mesh.schema.allocate( 100, 10);
+        mesh.points(100);
+        mesh.vertices(10);
+        Random random = new Random(System.currentTimeMillis());
+        for (int p=0; p< mesh.points(); p++){
+            var point3D = mesh.point(p);
+            point3D.x(random.nextInt(100));
+            point3D.y(random.nextInt(100));
+            point3D.z(random.nextInt(100));
+        }
+        for (int v=0; v< mesh.vertices(); v++){
+            var vertex3D = mesh.vertex(v);
+            vertex3D.from(random.nextInt(mesh.points()));
+            vertex3D.to(random.nextInt(mesh.points()));
+        }
+        System.out.println(Buffer.getLayout(mesh));
+    }
+}

--- a/hat/examples/experiments/src/main/java/experiments/ResultTable.java
+++ b/hat/examples/experiments/src/main/java/experiments/ResultTable.java
@@ -30,7 +30,6 @@ import hat.buffer.BufferAllocator;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
-import java.lang.foreign.GroupLayout;
 
 public interface ResultTable extends Buffer{
     interface Result extends Buffer.StructChild {
@@ -60,7 +59,7 @@ public interface ResultTable extends Buffer{
         };
         ResultTable.schema.toText(t->System.out.print(t));
         System.out.println();
-        Schema.BoundLayout boundLayout = ResultTable.schema.collectLayouts(1000);
+        var boundLayout = new Schema.BoundSchema<>(ResultTable.schema, 1000);
         System.out.println(boundLayout.groupLayout);
         System.out.println("[i4(length)i4(atomicResultTableCount)[1000:[f4(x)f4(y)f4(width)f4(height)](Result)](result)](ResultTable)");
        // var boundSchema = ResultTable.schema.allocate(bufferAllocator, 100);

--- a/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
@@ -27,6 +27,7 @@
 package experiments;
 
 
+import hat.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.ifacemapper.SegmentMapper;
@@ -53,7 +54,7 @@ public class SchemaLayoutTest {
 
 
         Cascade.schema.toText(t->System.out.print(t));
-        var boundLayout = Cascade.schema.collectLayouts(10,10,10);
+        var boundLayout = new Schema.BoundSchema<>(Cascade.schema,10,10,10);
         System.out.println(boundLayout.groupLayout);
         var cascade = Cascade.schema.allocate(bufferAllocator,10,10,10);
 

--- a/hat/examples/squares/src/main/java/squares/Squares.java
+++ b/hat/examples/squares/src/main/java/squares/Squares.java
@@ -35,7 +35,7 @@ import java.lang.runtime.CodeReflection;
 
 public class Squares {
     @CodeReflection
-    public static int square(int v) {
+    public static int squareit(int v) {
         return  v * v;
 
     }
@@ -44,7 +44,7 @@ public class Squares {
     public static void squareKernel(KernelContext kc, S32Array s32Array) {
         if (kc.x<kc.maxX){
            int value = s32Array.array(kc.x);     // arr[cc.x]
-           s32Array.array(kc.x, square(value));  // arr[cc.x]=value*value
+           s32Array.array(kc.x, squareit(value));  // arr[cc.x]=value*value
         }
     }
 

--- a/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
@@ -85,10 +85,10 @@ public abstract class C99NativeBackend extends NativeBackend {
 
         builder.nl().kernelEntrypoint(kernelCallGraph.entrypoint, args).nl();
 
-       // System.out.println("Original");
-       // System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op().toText());
-       // System.out.println("Lowered");
-       // System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().lower().op().toText());
+        System.out.println("Original");
+        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op().toText());
+        System.out.println("Lowered");
+        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().lower().op().toText());
 
         return builder.toString();
     }


### PR DESCRIPTION
Previously we have a Schema, where a Schema is a static description of a iface mapping. So it captures the types, the order and the relationship between fields. 

We don't want to create a new Schema when only the size of arrays differ.  

When we need real layout information we need to provide 'dimensions' for arrays which were unbound in the static schema. 

So before we allocate we create a BoundSchema this fills in the previously empty array dims and from this, we can create layouts .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.org/babylon.git pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/163.diff">https://git.openjdk.org/babylon/pull/163.diff</a>

</details>
