### PR TITLE
Only allow allocation via accelerator, and simplify schema binding

### DIFF
--- a/hat/backends/mock/src/main/java/hat/backend/MockBackend.java
+++ b/hat/backends/mock/src/main/java/hat/backend/MockBackend.java
@@ -25,6 +25,7 @@
 package hat.backend;
 
 
+import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.buffer.BackendConfig;
@@ -56,8 +57,8 @@ public class MockBackend extends NativeBackend {
         void junk(boolean junk);
 
         Schema<MockConfig> schema = Schema.of(MockConfig.class, s->s.fields("gpu", "junk"));
-        static MockConfig create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, boolean gpu) {
-            MockConfig config =schema.allocate(lookup,bufferAllocator);
+        static MockConfig create(Accelerator accelerator, boolean gpu) {
+            MockConfig config =schema.allocate(accelerator);
             config.gpu(gpu);
             return config;
         }
@@ -67,7 +68,7 @@ public class MockBackend extends NativeBackend {
 
     public MockBackend() {
         super("mock_backend");
-        getBackend(MockConfig.create(MethodHandles.lookup(),this,  true));
+        getBackend(null);//MockConfig.create(MethodHandles.lookup(),this,  true));
     }
 
     @Override

--- a/hat/backends/opencl/src/main/java/hat/backend/OpenCLBackend.java
+++ b/hat/backends/opencl/src/main/java/hat/backend/OpenCLBackend.java
@@ -25,6 +25,7 @@
 package hat.backend;
 
 
+import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.buffer.BackendConfig;
@@ -56,8 +57,8 @@ public class OpenCLBackend extends C99NativeBackend {
        // void verbose(boolean verbose);
         Schema<OpenCLConfig> schema = Schema.of(OpenCLConfig.class, s->s.fields("gpu"));
 
-        static OpenCLConfig create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, boolean gpu, boolean verbose) {
-            OpenCLConfig config =schema.allocate(lookup,bufferAllocator);
+        static OpenCLConfig create(Accelerator accelerator, boolean gpu, boolean verbose) {
+            OpenCLConfig config =schema.allocate(accelerator);
             config.gpu(gpu);
          //   config.verbose(verbose);
             return config;
@@ -68,7 +69,7 @@ public class OpenCLBackend extends C99NativeBackend {
 
     public OpenCLBackend() {
         super("opencl_backend");
-        getBackend(OpenCLConfig.create( MethodHandles.lookup(),this, true, true));
+        getBackend(null);//OpenCLConfig.create( MethodHandles.lookup(),this, true, true));
         info();
     }
 

--- a/hat/examples/experiments/src/main/java/experiments/InvokeToPtr.java
+++ b/hat/examples/experiments/src/main/java/experiments/InvokeToPtr.java
@@ -1,6 +1,7 @@
 package experiments;
 
 
+import hat.Accelerator;
 import hat.OpsAndTypes;
 
 import java.lang.foreign.Arena;
@@ -14,6 +15,7 @@ import java.lang.runtime.CodeReflection;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import hat.backend.DebugBackend;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.ifacemapper.BoundSchema;
@@ -39,14 +41,10 @@ public class InvokeToPtr {
 
 
     public static void main(String[] args) {
-        BufferAllocator bufferAllocator = new BufferAllocator() {
-            @Override
-            public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper, BoundSchema<T> boundSchema) {
-                return segmentMapper.allocate(Arena.global(),boundSchema);
-            }
-        };
 
-        PointyHat.ColoredWeightedPoint p = PointyHat.ColoredWeightedPoint.schema.allocate(MethodHandles.lookup(),bufferAllocator);
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(),new DebugBackend());
+
+        PointyHat.ColoredWeightedPoint p = PointyHat.ColoredWeightedPoint.schema.allocate(accelerator);
         System.out.println(Buffer.getLayout(p));
         Optional<Method> om = Stream.of(InvokeToPtr.class.getDeclaredMethods())
                 .filter(m -> m.getName().equals("testMethod"))

--- a/hat/examples/experiments/src/main/java/experiments/Mesh.java
+++ b/hat/examples/experiments/src/main/java/experiments/Mesh.java
@@ -109,8 +109,8 @@ public class Mesh {
                 .arrayLen("points").array("point", p -> p.fields("x", "y", "z"))
                 .arrayLen("vertices").array("vertex", v -> v.fields("from", "to"))
         );
-        static  MeshData create(MethodHandles.Lookup lookup,BufferAllocator bufferAllocator) {
-            return schema.allocate(lookup,bufferAllocator,100,10);
+        static  MeshData create(Accelerator accelerator) {
+            return schema.allocate(accelerator,100,10);
         }
     }
 
@@ -143,7 +143,7 @@ public class Mesh {
 
         var boundSchema = new BoundSchema<>(MeshData.schema, 100, 10);
         var meshDataNew = boundSchema.allocate(accelerator.lookup,accelerator);
-        var meshDataOld = MeshData.create(accelerator.lookup,accelerator);
+        var meshDataOld = MeshData.create(accelerator);
 
         String layoutNew = Buffer.getLayout(meshDataNew).toString();
         String layoutOld = Buffer.getLayout(meshDataOld).toString();

--- a/hat/examples/experiments/src/main/java/experiments/PointyHat.java
+++ b/hat/examples/experiments/src/main/java/experiments/PointyHat.java
@@ -57,8 +57,8 @@ public class PointyHat {
                 .field("color")
         );
 
-        static ColoredWeightedPoint create(MethodHandles.Lookup lookup,BufferAllocator bufferAllocator) {
-            return schema.allocate(lookup,bufferAllocator);
+        static ColoredWeightedPoint create(Accelerator accelerator) {
+            return schema.allocate(accelerator);
         }
     }
 
@@ -116,7 +116,7 @@ public class PointyHat {
                 System.out.println(ssaPtrForm.toText());
             }
         });
-        var coloredWeightedPoint = ColoredWeightedPoint.create(MethodHandles.lookup(),accelerator);
+        var coloredWeightedPoint = ColoredWeightedPoint.create(accelerator);
 
         int color = coloredWeightedPoint.color();
         // s1 -> *s2

--- a/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
+++ b/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
@@ -62,9 +62,9 @@ public class PointyHatArray {
                 )
         );
 
-        static PointArray create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int len) {
+        static PointArray create(Accelerator accelerator, int len) {
             System.out.println(LAYOUT);
-            PointArray pointArray= schema.allocate(lookup,bufferAllocator,100);
+            PointArray pointArray= schema.allocate(accelerator,100);
             pointArray.length(100);
             return pointArray;
         }
@@ -119,7 +119,7 @@ public class PointyHatArray {
                 System.out.println(ssaPtrForm.toText());
             }
         });
-        var pointArray = PointArray.create(accelerator.lookup,accelerator,100);
+        var pointArray = PointArray.create(accelerator,100);
         accelerator.compute(cc -> Compute.compute(cc, pointArray));
     }
 }

--- a/hat/examples/experiments/src/main/java/experiments/S08x3ImageTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/S08x3ImageTest.java
@@ -24,6 +24,8 @@
  */
 package experiments;
 
+import hat.Accelerator;
+import hat.backend.DebugBackend;
 import hat.buffer.Buffer;
 import hat.buffer.BufferAllocator;
 import hat.buffer.S08x3RGBImage;
@@ -36,13 +38,10 @@ import java.lang.invoke.MethodHandles;
 public class S08x3ImageTest implements Buffer {
 
     public static void main(String[] args) {
-        BufferAllocator bufferAllocator = new BufferAllocator() {
-            @Override
-            public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper, BoundSchema<T> boundSchema) {
-                return segmentMapper.allocate(Arena.global(),boundSchema);
-            }
-        };
-        var rgbS08x3Image = S08x3RGBImage.create(MethodHandles.lookup(), bufferAllocator,100,100);
+
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(),new DebugBackend());
+
+        var rgbS08x3Image = S08x3RGBImage.create(accelerator,100,100);
     }
 
 }

--- a/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
@@ -24,6 +24,8 @@
  */
 package experiments;
 
+import hat.Accelerator;
+import hat.backend.DebugBackend;
 import hat.buffer.BufferAllocator;
 import hat.buffer.S32Array2D;
 import hat.ifacemapper.BoundSchema;
@@ -36,13 +38,9 @@ import java.lang.invoke.MethodHandles;
 public class S32ArrayTest implements Buffer {
 
     public static void main(String[] args) {
-        BufferAllocator bufferAllocator = new BufferAllocator() {
-            @Override
-            public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper, BoundSchema<T> boundSchema) {
-                return segmentMapper.allocate(Arena.global(),boundSchema);
-            }
-        };
-        hat.buffer.S32Array s32Array  = hat.buffer.S32Array.create(MethodHandles.lookup(),bufferAllocator, 100);
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(),new DebugBackend());
+
+        hat.buffer.S32Array s32Array  = hat.buffer.S32Array.create(accelerator, 100);
         System.out.println("Layout from schema "+Buffer.getLayout(s32Array));
         S32Array2D.schema.toText(t->System.out.print(t));
     }

--- a/hat/examples/violajones/src/main/java/violajones/HaarViewer.java
+++ b/hat/examples/violajones/src/main/java/violajones/HaarViewer.java
@@ -25,6 +25,7 @@
 package violajones;
 
 
+import hat.Accelerator;
 import hat.buffer.BufferAllocator;
 import hat.buffer.F32Array2D;
 import hat.buffer.S32Array;
@@ -50,8 +51,8 @@ import java.awt.image.BufferedImage;
 import java.lang.invoke.MethodHandles;
 
 public class HaarViewer extends JFrame {
-    final MethodHandles.Lookup lookup;
-    final BufferedImage image;
+   final Accelerator accelerator;
+     final BufferedImage image;
     final S08x3RGBImage s08X3RGBImage;
 
 
@@ -66,7 +67,7 @@ public class HaarViewer extends JFrame {
         final F32Array2D integralImageF32;
         final F32Array2D integralSqImageF32;
 
-        public IntegralWindow(Container container, MethodHandles.Lookup lookup,BufferAllocator bufferAllocator, F32Array2D integralImageF32, F32Array2D integralSqImageF32) {
+        public IntegralWindow(Container container, Accelerator accelerator, F32Array2D integralImageF32, F32Array2D integralSqImageF32) {
             this.integralImageF32 = integralImageF32;
             this.integralSqImageF32 = integralSqImageF32;
 
@@ -75,8 +76,8 @@ public class HaarViewer extends JFrame {
                 int height = this.integralImageF32.height();
                 this.integral = new BufferedImage(width, height, BufferedImage.TYPE_USHORT_GRAY);
                 this.integralSq = new BufferedImage(width, height, BufferedImage.TYPE_USHORT_GRAY);
-                this.integralImageU16 = U16GreyImage.create(lookup,bufferAllocator,integral.getWidth(),integral.getHeight());
-                this.integralSqImageU16 = U16GreyImage.create(lookup,bufferAllocator, integral.getWidth(),integral.getHeight());
+                this.integralImageU16 = U16GreyImage.create(accelerator,integral.getWidth(),integral.getHeight());
+                this.integralSqImageU16 = U16GreyImage.create(accelerator, integral.getWidth(),integral.getHeight());
                 this.integralImageView = new JComponent() {
                     @Override
                     public void paint(Graphics g) {
@@ -171,8 +172,7 @@ public class HaarViewer extends JFrame {
     final double imageScale = .5;
 
 
-    public HaarViewer(MethodHandles.Lookup lookup,
-                      BufferAllocator bufferAllocator,
+    public HaarViewer(Accelerator accelerator,
                       BufferedImage image,
                       S08x3RGBImage s08X3RGBImage,
                       Cascade cascade,
@@ -180,7 +180,7 @@ public class HaarViewer extends JFrame {
                       F32Array2D integralSqImageF32
     ) {
         super("HaarViz");
-        this.lookup = lookup;
+        this.accelerator = accelerator;
         this.image = image;
         this.s08X3RGBImage = s08X3RGBImage;
         this.cascade = cascade;
@@ -249,7 +249,7 @@ public class HaarViewer extends JFrame {
         gridPanel.add(imageView);
         add(gridPanel, BorderLayout.CENTER);
         add(imagePanel, BorderLayout.EAST);
-        this.integralWindow = new IntegralWindow(this,lookup, bufferAllocator, integralImageF32, integralSqImageF32);
+        this.integralWindow = new IntegralWindow(this,accelerator, integralImageF32, integralSqImageF32);
         this.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         pack();
         setVisible(true);

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCompute.java
@@ -68,7 +68,7 @@ public class ViolaJonesCompute {
         System.out.println("result table layout "+Buffer.getLayout(resultTable));
         HaarViewer harViz = null;
         if (!headless){
-            harViz = new HaarViewer(accelerator.lookup,accelerator, nasa1996, rgbImage, cascade, null, null);
+            harViz = new HaarViewer(accelerator, nasa1996, rgbImage, cascade, null, null);
         }
 
         ScaleTable scaleTable = ScaleTable.createFrom(accelerator,new ScaleTable.Constraints(cascade,rgbImage.width(),rgbImage.height()));

--- a/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
+++ b/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
@@ -72,7 +72,7 @@ public class ViolaJones {
         CoreJavaViolaJones.rgbToGreyScale(rgbImage, greyImageF32);
         CoreJavaViolaJones.createIntegralImage(greyImageF32, integralImageF32, integralSqImageF32);
 
-        HaarViewer harViz = new HaarViewer(accelerator.lookup, accelerator, nasa, rgbImage, cascade, integralImageF32, integralSqImageF32);
+        HaarViewer harViz = new HaarViewer(accelerator, nasa, rgbImage, cascade, integralImageF32, integralSqImageF32);
 
         harViz.showIntegrals();
 

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -173,10 +173,9 @@ public interface Cascade extends Buffer {
             .arrayLen("treeCount").array("tree",tree->tree.fields("id","firstFeatureId","featureCount"))
     );
 
-    static Cascade create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int width, int height,
+    static Cascade create(Accelerator accelerator, int width, int height,
     int features,int stages,int trees){
-        var instance  = schema.allocate(lookup,
-                bufferAllocator,
+        var instance  = schema.allocate(accelerator,
                 features,
                 stages,
                 trees
@@ -189,13 +188,9 @@ public interface Cascade extends Buffer {
         return instance;
     }
 
-    static Cascade create(Accelerator accelerator, int width, int height,
-                          int features, int stages, int trees){
-       return create(accelerator.lookup,accelerator,width,height,features,stages,trees);
-    }
 
     static Cascade createFrom(Accelerator accelerator, Cascade cascade){
-        return create(accelerator.lookup,accelerator,cascade.width(),cascade.height(),cascade.featureCount(),cascade.stageCount(),cascade.treeCount()).copyFrom(cascade);
+        return create(accelerator,cascade.width(),cascade.height(),cascade.featureCount(),cascade.stageCount(),cascade.treeCount()).copyFrom(cascade);
     }
 
     default Cascade copyFrom(Cascade fromCascade){

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
@@ -72,14 +72,11 @@ public interface ResultTable extends Buffer {
             )
     );
 
-    static ResultTable create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator,int length){
-        var instance = schema.allocate(lookup,bufferAllocator,length);
+    static ResultTable create(Accelerator accelerator,int length){
+        var instance = schema.allocate(accelerator,length);
         instance.length(length);
         instance.atomicResultTableCount(0);
         return instance;
     }
 
-    static ResultTable create(Accelerator accelerator, int length){
-       return create(accelerator.lookup, accelerator,length);
-    }
 }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
@@ -175,18 +175,14 @@ public interface ScaleTable extends Buffer {
             )
     );
 
-    static ScaleTable create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int length){
-        var instance = schema.allocate(lookup,bufferAllocator,length);
+    static ScaleTable create(Accelerator accelerator, int length){
+        var instance = schema.allocate(accelerator,length);
         instance.length(length);
         return instance;
     }
 
-    static ScaleTable create(Accelerator accelerator, int length){
-        return create(accelerator.lookup, accelerator,length);
-    }
-
     static ScaleTable createFrom(Accelerator accelerator, Constraints constraints){
-        return create(accelerator.lookup, accelerator,constraints.scales).applyConstraints(constraints);
+        return create(accelerator,constraints.scales).applyConstraints(constraints);
     }
 
 }

--- a/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
@@ -58,9 +58,9 @@ public abstract class C99NativeBackend extends NativeBackend {
             this.kernelCallGraph = kernelCallGraph;
             this.text = text;
             this.kernelHandle = kernelHandle;
-            this.kernelContext = KernelContext.create(kernelCallGraph.computeContext.accelerator.lookup, c99NativeBackend, 0, 0);
+            this.kernelContext = KernelContext.create(kernelCallGraph.computeContext.accelerator, 0, 0);
             ndRangeAndArgs[0] = this.kernelContext;
-            this.argArray = ArgArray.create(kernelCallGraph.computeContext.accelerator.lookup, kernelCallGraph.computeContext.accelerator, ndRangeAndArgs);
+            this.argArray = ArgArray.create(kernelCallGraph.computeContext.accelerator, ndRangeAndArgs);
         }
 
         public void dispatch(NDRange ndRange, Object[] args) {

--- a/hat/hat/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/hat/src/main/java/hat/backend/DebugBackend.java
@@ -19,6 +19,11 @@ public class DebugBackend extends BackendAdaptor {
     public HowToRunCompute howToRunCompute=HowToRunCompute.REFLECT;
     public enum HowToRunKernel{REFLECT, BABYLON_INTERPRETER, BABYLON_CLASSFILE, LOWER_TO_SSA,LOWER_TO_SSA_AND_MAP_PTRS}
     HowToRunKernel howToRunKernel = HowToRunKernel.LOWER_TO_SSA_AND_MAP_PTRS;
+
+    public DebugBackend(){
+       this(HowToRunCompute.REFLECT, HowToRunKernel.REFLECT);
+    }
+
     public DebugBackend(HowToRunCompute howToRunCompute, HowToRunKernel howToRunKernel){
         this.howToRunCompute = howToRunCompute;
         this.howToRunKernel = howToRunKernel;

--- a/hat/hat/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/hat/src/main/java/hat/buffer/ArgArray.java
@@ -24,6 +24,7 @@
  */
 package hat.buffer;
 
+import hat.Accelerator;
 import hat.ifacemapper.Schema;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -264,7 +265,7 @@ public interface ArgArray extends Buffer {
         return (valueLayout.order().equals(ByteOrder.LITTLE_ENDIAN)) ? schema.toLowerCase() : schema;
     }
 
-    static ArgArray create(MethodHandles.Lookup lookup,BufferAllocator bufferAllocator, Object... args) {
+    static ArgArray create(Accelerator accelerator, Object... args) {
         String[] schemas = new String[args.length];
         StringBuilder argSchema = new StringBuilder();
         argSchema.append(args.length);
@@ -288,7 +289,7 @@ public interface ArgArray extends Buffer {
             argSchema.append(schemas[i]);
         }
         String schemaStr = argSchema.toString();
-        ArgArray argArray = schema.allocate(lookup,bufferAllocator,args.length,schemaStr.length() + 1);
+        ArgArray argArray = schema.allocate(accelerator,args.length,schemaStr.length() + 1);
         argArray.argc(args.length);
         argArray.setSchemaBytes(schemaStr);
         update(argArray, args);

--- a/hat/hat/src/main/java/hat/buffer/F32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array.java
@@ -47,20 +47,17 @@ public interface F32Array extends Buffer {
             .arrayLen("length").array("array"));
 
 
-    static F32Array create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int length){
-        var instance = schema.allocate(lookup,bufferAllocator, length);
+    static F32Array create(Accelerator accelerator, int length){
+        var instance = schema.allocate(accelerator, length);
         instance.length(length);
         return instance;
-    }
-    static F32Array create(Accelerator accelerator, int length){
-        return create(accelerator.lookup, accelerator, length);
     }
     default F32Array copyFrom(float[] floats) {
         MemorySegment.copy(floats, 0, Buffer.getMemorySegment(this), JAVA_FLOAT, 4, length());
         return this;
     }
     static F32Array createFrom(Accelerator accelerator, float[] arr){
-        return create(accelerator.lookup, accelerator, arr.length).copyFrom(arr);
+        return create( accelerator, arr.length).copyFrom(arr);
     }
 
 

--- a/hat/hat/src/main/java/hat/buffer/F32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array2D.java
@@ -57,14 +57,11 @@ public interface F32Array2D extends Buffer {
     Schema<F32Array2D> schema = Schema.of(F32Array2D.class, s32Array->s32Array
             .arrayLen("width","height").stride(1).array("array"));
 
-    static F32Array2D create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int width, int height){
-        var instance = schema.allocate(lookup,bufferAllocator, width,height);
+    static F32Array2D create(Accelerator accelerator, int width, int height){
+        var instance = schema.allocate(accelerator, width,height);
         instance.width(width);
         instance.height(height);
         return instance;
-    }
-    static F32Array2D create(Accelerator accelerator,  int width, int height){
-        return create(accelerator.lookup, accelerator, width,height);
     }
 
 }

--- a/hat/hat/src/main/java/hat/buffer/KernelContext.java
+++ b/hat/hat/src/main/java/hat/buffer/KernelContext.java
@@ -1,6 +1,7 @@
 package hat.buffer;
 
 
+import hat.Accelerator;
 import hat.ifacemapper.Schema;
 
 import java.lang.invoke.MethodHandles;
@@ -15,8 +16,8 @@ public interface KernelContext extends Buffer {
 
     Schema<KernelContext> schema = Schema.of(KernelContext.class, s->s.fields("x","maxX"));
 
-    static KernelContext create(MethodHandles.Lookup lookup,BufferAllocator bufferAllocator, int x, int maxX) {
-        KernelContext kernelContext =  schema.allocate(lookup,bufferAllocator);
+    static KernelContext create(Accelerator accelerator, int x, int maxX) {
+        KernelContext kernelContext =  schema.allocate(accelerator);
         kernelContext.x(x);
         kernelContext.maxX(maxX);
         return kernelContext;

--- a/hat/hat/src/main/java/hat/buffer/S08x3RGBImage.java
+++ b/hat/hat/src/main/java/hat/buffer/S08x3RGBImage.java
@@ -16,14 +16,10 @@ public interface S08x3RGBImage extends ImageIfaceBuffer<S08x3RGBImage> {
             .arrayLen("width", "height").stride(3).array("data")
     );
 
-    static S08x3RGBImage create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int width, int height){
-        var instance = schema.allocate(lookup, bufferAllocator,width,height);
+    static S08x3RGBImage create(Accelerator accelerator, int width, int height){
+        var instance = schema.allocate(accelerator,width,height);
         instance.width(width);
         instance.height(height);
         return instance;
     }
-    static S08x3RGBImage create(Accelerator accelerator, int width, int height){
-        return create(accelerator.lookup,accelerator,width,height);
-    }
-
 }

--- a/hat/hat/src/main/java/hat/buffer/S32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array.java
@@ -43,16 +43,13 @@ public interface S32Array extends Buffer {
     Schema<S32Array> schema = Schema.of(S32Array.class, s32Array->s32Array
             .arrayLen("length").array("array"));
 
-    static S32Array create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int length){
-        var instance = schema.allocate(lookup,bufferAllocator, length);
+    static S32Array create(Accelerator accelerator, int length){
+        var instance = schema.allocate(accelerator, length);
         instance.length(length);
         return instance;
     }
-    static S32Array create(Accelerator accelerator, int length){
-        return create(accelerator.lookup, accelerator, length);
-    }
     static S32Array createFrom(Accelerator accelerator, int[] arr){
-        return create(accelerator.lookup, accelerator, arr.length).copyfrom(arr);
+        return create( accelerator, arr.length).copyfrom(arr);
     }
     default S32Array copyfrom(int[] ints) {
         MemorySegment.copy(ints, 0, Buffer.getMemorySegment(this), JAVA_INT, 4, length());

--- a/hat/hat/src/main/java/hat/buffer/S32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array2D.java
@@ -54,14 +54,11 @@ public interface S32Array2D extends Buffer {
     Schema<S32Array2D> schema = Schema.of(S32Array2D.class, s32Array->s32Array
             .arrayLen("width","height").stride(1).array("array"));
 
-    static S32Array2D create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int width, int height){
-        var instance = schema.allocate(lookup,bufferAllocator, width,height);
+    static S32Array2D create(Accelerator accelerator, int width, int height){
+        var instance = schema.allocate(accelerator, width,height);
         instance.width(width);
         instance.height(height);
         return instance;
-    }
-    static S32Array2D create(Accelerator accelerator,  int width, int height){
-        return create(accelerator.lookup, accelerator, width,height);
     }
     default S32Array2D copyFrom(int[] ints) {
         MemorySegment.copy(ints, 0, Buffer.getMemorySegment(this), JAVA_INT, 2* JAVA_INT.byteSize(), width()*height());

--- a/hat/hat/src/main/java/hat/buffer/S32RGBAImage.java
+++ b/hat/hat/src/main/java/hat/buffer/S32RGBAImage.java
@@ -24,6 +24,7 @@
  */
 package hat.buffer;
 
+import hat.Accelerator;
 import hat.ifacemapper.Schema;
 
 import java.lang.invoke.MethodHandles;
@@ -42,8 +43,8 @@ public interface S32RGBAImage extends ImageIfaceBuffer<S32RGBAImage> {
     );
 
 
-    static S32RGBAImage create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int width, int height){
-        var instance = schema.allocate(lookup, bufferAllocator,width,height);
+    static S32RGBAImage create(Accelerator accelerator, int width, int height){
+        var instance = schema.allocate(accelerator,width,height);
         instance.width(width);
         instance.height(height);
         return instance;

--- a/hat/hat/src/main/java/hat/buffer/U16GreyImage.java
+++ b/hat/hat/src/main/java/hat/buffer/U16GreyImage.java
@@ -24,6 +24,7 @@
  */
 package hat.buffer;
 
+import hat.Accelerator;
 import hat.ifacemapper.Schema;
 
 import java.lang.invoke.MethodHandles;
@@ -40,8 +41,8 @@ public interface U16GreyImage extends ImageIfaceBuffer<U16GreyImage> {
             .arrayLen("width", "height").stride(1).array("data")
     );
 
-    static U16GreyImage create(MethodHandles.Lookup lookup, BufferAllocator bufferAllocator, int width, int height){
-        var instance = schema.allocate(lookup, bufferAllocator,width,height);
+    static U16GreyImage create(Accelerator accelerator, int width, int height){
+        var instance = schema.allocate(accelerator,width,height);
         instance.width(width);
         instance.height(height);
         return instance;


### PR DESCRIPTION
We now restrict allocations of iface mappings to accelerators.  

Simplified the code for mapping schemas.  Some code in Schema should have  been in BoundSchema.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/babylon.git pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/189.diff">https://git.openjdk.org/babylon/pull/189.diff</a>

</details>
