### PR TITLE
SSA transform with capturing lambdas

### DIFF
--- a/test/jdk/java/lang/reflect/code/TestSSA.java
+++ b/test/jdk/java/lang/reflect/code/TestSSA.java
@@ -32,6 +32,7 @@ import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
 import java.util.Optional;
+import java.util.function.IntSupplier;
 import java.util.stream.Stream;
 
 /*
@@ -122,12 +123,31 @@ public class TestSSA {
     }
 
     @Test
-    public void testNestedLoop() throws Throwable {
+    public void testNestedLoop() {
         CoreOp.FuncOp f = getFuncOp("nestedLoop");
 
         CoreOp.FuncOp lf = generate(f);
 
         Assert.assertEquals((int) Interpreter.invoke(lf, 10), nestedLoop(10));
+    }
+
+    @CodeReflection
+    static int nestedLambdaCapture(int i) {
+        IntSupplier s = () -> {
+            int j = i + 1;
+            IntSupplier s2 = () -> i + j;
+            return s2.getAsInt() + i;
+        };
+        return s.getAsInt();
+    }
+
+    @Test
+    public void testNestedLambdaCapture() {
+        CoreOp.FuncOp f = getFuncOp("nestedLambdaCapture");
+
+        CoreOp.FuncOp lf = generate(f);
+
+        Assert.assertEquals((int) Interpreter.invoke(lf, 10), nestedLambdaCapture(10));
     }
 
     static CoreOp.FuncOp generate(CoreOp.FuncOp f) {


### PR DESCRIPTION
Enhance the SSA transform to support lambdas that capture values. Such values are final or effectively final so the corresponding variables will only be loaded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/babylon.git pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/186.diff">https://git.openjdk.org/babylon/pull/186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/186#issuecomment-2234370108)