### PR TITLE
8337157: Second operand to array.load should be an int

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1033,7 +1033,7 @@ public class ReflectMethods extends TreeTranslator {
 
             Value array = toValue(tree.indexed);
 
-            Value index = toValue(tree.index);
+            Value index = toValue(tree.index, typeElementToType(JavaType.INT));
 
             result = append(CoreOp.arrayLoadOp(array, index));
         }

--- a/test/langtools/tools/javac/reflect/ArrayAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ArrayAccessTest.java
@@ -336,4 +336,19 @@ public class ArrayAccessTest {
         return ia.length + ia.hashCode();
     }
 
+    @CodeReflection
+    @IR("""
+            func @"test17" (%0 : java.lang.Object[])java.lang.Object -> {
+                %1 : Var<java.lang.Object[]> = var %0 @"a";
+                %2 : java.lang.Object[] = var.load %1;
+                %3 : char = constant @"c";
+                %4 : int = conv %3;
+                %5 : java.lang.Object = array.load %2 %4;
+                return %5;
+            };
+            """)
+    static Object test17(Object[] a) {
+        return a['c'];
+    }
+
 }


### PR DESCRIPTION
Convert array access indexing expression to int.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337157](https://bugs.openjdk.org/browse/JDK-8337157): Second operand to array.load should be an int (**Task** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.org/babylon.git pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/194.diff">https://git.openjdk.org/babylon/pull/194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/194#issuecomment-2249516833)