### PR TITLE
ArgBuffer now using schema

### DIFF
--- a/hat/hat/src/main/java/hat/ifacemapper/accessor/AccessorInfo.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/accessor/AccessorInfo.java
@@ -29,6 +29,7 @@ import hat.ifacemapper.Schema;
 import hat.util.Result;
 
 import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemorySegment;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -139,6 +140,8 @@ public record AccessorInfo(Key key,
             } else if (paramTypes.length == 0 && returnType.isPrimitive()) {
                 return SCALAR_VALUE_GETTER;
             } else if (paramTypes.length == 1 && paramTypes[0].isPrimitive() && returnType == Void.TYPE) {
+                return SCALAR_VALUE_SETTER;
+            } else if (paramTypes.length == 1 && MemorySegment.class.isAssignableFrom(paramTypes[0]) && returnType == Void.TYPE) {
                 return SCALAR_VALUE_SETTER;
             } else if (paramTypes.length == 1 && paramTypes[0] == Long.TYPE && returnType.isInterface()) {
                 return ARRAY_INTERFACE_GETTER;


### PR DESCRIPTION
Continuing the migration of buffers from manual layout to schema. 

Specifically ArgBuffer, used to convery args from java to native code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/babylon.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/173.diff">https://git.openjdk.org/babylon/pull/173.diff</a>

</details>
