### PR TITLE
Implementing Healing brush demo, highlighted some missing unary(and binary<<,>> operators)

### DIFF
--- a/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuilder.java
+++ b/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuilder.java
@@ -48,6 +48,7 @@ import hat.optools.ReturnOpWrapper;
 import hat.optools.StructuralOpWrapper;
 import hat.optools.TernaryOpWrapper;
 import hat.optools.TupleOpWrapper;
+import hat.optools.UnaryArithmeticOrLogicOperation;
 import hat.optools.VarDeclarationOpWrapper;
 import hat.optools.VarFuncDeclarationOpWrapper;
 import hat.optools.VarLoadOpWrapper;
@@ -102,8 +103,12 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
             case CoreOp.ModOp o -> 2;
             case CoreOp.MulOp o -> 2;
             case CoreOp.DivOp o -> 2;
+            case CoreOp.NotOp   o -> 2;
             case CoreOp.AddOp o -> 3;
             case CoreOp.SubOp o -> 3;
+            case CoreOp.AshrOp o -> 4;
+            case CoreOp.LshlOp o -> 4;
+            case CoreOp.LshrOp o -> 4;
             case CoreOp.LtOp o -> 5;
             case CoreOp.GtOp o -> 5;
             case CoreOp.LeOp o -> 5;
@@ -213,8 +218,12 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
             case CoreOp.GtOp o -> gt();
             case CoreOp.LeOp o -> lte();
             case CoreOp.GeOp o -> gte();
+            case CoreOp.AshrOp o -> cchevron().cchevron();
+            case CoreOp.LshlOp o -> ochevron().ochevron();
+            case CoreOp.LshrOp o -> cchevron().cchevron();
             case CoreOp.NeqOp o -> pling().equals();
             case CoreOp.EqOp o -> equals().equals();
+            case CoreOp.NotOp o -> pling();
             case CoreOp.AndOp o -> ampersand();
             case CoreOp.OrOp o -> bar();
             case CoreOp.XorOp o -> hat();
@@ -222,6 +231,14 @@ public abstract class C99HatBuilder<T extends C99HatBuilder<T>> extends C99CodeB
             case ExtendedOp.JavaConditionalOrOp o -> condOr();
             default -> throw new IllegalStateException("Unexpected value: " + op);
         };
+    }
+
+    @Override
+    public T unaryOperation(C99HatBuildContext buildContext, UnaryArithmeticOrLogicOperation unaryOperatorOpWrapper) {
+      //  parencedence(buildContext, binaryOperatorOpWrapper.op(), binaryOperatorOpWrapper.lhsAsOp());
+        symbol(unaryOperatorOpWrapper.op());
+        parencedence(buildContext, unaryOperatorOpWrapper.op(), unaryOperatorOpWrapper.operandNAsResult(0).op());
+        return self();
     }
 
     @Override

--- a/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuilderInterface.java
+++ b/hat/hat/src/main/java/hat/backend/c99codebuilders/C99HatBuilderInterface.java
@@ -44,6 +44,7 @@ import hat.optools.OpWrapper;
 import hat.optools.ReturnOpWrapper;
 import hat.optools.TernaryOpWrapper;
 import hat.optools.TupleOpWrapper;
+import hat.optools.UnaryArithmeticOrLogicOperation;
 import hat.optools.VarDeclarationOpWrapper;
 import hat.optools.VarFuncDeclarationOpWrapper;
 import hat.optools.VarLoadOpWrapper;
@@ -69,6 +70,8 @@ public interface C99HatBuilderInterface<T extends C99HatBuilder<?>> {
     public T fieldLoad(C99HatBuildContext buildContext, FieldLoadOpWrapper fieldLoadOpWrapper);
 
     public T fieldStore(C99HatBuildContext buildContext, FieldStoreOpWrapper fieldStoreOpWrapper);
+
+    T unaryOperation(C99HatBuildContext buildContext, UnaryArithmeticOrLogicOperation unaryOperatorOpWrapper);
 
 
     T binaryOperation(C99HatBuildContext buildContext, BinaryArithmeticOrLogicOperation binaryOperatorOpWrapper);
@@ -124,6 +127,7 @@ public interface C99HatBuilderInterface<T extends C99HatBuilder<?>> {
             case FieldLoadOpWrapper $ -> fieldLoad(buildContext, $);
             case FieldStoreOpWrapper $ -> fieldStore(buildContext, $);
             case BinaryArithmeticOrLogicOperation $ -> binaryOperation(buildContext, $);
+            case UnaryArithmeticOrLogicOperation $ -> unaryOperation(buildContext, $);
             case BinaryTestOpWrapper $ -> binaryTest(buildContext, $);
             case ConvOpWrapper $ -> conv(buildContext, $);
             case ConstantOpWrapper $ -> constant(buildContext, $);

--- a/hat/hat/src/main/java/hat/buffer/S32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array2D.java
@@ -27,6 +27,7 @@ package hat.buffer;
 import hat.Accelerator;
 import hat.ifacemapper.Schema;
 
+import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
 import java.lang.invoke.MethodHandles;
 
@@ -62,5 +63,8 @@ public interface S32Array2D extends Buffer {
     static S32Array2D create(Accelerator accelerator,  int width, int height){
         return create(accelerator.lookup, accelerator, width,height);
     }
-
+    default S32Array2D copyFrom(int[] ints) {
+        MemorySegment.copy(ints, 0, Buffer.getMemorySegment(this), JAVA_INT, 2* JAVA_INT.byteSize(), width()*height());
+        return this;
+    }
 }

--- a/hat/hat/src/main/java/hat/optools/OpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/OpWrapper.java
@@ -55,6 +55,7 @@ public class OpWrapper<T extends Op> {
             case ExtendedOp.JavaForOp $ -> (OW) new ForOpWrapper($);
             case ExtendedOp.JavaWhileOp $ -> (OW) new WhileOpWrapper($);
             case ExtendedOp.JavaIfOp $ -> (OW) new IfOpWrapper($);
+            case CoreOp.NotOp $ -> (OW) new UnaryArithmeticOrLogicOperation($);
             case CoreOp.BinaryOp $ -> (OW) new BinaryArithmeticOrLogicOperation($);
             case CoreOp.BinaryTestOp $ -> (OW) new BinaryTestOpWrapper($);
             case CoreOp.FuncOp $ -> (OW) new FuncOpWrapper($);

--- a/hat/hat/src/main/java/hat/optools/UnaryArithmeticOrLogicOperation.java
+++ b/hat/hat/src/main/java/hat/optools/UnaryArithmeticOrLogicOperation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.optools;
+
+import java.lang.reflect.code.op.CoreOp;
+
+public class UnaryArithmeticOrLogicOperation extends UnaryOpWrapper<CoreOp.UnaryOp> {
+    UnaryArithmeticOrLogicOperation(CoreOp.UnaryOp op) {
+        super(op);
+    }
+}


### PR DESCRIPTION
Whilst converting healing brush demo.  Found some missing C99 operator mappings. 

Specifically for precedence of logical not and shift operations. 

Those fixes are here

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.org/babylon.git pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/184.diff">https://git.openjdk.org/babylon/pull/184.diff</a>

</details>
