### PR TITLE
Another step towards lowering Ptrs through SSA

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/DebugBackend.java
+++ b/hat/examples/experiments/src/main/java/experiments/DebugBackend.java
@@ -11,6 +11,7 @@ import hat.ifacemapper.SegmentMapper;
 import java.lang.foreign.Arena;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.bytecode.BytecodeGenerator;
 import java.lang.reflect.code.interpreter.Interpreter;
@@ -102,8 +103,12 @@ class DebugBackend implements Backend {
                 System.out.println(highLevelForm.toText());
                 System.out.println("------------------");
 
-                // highLevelForm.lower();
-                CoreOp.FuncOp ssaInvokeForm = SSA.transform(highLevelForm);
+                CoreOp.FuncOp loweredForm = highLevelForm.transform(OpTransformer.LOWERING_TRANSFORMER);
+                System.out.println("Lowered form which maintains original invokes and args");
+                System.out.println(loweredForm.toText());
+                System.out.println("-------------- ----");
+
+                CoreOp.FuncOp ssaInvokeForm = SSA.transform(loweredForm);
                 System.out.println("SSA form which maintains original invokes and args");
                 System.out.println(ssaInvokeForm.toText());
                 System.out.println("------------------");

--- a/hat/hat/src/main/java/hat/ifacemapper/SegmentMapper.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/SegmentMapper.java
@@ -809,7 +809,7 @@ public interface SegmentMapper<T> {
                                    Class<T> type,
                                    MemoryLayout... elements) {
 
-        StructLayout structlayout = MemoryLayout.structLayout(elements).withName(type.getSimpleName());
+       StructLayout structlayout = MemoryLayout.structLayout(elements).withName(type.getSimpleName());
         return of(lookup, type, structlayout);
     }
 

--- a/hat/hat/src/main/java/hat/optools/FuncOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/FuncOpWrapper.java
@@ -27,6 +27,7 @@ package hat.optools;
 import hat.HatOps;
 import hat.KernelContext;
 import hat.buffer.Buffer;
+import hat.buffer.MappableIface;
 
 import java.lang.foreign.GroupLayout;
 import java.lang.reflect.code.Block;
@@ -71,7 +72,7 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
 
             public static boolean isIfaceBuffer(Class<?> hopefullyABufferClass) {
 
-                if (Buffer.class.isAssignableFrom(hopefullyABufferClass)) {
+                if (MappableIface.class.isAssignableFrom(hopefullyABufferClass)) {
                     return true;
                 } else {
                     Class<?> enclosingClass = hopefullyABufferClass.getEnclosingClass();

--- a/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -4,6 +4,7 @@ import hat.buffer.Buffer;
 import hat.buffer.KernelContext;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.code.Value;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.type.MethodRef;
@@ -65,6 +66,12 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
         }
     }
 
+    public Value getReceiver() {
+        return hasReceiver()?operandNAsValue(0):null;
+    }
+    public boolean hasReceiver() {
+        return op().hasReceiver();
+    }
 
     public enum IfaceBufferAccess {None, Access, Mutate}
 


### PR DESCRIPTION
Another incremental step towards moving Ptrs down through SSA form. 

Still only support for loads and stores (no array access)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.org/babylon.git pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/167.diff">https://git.openjdk.org/babylon/pull/167.diff</a>

</details>
