### PR TITLE
Convey dirty java buffer status to native code

### DIFF
--- a/hat/backends/opencl/cpp/opencl_backend.cpp
+++ b/hat/backends/opencl/cpp/opencl_backend.cpp
@@ -131,11 +131,18 @@ long OpenCLBackend::OpenCLProgram::OpenCLKernel::ndrange(void *argArray) {
         Arg_s *arg = argSled.arg(i);
         switch (arg->variant) {
             case '&': {
+               auto openclBuffer = new OpenCLBuffer(this, arg);
                 if (arg->idx == 0){
                     ndrange = static_cast<NDRange *>(arg->value.buffer.memorySegment);
-
+                }else{
+                     if (INFO){
+                        if (arg->value.buffer.state == 1) { //Java described this as dirty
+                            std::cout << "JAVA_DIRTY !"<<std::endl;
+                         }else{
+                            std::cout << "NOT JAVA_DIRTY"<<std::endl;
+                          }
+                     }
                 }
-                auto openclBuffer = new OpenCLBuffer(this, arg);
                 openclBuffer->copyToDevice();
                 cl_int status = clSetKernelArg(kernel, arg->idx, sizeof(cl_mem), &openclBuffer->clMem);
                 if (status != CL_SUCCESS) {

--- a/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/C99NativeBackend.java
@@ -25,6 +25,7 @@
 
 package hat.backend;
 
+import hat.ComputeContext;
 import hat.NDRange;
 import hat.backend.c99codebuilders.C99HatKernelBuilder;
 import hat.buffer.ArgArray;
@@ -60,13 +61,13 @@ public abstract class C99NativeBackend extends NativeBackend {
             this.kernelHandle = kernelHandle;
             this.kernelContext = KernelContext.create(kernelCallGraph.computeContext.accelerator, 0, 0);
             ndRangeAndArgs[0] = this.kernelContext;
-            this.argArray = ArgArray.create(kernelCallGraph.computeContext.accelerator, ndRangeAndArgs);
+            this.argArray = ArgArray.create(kernelCallGraph.computeContext.accelerator, kernelCallGraph.computeContext.runtimeInfo, ndRangeAndArgs);
         }
 
         public void dispatch(NDRange ndRange, Object[] args) {
             kernelContext.maxX(ndRange.kid.maxX);
             args[0] = this.kernelContext;
-            ArgArray.update(argArray, args);
+            ArgArray.update(argArray, kernelCallGraph.computeContext.runtimeInfo, args);
             c99NativeBackend.ndRange(kernelHandle, this.argArray);
         }
     }

--- a/hat/hat/src/main/java/hat/backend/NativeBackend.java
+++ b/hat/hat/src/main/java/hat/backend/NativeBackend.java
@@ -62,6 +62,8 @@ public abstract class NativeBackend extends NativeBackendDriver {
         if (computeContext.computeCallGraph.entrypoint.lowered == null) {
             computeContext.computeCallGraph.entrypoint.lowered = computeContext.computeCallGraph.entrypoint.funcOpWrapper().lower();
         }
+        computeContext.clearRuntimeInfo();
+
         boolean interpret = false;
         if (interpret) {
             Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op(), args);


### PR DESCRIPTION
Added java dirty flags to arg sled. Now the backend could choose to only txfer buffer if dirty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/202/head:pull/202` \
`$ git checkout pull/202`

Update a local copy of the PR: \
`$ git checkout pull/202` \
`$ git pull https://git.openjdk.org/babylon.git pull/202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 202`

View PR using the GUI difftool: \
`$ git pr show -t 202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/202.diff">https://git.openjdk.org/babylon/pull/202.diff</a>

</details>
