### PR TITLE
Immediate dominator map should be unmodifiable

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/Body.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Body.java
@@ -154,7 +154,7 @@ public final class Body implements CodeElement<Body, Block> {
     /**
      * Returns a map of block to its immediate dominator.
      *
-     * @return a map of block to its immediate dominator
+     * @return a map of block to its immediate dominator, as an unmodifiable map
      */
     public Map<Block, Block> immediateDominators() {
         /*
@@ -169,7 +169,10 @@ public final class Body implements CodeElement<Body, Block> {
             return idoms;
         }
 
-        Map<Block, Block> doms = idoms = new HashMap<>();
+        // @@@ Compute the idoms as a block index mapping using int[]
+        // and wrap and a specific map implementation
+
+        Map<Block, Block> doms = new HashMap<>();
         doms.put(entryBlock(), entryBlock());
 
         // Blocks are sorted in reverse postorder
@@ -209,7 +212,7 @@ public final class Body implements CodeElement<Body, Block> {
             }
         } while (changed);
 
-        return doms;
+        return idoms = Collections.unmodifiableMap(doms);
     }
 
     static Block intersect(Map<Block, Block> doms, Block b1, Block b2) {
@@ -233,7 +236,7 @@ public final class Body implements CodeElement<Body, Block> {
      * such that {@code B} dominates a predecessor of {@code C} but does not strictly dominate
      * {@code C}.
      *
-     * @return the dominance frontier of each block in the body
+     * @return the dominance frontier of each block in the body, as a modifiable map
      */
     public Map<Block, Set<Block>> dominanceFrontier() {
         // @@@ cache result?
@@ -247,7 +250,7 @@ public final class Body implements CodeElement<Body, Block> {
                 for (Block p : preds) {
                     Block runner = p;
                     while (runner != idoms.get(b)) {
-                        df.computeIfAbsent(runner, k -> new LinkedHashSet<>()).add(b);
+                        df.computeIfAbsent(runner, _ -> new LinkedHashSet<>()).add(b);
                         runner = idoms.get(runner);
                     }
                 }

--- a/test/jdk/java/lang/reflect/code/TestDominate.java
+++ b/test/jdk/java/lang/reflect/code/TestDominate.java
@@ -49,6 +49,29 @@ import static java.lang.reflect.code.op.CoreOp.func;
 
 public class TestDominate {
 
+    public void testUnmodifiableIdoms() {
+        CoreOp.FuncOp f = func("f", FunctionType.VOID).body(entry -> {
+            Block.Builder ifBlock = entry.block();
+            Block.Builder elseBlock = entry.block();
+            Block.Builder end = entry.block();
+
+            Op.Result p = entry.op(constant(JavaType.BOOLEAN, true));
+            entry.op(conditionalBranch(p, ifBlock.successor(), elseBlock.successor()));
+
+            ifBlock.op(branch(end.successor()));
+
+            elseBlock.op(branch(end.successor()));
+
+            end.op(_return());
+        });
+
+        Map<Block, Block> idoms = f.body().immediateDominators();
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> idoms.put(f.body().entryBlock(), f.body().entryBlock()));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                idoms::clear);
+    }
+
     @Test
     public void testIfElse() {
         CoreOp.FuncOp f = func("f", FunctionType.VOID).body(entry -> {


### PR DESCRIPTION
The cached Immediate dominator map returned by `Body::immediateDominators` was modifiable. Changed to make it unmodifiable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/187/head:pull/187` \
`$ git checkout pull/187`

Update a local copy of the PR: \
`$ git checkout pull/187` \
`$ git pull https://git.openjdk.org/babylon.git pull/187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 187`

View PR using the GUI difftool: \
`$ git pr show -t 187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/187.diff">https://git.openjdk.org/babylon/pull/187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/187#issuecomment-2237212479)