### PR TITLE
Hat more schema optimizations

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/S32Array.java
+++ b/hat/examples/experiments/src/main/java/experiments/S32Array.java
@@ -29,10 +29,8 @@ import hat.buffer.Buffer;
 
 public interface S32Array extends Buffer {
     int length();
-    void length(int i);
     int array(long idx);
     void array(long idx, int i);
     Schema<S32Array> schema = Schema.of(S32Array.class, s32Array->s32Array
             .arrayLen("length").array("array"));
-
 }

--- a/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
@@ -39,18 +39,25 @@ public class S32ArrayTest implements Buffer {
     public static void main(String[] args) {
         Accelerator accelerator = new Accelerator(MethodHandles.lookup(),new DebugBackend());
 
-        hat.buffer.S32Array s32Array  = hat.buffer.S32Array.create(accelerator, 100);
-        GroupLayout groupLayout = (GroupLayout) Buffer.getLayout(s32Array);
+        hat.buffer.S32Array2D s32Array2D  = S32Array2D.create(accelerator, 100, 200);
+        GroupLayout groupLayout = (GroupLayout) Buffer.getLayout(s32Array2D);
         System.out.println("Layout from buffer "+groupLayout);
-        BoundSchema<?> boundSchema = Buffer.getBoundSchema(s32Array);
+        BoundSchema<?> boundSchema = Buffer.getBoundSchema(s32Array2D);
         System.out.println("BoundSchema from buffer  "+boundSchema);
 
         BoundSchema.FieldLayout<?> fieldLayout =  boundSchema.rootBoundSchemaNode().getName("array");
         long arrayOffset = fieldLayout.offset();
-        MemoryLayout layaout = fieldLayout.layout();
+        MemoryLayout layout = fieldLayout.layout();
+
         if (fieldLayout instanceof BoundSchema.ArrayFieldLayout arrayFieldLayout){
             System.out.println("isArray");
-            arrayFieldLayout.offset(0);
+            arrayFieldLayout.elementOffset(0);
+            arrayFieldLayout.elementLayout(0);
+            if (arrayFieldLayout instanceof BoundSchema.BoundArrayFieldLayout boundArrayFieldLayout){
+                boundArrayFieldLayout.dimFields.forEach(dimLayout->{
+                    System.out.println(dimLayout.field.name + " "+dimLayout.offset());
+                });
+            }
         }
         S32Array2D.schema.toText(t->System.out.print(t));
     }

--- a/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/S32ArrayTest.java
@@ -26,13 +26,12 @@ package experiments;
 
 import hat.Accelerator;
 import hat.backend.DebugBackend;
-import hat.buffer.BufferAllocator;
 import hat.buffer.S32Array2D;
 import hat.ifacemapper.BoundSchema;
 import hat.buffer.Buffer;
-import hat.ifacemapper.SegmentMapper;
 
-import java.lang.foreign.Arena;
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryLayout;
 import java.lang.invoke.MethodHandles;
 
 public class S32ArrayTest implements Buffer {
@@ -41,7 +40,18 @@ public class S32ArrayTest implements Buffer {
         Accelerator accelerator = new Accelerator(MethodHandles.lookup(),new DebugBackend());
 
         hat.buffer.S32Array s32Array  = hat.buffer.S32Array.create(accelerator, 100);
-        System.out.println("Layout from schema "+Buffer.getLayout(s32Array));
+        GroupLayout groupLayout = (GroupLayout) Buffer.getLayout(s32Array);
+        System.out.println("Layout from buffer "+groupLayout);
+        BoundSchema<?> boundSchema = Buffer.getBoundSchema(s32Array);
+        System.out.println("BoundSchema from buffer  "+boundSchema);
+
+        BoundSchema.FieldLayout<?> fieldLayout =  boundSchema.rootBoundSchemaNode().getName("array");
+        long arrayOffset = fieldLayout.offset();
+        MemoryLayout layaout = fieldLayout.layout();
+        if (fieldLayout instanceof BoundSchema.ArrayFieldLayout arrayFieldLayout){
+            System.out.println("isArray");
+            arrayFieldLayout.offset(0);
+        }
         S32Array2D.schema.toText(t->System.out.print(t));
     }
 

--- a/hat/examples/violajones/src/main/java/violajones/XMLHaarCascadeModel.java
+++ b/hat/examples/violajones/src/main/java/violajones/XMLHaarCascadeModel.java
@@ -91,11 +91,6 @@ public class XMLHaarCascadeModel implements Cascade {
     }
 
     @Override
-    public void featureCount(int featureCount) {
-        throw new IllegalStateException("featureCount(int featureCount) unimplemented ");
-    }
-
-    @Override
     public Cascade.Stage stage(long idx) {
         return stages.get((int) idx);
     }
@@ -106,11 +101,6 @@ public class XMLHaarCascadeModel implements Cascade {
     }
 
     @Override
-    public void stageCount(int stageCount) {
-        throw new IllegalStateException("stageCount(int stageCount) unimplemented ");
-    }
-
-    @Override
     public Cascade.Tree tree(long idx) {
         return trees.get((int) idx);
     }
@@ -118,11 +108,6 @@ public class XMLHaarCascadeModel implements Cascade {
     @Override
     public int treeCount() {
         return trees.size();
-    }
-
-    @Override
-    public void treeCount(int treeCount) {
-        throw new IllegalStateException("void treeCount(int treeCount) unimplemented ");
     }
 
     @Override
@@ -172,13 +157,11 @@ public class XMLHaarCascadeModel implements Cascade {
         @Override
         public Cascade.Feature.LinkOrValue left() {
             return left;
-            // throw new IllegalStateException("Cascade.Feature.LinkOrValue left() unimplemented ");
-        }
+         }
 
         @Override
         public Cascade.Feature.LinkOrValue right() {
             return right;
-            //throw new IllegalStateException("Cascade.Feature.LinkOrValue right() unimplemented ");
         }
 
         @Override
@@ -221,7 +204,6 @@ public class XMLHaarCascadeModel implements Cascade {
             @Override
             public Anon anon() {
                 return this;
-                // throw new IllegalStateException("Anon anon() unimplemented ");
             }
 
             @Override

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -138,21 +138,21 @@ public interface Cascade extends Buffer {
     @After("height")
     int featureCount();
 
-    void featureCount(int featureCount);
+ //  void featureCount(int featureCount);
 
     @BoundBy("featureCount")
     Feature feature(long idx);
 
     int stageCount();
 
-    void stageCount(int stageCount);
+  //  void stageCount(int stageCount);
 
     @BoundBy("stageCount")
     Stage stage(long idx);
 
     int treeCount();
 
-    void treeCount(int treeCount);
+//void treeCount(int treeCount);
 
     @BoundBy("treeCount")
     Tree tree(long idx);
@@ -182,9 +182,6 @@ public interface Cascade extends Buffer {
         );
         instance.width(width);
         instance.height(height);
-        instance.featureCount(features);
-        instance.stageCount(stages);
-        instance.treeCount(trees);
         return instance;
     }
 
@@ -197,9 +194,6 @@ public interface Cascade extends Buffer {
         Cascade toCascade= this;
         toCascade.width(fromCascade.width());
         toCascade.height(fromCascade.height());
-        toCascade.featureCount(fromCascade.featureCount());
-        toCascade.stageCount(fromCascade.stageCount());
-        toCascade.treeCount(fromCascade.treeCount());
         for (int idx = 0; idx < fromCascade.featureCount(); idx++) {
             Cascade.Feature toFeature =  toCascade.feature(idx);
             Cascade.Feature fromFeature = fromCascade.feature(idx);

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ResultTable.java
@@ -52,7 +52,6 @@ public interface ResultTable extends Buffer {
 
     @After("atomicResultTableCount")
     int length();
-    void length(int length);
 
     @BoundBy("length")
     Result result(long idx);
@@ -66,17 +65,13 @@ public interface ResultTable extends Buffer {
 
     Schema<ResultTable> schema = Schema.of(ResultTable.class, resultTable->resultTable
             .atomic("atomicResultTableCount")
-            .arrayLen("length")
-            .array("result", array->array
+            .arrayLen("length").array("result", array->array
                     .fields("x", "y", "width", "height")
             )
     );
 
     static ResultTable create(Accelerator accelerator,int length){
-        var instance = schema.allocate(accelerator,length);
-        instance.length(length);
-        instance.atomicResultTableCount(0);
-        return instance;
+        return schema.allocate(accelerator,length);
     }
 
 }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/ScaleTable.java
@@ -147,7 +147,6 @@ public interface ScaleTable extends Buffer {
        }
 
     int length();
-    void length(int length);
 
     Scale scale(long idx);
 
@@ -176,9 +175,7 @@ public interface ScaleTable extends Buffer {
     );
 
     static ScaleTable create(Accelerator accelerator, int length){
-        var instance = schema.allocate(accelerator,length);
-        instance.length(length);
-        return instance;
+        return schema.allocate(accelerator,length);
     }
 
     static ScaleTable createFrom(Accelerator accelerator, Constraints constraints){

--- a/hat/hat/src/main/java/hat/buffer/F32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array.java
@@ -35,10 +35,7 @@ import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface F32Array extends Buffer {
-
     int length();
-    void length(int i);
-
     @BoundBy("length")
     float array(long idx);
     void array(long idx, float f);
@@ -46,11 +43,8 @@ public interface F32Array extends Buffer {
     Schema<F32Array> schema = Schema.of(F32Array.class, s32Array->s32Array
             .arrayLen("length").array("array"));
 
-
     static F32Array create(Accelerator accelerator, int length){
-        var instance = schema.allocate(accelerator, length);
-        instance.length(length);
-        return instance;
+        return schema.allocate(accelerator, length);
     }
     default F32Array copyFrom(float[] floats) {
         MemorySegment.copy(floats, 0, Buffer.getMemorySegment(this), JAVA_FLOAT, 4, length());

--- a/hat/hat/src/main/java/hat/buffer/F32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/F32Array2D.java
@@ -35,10 +35,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public interface F32Array2D extends Buffer {
     int width();
-    void width(int i);
 
     @After("width")
-    void height(int i);
     int height();
 
     @BoundBy({"width","height"})
@@ -58,10 +56,7 @@ public interface F32Array2D extends Buffer {
             .arrayLen("width","height").stride(1).array("array"));
 
     static F32Array2D create(Accelerator accelerator, int width, int height){
-        var instance = schema.allocate(accelerator, width,height);
-        instance.width(width);
-        instance.height(height);
-        return instance;
+        return schema.allocate(accelerator, width,height);
     }
 
 }

--- a/hat/hat/src/main/java/hat/buffer/S08x3RGBImage.java
+++ b/hat/hat/src/main/java/hat/buffer/S08x3RGBImage.java
@@ -6,20 +6,16 @@ import hat.ifacemapper.Schema;
 import java.lang.invoke.MethodHandles;
 
 public interface S08x3RGBImage extends ImageIfaceBuffer<S08x3RGBImage> {
+    int width();
+    int height();
     byte data(long idx);
     void data(long idx, byte v);
-    int width();
-    void width(int width);
-    int height();
-    void height(int height);
+
     Schema<S08x3RGBImage> schema = Schema.of(S08x3RGBImage.class, s -> s
             .arrayLen("width", "height").stride(3).array("data")
     );
 
     static S08x3RGBImage create(Accelerator accelerator, int width, int height){
-        var instance = schema.allocate(accelerator,width,height);
-        instance.width(width);
-        instance.height(height);
-        return instance;
+        return schema.allocate(accelerator,width,height);
     }
 }

--- a/hat/hat/src/main/java/hat/buffer/S32Array.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array.java
@@ -37,16 +37,13 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 public interface S32Array extends Buffer {
 
     int length();
-    void length(int i);
     int array(long idx);
     void array(long idx, int i);
     Schema<S32Array> schema = Schema.of(S32Array.class, s32Array->s32Array
             .arrayLen("length").array("array"));
 
     static S32Array create(Accelerator accelerator, int length){
-        var instance = schema.allocate(accelerator, length);
-        instance.length(length);
-        return instance;
+        return schema.allocate(accelerator, length);
     }
     static S32Array createFrom(Accelerator accelerator, int[] arr){
         return create( accelerator, arr.length).copyfrom(arr);
@@ -55,7 +52,6 @@ public interface S32Array extends Buffer {
         MemorySegment.copy(ints, 0, Buffer.getMemorySegment(this), JAVA_INT, 4, length());
         return this;
     }
-
     default S32Array copyTo(int[] ints) {
         MemorySegment.copy(Buffer.getMemorySegment(this), JAVA_INT, 4, ints, 0, length());
         return this;

--- a/hat/hat/src/main/java/hat/buffer/S32Array2D.java
+++ b/hat/hat/src/main/java/hat/buffer/S32Array2D.java
@@ -36,29 +36,22 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 public interface S32Array2D extends Buffer {
 
     int width();
-    void height(int i);
     int height();
-    void width(int i);
-
     int array(long idx);
-
     void array(long idx, int i);
 
     default int get(int x, int y) {
         return array((long) y * width() + x);
     }
-
     default void set(int x, int y, int v) {
         array((long) y * width() + x, v);
     }
+
     Schema<S32Array2D> schema = Schema.of(S32Array2D.class, s32Array->s32Array
-            .arrayLen("width","height").stride(1).array("array"));
+            .arrayLen("width","height").array("array"));
 
     static S32Array2D create(Accelerator accelerator, int width, int height){
-        var instance = schema.allocate(accelerator, width,height);
-        instance.width(width);
-        instance.height(height);
-        return instance;
+        return schema.allocate(accelerator, width,height);
     }
     default S32Array2D copyFrom(int[] ints) {
         MemorySegment.copy(ints, 0, Buffer.getMemorySegment(this), JAVA_INT, 2* JAVA_INT.byteSize(), width()*height());

--- a/hat/hat/src/main/java/hat/buffer/S32RGBAImage.java
+++ b/hat/hat/src/main/java/hat/buffer/S32RGBAImage.java
@@ -30,23 +30,14 @@ import hat.ifacemapper.Schema;
 import java.lang.invoke.MethodHandles;
 
 public interface S32RGBAImage extends ImageIfaceBuffer<S32RGBAImage> {
-    int data(long idx);
-
-    void data(long idx, int v);
-
     int width();
-    void width(int width);
     int height();
-    void height(int height);
+    int data(long idx);
+    void data(long idx, int v);
     Schema<S32RGBAImage> schema = Schema.of(S32RGBAImage.class, s -> s
             .arrayLen("width", "height").stride(1).array("data")
     );
-
-
     static S32RGBAImage create(Accelerator accelerator, int width, int height){
-        var instance = schema.allocate(accelerator,width,height);
-        instance.width(width);
-        instance.height(height);
-        return instance;
+        return schema.allocate(accelerator,width,height);
     }
 }

--- a/hat/hat/src/main/java/hat/buffer/U16GreyImage.java
+++ b/hat/hat/src/main/java/hat/buffer/U16GreyImage.java
@@ -30,21 +30,16 @@ import hat.ifacemapper.Schema;
 import java.lang.invoke.MethodHandles;
 
 public interface U16GreyImage extends ImageIfaceBuffer<U16GreyImage> {
+    int width();
+    int height();
     short data(long idx);
     void data(long idx, short v);
-    int width();
-    void width(int width);
-    int height();
-    void height(int height);
 
     Schema<U16GreyImage> schema = Schema.of(U16GreyImage.class, s -> s
-            .arrayLen("width", "height").stride(1).array("data")
+            .arrayLen("width", "height").array("data")
     );
 
     static U16GreyImage create(Accelerator accelerator, int width, int height){
-        var instance = schema.allocate(accelerator,width,height);
-        instance.width(width);
-        instance.height(height);
-        return instance;
+        return schema.allocate(accelerator,width,height);
     }
 }

--- a/hat/hat/src/main/java/hat/ifacemapper/BoundSchema.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/BoundSchema.java
@@ -51,17 +51,34 @@ public class BoundSchema<T extends Buffer> {
             this.len = len;
         }
 
-        public long offset(long idx) {
+        public long elementOffset(long idx) {
             return 0L;
+        }
+        public MemoryLayout elementLayout(long idx) {
+            return null;
         }
     }
 
     public static final class BoundArrayFieldLayout extends ArrayFieldLayout {
         public final int idx;
+        public final List<FieldLayout<?>>dimFields;
+
 
         BoundArrayFieldLayout(BoundSchemaNode<?> parent,Schema.FieldNode fieldControlledArray, MemoryLayout layout, int len, int idx) {
             super(parent, fieldControlledArray, layout, len);
             this.idx = idx;
+            this.dimFields = new ArrayList<>();
+            if (field instanceof Schema.FieldNode.PrimitiveFieldControlledArray primitiveFieldControlledArray){
+                 primitiveFieldControlledArray.arrayLenFields.forEach(f->{
+                    dimFields.add(parent.getName(f.name));
+                 });
+            }else if (field instanceof Schema.FieldNode.IfaceFieldControlledArray ifaceFieldControlledArray){
+                 ifaceFieldControlledArray.arrayLenFields.forEach(f->{
+                     dimFields.add(parent.getName(f.name));
+                 });
+            }else{
+                throw new IllegalStateException("not a bound field");
+            }
         }
     }
     public BoundSchema(Schema<T> schema, int... arrayLengths) {

--- a/hat/hat/src/main/java/hat/ifacemapper/BoundSchema.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/BoundSchema.java
@@ -10,6 +10,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
+import static hat.ifacemapper.BoundSchema.BoundSchemaNode.getBoundGroupLayout;
+
 
 public class BoundSchema<T extends Buffer> {
     final private List<BoundArrayFieldLayout> boundArrayFields = new ArrayList<>();
@@ -20,12 +22,23 @@ public class BoundSchema<T extends Buffer> {
 
 
     public static sealed class FieldLayout<T extends Schema.FieldNode> permits ArrayFieldLayout {
+        public BoundSchemaNode<?> parent;
         public final T field;
         public MemoryLayout layout;
+        MemoryLayout.PathElement pathElement;
 
-        FieldLayout(T field, MemoryLayout layout) {
+        FieldLayout(BoundSchemaNode<?> parent,T field, MemoryLayout layout) {
+            this.parent = parent;
             this.field = field;
             this.layout = layout;
+            this.pathElement =  MemoryLayout.PathElement.groupElement(field.name);
+        }
+
+        public long offset() {
+            return parent.memoryLayouts.getLast().byteOffset(pathElement);
+        }
+        public MemoryLayout layout() {
+            return parent.memoryLayouts.getLast().select(pathElement);
         }
     }
 
@@ -33,17 +46,21 @@ public class BoundSchema<T extends Buffer> {
             permits BoundArrayFieldLayout {
         public final int len;
 
-        ArrayFieldLayout(Schema.FieldNode fieldControlledArray, MemoryLayout layout, int len) {
-            super(fieldControlledArray, layout);
+        ArrayFieldLayout(BoundSchemaNode<?> parent, Schema.FieldNode fieldControlledArray, MemoryLayout layout, int len) {
+            super(parent, fieldControlledArray, layout);
             this.len = len;
+        }
+
+        public long offset(long idx) {
+            return 0L;
         }
     }
 
     public static final class BoundArrayFieldLayout extends ArrayFieldLayout {
         public final int idx;
 
-        BoundArrayFieldLayout(Schema.FieldNode fieldControlledArray, MemoryLayout layout, int len, int idx) {
-            super(fieldControlledArray, layout, len);
+        BoundArrayFieldLayout(BoundSchemaNode<?> parent,Schema.FieldNode fieldControlledArray, MemoryLayout layout, int len, int idx) {
+            super(parent, fieldControlledArray, layout, len);
             this.idx = idx;
         }
     }
@@ -51,7 +68,7 @@ public class BoundSchema<T extends Buffer> {
         this.schema = schema;
         this.arrayLengths = arrayLengths;
         this.rootBoundSchemaNode = new BoundSchemaNode<>((BoundSchema<Buffer>) this, null, this.schema.rootIfaceType);
-        this.groupLayout = rootBoundSchemaNode.getBoundGroupLayout(schema.rootIfaceType);
+        this.groupLayout = getBoundGroupLayout(rootBoundSchemaNode,schema.rootIfaceType);
         this.rootBoundSchemaNode.memoryLayouts.add(this.groupLayout);
     }
 
@@ -80,19 +97,19 @@ public class BoundSchema<T extends Buffer> {
     }
 
 
-    FieldLayout<?> createFieldBinding(Schema.FieldNode fieldNode, MemoryLayout memoryLayout) {
+    FieldLayout<?> createFieldBinding(BoundSchemaNode<?>parent, Schema.FieldNode fieldNode, MemoryLayout memoryLayout) {
         if (fieldNode instanceof Schema.FieldNode.IfaceFieldControlledArray
                 || fieldNode instanceof Schema.FieldNode.PrimitiveFieldControlledArray) {
             int idx = boundArrayFields.size();
-            var arraySizeBinding = new BoundArrayFieldLayout(fieldNode, memoryLayout, arrayLengths[idx], idx);
+            var arraySizeBinding = new BoundArrayFieldLayout(parent,fieldNode, memoryLayout, arrayLengths[idx], idx);
             boundArrayFields.add(arraySizeBinding);
             return arraySizeBinding;
         } else if (fieldNode instanceof Schema.FieldNode.IfaceFixedArray ifaceMapableFixedArray) {
-            return new ArrayFieldLayout(fieldNode, memoryLayout, ifaceMapableFixedArray.len);
+            return new ArrayFieldLayout(parent,fieldNode, memoryLayout, ifaceMapableFixedArray.len);
         } else if (fieldNode instanceof Schema.FieldNode.PrimitiveFixedArray primitiveFixedArray) {
-            return new ArrayFieldLayout(fieldNode, memoryLayout, primitiveFixedArray.len);
+            return new ArrayFieldLayout(parent,fieldNode, memoryLayout, primitiveFixedArray.len);
         } else {
-            return new FieldLayout<>(fieldNode, memoryLayout);
+            return new FieldLayout<>(parent,fieldNode, memoryLayout);
         }
     }
 
@@ -116,7 +133,7 @@ public class BoundSchema<T extends Buffer> {
 
 
         FieldLayout<?> createFieldBinding(Schema.FieldNode fieldNode, MemoryLayout memoryLayout) {
-            return boundSchema.createFieldBinding(fieldNode, memoryLayout);
+            return boundSchema.createFieldBinding(this,fieldNode, memoryLayout);
         }
 
         void bind(Schema.FieldNode fieldNode, MemoryLayout memoryLayout) {
@@ -134,12 +151,14 @@ public class BoundSchema<T extends Buffer> {
             return boundSchemaChildNode;
         }
 
-        public FieldLayout<?> getBoundFieldChild(String fieldName) {
+        public FieldLayout<?> getName(String fieldName) {
             return fieldLayouts.stream().filter(fieldLayout -> fieldLayout.field.name.equals(fieldName)).findFirst().orElseThrow();
+
+
         }
 
-        private GroupLayout getBoundGroupLayout(Schema.IfaceType ifaceType) {
-            BoundSchema.BoundSchemaNode<?> child = createChild(ifaceType);
+        static GroupLayout getBoundGroupLayout(BoundSchemaNode child, Schema.IfaceType ifaceType) {
+
             ifaceType.fields.forEach(fieldNode ->
                 child.bind(fieldNode,(switch (fieldNode) {
                             case Schema.SchemaNode.Padding field ->
@@ -150,12 +169,15 @@ public class BoundSchema<T extends Buffer> {
                                     MapperUtil.primitiveToLayout(field.type);
                             case Schema.FieldNode.AtomicField field ->
                                     MapperUtil.primitiveToLayout(field.type);
-                            case Schema.FieldNode.IfaceField field ->
-                                    child.getBoundGroupLayout(field.parent.getChild(field.ifaceType.iface));
+                            case Schema.FieldNode.IfaceField field -> {
+                                var fieldIfaceType = field.parent.getChild(field.ifaceType.iface);
+                                yield getBoundGroupLayout(child.createChild(ifaceType), fieldIfaceType);
+                            }
                             case Schema.FieldNode.PrimitiveField field ->
                                     MapperUtil.primitiveToLayout(field.type);
                             case Schema.FieldNode.IfaceFixedArray field -> {
-                                var elementLayout = child.getBoundGroupLayout(field.parent.getChild(field.ifaceType.iface))
+                                var fieldIfaceType = field.parent.getChild(field.ifaceType.iface);
+                                var elementLayout = getBoundGroupLayout(child.createChild(ifaceType), fieldIfaceType)
                                         .withName(field.ifaceType.iface.getSimpleName());
                                 yield MemoryLayout.sequenceLayout(field.len,elementLayout);
                             }
@@ -170,8 +192,8 @@ public class BoundSchema<T extends Buffer> {
                                 for (int i = 0; i < field.contributingDims; i++) {
                                     size *= child.takeArrayLen(); // this takes an arraylen and bumps the ptr
                                 }
-                                var elementLayout = child.getBoundGroupLayout(field.parent.getChild(field.ifaceType.iface))
-
+                                var fieldIfaceType = field.parent.getChild(field.ifaceType.iface);
+                                var elementLayout = getBoundGroupLayout(child.createChild(ifaceType), fieldIfaceType)
                                         .withName(field.ifaceType.iface.getSimpleName());
                                 yield MemoryLayout.sequenceLayout(size,elementLayout);
                             }

--- a/hat/hat/src/main/java/hat/ifacemapper/accessor/AccessorInfo.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/accessor/AccessorInfo.java
@@ -79,9 +79,9 @@ public record AccessorInfo(Key key,
         ARRAY_VALUE_GETTER_AND_SETTER(ARRAY, VALUE, GETTER_AND_SETTER),
         ARRAY_INTERFACE_GETTER(ARRAY, INTERFACE, GETTER);
 
-        private final Cardinality cardinality;
-        private final ValueType valueType;
-        private final AccessorType accessorType;
+        public final Cardinality cardinality;
+        public final ValueType valueType;
+        public final AccessorType accessorType;
 
         Key(Cardinality cardinality,
             ValueType valueType,


### PR DESCRIPTION
We no longer allow fields bound to array dims to be mutable. 

 Previously we forced the field to be mutable and relied on the correct value to be set immediately in the allocation method. 

Now  the field cannot be mutable (no length(int length setter)), the value 'behind the field' is automatically set when the schema is bound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/190/head:pull/190` \
`$ git checkout pull/190`

Update a local copy of the PR: \
`$ git checkout pull/190` \
`$ git pull https://git.openjdk.org/babylon.git pull/190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 190`

View PR using the GUI difftool: \
`$ git pr show -t 190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/190.diff">https://git.openjdk.org/babylon/pull/190.diff</a>

</details>
