### PR TITLE
Fix modeling if statements

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1455,8 +1455,9 @@ public class ReflectMethods extends TreeTranslator {
                 JCTree.JCStatement elsepart = tree.elsepart;
                 if (elsepart == null) {
                     tree = null;
-                }
-                else if (elsepart.getTag() == Tag.BLOCK) {
+                } else if (elsepart.getTag() == Tag.IF) {
+                    tree = (JCTree.JCIf) elsepart;
+                } else {
                     // Push else body
                     pushBody(elsepart, FunctionType.VOID);
 
@@ -1468,8 +1469,6 @@ public class ReflectMethods extends TreeTranslator {
                     popBody();
 
                     tree = null;
-                } else if (elsepart.getTag() == Tag.IF) {
-                    tree = (JCTree.JCIf) elsepart;
                 }
                 first = false;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1426,7 +1426,6 @@ public class ReflectMethods extends TreeTranslator {
         public void visitIf(JCTree.JCIf tree) {
             List<Body.Builder> bodies = new ArrayList<>();
 
-            boolean first = true;
             while (tree != null) {
                 // @@@ cond.type can be boolean or Boolean
                 JCTree.JCExpression cond = TreeInfo.skipParens(tree.cond);
@@ -1470,7 +1469,6 @@ public class ReflectMethods extends TreeTranslator {
 
                     tree = null;
                 }
-                first = false;
             }
 
             append(ExtendedOp._if(bodies));

--- a/test/langtools/tools/javac/reflect/CodeReflectionTester.java
+++ b/test/langtools/tools/javac/reflect/CodeReflectionTester.java
@@ -63,8 +63,7 @@ public class CodeReflectionTester {
 
     static void check(Method method) throws ReflectiveOperationException {
         if (!method.isAnnotationPresent(CodeReflection.class)) return;
-        Field field = method.getDeclaringClass().getDeclaredField(method.getName() + "$op");
-        String found = canonicalizeModel(method, (String) field.get(null));
+        String found = canonicalizeModel(method, method.getCodeModel().orElseThrow());
         IR ir = method.getAnnotation(IR.class);
         if (ir == null) {
             error("No @IR annotation found on reflective method");

--- a/test/langtools/tools/javac/reflect/IfTest.java
+++ b/test/langtools/tools/javac/reflect/IfTest.java
@@ -219,4 +219,106 @@ public class IfTest {
             return 3;
         }
     }
+
+    @CodeReflection
+    @IR("""
+            func @"test6" (%0 : IfTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                java.if
+                    ()boolean -> {
+                        %3 : int = var.load %2;
+                        %4 : int = constant @"1";
+                        %5 : boolean = lt %3 %4;
+                        yield %5;
+                    }
+                    ^then()void -> {
+                        %6 : int = constant @"1";
+                        var.store %2 %6;
+                        yield;
+                    }
+                    ^else()void -> {
+                        yield;
+                    };
+                return;
+            };
+            """)
+    void test6(int i) {
+        if (i < 1)
+            i = 1;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test7" (%0 : IfTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                java.if
+                    ()boolean -> {
+                        %3 : int = var.load %2;
+                        %4 : int = constant @"1";
+                        %5 : boolean = lt %3 %4;
+                        yield %5;
+                    }
+                    ^then()void -> {
+                        %6 : int = constant @"1";
+                        var.store %2 %6;
+                        yield;
+                    }
+                    ^else()void -> {
+                        %7 : int = constant @"2";
+                        var.store %2 %7;
+                        yield;
+                    };
+                return;
+            };
+            """)
+    void test7(int i) {
+        if (i < 1)
+            i = 1;
+        else
+            i = 2;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test8" (%0 : IfTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                java.if
+                    ()boolean -> {
+                        %3 : int = var.load %2;
+                        %4 : int = constant @"1";
+                        %5 : boolean = lt %3 %4;
+                        yield %5;
+                    }
+                    ^then()void -> {
+                        %6 : int = constant @"1";
+                        var.store %2 %6;
+                        yield;
+                    }
+                    ^else_if()boolean -> {
+                        %7 : int = var.load %2;
+                        %8 : int = constant @"2";
+                        %9 : boolean = lt %7 %8;
+                        yield %9;
+                    }
+                    ^then()void -> {
+                        %10 : int = constant @"2";
+                        var.store %2 %10;
+                        yield;
+                    }
+                    ^else()void -> {
+                        %11 : int = constant @"3";
+                        var.store %2 %11;
+                        yield;
+                    };
+                return;
+            };
+            """)
+    void test8(int i) {
+        if (i < 1)
+            i = 1;
+        else if (i < 2)
+            i = 2;
+        else
+            i = 3;
+    }
 }


### PR DESCRIPTION
The else part of an if statement was incorrectly handled if it was not a block.

Additionally fixed `CodeReflectionTester` used in the language tests. It now accesses a code model of a method via getCodeModel rather than directly accessing the field, thereby this is not dependent on how the model is stored in the class file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/181/head:pull/181` \
`$ git checkout pull/181`

Update a local copy of the PR: \
`$ git checkout pull/181` \
`$ git pull https://git.openjdk.org/babylon.git pull/181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 181`

View PR using the GUI difftool: \
`$ git pr show -t 181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/181.diff">https://git.openjdk.org/babylon/pull/181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/181#issuecomment-2229570286)