### PR TITLE
Reuse some iface mapper types in Schema and remove unused methods

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
+++ b/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
@@ -58,7 +58,7 @@ public class LayoutExample {
      */
 
         public interface Outer extends Buffer {
-            interface Inner extends Buffer.StructChild  {
+            interface Inner extends Struct {
                 int i();
 
                 void i(int v);

--- a/hat/examples/experiments/src/main/java/experiments/Mesh.java
+++ b/hat/examples/experiments/src/main/java/experiments/Mesh.java
@@ -44,7 +44,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public class Mesh {
     public interface MeshData extends CompleteBuffer {
-        interface Point3D extends StructChild {
+        interface Point3D extends Struct {
             int x();
 
             void x(int x);
@@ -65,7 +65,7 @@ public class Mesh {
 
         Point3D point(long idx);
 
-        interface Vertex3D extends StructChild {
+        interface Vertex3D extends Struct {
             int from();
 
             void from(int id);

--- a/hat/examples/experiments/src/main/java/experiments/PointyHat.java
+++ b/hat/examples/experiments/src/main/java/experiments/PointyHat.java
@@ -7,7 +7,6 @@ import hat.ComputeContext;
 import hat.KernelContext;
 import hat.ifacemapper.Schema;
 import hat.backend.DebugBackend;
-import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.buffer.CompleteBuffer;
 import hat.ifacemapper.HatData;
@@ -21,8 +20,8 @@ import java.lang.runtime.CodeReflection;
 
 public class PointyHat {
     public interface ColoredWeightedPoint extends CompleteBuffer {
-        interface WeightedPoint extends Buffer.StructChild {
-            interface Point extends Buffer.StructChild {
+        interface WeightedPoint extends Struct {
+            interface Point extends Struct {
 
                 int x();
 

--- a/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
+++ b/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
@@ -20,7 +20,7 @@ import java.lang.runtime.CodeReflection;
 
 public class PointyHatArray {
     public interface PointArray extends CompleteBuffer {
-        interface Point extends StructChild {
+        interface Point extends Struct {
 
             int x();
 

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -25,27 +25,12 @@
 package violajones.ifaces;
 
 import hat.ifacemapper.Schema;
-import hat.buffer.Buffer;
-import hat.buffer.BufferAllocator;
 import hat.buffer.CompleteBuffer;
-import hat.ifacemapper.SegmentMapper;
-import violajones.XMLHaarCascadeModel;
-
-import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.StructLayout;
-import java.lang.invoke.MethodHandles;
-
-import static java.lang.foreign.MemoryLayout.sequenceLayout;
-import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
-import static java.lang.foreign.ValueLayout.JAVA_BYTE;
-import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 public interface Cascade extends CompleteBuffer {
-    interface Feature extends StructChild{
+    interface Feature extends Struct {
 
-        interface Rect extends Buffer.StructChild{
+        interface Rect extends Struct {
             byte x();
 
             byte y();
@@ -68,8 +53,8 @@ public interface Cascade extends CompleteBuffer {
         }
 
 
-        interface LinkOrValue extends  Buffer.StructChild {
-            interface Anon  extends Buffer.UnionChild{
+        interface LinkOrValue extends Struct {
+            interface Anon  extends Union {
 
                 int featureId();
 
@@ -103,7 +88,7 @@ public interface Cascade extends CompleteBuffer {
         Feature.Rect rect(long idx);
     }
 
-    interface Stage extends Buffer.StructChild{
+    interface Stage extends Struct {
         float threshold();
 
         short firstTreeId();
@@ -121,7 +106,7 @@ public interface Cascade extends CompleteBuffer {
         void treeCount(short treeCount);
     }
 
-    interface Tree extends Buffer.StructChild{
+    interface Tree extends Struct {
         void id(int id);
 
         void firstFeatureId(short firstFeatureId);

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
@@ -26,11 +26,10 @@ package violajones.ifaces;
 
 import hat.buffer.IncompleteBuffer;
 import hat.ifacemapper.Schema;
-import hat.buffer.Buffer;
 
 public interface ResultTable extends IncompleteBuffer  {
 
-    interface Result extends Buffer.StructChild {
+    interface Result extends Struct {
         float x();
         float y();
         float width();

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
@@ -27,10 +27,9 @@ package violajones.ifaces;
 
 import hat.buffer.IncompleteBuffer;
 import hat.ifacemapper.Schema;
-import hat.buffer.Buffer;
 
 public interface ScaleTable extends IncompleteBuffer {
-    interface Scale extends Buffer.StructChild {
+    interface Scale extends Struct {
 
         float scaleValue();
 

--- a/hat/hat/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/hat/src/main/java/hat/backend/DebugBackend.java
@@ -6,6 +6,7 @@ import hat.NDRange;
 import hat.buffer.Buffer;
 import hat.callgraph.KernelCallGraph;
 import hat.callgraph.KernelEntrypoint;
+import hat.ifacemapper.HatData;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
@@ -154,6 +155,7 @@ public class DebugBackend implements Backend {
 
     @Override
     public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper) {
-        return segmentMapper.allocate(Arena.global());
+        return segmentMapper.allocate(Arena.global(), new HatData() {
+        });
     }
 }

--- a/hat/hat/src/main/java/hat/backend/JavaBackend.java
+++ b/hat/hat/src/main/java/hat/backend/JavaBackend.java
@@ -27,6 +27,7 @@ package hat.backend;
 
 import hat.ComputeContext;
 import hat.buffer.Buffer;
+import hat.ifacemapper.HatData;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
@@ -39,7 +40,8 @@ public abstract class JavaBackend implements Backend {
 
     @Override
     public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper){
-        return segmentMapper.allocate(arena);
+        return segmentMapper.allocate(arena, new HatData() {
+        });
     }
     @Override
     public void computeContextHandoff(ComputeContext computeContext) {

--- a/hat/hat/src/main/java/hat/backend/NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/NativeBackend.java
@@ -28,6 +28,7 @@ package hat.backend;
 import hat.ComputeContext;
 import hat.buffer.Buffer;
 import hat.callgraph.CallGraph;
+import hat.ifacemapper.HatData;
 import hat.ifacemapper.SegmentMapper;
 import hat.optools.FuncOpWrapper;
 
@@ -45,7 +46,8 @@ public abstract class NativeBackend extends NativeBackendDriver {
 
     @Override
     public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper){
-        return segmentMapper.allocate(arena);
+        return segmentMapper.allocate(arena, new HatData() {
+        });
     }
     public NativeBackend(String libName) {
         super(libName);

--- a/hat/hat/src/main/java/hat/buffer/Buffer.java
+++ b/hat/hat/src/main/java/hat/buffer/Buffer.java
@@ -34,18 +34,17 @@ import static hat.ifacemapper.MapperUtil.SECRET_HAT_DATA_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_LAYOUT_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_OFFSET_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_SEGMENT_METHOD_NAME;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface Buffer extends MappableIface {
 
-    interface UnionChild extends MappableIface {
+    interface Union extends MappableIface {
     }
 
-    interface StructChild extends MappableIface {
+    interface Struct extends MappableIface {
     }
 
     static <T extends Buffer> MemorySegment getMemorySegment(T buffer) {
-        try {
+       try {
             return (MemorySegment) buffer.getClass().getDeclaredMethod(SECRET_SEGMENT_METHOD_NAME).invoke(buffer);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
@@ -59,7 +58,6 @@ public interface Buffer extends MappableIface {
             throw new RuntimeException(e);
         }
     }
-
 
     static <T extends Buffer> MemoryLayout getLayout(T buffer) {
         try {
@@ -75,11 +73,6 @@ public interface Buffer extends MappableIface {
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    static <T extends Buffer> T setLength(T buffer, int length) {
-        Buffer.getMemorySegment(buffer).set(JAVA_INT, Buffer.getLayout(buffer).byteOffset(MemoryLayout.PathElement.groupElement("length")), length);
-        return buffer;
     }
 
 }

--- a/hat/hat/src/main/java/hat/buffer/KernelContext.java
+++ b/hat/hat/src/main/java/hat/buffer/KernelContext.java
@@ -1,5 +1,6 @@
 package hat.buffer;
 
+import hat.ifacemapper.HatData;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
@@ -16,7 +17,8 @@ public interface KernelContext extends CompleteBuffer {
     ).withName(KernelContext.class.getSimpleName());
 
     static KernelContext create(Arena arena, MethodHandles.Lookup lookup, int x, int maxX) {
-        KernelContext kernelContext = SegmentMapper.of(lookup, KernelContext.class,layout).allocate(arena);
+        KernelContext kernelContext = SegmentMapper.of(lookup, KernelContext.class,layout).allocate(arena, new HatData() {
+        });
         kernelContext.x(x);
         kernelContext.maxX(maxX);
         return kernelContext;

--- a/hat/hat/src/main/java/hat/buffer/U16GreyImage.java
+++ b/hat/hat/src/main/java/hat/buffer/U16GreyImage.java
@@ -36,5 +36,4 @@ public interface U16GreyImage extends ImageIfaceBuffer<U16GreyImage> {
     Schema<U16GreyImage> schema = Schema.of(U16GreyImage.class, s -> s
             .arrayLen("width", "height").stride(1).array("data")
     );
-
 }

--- a/hat/hat/src/main/java/hat/ifacemapper/MapperUtil.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/MapperUtil.java
@@ -43,6 +43,15 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_CHAR;
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+
 public final class MapperUtil {
 
     private MapperUtil() {
@@ -94,6 +103,7 @@ public final class MapperUtil {
         return SegmentMapper.Discoverable.class.isAssignableFrom(type) &&
                 method.getParameterCount() == 0 &&
                 (method.getReturnType() == MemorySegment.class && method.getName().equals("segment") ||
+                        method.getReturnType() == MemoryLayout.class && method.getName().equals("layout") ||
                         method.getReturnType() == long.class && method.getName().equals("offset"));
     }
 
@@ -140,5 +150,27 @@ public final class MapperUtil {
             throw new IllegalArgumentException("Unable to map methods: " + missing);
         }
 
+    }
+
+    public static MemoryLayout primitiveToLayout(Class<?> type) {
+        if (type == Integer.TYPE) {
+            return JAVA_INT;
+        } else if (type == Float.TYPE) {
+            return JAVA_FLOAT;
+        } else if (type == Long.TYPE) {
+            return JAVA_LONG;
+        } else if (type == Double.TYPE) {
+            return JAVA_DOUBLE;
+        } else if (type == Short.TYPE) {
+            return JAVA_SHORT;
+        } else if (type == Character.TYPE) {
+            return JAVA_CHAR;
+        } else if (type == Byte.TYPE) {
+            return JAVA_BYTE;
+        } else if (type == Boolean.TYPE) {
+            return JAVA_BOOLEAN;
+        } else {
+            throw new IllegalStateException("Expecting primitive   " + type);
+        }
     }
 }

--- a/hat/hat/src/main/java/hat/ifacemapper/Schema.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/Schema.java
@@ -2,26 +2,17 @@ package hat.ifacemapper;
 
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
+import hat.ifacemapper.accessor.AccessorInfo;
 import hat.util.Result;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-
-import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
-import static java.lang.foreign.ValueLayout.JAVA_BYTE;
-import static java.lang.foreign.ValueLayout.JAVA_CHAR;
-import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
-import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 public class Schema<T extends Buffer> {
     SchemaNode.TypeSchemaNode schemaRootField;
@@ -66,13 +57,13 @@ public class Schema<T extends Buffer> {
             if (field instanceof SchemaNode.FieldControlledArray fieldControlledArray) {
                 fieldToLayoutBinding = createFieldControlledArrayBinding(fieldControlledArray, memoryLayout);
             } else {
-                fieldToLayoutBinding = new FieldToLayoutBinding(field, memoryLayout);
+                fieldToLayoutBinding = new FieldToLayoutBinding<>(field, memoryLayout);
             }
             fieldToLayoutBindings.add(fieldToLayoutBinding);
             memoryLayouts.add(memoryLayout);
         }
 
-        public MemoryLayout[] array() {
+        public MemoryLayout[] memoryLayoutListToArray() {
             return memoryLayouts.toArray(new MemoryLayout[0]);
         }
 
@@ -88,7 +79,8 @@ public class Schema<T extends Buffer> {
         final private int[] arrayLengths;
         final Schema<T> schema;
         final public GroupLayout groupLayout;
-        public BoundSchema(Schema<T> schema, int ...arrayLengths) {
+
+        public BoundSchema(Schema<T> schema, int... arrayLengths) {
             super(null);
             this.schema = schema;
             this.arrayLengths = arrayLengths;
@@ -96,8 +88,8 @@ public class Schema<T extends Buffer> {
             LayoutToBoundFieldTreeNode scope = createChild();
             schema.schemaRootField.fields.forEach(c -> c.collectLayouts(scope));
             MemoryLayout memoryLayout = isUnion(schema.schemaRootField.type)
-                    ?MemoryLayout.unionLayout(scope.array())
-                    :MemoryLayout.structLayout(scope.array());
+                    ? MemoryLayout.unionLayout(scope.memoryLayoutListToArray())
+                    : MemoryLayout.structLayout(scope.memoryLayoutListToArray());
             bind(schema.schemaRootField, memoryLayout.withName(schema.iface.getSimpleName()));
             this.groupLayout = (GroupLayout) memoryLayouts.getFirst();
         }
@@ -133,79 +125,13 @@ public class Schema<T extends Buffer> {
             return parent.createFieldControlledArrayBinding(fieldControlledArray, memoryLayout);
         }
     }
-    enum Mode {
-        PRIMITIVE_GETTER_AND_SETTER,
-        PRIMITIVE_GETTER,
-        PRIMITIVE_SETTER,
-        IFACE_GETTER,
-        PRIMITIVE_ARRAY_SETTER,
-        PRIMITIVE_ARRAY_GETTER,
-        PRIMITIVE_ARRAY_GETTER_AND_SETTER,
-        IFACE_ARRAY_GETTER;
 
-        /**
-         * From the iface mapper we get these mappings
-         * <p>
-         * T foo()             getter iface|primitive  0 args                  , return T     returnType T
-         * T foo(long)    arraygetter iface|primitive  arg[0]==long            , return T     returnType T
-         * void foo(T)            setter       primitive  arg[0]==T               , return void  returnType T
-         * void foo(long, T) arraysetter       primitive  arg[0]==long, arg[1]==T , return void  returnType T
-         *
-         * @param m The reflected method
-         * @return Class represeting the type this method is mapped to
-         */
-        static Mode of(Method m) {
-            Class<?> returnType = m.getReturnType();
-            Class<?>[] paramTypes = m.getParameterTypes();
-            if (paramTypes.length == 0 && returnType.isInterface()) {
-                return IFACE_GETTER;
-            } else if (paramTypes.length == 0 && returnType.isPrimitive()) {
-                return PRIMITIVE_GETTER;
-            } else if (paramTypes.length == 1 && paramTypes[0].isPrimitive() && returnType == Void.TYPE) {
-                return PRIMITIVE_SETTER;
-            } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isInterface()) {
-                return IFACE_ARRAY_GETTER;
-            } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isPrimitive()) {
-                return PRIMITIVE_ARRAY_GETTER;
-            } else if (returnType == Void.TYPE && paramTypes.length == 2 &&
-                    paramTypes[0] == Long.TYPE && paramTypes[1].isPrimitive()) {
-                return PRIMITIVE_ARRAY_SETTER;
-            } else {
-                throw new IllegalStateException("no possible mode for "+m);
-            }
-        }
-    }
-
-    static Mode modeOf(Class<?> iface, String name) {
-        var methods = iface.getDeclaredMethods();
-        Result<Mode> modeResult = new Result<>();
-        Arrays.stream(methods).filter(method -> method.getName().equals(name)).forEach(matchingMethod -> {
-            var thisMode = Mode.of(matchingMethod);
-            if (!modeResult.isPresent()){
-                modeResult.of(thisMode);
-            } else if (( modeResult.get().equals(Mode.PRIMITIVE_ARRAY_GETTER) && thisMode.equals(Mode.PRIMITIVE_ARRAY_SETTER))
-                    || ( modeResult.get().equals(Mode.PRIMITIVE_ARRAY_SETTER) && thisMode.equals(Mode.PRIMITIVE_ARRAY_GETTER))) {
-                modeResult.of(Mode.PRIMITIVE_ARRAY_GETTER_AND_SETTER);
-            } else if (( modeResult.get().equals(Mode.PRIMITIVE_GETTER) && thisMode.equals(Mode.PRIMITIVE_SETTER))
-                    || ( modeResult.get().equals(Mode.PRIMITIVE_SETTER) && thisMode.equals(Mode.PRIMITIVE_GETTER))) {
-                modeResult.of(Mode.PRIMITIVE_GETTER_AND_SETTER);
-            }
-        });
-        if ( !modeResult.isPresent() ) {
-            throw new IllegalStateException("no possible mode for "+iface+" "+name);
-           // modeResult.of(Mode.PRIMITIVE_GETTER_AND_SETTER);
-        }
-        return modeResult.get();
-    }
-    /**
+    /*
      * From the iface mapper
      * T foo()             getter iface|primitive  0 args                  , return T     returnType T
      * T foo(long)    arraygetter iface|primitive  arg[0]==long            , return T     returnType T
      * void foo(T)            setter       primitive  arg[0]==T               , return void  returnType T
      * void foo(long, T) arraysetter       primitive  arg[0]==long, arg[1]==T , return void  returnType T
-     *
-     * @param iface The reflected method
-     * @return Class represeting the type this method is mapped to
      */
     static Class<?> typeOf(Class<?> iface, String name) {
         var methods = iface.getDeclaredMethods();
@@ -215,25 +141,25 @@ public class Schema<T extends Buffer> {
             Class<?>[] paramTypes = matchingMethod.getParameterTypes();
             Class<?> thisType = null;
             if (paramTypes.length == 0 && (returnType.isInterface() || returnType.isPrimitive())) {
-                thisType= returnType;
+                thisType = returnType;
             } else if (paramTypes.length == 1 && paramTypes[0].isPrimitive() && returnType == Void.TYPE) {
-                thisType=  paramTypes[0];
+                thisType = paramTypes[0];
             } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && (returnType.isInterface() || returnType.isPrimitive())) {
-                thisType=  returnType;
+                thisType = returnType;
             } else if (returnType == Void.TYPE && paramTypes.length == 2 &&
                     paramTypes[0] == Long.TYPE && paramTypes[1].isPrimitive()) {
-                thisType=  paramTypes[1];
+                thisType = paramTypes[1];
             } else {
-                throw new IllegalStateException("Can't determine iface mapping type for "+matchingMethod);
+                throw new IllegalStateException("Can't determine iface mapping type for " + matchingMethod);
             }
             if (!typeResult.isPresent() || typeResult.get().equals(thisType)) {
                 typeResult.of(thisType);
-            } else  {
+            } else {
                 throw new IllegalStateException("type mismatch for " + name);
             }
         });
         if (!typeResult.isPresent()) {
-            throw new IllegalStateException("No type mapping for "+iface+" "+name);
+            throw new IllegalStateException("No type mapping for " + iface + " " + name);
 
         }
         return typeResult.get();
@@ -244,33 +170,39 @@ public class Schema<T extends Buffer> {
     }
 
     static boolean isStruct(Class<?> clazz) {
-        return clazz.isInterface() && Buffer.StructChild.class.isAssignableFrom(clazz);
+        return clazz.isInterface() && Buffer.Struct.class.isAssignableFrom(clazz);
     }
 
     static boolean isStructOrBuffer(Class<?> clazz) {
-        return clazz.isInterface() && (Buffer.class.isAssignableFrom(clazz) || Buffer.StructChild.class.isAssignableFrom(clazz));
+        return clazz.isInterface() && (Buffer.class.isAssignableFrom(clazz) || Buffer.Struct.class.isAssignableFrom(clazz));
     }
 
     static boolean isUnion(Class<?> clazz) {
-        return clazz.isInterface() && Buffer.UnionChild.class.isAssignableFrom(clazz);
+        return clazz.isInterface() && Buffer.Union.class.isAssignableFrom(clazz);
     }
 
     public static abstract class SchemaNode {
         TypeSchemaNode parent;
+
         SchemaNode(TypeSchemaNode parent) {
             this.parent = parent;
         }
+
         public abstract void toText(String indent, Consumer<String> stringConsumer);
 
         public static abstract sealed class FieldSchemaNode extends SchemaNode permits NamedFieldSchemaNode, Padding {
             FieldSchemaNode(TypeSchemaNode parent) {
                 super(parent);
             }
+
             public abstract void toText(String indent, Consumer<String> stringConsumer);
+
             abstract void collectLayouts(LayoutToBoundFieldTreeNode layoutCollector);
         }
+
         public static final class Padding extends FieldSchemaNode {
             int len;
+
             Padding(TypeSchemaNode parent, int len) {
                 super(parent);
                 this.len = len;
@@ -288,26 +220,27 @@ public class Schema<T extends Buffer> {
         }
 
         public static abstract sealed class NamedFieldSchemaNode extends FieldSchemaNode permits Array, ArrayLen, AtomicField, Field {
-            Mode mode;
+            AccessorInfo.Key key;
             Class<?> type;
             final String name;
-            NamedFieldSchemaNode(TypeSchemaNode parent, Mode mode, Class<?> type, String name) {
+
+            NamedFieldSchemaNode(TypeSchemaNode parent, AccessorInfo.Key key, Class<?> type, String name) {
                 super(parent);
-                this.mode = mode;
-                 this.type = type;
+                this.key = key;
+                this.type = type;
                 this.name = name;
             }
         }
 
 
         public static final class ArrayLen extends NamedFieldSchemaNode {
-            ArrayLen(TypeSchemaNode parent, Mode mode, Class<?> type,  String name) {
-                super(parent,mode,type, name);
+            ArrayLen(TypeSchemaNode parent, AccessorInfo.Key key, Class<?> type, String name) {
+                super(parent, key, type, name);
             }
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + "arrayLen " + mode+":"+type);
+                stringConsumer.accept(indent + "arrayLen " + key + ":" + type);
             }
 
             @Override
@@ -319,13 +252,13 @@ public class Schema<T extends Buffer> {
         public static final class AtomicField extends NamedFieldSchemaNode {
 
 
-            AtomicField(TypeSchemaNode parent,  Mode mode, Class<?> type, String name) {
-                super(parent, mode, type,name);
+            AtomicField(TypeSchemaNode parent, AccessorInfo.Key key, Class<?> type, String name) {
+                super(parent, key, type, name);
             }
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + "atomic " + mode+":"+type);
+                stringConsumer.accept(indent + "atomic " + key + ":" + type);
             }
 
             @Override
@@ -337,14 +270,14 @@ public class Schema<T extends Buffer> {
         public static final class Field extends NamedFieldSchemaNode {
 
 
-            Field(TypeSchemaNode parent,  Mode mode, Class<?> type, String name) {
-                super(parent, mode, type,name);
+            Field(TypeSchemaNode parent, AccessorInfo.Key key, Class<?> type, String name) {
+                super(parent, key, type, name);
 
             }
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + "field " + mode+":"+type);
+                stringConsumer.accept(indent + "field " + key + ":" + type);
             }
 
             @Override
@@ -353,7 +286,7 @@ public class Schema<T extends Buffer> {
             }
         }
 
-        public static abstract sealed class TypeSchemaNode extends SchemaNode permits Union,Struct {
+        public static abstract sealed class TypeSchemaNode extends SchemaNode permits Union, Struct {
             private List<FieldSchemaNode> fields = new ArrayList<>();
             private List<TypeSchemaNode> types = new ArrayList<>();
             Class<?> type;
@@ -362,80 +295,62 @@ public class Schema<T extends Buffer> {
                 fields.add(child);
                 return child;
             }
+
             <T extends TypeSchemaNode> T addType(T child) {
                 types.add(child);
                 return child;
             }
 
-            TypeSchemaNode(TypeSchemaNode parent,  Class<?> type) {
+            TypeSchemaNode(TypeSchemaNode parent, Class<?> type) {
                 super(parent);
                 this.type = type;
             }
+
             /**
-             * Get a layout which describes the NameTypeAndMode.
+             * Get a layout which describes the type.
              * <p>
-             * If NameTypeAndMode holds a primitive (int, float) then just map to JAVA_INT, JAVA_FLOAT value layouts
+             * If tyoe holds a primitive (int, float) then just map to JAVA_INT, JAVA_FLOAT value layouts
              * Otherwise we look through the parent's children.  Which should include a type node struct/union matching the type.
              *
              * @param type
              * @param layoutToFieldBindingNode
              * @return
              */
-             MemoryLayout getLayout(Class<?> type, LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
-                MemoryLayout memoryLayout = null;
-                if (type == Integer.TYPE) {
-                    memoryLayout = JAVA_INT;
-                } else if (type == Float.TYPE) {
-                    memoryLayout = JAVA_FLOAT;
-                } else if (type == Long.TYPE) {
-                    memoryLayout = JAVA_LONG;
-                } else if (type == Double.TYPE) {
-                    memoryLayout = JAVA_DOUBLE;
-                } else if (type == Short.TYPE) {
-                    memoryLayout = JAVA_SHORT;
-                } else if (type == Character.TYPE) {
-                    memoryLayout = JAVA_CHAR;
-                } else if (type == Byte.TYPE) {
-                    memoryLayout = JAVA_BYTE;
-                } else if (type == Boolean.TYPE) {
-                    memoryLayout = JAVA_BOOLEAN;
+            MemoryLayout getLayout(Class<?> type, LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
+                if (type.isPrimitive()) {
+                    return MapperUtil.primitiveToLayout(type);
                 } else {
-                    TypeSchemaNode typeSchemaModeMatchingType = types.stream()
-                            .filter(typeSchemaNode -> typeSchemaNode.type.equals(type)).findFirst().get();
+                    TypeSchemaNode typeSchemaKeyMatchingType = types.stream()
+                            .filter(typeSchemaNode -> typeSchemaNode.type.equals(type))
+                            .findFirst()
+                            .orElseThrow();
                     LayoutToBoundFieldTreeNode scope = layoutToFieldBindingNode.createChild();
-                    typeSchemaModeMatchingType.fields.stream()
-                            .forEach(fieldSchemaNode ->
-                                fieldSchemaNode.collectLayouts(scope)
-                            );
-                    if (isUnion(typeSchemaModeMatchingType.type)) {
-                        memoryLayout = MemoryLayout.unionLayout(scope.array());
-                    } else if (isStructOrBuffer(typeSchemaModeMatchingType.type)) {
-                        memoryLayout = MemoryLayout.structLayout(scope.array());
-                    } else {
-                        throw new IllegalStateException("Recursing through layout collections and came across  " + typeSchemaModeMatchingType.type);
-                    }
+                    typeSchemaKeyMatchingType.fields.forEach(fieldSchemaNode ->
+                            fieldSchemaNode.collectLayouts(scope)
+                    );
+                    return isUnion(typeSchemaKeyMatchingType.type)
+                            ? MemoryLayout.unionLayout(scope.memoryLayoutListToArray())
+                            : MemoryLayout.structLayout(scope.memoryLayoutListToArray());
                 }
-                return memoryLayout;
             }
 
-
             public TypeSchemaNode struct(String name, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                parentSchemaNodeConsumer.accept(addType(new Struct(this,  typeOf(type,name))));
+                parentSchemaNodeConsumer.accept(addType(new Struct(this, typeOf(type, name))));
                 return this;
             }
 
             public TypeSchemaNode union(String name, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                parentSchemaNodeConsumer.accept(addType(new Union(this, typeOf(type,name))));
+                parentSchemaNodeConsumer.accept(addType(new Union(this, typeOf(type, name))));
                 return this;
             }
 
             public TypeSchemaNode field(String name) {
-                addField(new Field(this, modeOf(type, name), typeOf(type, name), name));
+                addField(new Field(this, AccessorInfo.Key.of(type, name), typeOf(type, name), name));
                 return this;
             }
 
             public TypeSchemaNode atomic(String name) {
-                addField(new AtomicField(this, modeOf(type, name), typeOf(type, name), name));
+                addField(new AtomicField(this, AccessorInfo.Key.of(type, name), typeOf(type, name), name));
                 return this;
             }
 
@@ -445,30 +360,30 @@ public class Schema<T extends Buffer> {
             }
 
             public TypeSchemaNode field(String name, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                 Mode fieldMode = modeOf(type, name);
-                 Class<?> fieldType = typeOf(type, name);
-                addField(new Field(this,fieldMode, fieldType, name));
-                TypeSchemaNode field = isStruct(fieldType)?new SchemaNode.Struct(this, fieldType):new SchemaNode.Union(this, fieldType);
+                AccessorInfo.Key fieldKey = AccessorInfo.Key.of(type, name);
+                Class<?> fieldType = typeOf(type, name);
+                addField(new Field(this, fieldKey, fieldType, name));
+                TypeSchemaNode field = isStruct(fieldType) ? new SchemaNode.Struct(this, fieldType) : new SchemaNode.Union(this, fieldType);
                 parentSchemaNodeConsumer.accept(addType(field));
                 return this;
             }
 
             public TypeSchemaNode fields(String name1, String name2, Consumer<TypeSchemaNode> parentSchemaNodeConsumer) {
-                Mode fieldMode1 = modeOf(type, name1);
-                Mode fieldMode2 = modeOf(type, name2);
-                if (!fieldMode1.equals(fieldMode2)){
-                    throw new IllegalStateException("fields "+name1+" and "+name2+" have different modes");
+                AccessorInfo.Key fieldKey1 = AccessorInfo.Key.of(type, name1);
+                AccessorInfo.Key fieldKey2 = AccessorInfo.Key.of(type, name2);
+                if (!fieldKey1.equals(fieldKey2)) {
+                    throw new IllegalStateException("fields " + name1 + " and " + name2 + " have different keys");
                 }
                 Class<?> structOrUnionType = typeOf(type, name1);
                 Class<?> fieldTypeCheck = typeOf(type, name2);
-                if (!structOrUnionType.equals(fieldTypeCheck)){
-                    throw new IllegalStateException("fields "+name1+" and "+name2+" have different types");
+                if (!structOrUnionType.equals(fieldTypeCheck)) {
+                    throw new IllegalStateException("fields " + name1 + " and " + name2 + " have different types");
                 }
-                addField(new Field(this,fieldMode1, structOrUnionType, name1));
-                addField(new Field(this,fieldMode2,  structOrUnionType, name2));
-                TypeSchemaNode typeSchemaNode=isStruct(type)
-                        ? new SchemaNode.Struct(this,  structOrUnionType)
-                        :new SchemaNode.Union(this,  structOrUnionType);
+                addField(new Field(this, fieldKey1, structOrUnionType, name1));
+                addField(new Field(this, fieldKey2, structOrUnionType, name2));
+                TypeSchemaNode typeSchemaNode = isStruct(type)
+                        ? new SchemaNode.Struct(this, structOrUnionType)
+                        : new SchemaNode.Union(this, structOrUnionType);
                 parentSchemaNodeConsumer.accept(addType(typeSchemaNode));
                 return this;
             }
@@ -481,45 +396,47 @@ public class Schema<T extends Buffer> {
             }
 
             public TypeSchemaNode array(String name, int len) {
-                addField(new FixedArray(this, modeOf(type,name), typeOf(type, name),name, len));
+                addField(new FixedArray(this, AccessorInfo.Key.of(type, name), typeOf(type, name), name, len));
                 return this;
             }
 
             public TypeSchemaNode array(String name, int len, Consumer<TypeSchemaNode> parentFieldConsumer) {
-                Mode arrayMode = modeOf(type, name);
+                AccessorInfo.Key arrayKey = AccessorInfo.Key.of(type, name);
                 Class<?> structOrUnionType = typeOf(type, name);
-               // ModeAndType newAccessStyle = ModeAndType.of(type, name);
                 TypeSchemaNode typeSchemaNode = isStruct(type)
-                                ?new SchemaNode.Struct(this, structOrUnionType)
-                                :new SchemaNode.Union(this, structOrUnionType);
+                        ? new SchemaNode.Struct(this, structOrUnionType)
+                        : new SchemaNode.Union(this, structOrUnionType);
                 parentFieldConsumer.accept(typeSchemaNode);
                 addType(typeSchemaNode);
-                addField(new FixedArray(this, arrayMode,structOrUnionType, name, len));
+                addField(new FixedArray(this, arrayKey, structOrUnionType, name, len));
                 return this;
             }
 
             private TypeSchemaNode fieldControlledArray(String name, List<ArrayLen> arrayLenFields, int stride) {
-                addField(new FieldControlledArray(this,  modeOf(type, name), typeOf(type, name),name, arrayLenFields, stride));
+                addField(new FieldControlledArray(this, AccessorInfo.Key.of(type, name), typeOf(type, name), name, arrayLenFields, stride));
                 return this;
             }
 
             public static class ArrayBuildState {
                 TypeSchemaNode typeSchemaNode;
                 List<ArrayLen> arrayLenFields;
-                int stride=1;
+                int stride = 1;
+
                 public TypeSchemaNode array(String name) {
                     return typeSchemaNode.fieldControlledArray(name, arrayLenFields, stride);
                 }
+
                 public ArrayBuildState stride(int stride) {
                     this.stride = stride;
                     return this;
                 }
+
                 public TypeSchemaNode array(String name, Consumer<TypeSchemaNode> parentFieldConsumer) {
                     Class<?> arrayType = typeOf(typeSchemaNode.type, name);
                     this.typeSchemaNode.fieldControlledArray(name, arrayLenFields, stride);
-                    TypeSchemaNode typeSchemaNode =isStruct(arrayType)
-                            ?new SchemaNode.Struct(this.typeSchemaNode, arrayType)
-                            :new SchemaNode.Union(this.typeSchemaNode,arrayType);
+                    TypeSchemaNode typeSchemaNode = isStruct(arrayType)
+                            ? new SchemaNode.Struct(this.typeSchemaNode, arrayType)
+                            : new SchemaNode.Union(this.typeSchemaNode, arrayType);
                     parentFieldConsumer.accept(typeSchemaNode);
                     this.typeSchemaNode.addType(typeSchemaNode);
                     return this.typeSchemaNode;
@@ -531,21 +448,15 @@ public class Schema<T extends Buffer> {
                 }
             }
 
-            public ArrayBuildState arrayLen(String ... arrayLenFieldNames) {
-                 List<ArrayLen> arrayLenFields = new ArrayList<>();
-                 Arrays.stream(arrayLenFieldNames).forEach(arrayLenFieldName-> {
-                    var arrayLenField = new ArrayLen(this, modeOf(type, arrayLenFieldName), typeOf(type, arrayLenFieldName), arrayLenFieldName);
+            public ArrayBuildState arrayLen(String... arrayLenFieldNames) {
+                List<ArrayLen> arrayLenFields = new ArrayList<>();
+                Arrays.stream(arrayLenFieldNames).forEach(arrayLenFieldName -> {
+                    var arrayLenField = new ArrayLen(this, AccessorInfo.Key.of(type, arrayLenFieldName), typeOf(type, arrayLenFieldName), arrayLenFieldName);
                     addField(arrayLenField);
                     arrayLenFields.add(arrayLenField);
                 });
                 return new ArrayBuildState(this, arrayLenFields);
             }
-
-            public void flexArray(String name) {
-                 throw new IllegalStateException("flex array");
-              //  addField(new FlexArray(this,null, name));
-            }
-
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
@@ -574,30 +485,28 @@ public class Schema<T extends Buffer> {
         }
 
         public static final class Struct extends TypeSchemaNode {
-            Struct(TypeSchemaNode parent,  Class<?> type) {
+            Struct(TypeSchemaNode parent, Class<?> type) {
                 super(parent, type);
             }
         }
 
         public static final class Union extends TypeSchemaNode {
-            Union(TypeSchemaNode parent,  Class<?> type) {
-                super(parent,  type);
+            Union(TypeSchemaNode parent, Class<?> type) {
+                super(parent, type);
             }
         }
 
-        public abstract static sealed class Array extends NamedFieldSchemaNode permits FieldControlledArray, FixedArray, FlexArray {
-          //  ModeAndType elementAccessStyle;
-            Array(TypeSchemaNode parent,  Mode mode, Class<?> type, String name) {
-                super(parent, mode,type, name);
-            ///    this.elementAccessStyle = elementAccessStyle;
+        public abstract static sealed class Array extends NamedFieldSchemaNode permits FieldControlledArray, FixedArray {
+            Array(TypeSchemaNode parent, AccessorInfo.Key key, Class<?> type, String name) {
+                super(parent, key, type, name);
             }
         }
 
         public static final class FixedArray extends Array {
             int len;
 
-            FixedArray(TypeSchemaNode parent,Mode mode, Class<?> type, String name, int len) {
-                super(parent,  mode, type, name);
+            FixedArray(TypeSchemaNode parent, AccessorInfo.Key key, Class<?> type, String name, int len) {
+                super(parent, key, type, name);
                 this.len = len;
             }
 
@@ -614,48 +523,32 @@ public class Schema<T extends Buffer> {
             }
         }
 
-        public static final  class FlexArray extends Array {
-            FlexArray(TypeSchemaNode parent,  Mode mode, Class<?> type, String name) {
-                super(parent,  mode,type, name);
-            }
-
-            @Override
-            public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + "array [?] ");
-            }
-
-            void collectLayouts(LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
-                layoutToFieldBindingNode.bind(this,
-                        MemoryLayout.sequenceLayout(0,
-                                parent.getLayout(type, layoutToFieldBindingNode).withName(type.getSimpleName())
-                        ).withName(name));
-            }
-        }
-
         public static final class FieldControlledArray extends Array {
             List<ArrayLen> arrayLenFields;
             int stride;
-            FieldControlledArray(TypeSchemaNode parent,   Mode mode, Class<?> type,String name, List<ArrayLen> arrayLenFields, int stride) {
-                super(parent, mode, type, name);
+            int contributingDims;
+
+            FieldControlledArray(TypeSchemaNode parent, AccessorInfo.Key key, Class<?> type, String name, List<ArrayLen> arrayLenFields, int stride) {
+                super(parent, key, type, name);
                 this.arrayLenFields = arrayLenFields;
                 this.stride = stride;
+                this.contributingDims = arrayLenFields.size();
             }
 
             @Override
             public void toText(String indent, Consumer<String> stringConsumer) {
-                stringConsumer.accept(indent + name + "[" + mode+":"+type + "] where len defined by " + arrayLenFields);
+                stringConsumer.accept(indent + name + "[" + key + ":" + type + "] where len defined by " + arrayLenFields);
             }
 
             @Override
             void collectLayouts(LayoutToBoundFieldTreeNode layoutToFieldBindingNode) {
-                // We have more than one ArrayLen
-                int i=stride;
-                for (int c = 0 ; c<arrayLenFields.size(); c++ ){
-                   var v =  layoutToFieldBindingNode.takeArrayLen();
-                   i*=v;
+                // To determine the actual 'array' size we multiply the contributing dims by the stride .
+                int size = stride; //usually 1 but developer can define.
+                for (int i = 0; i < contributingDims; i++) {
+                    size *= layoutToFieldBindingNode.takeArrayLen(); // this takes an arraylen and bumps the ptr
                 }
-                layoutToFieldBindingNode.bind(this, MemoryLayout.sequenceLayout(
-                       i,// layoutToFieldBindingNode.takeArrayLen(),
+
+                layoutToFieldBindingNode.bind(this, MemoryLayout.sequenceLayout(size,
                         parent.getLayout(type, layoutToFieldBindingNode).withName(type.getSimpleName())
                 ).withName(name));
             }
@@ -669,18 +562,20 @@ public class Schema<T extends Buffer> {
 
     public final static BufferAllocator GlobalArenaAllocator = new BufferAllocator() {
         public <T extends Buffer> T allocate(SegmentMapper<T> s) {
-            return s.allocate(Arena.global());
+            return s.allocate(Arena.global(), new HatData() {});
         }
     };
+
     public BoundSchema<T> boundSchema(int... boundLengths) {
         return new BoundSchema<>(this, boundLengths);
     }
 
-    public T allocate(BufferAllocator bufferAllocator,int... boundLengths) {
+    public T allocate(BufferAllocator bufferAllocator, int... boundLengths) {
         return boundSchema(boundLengths).allocate(bufferAllocator);
     }
+
     public T allocate(int... boundLengths) {
-        return allocate(GlobalArenaAllocator,boundLengths);
+        return allocate(GlobalArenaAllocator, boundLengths);
     }
 
     public static <T extends Buffer> Schema<T> of(Class<T> iface, Consumer<SchemaNode.TypeSchemaNode> parentFieldConsumer) {
@@ -688,6 +583,7 @@ public class Schema<T extends Buffer> {
         parentFieldConsumer.accept(struct);
         return new Schema<>(iface, struct);
     }
+
     public void toText(Consumer<String> stringConsumer) {
         schemaRootField.toText("", stringConsumer);
     }

--- a/hat/hat/src/main/java/hat/ifacemapper/SegmentInterfaceMapper.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/SegmentInterfaceMapper.java
@@ -218,7 +218,7 @@ public final class SegmentInterfaceMapper<T>
         // We need to materialize these methods so that the order is preserved
         // during generation of the class.
         List<AccessorInfo> virtualMethods = accessors().stream()
-                .filter(mi -> mi.key().valueType().isVirtual())
+                .filter(mi -> mi.key().valueType().equals(ValueType.INTERFACE))
                 .toList();
 
         byte[] bytes = ClassFile.of(ClassHierarchyResolverOption.of(ClassHierarchyResolver.ofClassLoading(loader)))

--- a/hat/hat/src/main/java/hat/ifacemapper/SegmentMapper.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/SegmentMapper.java
@@ -318,24 +318,7 @@ public interface SegmentMapper<T> {
      * @throws IndexOutOfBoundsException if
      *                                   {@code layout().byteSize() > segment.byteSize()}
      */
-    default T allocate(Arena arena) {
 
-        // To help debug we add a tail marker
-        // We add 16 bytes and then pad to the next 16 bytes
-        // and request alignment on 16 byte boundary
-        long byteSize = layout().byteSize();
-        long extendedByteSize = byteSize+16;
-        long byteSizePad = extendedByteSize%16;
-        if (byteSizePad != 0){
-            byteSizePad = 16-byteSizePad;
-        }
-        long extendedByteSizePaddedTo16Bytes = extendedByteSize+byteSizePad;
-        //System.out.println("Alloc 16 byte aligned layout + 16 bytes padded to next 16 bytes "+byteSize+"=>"+extendedByteSizePaddedTo16Bytes);
-        var segment = arena.allocate(extendedByteSizePaddedTo16Bytes, 16);
-        segment.set(ValueLayout.JAVA_LONG, extendedByteSizePaddedTo16Bytes-16,0x1face00000facadeL);
-        segment.set(ValueLayout.JAVA_LONG, extendedByteSizePaddedTo16Bytes-8, 0x1face00000facadeL);
-        return get(segment, layout(), hatData());
-    }
     default T allocate(Arena arena, HatData  hatData) {
 
         // To help debug we add a tail marker
@@ -383,35 +366,6 @@ public interface SegmentMapper<T> {
         return get(segment, groupLayout, hatData, 0L);
     }
 
-    /**
-     * {@return a new instance of type T projected at the provided external
-     * {@code segment} at the given {@code index} scaled by the
-     * {@code layout().byteSize()}}
-     * <p>
-     * Calling this method is equivalent to the following code:
-     * {@snippet lang = java:
-     *    get(segment, layout().byteSize() * index);
-     *}
-     *
-     * @param segment the external segment to be projected to the new instance
-     * @param index   a logical index, the offset in bytes (relative to the provided
-     *                segment address) at which the access operation will occur can
-     *                be expressed as {@code (index * layout().byteSize())}
-     * @throws IllegalStateException     if the {@linkplain MemorySegment#scope() scope}
-     *                                   associated with the provided segment is not
-     *                                   {@linkplain MemorySegment.Scope#isAlive() alive}
-     * @throws WrongThreadException      if this method is called from a thread {@code T},
-     *                                   such that {@code isAccessibleBy(T) == false}
-     * @throws IllegalArgumentException  if the access operation is
-     *                                   <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
-     *                                   of the {@link #layout()}
-     * @throws IndexOutOfBoundsException if {@code index * layout().byteSize()} overflows
-     * @throws IndexOutOfBoundsException if
-     *                                   {@code index * layout().byteSize() > segment.byteSize() - layout.byteSize()}
-     */
-    default T getAtIndex(MemorySegment segment, long index) {
-        return get(segment, layout().byteSize() * index);
-    }
 
     /**
      * {@return a new sequential {@code Stream} of elements of type T}
@@ -435,36 +389,6 @@ public interface SegmentMapper<T> {
                 .map(this::get);
     }
 
-    /**
-     * {@return a new sequential {@code Stream} of {@code pageSize} elements of
-     * type T starting at the element {@code pageNumber * pageSize}}
-     * <p>
-     * Calling this method is equivalent to the following code:
-     * {@snippet lang = java:
-     * stream(segment)
-     *     .skip(pageNumber * pageSize)
-     *     .limit(pageSize);
-     *}
-     * but may be much more efficient for large page numbers.
-     *
-     * @param segment    to carve out instances from
-     * @param pageSize   the size of each page
-     * @param pageNumber the page number to which to skip
-     * @throws IllegalArgumentException if {@code layout().byteSize() == 0}.
-     * @throws IllegalArgumentException if {@code segment.byteSize() % layout().byteSize() != 0}.
-     * @throws IllegalArgumentException if {@code layout().byteSize() % layout().byteAlignment() != 0}.
-     * @throws IllegalArgumentException if this segment is
-     *                                  <a href="MemorySegment.html#segment-alignment">incompatible with the
-     *                                  alignment constraint</a> in the layout of this segment mapper.
-     */
-    default Stream<T> page(MemorySegment segment,
-                           long pageSize,
-                           long pageNumber) {
-        long skipBytes = Math.min(segment.byteSize(), layout().scale(0, pageNumber * pageSize));
-        MemorySegment skippedSegment = segment.asSlice(skipBytes);
-        return stream(skippedSegment)
-                .limit(pageSize);
-    }
 
     /**
      * {@return a new instance of type T projected from at provided
@@ -582,9 +506,9 @@ public interface SegmentMapper<T> {
      *                                       {@linkplain SequenceLayout#elementCount() element count} of a sequence layout
      * @throws NullPointerException          if a required parameter is {@code null}
      */
-    default void setAtIndex(MemorySegment segment, long index, T t) {
-        set(segment, layout().byteSize() * index, t);
-    }
+   // default void setAtIndex(MemorySegment segment, long index, T t) {
+    //    set(segment, layout().byteSize() * index, t);
+  //  }
 
     /**
      * Writes the provided instance {@code t} of type T into the provided {@code segment}
@@ -754,48 +678,7 @@ public interface SegmentMapper<T> {
         Objects.requireNonNull(layout);
         return SegmentInterfaceMapper.create(lookup, type, layout, null);
     }
-    /**
-     * {@return a segment mapper that maps {@linkplain MemorySegment memory segments}
-     * to the provided interface {@code type} using the provided {@code layout}
-     * and using the provided {@code lookup}}
-     *
-     * @param lookup to use when performing reflective analysis on the
-     *               provided {@code type}
-     * @param type   to map memory segment from and to
-     * @param layout to be used when mapping the provided {@code type}
-     * @param length to replace the length of the last element (sequenceLayout)
-     * @param <T>    the type the returned mapper converts MemorySegments from and to
-     * @throws IllegalArgumentException if the provided {@code type} is not an interface
-     * @throws IllegalArgumentException if the provided {@code type} is a hidden interface
-     * @throws IllegalArgumentException if the provided {@code type} is a sealed interface
-     * @throws IllegalArgumentException if the provided interface {@code type} directly
-     *                                  declares any generic type parameter
-     * @throws IllegalArgumentException if the provided interface {@code type} cannot be
-     *                                  reflectively analysed using the provided {@code lookup}
-     * @throws IllegalArgumentException if the provided interface {@code type} contains
-     *                                  methods for which there are no exact mapping (of names and types) in
-     *                                  the provided {@code layout} or if the provided {@code type} is not public or
-     *                                  if the method is otherwise unable to create a segment mapper as specified above
-     * @implNote The order in which methods appear (e.g. in the {@code toString} method)
-     * is derived from the provided {@code layout}.
-     * @implNote The returned class can be a
-     * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
-     * class; programmers should treat instances that are
-     * {@linkplain Object#equals(Object) equal} as interchangeable and should
-     * not use instances for synchronization, or unpredictable behavior may
-     * occur. For example, in a future release, synchronization may fail.
-     * @implNote The returned class can be a {@linkplain Class#isHidden() hidden} class.
-     */
 
-    static <T> SegmentMapper<T> ofIncomplete(MethodHandles.Lookup lookup,
-                                   Class<T> type,
-                                   GroupLayout layout, long length) {
-        var members= layout.memberLayouts().toArray(new MemoryLayout[0]);
-        SequenceLayout sequenceLayout = (SequenceLayout) members[members.length-1];
-        var newLayout = MemoryLayout.sequenceLayout(length,sequenceLayout.elementLayout()).withName(sequenceLayout.name().get());
-        members[members.length-1]=newLayout;
-        return of(lookup,type,members);
-    }
     static <T extends Buffer> SegmentMapper<T> of(MethodHandles.Lookup lookup, Class<T> type, GroupLayout layout, HatData hatData) {
         Objects.requireNonNull(lookup);
         MapperUtil.requireImplementableInterfaceType(type);
@@ -825,7 +708,10 @@ public interface SegmentMapper<T> {
          * {@return the backing segment of this instance}
          */
         MemorySegment segment();
-
+        /**
+         * {@return the backing segment of this instance}
+         */
+        MemoryLayout layout();
         /**
          * {@return the offset in the backing segment of this instance}
          */

--- a/hat/hat/src/main/java/hat/ifacemapper/accessor/AccessorInfo.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/accessor/AccessorInfo.java
@@ -25,12 +25,17 @@
 
 package hat.ifacemapper.accessor;
 
+import hat.ifacemapper.Schema;
+import hat.util.Result;
+
 import java.lang.foreign.GroupLayout;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
 
 import static hat.ifacemapper.accessor.AccessorInfo.AccessorType.GETTER;
+import static hat.ifacemapper.accessor.AccessorInfo.AccessorType.GETTER_AND_SETTER;
 import static hat.ifacemapper.accessor.AccessorInfo.AccessorType.SETTER;
 import static hat.ifacemapper.accessor.Cardinality.ARRAY;
 import static hat.ifacemapper.accessor.Cardinality.SCALAR;
@@ -55,24 +60,22 @@ public record AccessorInfo(Key key,
                 .orElse(layoutInfo().layout());
     }
 
-    public enum AccessorType {GETTER, SETTER}
+    public enum AccessorType {GETTER, SETTER,GETTER_AND_SETTER}
 
     /**
      * These are the various combinations that exists. Not all of them are
      * supported even though they can sometimes be expressed in interfaces and records.
      */
     public enum Key {
-
         //                                                 Mapping supported for
         SCALAR_VALUE_GETTER(SCALAR, VALUE, GETTER, EnumSet.of(INTERFACE)),
         SCALAR_VALUE_SETTER(SCALAR, VALUE, SETTER, EnumSet.of(INTERFACE)),
+        SCALAR_VALUE_GETTER_AND_SETTER(SCALAR, VALUE, GETTER_AND_SETTER, EnumSet.of(INTERFACE)),
         SCALAR_INTERFACE_GETTER(SCALAR, INTERFACE, GETTER, EnumSet.of(INTERFACE)),
-        SCALAR_INTERFACE_SETTER(SCALAR, INTERFACE, SETTER, EnumSet.noneOf(ValueType.class)),
         ARRAY_VALUE_GETTER(ARRAY, VALUE, GETTER, EnumSet.of(INTERFACE)),
         ARRAY_VALUE_SETTER(ARRAY, VALUE, SETTER, EnumSet.of(INTERFACE)),
-        ARRAY_INTERFACE_GETTER(ARRAY, INTERFACE, GETTER, EnumSet.of(INTERFACE)),
-        ARRAY_INTERFACE_SETTER(ARRAY, INTERFACE, SETTER, EnumSet.noneOf(ValueType.class));
-
+        ARRAY_VALUE_GETTER_AND_SETTER(ARRAY, VALUE, GETTER_AND_SETTER, EnumSet.of(INTERFACE)),
+        ARRAY_INTERFACE_GETTER(ARRAY, INTERFACE, GETTER, EnumSet.of(INTERFACE));
 
         private final Cardinality cardinality;
         private final ValueType valueType;
@@ -115,6 +118,60 @@ public record AccessorInfo(Key key,
                 }
             }
             throw new InternalError("Should not reach here");
+        }
+
+        /**
+         * From the iface mapper we get these mappings
+         * <p>
+         * T foo()             getter iface|primitive  0 args                  , return T     returnType T
+         * T foo(long)    arraygetter iface|primitive  arg[0]==long            , return T     returnType T
+         * void foo(T)            setter       primitive  arg[0]==T               , return void  returnType T
+         * void foo(long, T) arraysetter       primitive  arg[0]==long, arg[1]==T , return void  returnType T
+         *
+         * @param m The reflected method
+         * @return Class represeting the type this method is mapped to
+         */
+        public static Key of(Method m) {
+            Class<?> returnType = m.getReturnType();
+            Class<?>[] paramTypes = m.getParameterTypes();
+            if (paramTypes.length == 0 && returnType.isInterface()) {
+                return SCALAR_INTERFACE_GETTER;
+            } else if (paramTypes.length == 0 && returnType.isPrimitive()) {
+                return SCALAR_VALUE_GETTER;
+            } else if (paramTypes.length == 1 && paramTypes[0].isPrimitive() && returnType == Void.TYPE) {
+                return SCALAR_VALUE_SETTER;
+            } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isInterface()) {
+                return ARRAY_INTERFACE_GETTER;
+            } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isPrimitive()) {
+                return ARRAY_VALUE_GETTER;
+            } else if (returnType == Void.TYPE && paramTypes.length == 2 &&
+                    paramTypes[0] == Long.TYPE && paramTypes[1].isPrimitive()) {
+                return ARRAY_VALUE_SETTER;
+            } else {
+                throw new IllegalStateException("no possible key for " + m);
+            }
+        }
+
+        public static Key of(Class<?> iface, String name) {
+            var methods = iface.getDeclaredMethods();
+            Result<Key> modeResult = new Result<>();
+            Arrays.stream(methods).filter(method -> method.getName().equals(name)).forEach(matchingMethod -> {
+                var thisMode = Key.of(matchingMethod);
+                if (!modeResult.isPresent()) {
+                    modeResult.of(thisMode);
+                } else if ((modeResult.get().equals(ARRAY_VALUE_GETTER) && thisMode.equals(ARRAY_VALUE_SETTER))
+                        || (modeResult.get().equals(ARRAY_VALUE_SETTER) && thisMode.equals(ARRAY_VALUE_GETTER))) {
+                    modeResult.of(ARRAY_VALUE_GETTER_AND_SETTER);
+                } else if ((modeResult.get().equals(SCALAR_VALUE_GETTER) && thisMode.equals(SCALAR_VALUE_SETTER))
+                        || (modeResult.get().equals(SCALAR_VALUE_SETTER) && thisMode.equals(SCALAR_VALUE_GETTER))) {
+                    modeResult.of(SCALAR_VALUE_GETTER_AND_SETTER);
+                }
+            });
+            if (!modeResult.isPresent()) {
+                throw new IllegalStateException("no possible key for " + iface + " " + name);
+                // modeResult.of(Mode.PRIMITIVE_GETTER_AND_SETTER);
+            }
+            return modeResult.get();
         }
     }
 

--- a/hat/hat/src/main/java/hat/ifacemapper/accessor/Accessors.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/accessor/Accessors.java
@@ -151,7 +151,7 @@ public final class Accessors {
 
         Class<?> targetType = (accessorType == AccessorInfo.AccessorType.GETTER)
                 ? method.getReturnType()
-                : getterType(method);
+                : setterType(method);
 
         ValueType valueType = valueTypeFor(method, targetType);
 
@@ -211,7 +211,7 @@ public final class Accessors {
         return valueType;
     }
 
-    private static Class<?> getterType(Method method) {
+    private static Class<?> setterType(Method method) {
         if (method.getParameterCount() == 0) {
             throw new IllegalArgumentException("A setter must take at least one argument: " + method);
         }

--- a/hat/hat/src/main/java/hat/ifacemapper/accessor/ArrayInfo.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/accessor/ArrayInfo.java
@@ -30,8 +30,7 @@ import java.lang.foreign.SequenceLayout;
 import java.util.ArrayList;
 import java.util.List;
 
-public record ArrayInfo(MemoryLayout elementLayout,
-                        List<Long> dimensions) {
+public record ArrayInfo(MemoryLayout elementLayout, List<Long> dimensions) {
 
     static ArrayInfo of(SequenceLayout layout) {
         return recurse(new ArrayInfo(layout, new ArrayList<>()));
@@ -39,7 +38,6 @@ public record ArrayInfo(MemoryLayout elementLayout,
 
     private static ArrayInfo recurse(ArrayInfo info) {
         if (!(info.elementLayout instanceof SequenceLayout sl)) {
-            // We are done. Create an immutable record
             return new ArrayInfo(info.elementLayout(), List.copyOf(info.dimensions()));
         }
         info.dimensions().add(sl.elementCount());

--- a/hat/hat/src/main/java/hat/ifacemapper/accessor/ValueType.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/accessor/ValueType.java
@@ -1,15 +1,5 @@
 package hat.ifacemapper.accessor;
 
 public enum ValueType {
-    VALUE(false), INTERFACE(true);
-
-    private final boolean virtual;
-
-    ValueType(boolean virtual) {
-        this.virtual = virtual;
-    }
-
-    public boolean isVirtual() {
-        return virtual;
-    }
+    VALUE, INTERFACE
 }


### PR DESCRIPTION
Schema was replicating some work that the iface mapper was already doing.  So reused ifacemapper types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/babylon.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/172.diff">https://git.openjdk.org/babylon/pull/172.diff</a>

</details>
