### PR TITLE
Correct bytecode gen for lambda capture

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -1195,9 +1195,10 @@ public final class BytecodeGenerator {
 
             // Quoted the lambda expression
             Value q = b.op(CoreOp.quoted(b.parentBody(), qb -> {
-                // Map the lambda's parent block to the quoted block
-                // We are copying lop in the context of the quoted block
-                qb.context().mapBlock(lop.parentBlock(), qb);
+                // Map the entry block of the lambda's ancestor body to the quoted block
+                // We are copying lop in the context of the quoted block, the block mapping
+                // ensures the use of captured values are reachable when building
+                qb.context().mapBlock(lop.ancestorBody().entryBlock(), qb);
                 // Map the lambda's captured values
                 qb.context().mapValues(captures, outputCaptures);
                 // Return the lambda to be copied in the quoted operation

--- a/test/jdk/java/lang/reflect/code/bytecode/TestNestedCapturingLambda.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestNestedCapturingLambda.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestNestedCapturingLambda
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.Quotable;
+import java.lang.reflect.code.bytecode.BytecodeGenerator;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.function.IntSupplier;
+import java.util.stream.Stream;
+
+public class TestNestedCapturingLambda {
+
+    @FunctionalInterface
+    interface QIntSupplier extends IntSupplier, Quotable {
+    }
+
+    @CodeReflection
+    static public int f(int a) {
+        if (a > 0) {
+            QIntSupplier s = () -> a;
+            test(s, a);
+            return s.getAsInt();
+        } else {
+            return 0;
+        }
+    }
+
+    static void test(QIntSupplier s, int a) {
+        @SuppressWarnings("unchecked")
+        CoreOp.Var<Integer> capture = (CoreOp.Var<Integer>) s.quoted().capturedValues().values().iterator().next();
+        Assert.assertEquals(capture.value().intValue(), a);
+    }
+
+    @Test
+    public void testf() throws Throwable {
+        CoreOp.FuncOp f = getFuncOp("f");
+
+        MethodHandle mh = generate(f);
+
+        Assert.assertEquals((int) mh.invoke(42), f(42));
+        Assert.assertEquals((int) mh.invoke(-1), f(-1));
+    }
+
+    static MethodHandle generate(CoreOp.FuncOp f) {
+        f.writeTo(System.out);
+
+        CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
+    }
+
+    static CoreOp.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestNestedCapturingLambda.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}


### PR DESCRIPTION
The byte code generator was incorrectly establishing the block mapping when generating models for quotable lambdas.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/babylon.git pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/185.diff">https://git.openjdk.org/babylon/pull/185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/185#issuecomment-2233963168)