### PR TITLE
Hat move schema to ifacemapper and switch ViolaJones  buffers to used schema

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/Cascade.java
+++ b/hat/examples/experiments/src/main/java/experiments/Cascade.java
@@ -24,13 +24,8 @@
  */
 package experiments;
 
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
-import hat.buffer.BufferAllocator;
-import hat.buffer.CompleteBuffer;
-import hat.ifacemapper.SegmentMapper;
-
-import java.lang.foreign.Arena;
 
 public interface Cascade extends Buffer {
     int width();

--- a/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
+++ b/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
@@ -27,7 +27,7 @@
 package experiments;
 
 
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.MappableIface;
 

--- a/hat/examples/experiments/src/main/java/experiments/Mesh.java
+++ b/hat/examples/experiments/src/main/java/experiments/Mesh.java
@@ -27,7 +27,7 @@ package experiments;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.backend.DebugBackend;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;

--- a/hat/examples/experiments/src/main/java/experiments/PointyHat.java
+++ b/hat/examples/experiments/src/main/java/experiments/PointyHat.java
@@ -5,7 +5,7 @@ package experiments;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.backend.DebugBackend;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;

--- a/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
+++ b/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
@@ -5,7 +5,7 @@ package experiments;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.backend.DebugBackend;
 import hat.buffer.BufferAllocator;
 import hat.buffer.CompleteBuffer;

--- a/hat/examples/experiments/src/main/java/experiments/ResultTable.java
+++ b/hat/examples/experiments/src/main/java/experiments/ResultTable.java
@@ -24,7 +24,7 @@
  */
 package experiments;
 
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.ifacemapper.SegmentMapper;

--- a/hat/examples/experiments/src/main/java/experiments/S32Array.java
+++ b/hat/examples/experiments/src/main/java/experiments/S32Array.java
@@ -24,7 +24,7 @@
  */
 package experiments;
 
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 
 public interface S32Array extends Buffer {

--- a/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
@@ -24,7 +24,7 @@
  */
 package experiments;
 
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 
 public class S32ArrayTest implements Buffer {

--- a/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/SchemaLayoutTest.java
@@ -27,7 +27,7 @@
 package experiments;
 
 
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.ifacemapper.SegmentMapper;

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
@@ -25,28 +25,20 @@
 package violajones;
 
 import hat.Accelerator;
-import hat.ComputeContext;
-import hat.KernelContext;
-import hat.Schema;
 import hat.backend.Backend;
-import hat.backend.JavaMultiThreadedBackend;
-import hat.backend.JavaSequentialBackend;
 import hat.buffer.Buffer;
-import hat.buffer.F32Array2D;
 import org.xml.sax.SAXException;
 import violajones.attic.ViolaJones;
 import violajones.attic.ViolaJonesRaw;
 import violajones.buffers.RgbS08x3Image;
 import violajones.ifaces.Cascade;
 import violajones.ifaces.ResultTable;
-import violajones.ifaces.ScaleTable;
 
 import javax.imageio.ImageIO;
 import javax.xml.parsers.ParserConfigurationException;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.lang.runtime.CodeReflection;
 
 public class ViolaJonesCompute {
 

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
@@ -63,9 +63,19 @@ public class ViolaJonesCompute {
 
        var cascade2 = Cascade.schema.allocate(accelerator,haarCascade.featureCount(),haarCascade.stageCount(),haarCascade.treeCount());
 
+       String layoutFromCascade = Buffer.getLayout(cascade).toString();
+        String layoutFromCascadeSchema = Buffer.getLayout(cascade2).toString();
+        if (layoutFromCascadeSchema.equals(layoutFromCascade)) {
+            System.out.println("Original   " + layoutFromCascade);
+            System.out.println("Same as");
+            System.out.println("Schema     " + layoutFromCascadeSchema);
+        }else{
+            System.out.println("Original   " + layoutFromCascade);
+            System.out.println("NOT the Same as");
+            System.out.println("Schema     " + layoutFromCascadeSchema);
+            throw new IllegalStateException("layouts not the same ");
+        }
 
-       System.out.println("Original   "+Buffer.getLayout(cascade));
-        System.out.println("Schema     "+Buffer.getLayout(cascade2));
         RgbS08x3Image rgbImage = RgbS08x3Image.create(accelerator, nasa1996);
         ResultTable resultTable = ResultTable.create(accelerator, 1000);
         System.out.println("result table layout "+Buffer.getLayout(resultTable));

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
@@ -312,7 +312,7 @@ public class ViolaJonesCoreCompute {
     }
 
     @CodeReflection
-    static public void compute(final ComputeContext cc, Cascade cascade, BufferedImage bufferedImage, RgbS08x3Image rgbS08x3Image, ResultTable resultTable) {
+    static public void compute(final ComputeContext cc, Cascade cascade, BufferedImage bufferedImage, RgbS08x3Image rgbS08x3Image, ResultTable resultTable, ScaleTable scaleTable) {
         long start = System.currentTimeMillis();
         int width = rgbS08x3Image.width();
 
@@ -330,8 +330,11 @@ public class ViolaJonesCoreCompute {
         //javaIntegralRow(integralImage, integralSqImage);
         cc.dispatchKernel(width, kc -> integralColKernel(kc, greyImage, integralImage, integralSqImage));
         cc.dispatchKernel(height, kc -> integralRowKernel(kc, integralImage, integralSqImage));
+
+
         // harViz.showIntegrals();
-        ScaleTable scaleTable = ScaleTable.create(cc, cascade, width, height);
+
+       // create(cc, constraints);
         System.out.print("range requested=");
         System.out.print(scaleTable.multiScaleAccumulativeRange());
         System.out.println();

--- a/hat/examples/violajones/src/main/java/violajones/buffers/GreyU16Image.java
+++ b/hat/examples/violajones/src/main/java/violajones/buffers/GreyU16Image.java
@@ -24,7 +24,6 @@
  */
 package violajones.buffers;
 
-import hat.Accelerator;
 import hat.buffer.BufferAllocator;
 import hat.buffer.ImageBuffer;
 
@@ -34,25 +33,13 @@ import java.lang.foreign.StructLayout;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 public interface GreyU16Image extends ImageBuffer {
-
     StructLayout layout =  ImageBuffer.createLayout(GreyU16Image.class,JAVA_SHORT);
     private static GreyU16Image create(BufferAllocator bufferAllocator, int width, int height) {
         return ImageBuffer.create(bufferAllocator, GreyU16Image.class, layout,width, height, BufferedImage.TYPE_USHORT_GRAY, 1);
     }
-
     static GreyU16Image create(BufferAllocator bufferAllocator, BufferedImage bufferedImage) {
         return create(bufferAllocator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
     }
-
     short data(long idx);
-
     void data(long idx, short v);
-
-    default short get(int x, int y) {
-        return data((long) y * width() + x);
-    }
-
-    default void set(int x, int y, short v) {
-        data((long) y * width() + x, v);
-    }
 }

--- a/hat/examples/violajones/src/main/java/violajones/buffers/RgbS08x3Image.java
+++ b/hat/examples/violajones/src/main/java/violajones/buffers/RgbS08x3Image.java
@@ -24,12 +24,9 @@
  */
 package violajones.buffers;
 
-import hat.Accelerator;
 import hat.buffer.BufferAllocator;
 import hat.buffer.ImageBuffer;
-
 import java.awt.image.BufferedImage;
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
@@ -45,17 +42,8 @@ public interface RgbS08x3Image extends ImageBuffer {
         return create(bufferAllocator, bufferedImage.getWidth(), bufferedImage.getHeight()).syncFromRaster(bufferedImage);
 
     }
-
     byte data(long idx);
 
     void data(long idx, byte v);
-
-    default byte get(int x, int y, int deltaMod3) {
-        return data(((long) y * width() * 3 + x * 3) + deltaMod3);
-    }
-
-    default void set(int x, int y, int deltaMod3, byte v) {
-        data(((long) y * width() * 3 + x * 3) + deltaMod3, v);
-    }
 
 }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -46,14 +46,6 @@ public interface Cascade extends CompleteBuffer {
     interface Feature extends StructChild{
 
         interface Rect extends Buffer.StructChild{
-            StructLayout layout = MemoryLayout.structLayout(
-                    JAVA_BYTE.withName("x"),
-                    JAVA_BYTE.withName("y"),
-                    JAVA_BYTE.withName("width"),
-                    JAVA_BYTE.withName("height"),
-                    JAVA_FLOAT.withName("weight")
-            ).withName("Rect");
-
             byte x();
 
             byte y();
@@ -78,10 +70,6 @@ public interface Cascade extends CompleteBuffer {
 
         interface LinkOrValue extends  Buffer.StructChild {
             interface Anon  extends Buffer.UnionChild{
-                MemoryLayout layout = MemoryLayout.unionLayout(
-                        JAVA_INT.withName("featureId"),
-                        JAVA_FLOAT.withName("value")
-                ).withName("Anon");
 
                 int featureId();
 
@@ -91,28 +79,12 @@ public interface Cascade extends CompleteBuffer {
 
                 void value(float value);
             }
-
-            StructLayout layout = MemoryLayout.structLayout(
-                    JAVA_BOOLEAN.withName("hasValue"),
-                    MemoryLayout.paddingLayout(3),
-                    Feature.LinkOrValue.Anon.layout.withName("anon")
-            ).withName("LinkOrValue");
-
             boolean hasValue();
 
             void hasValue(boolean hasValue);
 
             Feature.LinkOrValue.Anon anon();
         }
-
-        StructLayout layout = MemoryLayout.structLayout(
-                JAVA_INT.withName("id"),
-                JAVA_FLOAT.withName("threshold"),
-                Feature.LinkOrValue.layout.withName("left"),
-                Feature.LinkOrValue.layout.withName("right"),
-                MemoryLayout.sequenceLayout(3, Feature.Rect.layout).withName("rect")
-        ).withName(Feature.class.getSimpleName());
-
         int id();
 
 
@@ -132,13 +104,6 @@ public interface Cascade extends CompleteBuffer {
     }
 
     interface Stage extends Buffer.StructChild{
-        StructLayout layout = MemoryLayout.structLayout(
-                JAVA_INT.withName("id"),
-                JAVA_FLOAT.withName("threshold"),
-                JAVA_SHORT.withName("firstTreeId"),
-                JAVA_SHORT.withName("treeCount")
-        ).withName(Stage.class.getSimpleName());
-
         float threshold();
 
         short firstTreeId();
@@ -157,12 +122,6 @@ public interface Cascade extends CompleteBuffer {
     }
 
     interface Tree extends Buffer.StructChild{
-        StructLayout layout = MemoryLayout.structLayout(
-                JAVA_INT.withName("id"),
-                JAVA_SHORT.withName("firstFeatureId"),
-                JAVA_SHORT.withName("featureCount")
-        ).withName(Tree.class.getSimpleName());
-
         void id(int id);
 
         void firstFeatureId(short firstFeatureId);
@@ -176,73 +135,6 @@ public interface Cascade extends CompleteBuffer {
         short firstFeatureId();
 
         short featureCount();
-    }
-
-    static Cascade create(BufferAllocator bufferAllocator, XMLHaarCascadeModel haarCascade) {
-
-        Cascade cascade = bufferAllocator.allocate(SegmentMapper.of(MethodHandles.lookup(), Cascade.class,
-                JAVA_INT.withName("width"),
-                JAVA_INT.withName("height"),
-                JAVA_INT.withName("featureCount"),
-                sequenceLayout(haarCascade.features.size(), Feature.layout.withName(Feature.class.getSimpleName())).withName("feature"),
-                JAVA_INT.withName("stageCount"),
-                sequenceLayout(haarCascade.stages.size(), Stage.layout.withName(Stage.class.getSimpleName())).withName("stage"),
-                JAVA_INT.withName("treeCount"),
-                sequenceLayout(haarCascade.trees.size(), Tree.layout.withName(Tree.class.getSimpleName())).withName("tree")
-        ));
-        cascade.width(haarCascade.width());
-        cascade.height(haarCascade.height());
-        cascade.featureCount(haarCascade.features.size());
-        cascade.stageCount(haarCascade.stages.size());
-        cascade.treeCount(haarCascade.trees.size());
-        for (int idx = 0; idx < haarCascade.features.size(); idx++) {
-            Cascade.Feature cascadeFeature = cascade.feature(idx);
-            var haarfeature = haarCascade.features.get(idx);
-            cascadeFeature.id(haarfeature.id());
-            cascadeFeature.threshold(haarfeature.threshold());
-            Cascade.Feature.LinkOrValue cascadeLeft = cascadeFeature.left();
-            cascadeLeft.hasValue(haarfeature.left.hasValue());
-            if (haarfeature.left.hasValue()) {
-                cascadeLeft.anon().value(haarfeature.left.value());
-            } else {
-                cascadeLeft.anon().value(haarfeature.left.featureId());
-            }
-            Cascade.Feature.LinkOrValue cascadeRight = cascadeFeature.right();
-            cascadeRight.hasValue(haarfeature.right.hasValue());
-            if (haarfeature.right.hasValue()) {
-                cascadeRight.anon().value(haarfeature.right.value());
-            } else {
-                cascadeRight.anon().featureId(haarfeature.right.featureId());
-            }
-            for (int r = 0; r < 3; r++) {
-                var haarrect = haarfeature.rects[r];
-                if (haarrect != null) {
-                    Cascade.Feature.Rect cascadeRect = cascadeFeature.rect(r);
-                    cascadeRect.x(haarrect.x());
-                    cascadeRect.y(haarrect.y());
-                    cascadeRect.width(haarrect.width());
-                    cascadeRect.height(haarrect.height());
-                    cascadeRect.weight(haarrect.weight());
-                }
-            }
-        }
-
-
-        for (XMLHaarCascadeModel.Stage haarstage : haarCascade.stages) {
-            Cascade.Stage cascadeStage = cascade.stage(haarstage.id);
-            cascadeStage.id(haarstage.id());
-            cascadeStage.threshold(haarstage.threshold());
-            cascadeStage.firstTreeId(haarstage.firstTreeId());
-            cascadeStage.treeCount(haarstage.treeCount());
-        }
-
-        for (XMLHaarCascadeModel.Tree haarTree : haarCascade.trees) {
-            Cascade.Tree cascadeTree = cascade.tree(haarTree.id());
-            cascadeTree.id(haarTree.id());
-            cascadeTree.firstFeatureId(haarTree.firstFeatureId());
-            cascadeTree.featureCount(haarTree.featureCount());
-        }
-        return cascade;
     }
 
     Feature feature(long idx);
@@ -285,4 +177,60 @@ public interface Cascade extends CompleteBuffer {
             .arrayLen("treeCount").array("tree",tree->tree.fields("id","firstFeatureId","featureCount"))
     );
 
+    default Cascade copyFrom(Cascade fromCascade){
+        Cascade toCascade= this;
+        toCascade.width(fromCascade.width());
+        toCascade.height(fromCascade.height());
+        toCascade.featureCount(fromCascade.featureCount());
+        toCascade.stageCount(fromCascade.stageCount());
+        toCascade.treeCount(fromCascade.treeCount());
+        for (int idx = 0; idx < fromCascade.featureCount(); idx++) {
+            Cascade.Feature toFeature =  toCascade.feature(idx);
+            Cascade.Feature fromFeature = fromCascade.feature(idx);
+            toFeature.id(fromFeature.id());
+            toFeature.threshold(fromFeature.threshold());
+            Cascade.Feature.LinkOrValue toLeftLinkOrValue = toFeature.left();
+            toLeftLinkOrValue.hasValue(fromFeature.left().hasValue());
+            if (fromFeature.left().hasValue()) {
+                toLeftLinkOrValue.anon().value(fromFeature.left().anon().value());
+            } else {
+                toLeftLinkOrValue.anon().value(fromFeature.left().anon().featureId());
+            }
+            Cascade.Feature.LinkOrValue toRightLinkOrValue = toFeature.right();
+            toRightLinkOrValue.hasValue(fromFeature.right().hasValue());
+            if (fromFeature.right().hasValue()) {
+                toRightLinkOrValue.anon().value(fromFeature.right().anon().value());
+            } else {
+                toRightLinkOrValue.anon().featureId(fromFeature.right().anon().featureId());
+            }
+            for (int r = 0; r < 3; r++) {
+                var fromRect = fromFeature.rect(r);
+                if (fromRect != null) {
+                    var toRect = toFeature.rect(r);
+                    toRect.x(fromRect.x());
+                    toRect.y(fromRect.y());
+                    toRect.width(fromRect.width());
+                    toRect.height(fromRect.height());
+                    toRect.weight(fromRect.weight());
+                }
+            }
+        }
+
+        for (int stageIdx = 0; stageIdx<fromCascade.stageCount(); stageIdx++) {
+            Cascade.Stage fromStage =  fromCascade.stage(stageIdx);// stage(haarstage.id);
+            Cascade.Stage toStage =  toCascade.stage(stageIdx);
+            toStage.id(fromStage.id());
+            toStage.threshold(fromStage.threshold());
+            toStage.firstTreeId(fromStage.firstTreeId());
+            toStage.treeCount(fromStage.treeCount());
+        }
+        for (int treeIdx=0; treeIdx <fromCascade.treeCount(); treeIdx++) {
+            Cascade.Tree toTree =  toCascade.tree(treeIdx);
+            Cascade.Tree fromTree =  fromCascade.tree(treeIdx);
+            toTree.id(fromTree.id());
+            toTree.firstFeatureId(fromTree.firstFeatureId());
+            toTree.featureCount(fromTree.featureCount());
+        }
+        return toCascade;
+    }
 }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -281,7 +281,7 @@ public interface Cascade extends CompleteBuffer {
                     )
                     .array("rect", 3 , rect->rect.fields("x","y","width","height","weight"))
             )
-            .arrayLen("stageCount").array("stage", stage->stage.fields("id","threshold","treeCount","firstTreeId"))
+            .arrayLen("stageCount").array("stage", stage->stage.fields("id","threshold","firstTreeId","treeCount"))
             .arrayLen("treeCount").array("tree",tree->tree.fields("id","firstFeatureId","featureCount"))
     );
 

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -24,8 +24,7 @@
  */
 package violajones.ifaces;
 
-import hat.Accelerator;
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.buffer.CompleteBuffer;

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
@@ -24,8 +24,7 @@
  */
 package violajones.ifaces;
 
-import hat.Accelerator;
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.buffer.Table;

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
@@ -24,6 +24,7 @@
  */
 package violajones.ifaces;
 
+import hat.buffer.IncompleteBuffer;
 import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
@@ -37,53 +38,25 @@ import java.lang.invoke.MethodHandles;
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
-public interface ResultTable extends Table<ResultTable.Result> {
+public interface ResultTable extends IncompleteBuffer  {
 
-    interface Result {
-        StructLayout layout = MemoryLayout.structLayout(
-                JAVA_FLOAT.withName("x"),
-                JAVA_FLOAT.withName("y"),
-                JAVA_FLOAT.withName("width"),
-                JAVA_FLOAT.withName("height")
-        ).withName("Result");
-
+    interface Result extends Buffer.StructChild {
         float x();
-
         float y();
-
         float width();
-
         float height();
-
-
         void x(float x);
-
         void y(float y);
-
         void width(float width);
-
         void height(float height);
     }
 
-    StructLayout layout = MemoryLayout.structLayout(
-            JAVA_INT.withName("length"),
-            JAVA_INT.withName("atomicResultTableCount"),
-            MemoryLayout.sequenceLayout(0, ResultTable.Result.layout).withName("result")
-    );
-
-    static ResultTable create(BufferAllocator bufferAllocator, int length) {
-        return Buffer.setLength(
-                bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(),ResultTable.class,layout,length)),length);
-    }
-
-    default Result get(int i) {
-        return result(i);
-    }
+    int length();
+    void length(int length);
 
     Result result(long idx);
 
     void atomicResultTableCount(int atomicResultTableCount);
-
     int atomicResultTableCount();
 
     default int atomicResultTableCountInc() {
@@ -92,15 +65,10 @@ public interface ResultTable extends Table<ResultTable.Result> {
         return index;
     }
 
-    Schema<ResultTable> schema = null;/*Schema.of(ResultTable.class, resultTable->resultTable
+    Schema<ResultTable> schema = Schema.of(ResultTable.class, resultTable->resultTable
             .atomic("atomicResultTableCount")
             .arrayLen("length").array("result", array->array
-                    .fields(
-                            "x",
-                            "y",
-                            "width",
-                            "height"
-                    )
+                    .fields("x", "y", "width", "height")
             )
-    );*/
+    );
 }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
@@ -25,6 +25,7 @@
 package violajones.ifaces;
 
 
+import hat.buffer.IncompleteBuffer;
 import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
@@ -38,21 +39,8 @@ import java.lang.invoke.MethodHandles;
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
-public interface ScaleTable extends Table<ScaleTable.Scale> {
-    interface Scale extends Buffer {
-        StructLayout layout = MemoryLayout.structLayout(
-                JAVA_FLOAT.withName("scaleValue"),
-                JAVA_FLOAT.withName("scaledXInc"),
-                JAVA_FLOAT.withName("scaledYInc"),
-                JAVA_FLOAT.withName("invArea"),
-                JAVA_INT.withName("scaledFeatureWidth"),
-                JAVA_INT.withName("scaledFeatureHeight"),
-                JAVA_INT.withName("gridWidth"),
-                JAVA_INT.withName("gridHeight"),
-                JAVA_INT.withName("gridSize"),
-                JAVA_INT.withName("accumGridSizeMin"),
-                JAVA_INT.withName("accumGridSizeMax")
-        ).withName("Scale");
+public interface ScaleTable extends IncompleteBuffer {
+    interface Scale extends Buffer.StructChild {
 
         float scaleValue();
 
@@ -97,74 +85,59 @@ public interface ScaleTable extends Table<ScaleTable.Scale> {
         void accumGridSizeMin(int accumGridSizeMin);
 
         void accumGridSizeMax(int accumGridSizeMax);
-
-        default void copyFrom(Scale s) {
-            scaleValue(s.scaleValue());
-            accumGridSizeMax(s.accumGridSizeMax());
-            accumGridSizeMin(s.accumGridSizeMin());
-            gridSize(s.gridSize());
-            gridWidth(s.gridWidth());
-            gridHeight(s.gridHeight());
-            invArea(s.invArea());
-            scaledFeatureWidth(s.scaledFeatureWidth());
-            scaledFeatureHeight(s.scaledFeatureHeight());
-            scaledXInc(s.scaledXInc());
-            scaledYInc(s.scaledYInc());
-        }
-    }
-    StructLayout layout =  MemoryLayout.structLayout(
-            JAVA_INT.withName("length"),
-            JAVA_INT.withName("multiScaleAccumulativeRange"),
-            MemoryLayout.sequenceLayout(0, ScaleTable.Scale.layout).withName("scale")
-    ).withName(ScaleTable.class.getSimpleName());
-    private static ScaleTable create(BufferAllocator bufferAllocator, int length) {
-        return Buffer.setLength(
-                bufferAllocator.allocate(SegmentMapper.ofIncomplete(MethodHandles.lookup(),ScaleTable.class,layout,length)),length);
     }
 
-    static ScaleTable create(BufferAllocator bufferAllocator, Cascade cascade, int imageWidth, int imageHeight) {
-
-        final float startScale = 1f;
-        final float scaleMultiplier = 2f;
-        final float increment = 0.06f;
-
-        // We need to capture multi scale data
-        // this is unique per image as it is
-        // based on size, how many scales we want and the overlap desired
-
-        var maxScale = (Math.min(
-                (float) imageWidth / cascade.width(),
-                (float) imageHeight / cascade.height()));
-
-        //System.out.println("Image " + imageWidth + "x" + imageHeight);
-        // Alas we need to do this twice. We need a count to allocate the segment size
-        int multiScaleCountVar = 0;
-        for (float scale = startScale; scale < maxScale; scale *= scaleMultiplier) {
-            multiScaleCountVar++;
+     class Constraints{
+        final float startScale;
+        final float scaleMultiplier;
+        final float increment;
+        final int cascadeWidth; int cascadeHeight;  int imageWidth; int imageHeight;
+        final float maxScale;
+        public final int scales;
+        Constraints(float startScale, float scaleMultiplier, float increment, int cascadeWidth, int cascadeHeight, int imageWidth, int imageHeight){
+            this.startScale = startScale;
+            this.scaleMultiplier = scaleMultiplier;
+            this.increment = increment;
+            this.cascadeWidth = cascadeWidth;
+            this.cascadeHeight = cascadeHeight;
+            this.imageWidth = imageWidth;
+            this.imageHeight = imageHeight;
+            this.maxScale  = (Math.min(
+                    (float) imageWidth / cascadeWidth,
+                    (float) imageHeight / cascadeHeight));
+            int nonFinalScales = 0;
+            for (float scale = this.startScale; scale < this.maxScale; scale *= scaleMultiplier) {
+                nonFinalScales++;
+            }
+            this.scales = nonFinalScales;
         }
+        Constraints( int cascadeWidth, int cascadeHeight, int imageWidth, int imageHeight){
+           this(1f,2f,0.06f,cascadeWidth,cascadeHeight,imageWidth,imageHeight);
+        }
+        public Constraints(Cascade cascade, int imageWidth, int imageHeight){
+            this(1f,2f,0.06f,cascade.width(),cascade.height(),imageWidth,imageHeight);
+        }
+    }
 
-        ScaleTable scaleTable = ScaleTable.create(bufferAllocator, multiScaleCountVar);
-
-        // now we know the size
-
+      default void applyConstraints ( Constraints constraints) {
         int multiScaleAccumulativeRangeVar = 0;
         long idx = 0;
-        for (float scaleValue = startScale; scaleValue < maxScale; scaleValue *= scaleMultiplier) {
-            ScaleTable.Scale scale = scaleTable.scale(idx++);
+        for (float scaleValue = constraints.startScale; scaleValue < constraints.maxScale; scaleValue *= constraints.scaleMultiplier) {
+            ScaleTable.Scale scale = scale(idx++);
             scale.accumGridSizeMin(multiScaleAccumulativeRangeVar);
             scale.scaleValue(scaleValue);
-            final int scaledFeatureWidth = (int) (cascade.width() * scaleValue);
-            final int scaledFeatureHeight = (int) (cascade.height() * scaleValue);
+            final int scaledFeatureWidth = (int) (constraints.cascadeWidth * scaleValue);
+            final int scaledFeatureHeight = (int) (constraints.cascadeHeight * scaleValue);
             scale.scaledFeatureWidth(scaledFeatureWidth);
             scale.scaledFeatureHeight(scaledFeatureHeight);
 
-            final float scaledXInc = scaledFeatureWidth * increment;
-            final float scaledYInc = scaledFeatureHeight * increment;
+            final float scaledXInc = scaledFeatureWidth * constraints.increment;
+            final float scaledYInc = scaledFeatureHeight * constraints.increment;
             scale.scaledXInc(scaledXInc);
             scale.scaledYInc(scaledYInc);
 
-            int gridWidth = (int) ((imageWidth - scaledFeatureWidth) / scaledXInc);
-            int gridHeight = (int) ((imageHeight - scaledFeatureHeight) / scaledYInc);
+            int gridWidth = (int) ((constraints.imageWidth - scaledFeatureWidth) / scaledXInc);
+            int gridHeight = (int) ((constraints.imageHeight - scaledFeatureHeight) / scaledYInc);
             scale.gridWidth(gridWidth);
             scale.gridHeight(gridHeight);
 
@@ -174,17 +147,16 @@ public interface ScaleTable extends Table<ScaleTable.Scale> {
             scale.invArea(invArea);
             multiScaleAccumulativeRangeVar += gridSize;
         }
-        scaleTable.multiScaleAccumulativeRange(multiScaleAccumulativeRangeVar);
-        //System.out.println("Scales " + scaleTable.length());
+        multiScaleAccumulativeRange(multiScaleAccumulativeRangeVar);
+
         System.out.println("Scaled overlapping rectangles to search " + multiScaleAccumulativeRangeVar);
-        return scaleTable;
-    }
+       }
+
+    int length();
+    void length(int length);
 
     Scale scale(long idx);
 
-    default Scale get(int i) {
-        return scale(i);
-    }
 
     void multiScaleAccumulativeRange(int multiScaleAccumulativeRange);
 
@@ -194,7 +166,7 @@ public interface ScaleTable extends Table<ScaleTable.Scale> {
     default int rangeModGroupSize(int groupSize) {
         return ((multiScaleAccumulativeRange() / groupSize) + ((multiScaleAccumulativeRange() % groupSize) == 0 ? 0 : 1)) * groupSize;
     }
-    Schema<ScaleTable> schema = null;/*Schema.of(ScaleTable.class, scaleTable->scaleTable
+    Schema<ScaleTable> schema = Schema.of(ScaleTable.class, scaleTable->scaleTable
             .field("multiScaleAccumulativeRange")
             .arrayLen("length").array("scale", array->array
                     .fields(
@@ -207,5 +179,5 @@ public interface ScaleTable extends Table<ScaleTable.Scale> {
                             "accumGridSizeMin", "accumGridSizeMax"
                     )
             )
-    );*/
+    );
 }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
@@ -25,16 +25,13 @@
 package violajones.ifaces;
 
 
-import hat.Accelerator;
-import hat.Schema;
+import hat.ifacemapper.Schema;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.buffer.Table;
 import hat.ifacemapper.SegmentMapper;
 
-import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.StructLayout;
 import java.lang.invoke.MethodHandles;
 

--- a/hat/hat/src/main/java/hat/ifacemapper/Schema.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/Schema.java
@@ -1,8 +1,8 @@
-package hat;
+package hat.ifacemapper;
 
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
-import hat.ifacemapper.SegmentMapper;
+import hat.util.Result;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.GroupLayout;
@@ -28,16 +28,16 @@ public class Schema<T extends Buffer> {
     public Class<T> iface;
 
     static abstract sealed class LayoutToBoundFieldTreeNode permits ChildLayoutToBoundFieldTreeNode, BoundSchema {
-        static class FieldLayoutBinding<T extends SchemaNode> {
+        static class FieldToLayoutBinding<T extends SchemaNode> {
             final T field;
             MemoryLayout layout;
-            FieldLayoutBinding(T field, MemoryLayout layout) {
+            FieldToLayoutBinding(T field, MemoryLayout layout) {
                 this.field = field;
                 this.layout = layout;
             }
         }
 
-        static class FieldControlledArrayBinding extends FieldLayoutBinding<SchemaNode.FieldControlledArray> {
+        static class FieldControlledArrayBinding extends FieldToLayoutBinding<SchemaNode.FieldControlledArray> {
             final int idx;
             final int len;
 
@@ -51,7 +51,7 @@ public class Schema<T extends Buffer> {
         final protected LayoutToBoundFieldTreeNode parent;
         final List<ChildLayoutToBoundFieldTreeNode> children = new ArrayList<>();
         final List<MemoryLayout> memoryLayouts = new ArrayList<>();
-        final List<FieldLayoutBinding> fieldToLayoutBindings = new ArrayList<>();
+        final List<FieldToLayoutBinding<?>> fieldToLayoutBindings = new ArrayList<>();
 
         LayoutToBoundFieldTreeNode(LayoutToBoundFieldTreeNode parent) {
             this.parent = parent;
@@ -62,13 +62,13 @@ public class Schema<T extends Buffer> {
         abstract FieldControlledArrayBinding createFieldControlledArrayBinding(SchemaNode.FieldControlledArray fieldControlledArray, MemoryLayout memoryLayout);
 
         void bind(SchemaNode field, MemoryLayout memoryLayout) {
-            FieldLayoutBinding fieldLayoutBinding = null;
+            FieldToLayoutBinding<?> fieldToLayoutBinding = null;
             if (field instanceof SchemaNode.FieldControlledArray fieldControlledArray) {
-                fieldLayoutBinding = createFieldControlledArrayBinding(fieldControlledArray, memoryLayout);
+                fieldToLayoutBinding = createFieldControlledArrayBinding(fieldControlledArray, memoryLayout);
             } else {
-                fieldLayoutBinding = new FieldLayoutBinding(field, memoryLayout);
+                fieldToLayoutBinding = new FieldToLayoutBinding(field, memoryLayout);
             }
-            fieldToLayoutBindings.add(fieldLayoutBinding);
+            fieldToLayoutBindings.add(fieldToLayoutBinding);
             memoryLayouts.add(memoryLayout);
         }
 
@@ -95,7 +95,7 @@ public class Schema<T extends Buffer> {
             this.arraySizeBindings = new ArrayList<>();
             LayoutToBoundFieldTreeNode scope = createChild();
             schema.schemaRootField.fields.forEach(c -> c.collectLayouts(scope));
-            MemoryLayout memoryLayout = isUnion(schema.schemaRootField.nameTypeAndMode.type)
+            MemoryLayout memoryLayout = isUnion(schema.schemaRootField.modeAndType.type)
                     ?MemoryLayout.unionLayout(scope.array())
                     :MemoryLayout.structLayout(scope.array());
             bind(schema.schemaRootField, memoryLayout.withName(schema.iface.getSimpleName()));
@@ -134,69 +134,48 @@ public class Schema<T extends Buffer> {
         }
     }
 
-    public static class NameTypeAndMode {
-        enum Mode {
-            ROOT,
-            PRIMITIVE_GETTER_AND_SETTER,
-            PRIMITIVE_GETTER,
-            PRIMITIVE_SETTER,
-            IFACE_GETTER,
-            PRIMITIVE_ARRAY_SETTER,
-            PRIMITIVE_ARRAY_GETTER,
-            PRIMITIVE_ARRAY_GETTER_AND_SETTER,
-            IFACE_ARRAY_GETTER;
-
-            /**
-             * From the iface mapper we get these mappings
-             *
-             * T foo()             getter iface|primitive  0 args                  , return T     returnType T
-             * T foo(long)    arraygetter iface|primitive  arg[0]==long            , return T     returnType T
-             * void foo(T)            setter       primitive  arg[0]==T               , return void  returnType T
-             * void foo(long, T) arraysetter       primitive  arg[0]==long, arg[1]==T , return void  returnType T
-             *
-             * @param m The reflected method
-             * @return Class represeting the type this method is mapped to
-             */
-            static Mode of(Method m) {
-                Class<?> returnType = m.getReturnType();
-                Class<?>[] paramTypes = m.getParameterTypes();
-                if (paramTypes.length == 0 && returnType.isInterface()) {
-                    return IFACE_GETTER;
-                } else if (paramTypes.length == 0 && returnType.isPrimitive()) {
-                    return PRIMITIVE_GETTER;
-                } else if (paramTypes.length == 1 && paramTypes[0].isPrimitive() && returnType == Void.TYPE) {
-                    return PRIMITIVE_SETTER;
-                } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isInterface()) {
-                    return IFACE_ARRAY_GETTER;
-                } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isPrimitive()) {
-                    return PRIMITIVE_ARRAY_GETTER;
-                } else if (returnType == Void.TYPE && paramTypes.length == 2 &&
-                        paramTypes[0] == Long.TYPE && paramTypes[1].isPrimitive()) {
-                    return PRIMITIVE_ARRAY_SETTER;
-                } else {
-                    System.out.println("skiping " + m);
-                    return null;
-                }
-            }
+    /**
+     * From the iface mapper
+     * T foo()             getter iface|primitive  0 args                  , return T     returnType T
+     * T foo(long)    arraygetter iface|primitive  arg[0]==long            , return T     returnType T
+     * void foo(T)            setter       primitive  arg[0]==T               , return void  returnType T
+     * void foo(long, T) arraysetter       primitive  arg[0]==long, arg[1]==T , return void  returnType T
+     *
+     * @param m The reflected method
+     * @return Class represeting the type this method is mapped to
+     */
+    static Class<?> methodToType(Method m) {
+        Class<?> returnType = m.getReturnType();
+        Class<?>[] paramTypes = m.getParameterTypes();
+        if (paramTypes.length == 0 && (returnType.isInterface() || returnType.isPrimitive())) {
+            return returnType;
+        } else if (paramTypes.length == 1 && paramTypes[0].isPrimitive() && returnType == Void.TYPE) {
+            return paramTypes[0];
+        } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && (returnType.isInterface() || returnType.isPrimitive())) {
+            return returnType;
+        } else if (returnType == Void.TYPE && paramTypes.length == 2 &&
+                paramTypes[0] == Long.TYPE && paramTypes[1].isPrimitive()) {
+            return paramTypes[1];
+        } else {
+            System.out.println("skipping " + m);
+            return null;
         }
-
-        Mode mode;
-        Class<?> type;
-        String name;
-
-        NameTypeAndMode(Mode mode, Class<?> type, String name) {
-            this.mode = mode;
-            this.type = type;
-            this.name = name;
-        }
-
-        @Override
-        public String toString() {
-            return mode.name() + ":" + type.getSimpleName() + ":" + name;
-        }
+    }
+    enum Mode {
+        UNKNOWN,
+        ROOT,
+        PRIMITIVE_GETTER_AND_SETTER,
+        PRIMITIVE_GETTER,
+        PRIMITIVE_SETTER,
+        IFACE_GETTER,
+        PRIMITIVE_ARRAY_SETTER,
+        PRIMITIVE_ARRAY_GETTER,
+        PRIMITIVE_ARRAY_GETTER_AND_SETTER,
+        IFACE_ARRAY_GETTER;
 
         /**
-         * From the iface mapper
+         * From the iface mapper we get these mappings
+         * <p>
          * T foo()             getter iface|primitive  0 args                  , return T     returnType T
          * T foo(long)    arraygetter iface|primitive  arg[0]==long            , return T     returnType T
          * void foo(T)            setter       primitive  arg[0]==T               , return void  returnType T
@@ -205,57 +184,88 @@ public class Schema<T extends Buffer> {
          * @param m The reflected method
          * @return Class represeting the type this method is mapped to
          */
-        static Class<?> methodToType(Method m) {
+        static Mode of(Method m) {
             Class<?> returnType = m.getReturnType();
             Class<?>[] paramTypes = m.getParameterTypes();
-            if (paramTypes.length == 0 && (returnType.isInterface() || returnType.isPrimitive())) {
-                return returnType;
+            if (paramTypes.length == 0 && returnType.isInterface()) {
+                return IFACE_GETTER;
+            } else if (paramTypes.length == 0 && returnType.isPrimitive()) {
+                return PRIMITIVE_GETTER;
             } else if (paramTypes.length == 1 && paramTypes[0].isPrimitive() && returnType == Void.TYPE) {
-                return paramTypes[0];
-            } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && (returnType.isInterface() || returnType.isPrimitive())) {
-                return returnType;
+                return PRIMITIVE_SETTER;
+            } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isInterface()) {
+                return IFACE_ARRAY_GETTER;
+            } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isPrimitive()) {
+                return PRIMITIVE_ARRAY_GETTER;
             } else if (returnType == Void.TYPE && paramTypes.length == 2 &&
                     paramTypes[0] == Long.TYPE && paramTypes[1].isPrimitive()) {
-                return paramTypes[1];
+                return PRIMITIVE_ARRAY_SETTER;
             } else {
-                System.out.println("skipping " + m);
+                System.out.println("skiping " + m);
                 return null;
             }
         }
+    }
+    public static class ModeAndType {
 
-        static NameTypeAndMode of(Class<?> iface, String name) {
-            NameTypeAndMode accessStyle = new NameTypeAndMode(null, null, name);
-            var methods = iface.getDeclaredMethods();
-            Arrays.stream(methods).filter(method -> method.getName().equals(name)).forEach(matchingMethod -> {
-                NameTypeAndMode.Mode mode = NameTypeAndMode.Mode.of(matchingMethod);
-                Class<?> type = methodToType(matchingMethod);
-                accessStyle.type = type;
-                if (accessStyle.type == null) {
-                    accessStyle.type = type;
-                } else if (!accessStyle.type.equals(type)) {
-                    throw new IllegalStateException("type mismatch for " + name);
-                }
-                if (accessStyle.mode == null){
-                    // We don't have one already
-                    accessStyle.mode = mode;
-                } else if ((accessStyle.mode.equals(Mode.PRIMITIVE_ARRAY_GETTER) && mode.equals(Mode.PRIMITIVE_ARRAY_SETTER))
-                        || (accessStyle.mode.equals(Mode.PRIMITIVE_ARRAY_SETTER) && mode.equals(Mode.PRIMITIVE_ARRAY_GETTER))) {
-                    // mode was already an array getter or setter and is now a GETTER_AND_SETTER
-                    accessStyle.mode = Mode.PRIMITIVE_ARRAY_GETTER_AND_SETTER;
-                } else if ((accessStyle.mode.equals(Mode.PRIMITIVE_GETTER) && mode.equals(Mode.PRIMITIVE_SETTER))
-                        || (accessStyle.mode.equals(Mode.PRIMITIVE_SETTER) && mode.equals(Mode.PRIMITIVE_GETTER))) {
-                    // mode was already a primitive getter or setter and is now a GETTER_AND_SETTER
-                    accessStyle.mode= Mode.PRIMITIVE_GETTER_AND_SETTER;
-                }
+        Mode mode;
+        Class<?> type;
+        ModeAndType(Mode mode, Class<?> type) {
+            this.mode = mode;
+            this.type = type;
 
-            });
-            if (accessStyle.type == null && accessStyle.mode == null) {
-                accessStyle.type = iface;
-                accessStyle.name = "root";
-                accessStyle.mode = Mode.ROOT;
-            }
+        }
+
+        @Override
+        public String toString() {
+            return mode.name() + ":" + type.getSimpleName() ;
+        }
+
+
+        static ModeAndType of(Class<?> iface, String name) {
+            ModeAndType accessStyle = new ModeAndType(modeOf(iface, name), typeOf(iface, name));
             return accessStyle;
         }
+    }
+    static Mode modeOf(Class<?> iface, String name) {
+        var methods = iface.getDeclaredMethods();
+        Result<Mode> modeResult = new Result<>();
+        Arrays.stream(methods).filter(method -> method.getName().equals(name)).forEach(matchingMethod -> {
+            var thisMode = Mode.of(matchingMethod);
+            if (thisMode == null){
+                throw new IllegalStateException("Could not determine the mode of method "+name);
+            }
+            if (!modeResult.isPresent()){
+                modeResult.of(thisMode);
+            } else if (( modeResult.get().equals(Mode.PRIMITIVE_ARRAY_GETTER) && thisMode.equals(Mode.PRIMITIVE_ARRAY_SETTER))
+                    || ( modeResult.get().equals(Mode.PRIMITIVE_ARRAY_SETTER) && thisMode.equals(Mode.PRIMITIVE_ARRAY_GETTER))) {
+                modeResult.of(Mode.PRIMITIVE_ARRAY_GETTER_AND_SETTER);
+            } else if (( modeResult.get().equals(Mode.PRIMITIVE_GETTER) && thisMode.equals(Mode.PRIMITIVE_SETTER))
+                    || ( modeResult.get().equals(Mode.PRIMITIVE_SETTER) && thisMode.equals(Mode.PRIMITIVE_GETTER))) {
+                modeResult.of(Mode.PRIMITIVE_GETTER_AND_SETTER);
+            }
+        });
+        if ( !modeResult.isPresent() || modeResult.get().equals(Mode.UNKNOWN)) {
+            modeResult.of(Mode.PRIMITIVE_GETTER_AND_SETTER);
+        }
+        return modeResult.get();
+    }
+
+    static Class<?> typeOf(Class<?> iface, String name) {
+        var methods = iface.getDeclaredMethods();
+        Result<Class<?>> typeResult = new Result<>();
+        Arrays.stream(methods).filter(method -> method.getName().equals(name)).forEach(matchingMethod -> {
+            var thisType = methodToType(matchingMethod);
+            if (!typeResult.isPresent() || typeResult.get().equals(thisType)) {
+                typeResult.of(thisType);
+            } else  {
+                throw new IllegalStateException("type mismatch for " + name);
+            }
+        });
+        if (!typeResult.isPresent()) {
+            typeResult.of(iface);
+        }
+        return typeResult.get();
     }
 
     static boolean isBuffer(Class<?> clazz) {
@@ -281,14 +291,13 @@ public class Schema<T extends Buffer> {
         }
         public abstract void toText(String indent, Consumer<String> stringConsumer);
 
-        public static abstract sealed class FieldSchemaNode extends SchemaNode permits Array, ArrayLen, AtomicField, Field, Padding {
+        public static abstract sealed class FieldSchemaNode extends SchemaNode permits NamedFieldSchemaNode, Padding {
             FieldSchemaNode(TypeSchemaNode parent) {
                 super(parent);
             }
             public abstract void toText(String indent, Consumer<String> stringConsumer);
             abstract void collectLayouts(LayoutToBoundFieldTreeNode layoutCollector);
         }
-
         public static final class Padding extends FieldSchemaNode {
             int len;
             Padding(TypeSchemaNode parent, int len) {
@@ -307,67 +316,78 @@ public class Schema<T extends Buffer> {
             }
         }
 
-        public static final class ArrayLen extends FieldSchemaNode {
-            NameTypeAndMode nameTypeAndMode;
-
-            ArrayLen(TypeSchemaNode parent, NameTypeAndMode nameTypeAndMode) {
+        public static abstract sealed class NamedFieldSchemaNode extends FieldSchemaNode permits Array, ArrayLen, AtomicField, Field {
+          //  Mode mode;
+         //   Class<?> type;
+            final ModeAndType modeAndType;
+            final String name;
+            NamedFieldSchemaNode(TypeSchemaNode parent, ModeAndType  modeAndType, String name) {
                 super(parent);
-                this.nameTypeAndMode = nameTypeAndMode;
-            }
-
-            @Override
-            public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + "arrayLen " + nameTypeAndMode);
-            }
-
-            @Override
-            void collectLayouts(LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
-                layoutToFieldBindingNode.bind(this, parent.getLayout(nameTypeAndMode, layoutToFieldBindingNode).withName(nameTypeAndMode.name));
+              //  this.mode = mode;
+              //  this.type = type;
+                this.modeAndType = modeAndType;
+                this.name = name;
             }
         }
 
-        public static final class AtomicField extends FieldSchemaNode {
-            NameTypeAndMode nameTypeAndMode;
 
-            AtomicField(TypeSchemaNode parent, NameTypeAndMode nameTypeAndMode) {
-                super(parent);
-                this.nameTypeAndMode = nameTypeAndMode;
+        public static final class ArrayLen extends NamedFieldSchemaNode {
+            ArrayLen(TypeSchemaNode parent, ModeAndType modeAndType,  String name) {
+                super(parent,modeAndType, name);
             }
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + "atomic " + nameTypeAndMode);
+                stringConsumer.accept(indent + "arrayLen " + modeAndType);
             }
 
             @Override
             void collectLayouts(LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
-                layoutToFieldBindingNode.bind(this, parent.getLayout(nameTypeAndMode, layoutToFieldBindingNode).withName(nameTypeAndMode.name));
+                layoutToFieldBindingNode.bind(this, parent.getLayout(modeAndType, layoutToFieldBindingNode).withName(name));
             }
         }
 
-        public static final class Field extends FieldSchemaNode {
-            NameTypeAndMode nameTypeAndMode;
+        public static final class AtomicField extends NamedFieldSchemaNode {
 
-            Field(TypeSchemaNode parent, NameTypeAndMode nameTypeAndMode) {
-                super(parent);
-                this.nameTypeAndMode = nameTypeAndMode;
+
+            AtomicField(TypeSchemaNode parent,  ModeAndType modeAndType, String name) {
+                super(parent, modeAndType,name);
             }
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + "field " + nameTypeAndMode);
+                stringConsumer.accept(indent + "atomic " + modeAndType);
             }
 
             @Override
             void collectLayouts(LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
-                layoutToFieldBindingNode.bind(this, parent.getLayout(nameTypeAndMode, layoutToFieldBindingNode).withName(nameTypeAndMode.name));
+                layoutToFieldBindingNode.bind(this, parent.getLayout(modeAndType, layoutToFieldBindingNode).withName(name));
+            }
+        }
+
+        public static final class Field extends NamedFieldSchemaNode {
+
+
+            Field(TypeSchemaNode parent,  ModeAndType modeAndType, String name) {
+                super(parent, modeAndType,name);
+
+            }
+
+            @Override
+            public void toText(String indent, Consumer<String> stringConsumer) {
+                stringConsumer.accept(indent + "field " + modeAndType);
+            }
+
+            @Override
+            void collectLayouts(LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
+                layoutToFieldBindingNode.bind(this, parent.getLayout(modeAndType, layoutToFieldBindingNode).withName(name));
             }
         }
 
         public static abstract sealed class TypeSchemaNode extends SchemaNode permits Union,Struct {
             private List<FieldSchemaNode> fields = new ArrayList<>();
             private List<TypeSchemaNode> types = new ArrayList<>();
-            NameTypeAndMode nameTypeAndMode;
+            ModeAndType modeAndType;
 
             <T extends FieldSchemaNode> T addField(T child) {
                 fields.add(child);
@@ -378,9 +398,9 @@ public class Schema<T extends Buffer> {
                 return child;
             }
 
-            TypeSchemaNode(TypeSchemaNode parent, NameTypeAndMode nameTypeAndMode) {
+            TypeSchemaNode(TypeSchemaNode parent, ModeAndType modeAndType) {
                 super(parent);
-                this.nameTypeAndMode = nameTypeAndMode;
+                this.modeAndType = modeAndType;
             }
             /**
              * Get a layout which describes the NameTypeAndMode.
@@ -388,42 +408,42 @@ public class Schema<T extends Buffer> {
              * If NameTypeAndMode holds a primitive (int, float) then just map to JAVA_INT, JAVA_FLOAT value layouts
              * Otherwise we look through the parent's children.  Which should include a type node struct/union matching the type.
              *
-             * @param nameTypeAndMode
+             * @param modeAndType
              * @param layoutToFieldBindingNode
              * @return
              */
-             MemoryLayout getLayout(NameTypeAndMode nameTypeAndMode, LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
+             MemoryLayout getLayout(ModeAndType modeAndType, LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
                 MemoryLayout memoryLayout = null;
-                if (nameTypeAndMode.type == Integer.TYPE) {
+                if (modeAndType.type == Integer.TYPE) {
                     memoryLayout = JAVA_INT;
-                } else if (nameTypeAndMode.type == Float.TYPE) {
+                } else if (modeAndType.type == Float.TYPE) {
                     memoryLayout = JAVA_FLOAT;
-                } else if (nameTypeAndMode.type == Long.TYPE) {
+                } else if (modeAndType.type == Long.TYPE) {
                     memoryLayout = JAVA_LONG;
-                } else if (nameTypeAndMode.type == Double.TYPE) {
+                } else if (modeAndType.type == Double.TYPE) {
                     memoryLayout = JAVA_DOUBLE;
-                } else if (nameTypeAndMode.type == Short.TYPE) {
+                } else if (modeAndType.type == Short.TYPE) {
                     memoryLayout = JAVA_SHORT;
-                } else if (nameTypeAndMode.type == Character.TYPE) {
+                } else if (modeAndType.type == Character.TYPE) {
                     memoryLayout = JAVA_CHAR;
-                } else if (nameTypeAndMode.type == Byte.TYPE) {
+                } else if (modeAndType.type == Byte.TYPE) {
                     memoryLayout = JAVA_BYTE;
-                } else if (nameTypeAndMode.type == Boolean.TYPE) {
+                } else if (modeAndType.type == Boolean.TYPE) {
                     memoryLayout = JAVA_BOOLEAN;
                 } else {
                     TypeSchemaNode o = types.stream()
-                            .filter(p -> p.nameTypeAndMode.type.equals(nameTypeAndMode.type)).findFirst().get();
+                            .filter(p -> p.modeAndType.type.equals(modeAndType.type)).findFirst().get();
                     LayoutToBoundFieldTreeNode scope = layoutToFieldBindingNode.createChild();
                     o.fields.stream()
                             .forEach(fieldSchemaNode -> {
                                 fieldSchemaNode.collectLayouts(scope);
                             });
-                    if (isUnion(o.nameTypeAndMode.type)) {
+                    if (isUnion(o.modeAndType.type)) {
                         memoryLayout = MemoryLayout.unionLayout(scope.array());
-                    } else if (isStructOrBuffer(o.nameTypeAndMode.type)) {
+                    } else if (isStructOrBuffer(o.modeAndType.type)) {
                         memoryLayout = MemoryLayout.structLayout(scope.array());
                     } else {
-                        throw new IllegalStateException("Recursing through layout collections and came across  " + o.nameTypeAndMode.type);
+                        throw new IllegalStateException("Recursing through layout collections and came across  " + o.modeAndType.type);
                     }
                 }
                 return memoryLayout;
@@ -431,22 +451,22 @@ public class Schema<T extends Buffer> {
 
 
             public TypeSchemaNode struct(String name, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                parentSchemaNodeConsumer.accept(addType(new Struct(this, NameTypeAndMode.of(nameTypeAndMode.type, name))));
+                parentSchemaNodeConsumer.accept(addType(new Struct(this, ModeAndType.of(modeAndType.type, name))));
                 return this;
             }
 
             public TypeSchemaNode union(String name, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                parentSchemaNodeConsumer.accept(addType(new Union(this, NameTypeAndMode.of(nameTypeAndMode.type, name))));
+                parentSchemaNodeConsumer.accept(addType(new Union(this, ModeAndType.of(modeAndType.type, name))));
                 return this;
             }
 
             public TypeSchemaNode field(String name) {
-                addField(new Field(this, NameTypeAndMode.of(nameTypeAndMode.type, name)));
+                addField(new Field(this, ModeAndType.of(modeAndType.type, name), name));
                 return this;
             }
 
             public TypeSchemaNode atomic(String name) {
-                addField(new AtomicField(this, NameTypeAndMode.of(nameTypeAndMode.type, name)));
+                addField(new AtomicField(this, ModeAndType.of(modeAndType.type, name), name));
                 return this;
             }
 
@@ -456,18 +476,18 @@ public class Schema<T extends Buffer> {
             }
 
             public TypeSchemaNode field(String name, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                NameTypeAndMode newAccessStyle = NameTypeAndMode.of(nameTypeAndMode.type, name);
-                addField(new Field(this, newAccessStyle));
+                ModeAndType newAccessStyle = ModeAndType.of(modeAndType.type, name);
+                addField(new Field(this, newAccessStyle, name));
                 TypeSchemaNode field = isStruct(newAccessStyle.type)?new SchemaNode.Struct(this, newAccessStyle):new SchemaNode.Union(this, newAccessStyle);
                 parentSchemaNodeConsumer.accept(addType(field));
                 return this;
             }
 
             public TypeSchemaNode fields(String name1, String name2, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                NameTypeAndMode newAccessStyle1 = NameTypeAndMode.of(nameTypeAndMode.type, name1);
-                NameTypeAndMode newAccessStyle2 = NameTypeAndMode.of(nameTypeAndMode.type, name2);
-                addField(new Field(this, newAccessStyle1));
-                addField(new Field(this, newAccessStyle2));
+                ModeAndType newAccessStyle1 = ModeAndType.of(modeAndType.type, name1);
+                ModeAndType newAccessStyle2 = ModeAndType.of(modeAndType.type, name2);
+                addField(new Field(this,  newAccessStyle1, name1));
+                addField(new Field(this, newAccessStyle2, name2));
                 TypeSchemaNode typeSchemaNode=isStruct(newAccessStyle1.type)
                         ? new SchemaNode.Struct(this, newAccessStyle1)
                         :new SchemaNode.Union(this, newAccessStyle2);
@@ -483,23 +503,23 @@ public class Schema<T extends Buffer> {
             }
 
             public TypeSchemaNode array(String name, int len) {
-                addField(new FixedArray(this, name, NameTypeAndMode.of(nameTypeAndMode.type, name), len));
+                addField(new FixedArray(this, ModeAndType.of(modeAndType.type, name),name, len));
                 return this;
             }
 
             public TypeSchemaNode array(String name, int len, Consumer<TypeSchemaNode> parentFieldConsumer) {
-                NameTypeAndMode newAccessStyle = NameTypeAndMode.of(nameTypeAndMode.type, name);
-                TypeSchemaNode typeSchemaNode = isStruct(nameTypeAndMode.type)
+                ModeAndType newAccessStyle = ModeAndType.of(modeAndType.type, name);
+                TypeSchemaNode typeSchemaNode = isStruct(modeAndType.type)
                                 ?new SchemaNode.Struct(this, newAccessStyle)
                                 :new SchemaNode.Union(this, newAccessStyle);
                 parentFieldConsumer.accept(typeSchemaNode);
                 addType(typeSchemaNode);
-                addField(new FixedArray(this, name, NameTypeAndMode.of(nameTypeAndMode.type, name), len));
+                addField(new FixedArray(this,  ModeAndType.of(modeAndType.type, name), name, len));
                 return this;
             }
 
             private TypeSchemaNode fieldControlledArray(String name, ArrayLen arrayLen) {
-                addField(new FieldControlledArray(this, name, NameTypeAndMode.of(nameTypeAndMode.type, name), arrayLen));
+                addField(new FieldControlledArray(this,  ModeAndType.of(modeAndType.type, name),name, arrayLen));
                 return this;
             }
 
@@ -512,7 +532,7 @@ public class Schema<T extends Buffer> {
                 }
 
                 public TypeSchemaNode array(String name, Consumer<TypeSchemaNode> parentFieldConsumer) {
-                    NameTypeAndMode newAccessStyle = NameTypeAndMode.of(typeSchemaNode.nameTypeAndMode.type, name);
+                    ModeAndType newAccessStyle = ModeAndType.of(typeSchemaNode.modeAndType.type, name);
                     this.typeSchemaNode.fieldControlledArray(name, arrayLenField);
                     TypeSchemaNode typeSchemaNode =isStruct(newAccessStyle.type)
                             ?new SchemaNode.Struct(this.typeSchemaNode, newAccessStyle)
@@ -529,27 +549,27 @@ public class Schema<T extends Buffer> {
             }
 
             public ArrayBuildState arrayLen(String arrayLenFieldName) {
-                var arrayLenField = new ArrayLen(this, NameTypeAndMode.of(nameTypeAndMode.type, arrayLenFieldName));
+                var arrayLenField = new ArrayLen(this,  ModeAndType.of(modeAndType.type, arrayLenFieldName),arrayLenFieldName );
                 addField(arrayLenField);
                 return new ArrayBuildState(this, arrayLenField);
             }
 
             public void flexArray(String name) {
-                addField(new FlexArray(this, name, null));
+                addField(new FlexArray(this,null, name));
             }
 
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
                 stringConsumer.accept(indent);
-                if (isUnion(nameTypeAndMode.type)) {
+                if (isUnion(modeAndType.type)) {
                     stringConsumer.accept("union");
-                } else if (isStructOrBuffer(nameTypeAndMode.type)) {
+                } else if (isStructOrBuffer(modeAndType.type)) {
                     stringConsumer.accept("struct");
                 } else {
                     throw new IllegalStateException("Oh my ");
                 }
-                stringConsumer.accept(" " + nameTypeAndMode + "{");
+                stringConsumer.accept(" " + modeAndType + "{");
                 stringConsumer.accept("\n");
                 types.forEach(c -> {
                     c.toText(indent + " TYPE: ", stringConsumer);
@@ -566,23 +586,21 @@ public class Schema<T extends Buffer> {
         }
 
         public static final class Struct extends TypeSchemaNode {
-            Struct(TypeSchemaNode parent, NameTypeAndMode nameTypeAndMode) {
-                super(parent, nameTypeAndMode);
+            Struct(TypeSchemaNode parent, ModeAndType modeAndType) {
+                super(parent, modeAndType);
             }
         }
 
         public static final class Union extends TypeSchemaNode {
-            Union(TypeSchemaNode parent, NameTypeAndMode nameTypeAndMode) {
-                super(parent, nameTypeAndMode);
+            Union(TypeSchemaNode parent, ModeAndType modeAndType) {
+                super(parent, modeAndType);
             }
         }
 
-        public abstract static sealed class Array extends FieldSchemaNode permits FieldControlledArray, FixedArray, FlexArray {
-            String name;
-            NameTypeAndMode elementAccessStyle;
-            Array(TypeSchemaNode parent, String name, NameTypeAndMode elementAccessStyle) {
-                super(parent);
-                this.name = name;
+        public abstract static sealed class Array extends NamedFieldSchemaNode permits FieldControlledArray, FixedArray, FlexArray {
+            ModeAndType elementAccessStyle;
+            Array(TypeSchemaNode parent,  ModeAndType elementAccessStyle, String name) {
+                super(parent, elementAccessStyle, name);
                 this.elementAccessStyle = elementAccessStyle;
             }
         }
@@ -590,8 +608,8 @@ public class Schema<T extends Buffer> {
         public static final class FixedArray extends Array {
             int len;
 
-            FixedArray(TypeSchemaNode parent, String name, NameTypeAndMode elementAccessStyle, int len) {
-                super(parent, name, elementAccessStyle);
+            FixedArray(TypeSchemaNode parent, ModeAndType elementAccessStyle, String name, int len) {
+                super(parent,  elementAccessStyle, name);
                 this.len = len;
             }
 
@@ -604,13 +622,13 @@ public class Schema<T extends Buffer> {
             void collectLayouts(LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
                 layoutToFieldBindingNode.bind(this, MemoryLayout.sequenceLayout(len,
                         parent.getLayout(elementAccessStyle, layoutToFieldBindingNode).withName(elementAccessStyle.type.getSimpleName())
-                ).withName(elementAccessStyle.name));
+                ).withName(name));
             }
         }
 
         public static final  class FlexArray extends Array {
-            FlexArray(TypeSchemaNode parent, String name, NameTypeAndMode elementAccessStyle) {
-                super(parent, name, elementAccessStyle);
+            FlexArray(TypeSchemaNode parent,  ModeAndType elementAccessStyle, String name) {
+                super(parent,  elementAccessStyle, name);
             }
 
             @Override
@@ -622,21 +640,21 @@ public class Schema<T extends Buffer> {
                 layoutToFieldBindingNode.bind(this,
                         MemoryLayout.sequenceLayout(0,
                                 parent.getLayout(elementAccessStyle, layoutToFieldBindingNode).withName(elementAccessStyle.type.getSimpleName())
-                        ).withName(elementAccessStyle.name));
+                        ).withName(name));
             }
         }
 
         public static final class FieldControlledArray extends Array {
             ArrayLen arrayLen;
 
-            FieldControlledArray(TypeSchemaNode parent, String name, NameTypeAndMode elementAccessStyle, ArrayLen arrayLen) {
-                super(parent, name, elementAccessStyle);
+            FieldControlledArray(TypeSchemaNode parent,  ModeAndType elementAccessStyle,String name, ArrayLen arrayLen) {
+                super(parent, elementAccessStyle, name);
                 this.arrayLen = arrayLen;
             }
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + elementAccessStyle.name + "[" + elementAccessStyle + "] where len defined by " + arrayLen.nameTypeAndMode);
+                stringConsumer.accept(indent + name + "[" + elementAccessStyle + "] where len defined by " + arrayLen.modeAndType);
             }
 
             @Override
@@ -644,7 +662,7 @@ public class Schema<T extends Buffer> {
                 layoutToFieldBindingNode.bind(this, MemoryLayout.sequenceLayout(
                         layoutToFieldBindingNode.takeArrayLen(),
                         parent.getLayout(elementAccessStyle, layoutToFieldBindingNode).withName(elementAccessStyle.type.getSimpleName())
-                ).withName(elementAccessStyle.name));
+                ).withName(name));
             }
         }
     }
@@ -671,8 +689,8 @@ public class Schema<T extends Buffer> {
     }
 
     public static <T extends Buffer> Schema<T> of(Class<T> iface, Consumer<SchemaNode.TypeSchemaNode> parentFieldConsumer) {
-        NameTypeAndMode nameTypeAndMode = NameTypeAndMode.of(iface, iface.getSimpleName());
-        var struct = new SchemaNode.Struct(null, nameTypeAndMode);
+        ModeAndType modeAndType = ModeAndType.of(iface, iface.getSimpleName());
+        var struct = new SchemaNode.Struct(null, modeAndType);
         parentFieldConsumer.accept(struct);
         return new Schema<>(iface, struct);
     }

--- a/hat/hat/src/main/java/hat/ifacemapper/SegmentInterfaceMapper.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/SegmentInterfaceMapper.java
@@ -26,7 +26,6 @@
 package hat.ifacemapper;
 
 
-import hat.Schema;
 import hat.ifacemapper.accessor.AccessorInfo;
 import hat.ifacemapper.accessor.Accessors;
 import hat.ifacemapper.accessor.ValueType;


### PR DESCRIPTION
Schema now part of iface mapper
To prove we have the same layout, ViolaJones example now uses schema rather than layout to bind fields.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/babylon.git pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/170.diff">https://git.openjdk.org/babylon/pull/170.diff</a>

</details>
