### PR TITLE
Unary plus

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -451,7 +451,7 @@ public class ReflectMethods extends TreeTranslator {
                 // statements
                 Tag.SWITCH, Tag.SYNCHRONIZED,
                 // operators
-                Tag.COMPL, Tag.POS,
+                Tag.COMPL,
 
                 // the nodes below are not as relevant, either because they have already
                 // been handled by an earlier compiler pass, or because they are typically
@@ -463,7 +463,7 @@ public class ReflectMethods extends TreeTranslator {
                 Tag.TOPLEVEL, Tag.PACKAGEDEF, Tag.IMPORT, Tag.METHODDEF,
                 // modules (likely outside the scope for code models)
                 Tag.MODULEDEF, Tag.EXPORTS, Tag.OPENS, Tag.PROVIDES, Tag.REQUIRES, Tag.USES,
-                // switch labels (these are handled by the encloising construct, SWITCH or SWITCH_EXPRESSION)
+                // switch labels (these are handled by the enclosing construct, SWITCH or SWITCH_EXPRESSION)
                 Tag.CASE, Tag.DEFAULTCASELABEL, Tag.CONSTANTCASELABEL, Tag.PATTERNCASELABEL,
                 // patterns (these are handled by the enclosing construct, like IF, SWITCH_EXPRESSION, TYPETEST)
                 Tag.ANYPATTERN, Tag.BINDINGPATTERN, Tag.RECORDPATTERN,
@@ -2124,6 +2124,10 @@ public class ReflectMethods extends TreeTranslator {
                 case NOT -> {
                     Value rhs = toValue(tree.arg, tree.type);
                     result = append(CoreOp.not(rhs));
+                }
+                case POS -> {
+                    // Result is value of the operand
+                    result = toValue(tree.arg, tree.type);
                 }
                 default -> throw unsupported(tree);
             }

--- a/test/langtools/tools/javac/reflect/UnaryopTest.java
+++ b/test/langtools/tools/javac/reflect/UnaryopTest.java
@@ -34,26 +34,53 @@ import java.lang.runtime.CodeReflection;
 public class UnaryopTest {
     @CodeReflection
     @IR("""
-            func @"test" (%0 : UnaryopTest, %1 : int)int -> {
-                %2 : Var<int> = var %1 @"v";
-                %3 : int = var.load %2;
-                %4 : int = neg %3;
-                return %4;
+            func @"test" (%0 : int)int -> {
+                %1 : Var<int> = var %0 @"v" ;
+                %2 : int = var.load %1 ;
+                %3 : int = neg %2 ;
+                return %3 ;
             };
             """)
-    int test(int v) {
+    static int test(int v) {
         return -v;
     }
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : UnaryopTest, %1 : int)int -> {
-                %2 : Var<int> = var %1 @"v";
-                %3 : int = var.load %2;
-                return %3;
+            func @"test2" (%0 : int)int -> {
+                %1 : Var<int> = var %0 @"v";
+                %2 : int = var.load %1;
+                return %2;
             };
             """)
-    int test2(int v) {
+    static int test2(int v) {
+        return +v;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test3"  (%0 : int)java.lang.Integer -> {
+                %1 : Var<int> = var %0 @"v" ;
+                %2 : int = var.load %1 ;
+                %3 : java.lang.Integer = invoke %2 @"java.lang.Integer::valueOf(int)java.lang.Integer" ;
+                return %3 ;
+            };
+            """)
+    static Integer test3(int v) {
+        return +v;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test4"  (%0 : java.lang.Integer)java.lang.Integer -> {
+                %1 : Var<java.lang.Integer> = var %0 @"v" ;
+                %2 : java.lang.Integer = var.load %1 ;
+                %3 : int = invoke %2 @"java.lang.Integer::intValue()int" ;
+                %4 : java.lang.Integer = invoke %3 @"java.lang.Integer::valueOf(int)java.lang.Integer" ;
+                return %4 ;
+            };
+            """)
+    static Integer test4(Integer v) {
         return +v;
     }
 }

--- a/test/langtools/tools/javac/reflect/UnaryopTest.java
+++ b/test/langtools/tools/javac/reflect/UnaryopTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Smoke test for code reflection with unary operations.
+ * @build UnaryopTest
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester UnaryopTest
+ */
+
+import java.lang.runtime.CodeReflection;
+
+public class UnaryopTest {
+    @CodeReflection
+    @IR("""
+            func @"test" (%0 : UnaryopTest, %1 : int)int -> {
+                %2 : Var<int> = var %1 @"v";
+                %3 : int = var.load %2;
+                %4 : int = neg %3;
+                return %4;
+            };
+            """)
+    int test(int v) {
+        return -v;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test2" (%0 : UnaryopTest, %1 : int)int -> {
+                %2 : Var<int> = var %1 @"v";
+                %3 : int = var.load %2;
+                return %3;
+            };
+            """)
+    int test2(int v) {
+        return +v;
+    }
+}

--- a/test/langtools/tools/javac/reflect/UnaryopTest.java
+++ b/test/langtools/tools/javac/reflect/UnaryopTest.java
@@ -66,6 +66,7 @@ public class UnaryopTest {
                 return %3 ;
             };
             """)
+    // Tests that numeric promotion occurs
     static Integer test3(int v) {
         return +v;
     }
@@ -80,6 +81,7 @@ public class UnaryopTest {
                 return %4 ;
             };
             """)
+    // Tests that numeric promotion is retained
     static Integer test4(Integer v) {
         return +v;
     }


### PR DESCRIPTION
Support unary plus operator. No need to explicitly model as it has no direct operational semantics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [4ce02a21](https://git.openjdk.org/babylon/pull/213/files/4ce02a2196992d39c02b0d66817ebd0d8614c3e7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.org/babylon.git pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/213.diff">https://git.openjdk.org/babylon/pull/213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/213#issuecomment-2287467336)