### PR TITLE
KernelContext now using schema

### DIFF
--- a/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
@@ -55,13 +55,12 @@ public abstract class C99NativeBackend extends NativeBackend {
             this.kernelCallGraph = kernelCallGraph;
             this.text = text;
             this.kernelHandle = kernelHandle;
-            this.kernelContext =KernelContext.create(c99NativeBackend.arena,kernelCallGraph.computeContext.accelerator.lookup,0,0);
+            this.kernelContext =KernelContext.create(c99NativeBackend,0,0);
             ndRangeAndArgs[0]=this.kernelContext;
             this.argArray = ArgArray.create(kernelCallGraph.computeContext.accelerator, ndRangeAndArgs);
         }
 
         public void dispatch(NDRange ndRange, Object[] args) {
-         //   KernelContext kernelContext = (KernelContext) args[0];
             kernelContext.maxX(ndRange.kid.maxX);
             args[0]=this.kernelContext;
             ArgArray.update(argArray, args);

--- a/hat/hat/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/hat/src/main/java/hat/buffer/ArgArray.java
@@ -24,41 +24,17 @@
  */
 package hat.buffer;
 
-import hat.Accelerator;
 import hat.ifacemapper.Schema;
-import hat.ifacemapper.SegmentMapper;
-
-import java.lang.foreign.GroupLayout;
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.lang.invoke.MethodHandles;
 import java.nio.ByteOrder;
-
-import static java.lang.foreign.ValueLayout.ADDRESS;
-import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
-import static java.lang.foreign.ValueLayout.JAVA_CHAR;
-import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
-import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
-
 
 public interface ArgArray extends IncompleteBuffer {
     interface Arg extends Buffer.Struct{
         interface Value extends Buffer.Union{
             interface Buf extends Buffer.Struct{
-             /*   MemoryLayout layout = MemoryLayout.structLayout(
-                        ADDRESS.withName("address"), // segment ptr
-                        JAVA_LONG.withName("bytes"),
-                        ADDRESS.withName("vendorPtr"), // CLBuf *buf;   CUdeviceptr buf; void *buf ?
-                        JAVA_BYTE.withName("access"), //0=??/1=RO/2=WO/3=RW
-                        JAVA_BYTE.withName("state"), //0=UNKNOWN/1=GPUDIRTY/2=JAVADIRTY
-                        MemoryLayout.paddingLayout(16 - JAVA_BYTE.byteSize() - JAVA_BYTE.byteSize())
-                ).withName(Buf.class.getSimpleName()); */
-
                 MemorySegment address();
 
                 void address(MemorySegment address);
@@ -78,22 +54,7 @@ public interface ArgArray extends IncompleteBuffer {
                 byte state();
 
                 void state(byte state);
-
             }
-
-           /* MemoryLayout layout = MemoryLayout.unionLayout(
-                    JAVA_BOOLEAN.withName("z1"),
-                    JAVA_BYTE.withName("s8"),
-                    JAVA_CHAR.withName("u16"),
-                    JAVA_SHORT.withName("s16"),
-                    JAVA_INT.withName("s32"),
-                    JAVA_INT.withName("u32"),
-                    JAVA_FLOAT.withName("f32"),
-                    JAVA_LONG.withName("s64"),
-                    JAVA_LONG.withName("u64"),
-                    JAVA_DOUBLE.withName("f64"),
-                    Buf.layout.withName("buf")
-            ).withName(Value.class.getSimpleName());*/
 
             boolean z1();
 
@@ -137,13 +98,6 @@ public interface ArgArray extends IncompleteBuffer {
 
             Buf buf();
         }
-
-      /*  MemoryLayout layout = MemoryLayout.structLayout(
-                JAVA_INT.withName("idx"),      //4
-                JAVA_BYTE.withName("variant"), //5
-                MemoryLayout.paddingLayout(16 - JAVA_INT.byteSize() - JAVA_BYTE.byteSize()),
-                Value.layout.withName("value")
-        ).withName(Arg.class.getSimpleName());*/
 
         int idx();
 
@@ -260,6 +214,22 @@ public interface ArgArray extends IncompleteBuffer {
             value().f64(f64);
         }
     }
+    int argc();
+
+    void argc(int argc);
+
+    int schemaLen();
+
+    void schemaLen(int schemaLen);
+
+    byte schemaBytes(long idx);
+
+    void schemaBytes(long idx, byte b);
+    Arg arg(long idx);
+
+    MemorySegment vendorPtr();
+
+    void vendorPtr(MemorySegment vendorPtr);
 
     Schema<ArgArray> schema = Schema.of(ArgArray.class, s->s
             .arrayLen("argc")
@@ -295,34 +265,6 @@ public interface ArgArray extends IncompleteBuffer {
         return (valueLayout.order().equals(ByteOrder.LITTLE_ENDIAN)) ? schema.toLowerCase() : schema;
     }
 
-    static void update(ArgArray argArray, Object... args) {
-        for (int i = 0; i < args.length; i++) {
-            Object argObject = args[i];
-            Arg arg = argArray.arg(i);
-            arg.idx(i);
-            switch (argObject) {
-                case Boolean z1 -> arg.z1(z1);
-                case Byte s8 -> arg.s8(s8);
-                case Short s16 -> arg.s16(s16);
-                case Character u16 -> arg.u16(u16);
-                case Float f32 -> arg.f32(f32);
-                case Integer s32 -> arg.s32(s32);
-                case Long s64 -> arg.s64(s64);
-                case Double f64 -> arg.f64(f64);
-                case Buffer buffer -> {
-                    MemorySegment segment = Buffer.getMemorySegment(buffer);
-                    arg.variant((byte) '&');
-                    Arg.Value value = arg.value();
-                    Arg.Value.Buf buf = value.buf();
-                    buf.address(segment);
-                    buf.bytes(segment.byteSize());
-                }
-                default -> throw new IllegalStateException("Unexpected value: " + argObject);
-            }
-
-        }
-    }
-
     static ArgArray create(BufferAllocator bufferAllocator, Object... args) {
         String[] schemas = new String[args.length];
         StringBuilder argSchema = new StringBuilder();
@@ -348,31 +290,14 @@ public interface ArgArray extends IncompleteBuffer {
             argSchema.append(schemas[i]);
         }
         String schemaStr = argSchema.toString();
-/*
-        ArgArray argArray1 = bufferAllocator.allocate(SegmentMapper.of(MethodHandles.lookup(), ArgArray.class,
-                JAVA_INT.withName("argc"),
-                MemoryLayout.paddingLayout(16 - JAVA_INT.byteSize()),
-                MemoryLayout.sequenceLayout(args.length, Arg.layout).withName("arg"),
-                ADDRESS.withName("vendorPtr"),
-                JAVA_INT.withName("schemaLen"),
-                MemoryLayout.sequenceLayout(schemaStr.length() + 1, JAVA_BYTE).withName("schemaBytes")
-        ));
-        argArray1.argc(args.length);
-        argArray1.setSchemaBytes(schemaStr);
-
-        String layout = Buffer.getLayout(argArray1).toString();
-        */
-        var boundSchema = schema.boundSchema(args.length,schemaStr.length() + 1);
-      /*  String layoutFromSchema = boundSchema.groupLayout.toString();
-         if (!layoutFromSchema.equals(layout)){
-            System.err.println("          layout:"+layout);
-            System.err.println("          schema:"+layoutFromSchema);
-           // System.exit(1);
-
-         } */
-        ArgArray argArray = boundSchema.allocate(bufferAllocator);
+        ArgArray argArray = schema.allocate(bufferAllocator,args.length,schemaStr.length() + 1);
         argArray.argc(args.length);
         argArray.setSchemaBytes(schemaStr);
+        update(argArray, args);
+        return argArray;
+    }
+
+    static void update(ArgArray argArray, Object... args) {
         for (int i = 0; i < args.length; i++) {
             Object argObject = args[i];
             Arg arg = argArray.arg(i);
@@ -396,22 +321,9 @@ public interface ArgArray extends IncompleteBuffer {
                 }
                 default -> throw new IllegalStateException("Unexpected value: " + argObject);
             }
-
         }
-        return argArray;
     }
 
-    int argc();
-
-    void argc(int argc);
-
-    int schemaLen();
-
-    void schemaLen(int schemaLen);
-
-    byte schemaBytes(long idx);
-
-    void schemaBytes(long idx, byte b);
 
     default String getSchemaBytes() {
         byte[] bytes = new byte[schemaLen() + 1];
@@ -431,12 +343,6 @@ public interface ArgArray extends IncompleteBuffer {
         }
         schemaBytes(schemaStrBytes.length, (byte) 0);
     }
-
-    Arg arg(long idx);
-
-    MemorySegment vendorPtr();
-
-    void vendorPtr(MemorySegment vendorPtr);
 
 
     default String dump() {

--- a/hat/hat/src/main/java/hat/buffer/KernelContext.java
+++ b/hat/hat/src/main/java/hat/buffer/KernelContext.java
@@ -1,6 +1,7 @@
 package hat.buffer;
 
 import hat.ifacemapper.HatData;
+import hat.ifacemapper.Schema;
 import hat.ifacemapper.SegmentMapper;
 
 import java.lang.foreign.Arena;
@@ -11,20 +12,18 @@ import java.lang.invoke.MethodHandles;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface KernelContext extends CompleteBuffer {
-    StructLayout layout = MemoryLayout.structLayout(
-            JAVA_INT.withName("x"),
-            JAVA_INT.withName("maxX")
-    ).withName(KernelContext.class.getSimpleName());
-
-    static KernelContext create(Arena arena, MethodHandles.Lookup lookup, int x, int maxX) {
-        KernelContext kernelContext = SegmentMapper.of(lookup, KernelContext.class,layout).allocate(arena, new HatData() {
-        });
-        kernelContext.x(x);
-        kernelContext.maxX(maxX);
-        return kernelContext;
-    }
     int x();
     void x(int x);
     int maxX();
     void maxX(int maxX);
+
+    Schema<KernelContext> schema = Schema.of(KernelContext.class, s->s.fields("x","maxX"));
+
+    static KernelContext create(BufferAllocator bufferAllocator, int x, int maxX) {
+        KernelContext kernelContext =  schema.allocate(bufferAllocator);
+        kernelContext.x(x);
+        kernelContext.maxX(maxX);
+        return kernelContext;
+    }
+
 }


### PR DESCRIPTION
More uses of schema.  Now KernelContext swapped to use schema.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/babylon.git pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/174.diff">https://git.openjdk.org/babylon/pull/174.diff</a>

</details>
