### PR TITLE
We previously disalowed all field accesses. Static final primitives are safe

### DIFF
--- a/hat/hat/src/main/java/hat/backend/NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/NativeBackend.java
@@ -75,7 +75,7 @@ public abstract class NativeBackend extends NativeBackendDriver {
 
     static FuncOpWrapper injectBufferTracking(CallGraph.ResolvedMethodCall resolvedMethodCall) {
         FuncOpWrapper originalFuncOpWrapper = resolvedMethodCall.funcOpWrapper();
-
+        originalFuncOpWrapper.op().writeTo(System.out);
         var transformed = originalFuncOpWrapper.transformInvokes((builder, invokeOpWrapper) -> {
                     if (invokeOpWrapper.isIfaceBufferMethod()) {
                         CopyContext cc = builder.context();

--- a/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuilder.java
+++ b/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuilder.java
@@ -58,7 +58,9 @@ import hat.util.StreamCounter;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
+import java.lang.reflect.Field;
 import java.lang.reflect.code.Op;
+import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.op.ExtendedOp;
 import java.lang.reflect.code.type.ClassType;
@@ -183,9 +185,13 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
     public T fieldLoad(C99HatBuildContext buildContext, FieldLoadOpWrapper fieldLoadOpWrapper) {
         if (fieldLoadOpWrapper.isKernelContextAccess()) {
             identifier("kc").rarrow().identifier(fieldLoadOpWrapper.fieldName());
+        } else if (fieldLoadOpWrapper.isStaticFinalPrimitive()) {
+            Object value = fieldLoadOpWrapper.getStaticFinalPrimitiveValue();
+            literal(value.toString());
         } else {
-            // throw new IllegalStateException("What is this field load ?" + fieldLoadOpWrapper.fieldRef());
+            throw new IllegalStateException("What is this field load ?" + fieldLoadOpWrapper.fieldRef());
         }
+
         return self();
     }
 
@@ -440,8 +446,8 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
                                         sbrace(_ -> literal(1));
                                     } else {
                                         boolean[] done = new boolean[]{false};
-                                        boundSchema.boundArrayFields().forEach(a->{
-                                            if (a.field.equals(array)){
+                                        boundSchema.boundArrayFields().forEach(a -> {
+                                            if (a.field.equals(array)) {
                                                 sbrace(_ -> literal(a.len));
                                                 done[0] = true;
                                             }
@@ -481,7 +487,7 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
                                     throw new IllegalStateException("what kind of array ");
                                 }
                             }
-                        }else if (field instanceof Schema.SchemaNode.Padding){
+                        } else if (field instanceof Schema.SchemaNode.Padding) {
                             // SKIP
                         } else {
                             throw new IllegalStateException("hmm");

--- a/hat/hat/src/main/java/hat/optools/FieldAccessOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/FieldAccessOpWrapper.java
@@ -24,9 +24,14 @@
  */
 package hat.optools;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Type;
+import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.type.ClassType;
 import java.lang.reflect.code.type.FieldRef;
+import java.lang.reflect.code.type.JavaType;
+import java.lang.reflect.code.type.PrimitiveType;
 
 public abstract class FieldAccessOpWrapper<T extends CoreOp.FieldAccessOp> extends OpWrapper<T> {
     FieldAccessOpWrapper(T op) {
@@ -36,9 +41,15 @@ public abstract class FieldAccessOpWrapper<T extends CoreOp.FieldAccessOp> exten
     public boolean isKernelContextAccess() {
         var refType = fieldRef().refType();
         if (refType instanceof ClassType classType) {
+            // This should not rely on string
             return (classType.toClassName().equals("hat.KernelContext"));
         }
         return false;
+    }
+
+    public boolean isStaticFinalPrimitive() {
+      return hasNoOperands() && resultType() instanceof PrimitiveType;
+      // Can we check for final?
     }
 
     public FieldRef fieldRef() {
@@ -47,6 +58,10 @@ public abstract class FieldAccessOpWrapper<T extends CoreOp.FieldAccessOp> exten
 
     public String fieldName() {
         return fieldRef().name();
+    }
+
+    public TypeElement fieldType() {
+        return fieldRef().refType();
     }
 
 }

--- a/hat/hat/src/main/java/hat/optools/FieldLoadOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/FieldLoadOpWrapper.java
@@ -24,6 +24,8 @@
  */
 package hat.optools;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.code.TypeElement;
 import java.lang.reflect.code.op.CoreOp;
 
 public class FieldLoadOpWrapper extends FieldAccessOpWrapper<CoreOp.FieldAccessOp.FieldLoadOp> implements LoadOpWrapper {
@@ -33,4 +35,20 @@ public class FieldLoadOpWrapper extends FieldAccessOpWrapper<CoreOp.FieldAccessO
         super(op);
     }
 
+    public Object getStaticFinalPrimitiveValue() {
+        TypeElement te = fieldType();
+        String fieldName = fieldName();
+        try {
+            Class<?> clazz = Class.forName(te.toString());
+            Field field = clazz.getField(fieldName);
+           return  field.get(null);
+
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
Allow access to primitive static final fields in enclosing compute class. 