### PR TITLE
Simplifying InvokePtr example

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
+++ b/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
@@ -29,6 +29,7 @@ package experiments;
 
 import hat.Schema;
 import hat.buffer.Buffer;
+import hat.buffer.MappableIface;
 
 import java.lang.constant.ClassDesc;
 import java.lang.foreign.*;
@@ -169,8 +170,7 @@ public class LayoutExample {
 
     static boolean isBufferOrBufferChild(Class<?> maybeIface) {
         return  maybeIface.isInterface() && (
-                Buffer.class.isAssignableFrom(maybeIface)
-                        || Buffer.Child.class.isAssignableFrom(maybeIface)
+                MappableIface.class.isAssignableFrom(maybeIface)
         );
 
     }

--- a/hat/hat/src/main/java/hat/Schema.java
+++ b/hat/hat/src/main/java/hat/Schema.java
@@ -103,9 +103,7 @@ public class Schema<T extends Buffer> {
         }
 
         public T allocate(BufferAllocator bufferAllocator) {
-            System.out.println(groupLayout);
-            var segmentMapper = SegmentMapper.of(MethodHandles.lookup(), schema.iface, groupLayout);
-            return bufferAllocator.allocate(segmentMapper);
+            return bufferAllocator.allocate(SegmentMapper.of(MethodHandles.lookup(), schema.iface, groupLayout));
         }
 
         @Override
@@ -661,8 +659,12 @@ public class Schema<T extends Buffer> {
             return s.allocate(Arena.global());
         }
     };
+    public BoundSchema<T> boundSchema(int... boundLengths) {
+        return new BoundSchema<>(this, boundLengths);
+    }
+
     public T allocate(BufferAllocator bufferAllocator,int... boundLengths) {
-        return new BoundSchema<>(this, boundLengths).allocate(bufferAllocator);
+        return boundSchema(boundLengths).allocate(bufferAllocator);
     }
     public T allocate(int... boundLengths) {
         return allocate(GlobalArenaAllocator,boundLengths);

--- a/hat/hat/src/main/java/hat/buffer/Buffer.java
+++ b/hat/hat/src/main/java/hat/buffer/Buffer.java
@@ -24,13 +24,8 @@
  */
 package hat.buffer;
 
-import hat.Schema;
 import hat.ifacemapper.HatData;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.reflect.InvocationTargetException;
@@ -41,26 +36,12 @@ import static hat.ifacemapper.MapperUtil.SECRET_OFFSET_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_SEGMENT_METHOD_NAME;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
-public interface Buffer {
-    //@Retention(RetentionPolicy.RUNTIME)
-    //@Target(ElementType.TYPE)
-    //public @interface Struct {
-   // }
+public interface Buffer extends MappableIface {
 
-    //@Retention(RetentionPolicy.RUNTIME)
-    //@Target(ElementType.TYPE)
-    //public @interface Union {
-   // }
-
-    interface Child {
+    interface UnionChild extends MappableIface {
     }
 
-    //@Union
-    interface UnionChild extends Child {
-    }
-
-    //@Struct
-    interface StructChild extends Child {
+    interface StructChild extends MappableIface {
     }
 
     static <T extends Buffer> MemorySegment getMemorySegment(T buffer) {

--- a/hat/hat/src/main/java/hat/buffer/MappableIface.java
+++ b/hat/hat/src/main/java/hat/buffer/MappableIface.java
@@ -1,0 +1,4 @@
+package hat.buffer;
+
+public interface MappableIface {
+}


### PR DESCRIPTION
Some mildly cosmetic changes to InvokePtr expermental code, in prep for Schema and HatPtr work

Created a common interface type Builder, Builder.StructChild an Builder.UnionChild all extend MappableIface

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/babylon.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/166.diff">https://git.openjdk.org/babylon/pull/166.diff</a>

</details>
