### PR TITLE
Simplified injection of Pre/Post calls Mutate,Access and Escape

### DIFF
--- a/hat/examples/life/src/main/java/life/Viewer.java
+++ b/hat/examples/life/src/main/java/life/Viewer.java
@@ -159,7 +159,7 @@ public class Viewer extends JFrame {
 
     void setGeneration(int generation, float ms){
         this.generation.setText(String.format("%8d",generation));
-        this.generationsPerSecond.setText(String.format("%5.2f",ms/generation));
+        this.generationsPerSecond.setText(String.format("%5.2f",(generation*1000)/ms));
         mainPanel.repaint();
     }
 

--- a/hat/hat/src/main/java/hat/ComputeContext.java
+++ b/hat/hat/src/main/java/hat/ComputeContext.java
@@ -64,19 +64,15 @@ import java.util.function.Consumer;
  */
 public class ComputeContext implements BufferAllocator {
 
-
-    public static final MethodRef M_CC_PRE_MUTATE = MethodRef.method(ComputeContext.class, "preMutate",
-            void.class, Buffer.class);
-    public static final MethodRef M_CC_POST_MUTATE = MethodRef.method(ComputeContext.class, "postMutate",
-            void.class, Buffer.class);
-    public static final MethodRef M_CC_PRE_ACCESS = MethodRef.method(ComputeContext.class, "preAccess",
-            void.class, Buffer.class);
-    public static final MethodRef M_CC_POST_ACCESS = MethodRef.method(ComputeContext.class, "postAccess",
-            void.class, Buffer.class);
-    public static final MethodRef M_CC_PRE_ESCAPE = MethodRef.method(ComputeContext.class, "preEscape",
-            void.class, Buffer.class);
-    public static final MethodRef M_CC_POST_ESCAPE = MethodRef.method(ComputeContext.class, "postEscape",
-            void.class, Buffer.class);
+    public  enum WRAPPER {
+        MUTATE("Mutate"), ACCESS("Access"), ESCAPE("Escape");
+        final public MethodRef pre;
+        final public MethodRef post;
+        WRAPPER(String name){
+            this.pre = MethodRef.method(ComputeContext.class, "pre"+name, void.class, Buffer.class);
+            this.post = MethodRef.method(ComputeContext.class, "post"+name, void.class, Buffer.class);
+        }
+    }
     public final Accelerator accelerator;
 
 
@@ -154,12 +150,12 @@ public class ComputeContext implements BufferAllocator {
     }
 
     public void postMutate(Buffer b) {
-        //System.out.println("postMutate " + b);
+       // System.out.println("postMutate " + b);
         runtimeInfo.javaDirty.add(b);
     }
 
     public void preAccess(Buffer b) {
-        //System.out.println("preAccess " + b);
+       // System.out.println("preAccess " + b);
         if (runtimeInfo.gpuDirty.contains(b)){
             throw new IllegalStateException("We want to access a buffer on the java side but it is marked as gpu dirty.");
         }
@@ -170,14 +166,13 @@ public class ComputeContext implements BufferAllocator {
     }
 
     public void preEscape(Buffer b) {
-        //System.out.println("preEscape " + b);
-
+       // System.out.println("preEscape " + b);
         if (runtimeInfo.gpuDirty.contains(b)){
             throw new IllegalStateException("We called a method which escapes a buffer on the java side but it is marked as gpu dirty.");
         }
     }
     public void postEscape(Buffer b) {
-        //System.out.println("postEscape " + b);
+       // System.out.println("postEscape " + b);
         runtimeInfo.javaDirty.add(b);
     }
 
@@ -187,7 +182,6 @@ public class ComputeContext implements BufferAllocator {
     }
 
     public interface QuotableKernelContextConsumer extends Quotable, Consumer<KernelContext> {
-
 
     }
 

--- a/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -29,12 +29,11 @@ import hat.buffer.Buffer;
 import hat.buffer.KernelContext;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.code.Block;
 import java.lang.reflect.code.Value;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.type.ClassType;
 import java.lang.reflect.code.type.JavaType;
 import java.lang.reflect.code.type.MethodRef;
-import java.lang.reflect.code.type.PrimitiveType;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -60,20 +59,23 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
 
 
     public boolean isRawKernelCall() {
-        boolean isRawKernelCall= (operandCount()>1 && operandNAsValue(0) instanceof Value value
+        boolean isRawKernelCall = (operandCount() > 1 && operandNAsValue(0) instanceof Value value
                 && value.type() instanceof JavaType javaType
                 && (isAssignable(javaType, hat.KernelContext.class) || isAssignable(javaType, hat.buffer.KernelContext.class))
         );
         return isRawKernelCall;
     }
+
     public boolean isKernelContextMethod() {
         return isAssignable(javaRefType(), KernelContext.class);
 
     }
+
     public boolean isComputeContextMethod() {
         return isAssignable(javaRefType(), ComputeContext.class);
 
     }
+
     private boolean isReturnTypeAssignableFrom(Class<?> clazz) {
         Optional<Class<?>> optionalClazz = javaReturnClass();
         return optionalClazz.isPresent() && clazz.isAssignableFrom(optionalClazz.get());
@@ -99,17 +101,17 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
         Optional<Method> nonDeclaredMethod = Stream.of(declaringClass.getMethods())
                 .filter(method -> method.getName().equals(methodRef().name()))
                 .findFirst();
-        if (nonDeclaredMethod.isPresent()){
+        if (nonDeclaredMethod.isPresent()) {
             return nonDeclaredMethod.get();
-        }else {
+        } else {
             throw new IllegalStateException("what were we looking for ?"); // getClass causes this
-            //return nonDeclaredMethod.get();
         }
     }
 
     public Value getReceiver() {
-        return hasReceiver()?operandNAsValue(0):null;
+        return hasReceiver() ? operandNAsValue(0) : null;
     }
+
     public boolean hasReceiver() {
         return op().hasReceiver();
     }


### PR DESCRIPTION
As we move toward buffer tracking I simplified injection (transform) for Mutate, Access and Escape calls. 

We still need to inject to inject params into dirty sets. So first dispath always copies... 

Fixed small bug in Life demo

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/babylon.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/203.diff">https://git.openjdk.org/babylon/pull/203.diff</a>

</details>
