### PR TITLE
Pom fixes for life and heal examples

### DIFF
--- a/hat/examples/heal/pom.xml
+++ b/hat/examples/heal/pom.xml
@@ -35,7 +35,7 @@ questions.
    <parent>
      <groupId>oracle.code</groupId>
      <version>1.0</version>
-     <artifactId>hat.hattricks</artifactId>
+     <artifactId>hat.examples</artifactId>
    </parent>
 
 

--- a/hat/examples/life/pom.xml
+++ b/hat/examples/life/pom.xml
@@ -36,7 +36,7 @@ questions.
    <parent>
      <groupId>oracle.code</groupId>
      <version>1.0</version>
-     <artifactId>hat.hattricks</artifactId>
+     <artifactId>hat.examples</artifactId>
    </parent>
 
 


### PR DESCRIPTION
Discovered pom.xml issues with life/pom.xml and heal/pom.xml.  Curiously only showed up using older maven.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/babylon.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/205.diff">https://git.openjdk.org/babylon/pull/205.diff</a>

</details>
