### PR TITLE
8337155: Support expressions returning boxed booleans for the condition blocks of if/do/while

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1434,6 +1434,7 @@ public class ReflectMethods extends TreeTranslator {
                 pushBody(cond,
                         FunctionType.functionType(JavaType.BOOLEAN));
                 Value last = toValue(cond);
+                last = convert(last, typeElementToType(JavaType.BOOLEAN));
                 // Yield the boolean result of the condition
                 append(CoreOp._yield(last));
                 bodies.add(stack.body);
@@ -1645,6 +1646,7 @@ public class ReflectMethods extends TreeTranslator {
             pushBody(cond, FunctionType.functionType(JavaType.BOOLEAN));
             Value last = toValue(cond);
             // Yield the boolean result of the condition
+            last = convert(last, typeElementToType(JavaType.BOOLEAN));
             append(CoreOp._yield(last));
             Body.Builder condition = stack.body;
 
@@ -1682,6 +1684,7 @@ public class ReflectMethods extends TreeTranslator {
             // Push while condition
             pushBody(cond, FunctionType.functionType(JavaType.BOOLEAN));
             Value last = toValue(cond);
+            last = convert(last, typeElementToType(JavaType.BOOLEAN));
             // Yield the boolean result of the condition
             append(CoreOp._yield(last));
             Body.Builder condition = stack.body;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1427,7 +1427,6 @@ public class ReflectMethods extends TreeTranslator {
             List<Body.Builder> bodies = new ArrayList<>();
 
             while (tree != null) {
-                // @@@ cond.type can be boolean or Boolean
                 JCTree.JCExpression cond = TreeInfo.skipParens(tree.cond);
 
                 // Push if condition
@@ -1639,7 +1638,6 @@ public class ReflectMethods extends TreeTranslator {
         @Override
         public void visitWhileLoop(JCTree.JCWhileLoop tree) {
             // @@@ Patterns
-            // @@@ cond.type can be boolean or Boolean
             JCTree.JCExpression cond = TreeInfo.skipParens(tree.cond);
 
             // Push while condition
@@ -1669,7 +1667,6 @@ public class ReflectMethods extends TreeTranslator {
         @Override
         public void visitDoLoop(JCTree.JCDoWhileLoop tree) {
             // @@@ Patterns
-            // @@@ cond.type can be boolean or Boolean
             JCTree.JCExpression cond = TreeInfo.skipParens(tree.cond);
 
             // Push while body

--- a/test/langtools/tools/javac/reflect/IfTest.java
+++ b/test/langtools/tools/javac/reflect/IfTest.java
@@ -321,4 +321,38 @@ public class IfTest {
         else
             i = 3;
     }
+
+    @IR("""
+            func @"test9" (%0 : java.lang.Boolean)void -> {
+                %1 : Var<java.lang.Boolean> = var %0 @"b";
+                %2 : int = constant @"0";
+                %3 : Var<int> = var %2 @"i";
+                java.if
+                    ()boolean -> {
+                        %4 : java.lang.Boolean = var.load %1;
+                        %5 : boolean = invoke %4 @"java.lang.Boolean::booleanValue()boolean";
+                        yield %5;
+                    }
+                    ()void -> {
+                        %6 : int = constant @"1";
+                        var.store %3 %6;
+                        yield;
+                    }
+                    ()void -> {
+                        %7 : int = constant @"2";
+                        var.store %3 %7;
+                        yield;
+                    };
+                return;
+            };
+            """)
+    @CodeReflection
+    static void test9(Boolean b) {
+        int i;
+        if (b) {
+            i = 1;
+        } else {
+            i = 2;
+        }
+    }
 }

--- a/test/langtools/tools/javac/reflect/WhileLoopTest.java
+++ b/test/langtools/tools/javac/reflect/WhileLoopTest.java
@@ -125,4 +125,73 @@ public class WhileLoopTest {
             i = i + 1;
         } while (i < 10);
     }
+
+
+    @IR("""
+            func @"tes4" ()void -> {
+                  %0 : boolean = constant @"true";
+                  %1 : java.lang.Boolean = invoke %0 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
+                  %2 : Var<java.lang.Boolean> = var %1 @"b";
+                  %3 : int = constant @"0";
+                  %4 : Var<int> = var %3 @"i";
+                  java.while
+                      ()boolean -> {
+                          %5 : java.lang.Boolean = var.load %2;
+                          %6 : boolean = invoke %5 @"java.lang.Boolean::booleanValue()boolean";
+                          yield %6;
+                      }
+                      ()void -> {
+                          %7 : int = var.load %4;
+                          %8 : int = constant @"1";
+                          %9 : int = add %7 %8;
+                          var.store %4 %9;
+                          %10 : int = var.load %4;
+                          %11 : int = constant @"10";
+                          %12 : boolean = lt %10 %11;
+                          %13 : java.lang.Boolean = invoke %12 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
+                          var.store %2 %13;
+                          java.continue;
+                      };
+                  return;
+              };
+            """)
+    @CodeReflection
+    static void tes4() {
+        Boolean b = true;
+        int i = 0;
+        while (b) {
+            i++;
+            b = i < 10;
+        }
+    }
+
+    @IR("""
+            func @"test5" (%0 : int)void -> {
+                %1 : Var<int> = var %0 @"i";
+                %2 : java.lang.Boolean = constant @null;
+                %3 : Var<java.lang.Boolean> = var %2 @"b";
+                java.do.while
+                    ()void -> {
+                        %4 : int = var.load %1;
+                        %5 : int = constant @"10";
+                        %6 : boolean = lt %4 %5;
+                        %7 : java.lang.Boolean = invoke %6 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
+                        var.store %3 %7;
+                        java.continue;
+                    }
+                    ()boolean -> {
+                        %8 : java.lang.Boolean = var.load %3;
+                        %9 : boolean = invoke %8 @"java.lang.Boolean::booleanValue()boolean";
+                        yield %9;
+                    };
+                return;
+            };
+            """)
+    @CodeReflection
+    static void test5(int i) {
+        Boolean b;
+        do {
+            b = i < 10;
+        } while (b);
+    }
 }


### PR DESCRIPTION
Condition body of if or while or do-while should yield a boolean value

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337155](https://bugs.openjdk.org/browse/JDK-8337155): Support expressions returning boxed booleans for the condition blocks of if/do/while (**Task** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [191caf2a](https://git.openjdk.org/babylon/pull/193/files/191caf2aedf59bf3260fa544ebb66bc0bbefab24)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [191caf2a](https://git.openjdk.org/babylon/pull/193/files/191caf2aedf59bf3260fa544ebb66bc0bbefab24)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/193/head:pull/193` \
`$ git checkout pull/193`

Update a local copy of the PR: \
`$ git checkout pull/193` \
`$ git pull https://git.openjdk.org/babylon.git pull/193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 193`

View PR using the GUI difftool: \
`$ git pr show -t 193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/193.diff">https://git.openjdk.org/babylon/pull/193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/193#issuecomment-2249284718)