### PR TITLE
Bytecode round 10

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -197,6 +197,7 @@ public final class BytecodeGenerator {
     private final BitSet[] blocksRegionStack;
     private final BitSet blocksToVisit, catchingBlocks;
     private final Map<Value, Slot> slots;
+    private final Map<Value, Value> valueMap;
     private final List<LambdaOp> lambdaSink;
     private final BitSet quotable;
     private Op.Result oprOnStack;
@@ -222,6 +223,7 @@ public final class BytecodeGenerator {
         this.blocksToVisit = new BitSet(blocks.size());
         this.catchingBlocks = new BitSet();
         this.slots = new HashMap<>();
+        this.valueMap = new HashMap<>();
         this.lambdaSink = lambdaSink;
         this.quotable = quotable;
     }
@@ -273,7 +275,8 @@ public final class BytecodeGenerator {
         }
     }
 
-    private Slot load(Value v) {
+    private void load(Value v) {
+        v = valueMap.getOrDefault(v, v);
         if (v instanceof Op.Result or &&
                 or.op() instanceof CoreOp.ConstantOp constantOp &&
                 !constantOp.resultType().equals(JavaType.J_L_CLASS)) {
@@ -288,11 +291,9 @@ public final class BytecodeGenerator {
                 case Constable c -> c.describeConstable().orElseThrow();
                 default -> throw new IllegalArgumentException("Unexpected constant value: " + constantOp.value());
             });
-            return null;
         } else {
             Slot slot = slots.get(v);
             cob.loadLocal(slot.typeKind(), slot.slot());
-            return slot;
         }
     }
 
@@ -1110,23 +1111,43 @@ public final class BytecodeGenerator {
     }
 
     private void assignBlockArguments(Block.Reference ref) {
+        Block target = ref.targetBlock();
         List<Value> sargs = ref.arguments();
-        List<Block.Parameter> bargs = ref.targetBlock().parameters();
-        // First push successor arguments on the stack, then pop and assign
-        // so as not to overwrite slots that are reused slots at different argument positions
-        boolean jumpingToCatchBlock = catchingBlocks.get(ref.targetBlock().index());
-        for (int i = 0; i < bargs.size(); i++) {
-            Block.Parameter barg = bargs.get(i);
-            Value value = sargs.get(i);
-            if (!barg.uses().isEmpty() && !barg.equals(value)) {
-                if (oprOnStack == value) {
-                    oprOnStack = null;
-                } else {
-                    load(value);
-                }
-                if (!jumpingToCatchBlock) { // Catch block expects the exception parameter on stack
+        if (catchingBlocks.get(target.index())) {
+            // Jumping to an exceptio handler, exception parameter is expected on stack
+            Value value = sargs.getFirst();
+            if (oprOnStack == value) {
+                oprOnStack = null;
+            } else {
+                load(value);
+            }
+        } else if (target.predecessors().size() > (target.isEntryBlock() ? 0 : 1)) {
+            List<Block.Parameter> bargs = target.parameters();
+            // First push successor arguments on the stack, then pop and assign
+            // so as not to overwrite slots that are reused slots at different argument positions
+            for (int i = 0; i < bargs.size(); i++) {
+                Block.Parameter barg = bargs.get(i);
+                Value value = sargs.get(i);
+                if (!barg.uses().isEmpty() && !barg.equals(value)) {
+                    if (oprOnStack == value) {
+                        oprOnStack = null;
+                    } else {
+                        load(value);
+                    }
                     storeIfUsed(barg);
                 }
+            }
+        } else {
+            // Single-predecessor block can just map parameter slots
+            List<Block.Parameter> bargs = ref.targetBlock().parameters();
+            for (int i = 0; i < bargs.size(); i++) {
+                Value value = sargs.get(i);
+                if (oprOnStack == value) {
+                    storeIfUsed(oprOnStack);
+                    oprOnStack = null;
+                }
+                // Map slot of the block argument to slot of the value
+                valueMap.put(bargs.get(i), valueMap.getOrDefault(value, value));
             }
         }
     }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -1114,7 +1114,7 @@ public final class BytecodeGenerator {
         Block target = ref.targetBlock();
         List<Value> sargs = ref.arguments();
         if (catchingBlocks.get(target.index())) {
-            // Jumping to an exceptio handler, exception parameter is expected on stack
+            // Jumping to an exception handler, exception parameter is expected on stack
             Value value = sargs.getFirst();
             if (oprOnStack == value) {
                 oprOnStack = null;

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/SlotSSA.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/SlotSSA.java
@@ -92,12 +92,8 @@ public final class SlotSSA {
                         joinBlockArguments.computeIfAbsent(s.targetBlock(), b -> {
                             Block.Builder bb = cc.getBlock(b);
                             return joinPoints.get(b).entrySet().stream().collect(Collectors.toMap(
-                                    // @@@
                                     me -> me.getKey(),
-                                    me -> bb.parameter(joinValues.stream().filter(sv -> sv.slot == me.getKey()).findAny().map(sv ->
-                                            (sv.value instanceof SlotBlockArgument vba
-                                                ? joinBlockArguments.get(vba.b()).get(vba.slot())
-                                                : cc.getValue((Value) sv.value)).type()).orElseThrow())));
+                                    me -> bb.parameter(me.getValue())));
                         });
 
                         // Append successor arguments

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -92,8 +92,8 @@ public class TestSmallCorpus {
             stats.getValue().entrySet().stream().sorted((e1, e2) -> Integer.compare(e2.getValue(), e1.getValue())).forEach(e -> System.out.println(e.getValue() +"x " + e.getKey() + "\n"));
         }
 
-        // Roundtrip is >90% stable, no exceptions, no verification errors
-        Assert.assertTrue(stable > 59900 && unstable < 5500 && errorStats.isEmpty(), String.format("""
+        // Roundtrip is >93% stable, no exceptions, no verification errors
+        Assert.assertTrue(stable > 61200 && unstable < 4100 && errorStats.isEmpty(), String.format("""
 
                     stable: %d
                     unstable: %d
@@ -125,10 +125,10 @@ public class TestSmallCorpus {
                             var secondNormalized = normalize(secondModel);
                             if (!firstNormalized.equals(secondNormalized)) {
                                 unstable++;
-//                                System.out.println(clm.thisClass().asInternalName() + "::" + originalModel.methodName().stringValue() + originalModel.methodTypeSymbol().displayDescriptor());
-//                                printInColumns(firstLift, secondLift);
-//                                printInColumns(firstNormalized, secondNormalized);
-//                                System.out.println();
+                                System.out.println(clm.thisClass().asInternalName() + "::" + originalModel.methodName().stringValue() + originalModel.methodTypeSymbol().displayDescriptor());
+                                printInColumns(firstLift, secondLift);
+                                printInColumns(firstNormalized, secondNormalized);
+                                System.out.println();
                             } else {
                                 stable++;
                             }
@@ -155,22 +155,22 @@ public class TestSmallCorpus {
         }
     }
 
-//    private static void printInColumns(CoreOp.FuncOp first, CoreOp.FuncOp second) {
-//        StringWriter fw = new StringWriter();
-//        first.writeTo(fw);
-//        StringWriter sw = new StringWriter();
-//        second.writeTo(sw);
-//        printInColumns(fw.toString().lines().toList(), sw.toString().lines().toList());
-//    }
-//
-//    private static void printInColumns(List<String> first, List<String> second) {
-//        System.out.println("-".repeat(COLUMN_WIDTH ) + "--+-" + "-".repeat(COLUMN_WIDTH ));
-//        for (int i = 0; i < first.size() || i < second.size(); i++) {
-//            String f = i < first.size() ? first.get(i) : "";
-//            String s = i < second.size() ? second.get(i) : "";
-//            System.out.println(" " + f + (f.length() < COLUMN_WIDTH ? " ".repeat(COLUMN_WIDTH - f.length()) : "") + (f.equals(s) ? " | " : " x ") + s);
-//        }
-//    }
+    private static void printInColumns(CoreOp.FuncOp first, CoreOp.FuncOp second) {
+        StringWriter fw = new StringWriter();
+        first.writeTo(fw);
+        StringWriter sw = new StringWriter();
+        second.writeTo(sw);
+        printInColumns(fw.toString().lines().toList(), sw.toString().lines().toList());
+    }
+
+    private static void printInColumns(List<String> first, List<String> second) {
+        System.out.println("-".repeat(COLUMN_WIDTH ) + "--+-" + "-".repeat(COLUMN_WIDTH ));
+        for (int i = 0; i < first.size() || i < second.size(); i++) {
+            String f = i < first.size() ? first.get(i) : "";
+            String s = i < second.size() ? second.get(i) : "";
+            System.out.println(" " + f + (f.length() < COLUMN_WIDTH ? " ".repeat(COLUMN_WIDTH - f.length()) : "") + (f.equals(s) ? " | " : " x ") + s);
+        }
+    }
 
     private static CoreOp.FuncOp lift(MethodModel mm) {
         return BytecodeLift.lift(mm);

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -92,8 +92,8 @@ public class TestSmallCorpus {
             stats.getValue().entrySet().stream().sorted((e1, e2) -> Integer.compare(e2.getValue(), e1.getValue())).forEach(e -> System.out.println(e.getValue() +"x " + e.getKey() + "\n"));
         }
 
-        // Roundtrip is >99% stable, ~40 remaining lift, generate and verification erros
-        Assert.assertTrue(stable > 65100 && unstable < 140 && errorStats.isEmpty(), String.format("""
+        // Roundtrip is >99% stable, no exceptions, no verification errors
+        Assert.assertTrue(stable > 65200 && unstable < 140 && errorStats.isEmpty(), String.format("""
 
                     stable: %d
                     unstable: %d


### PR DESCRIPTION
This time I focused on the roundtrip stabilizations, namely:
- BytecodeLift: injected blocks do not pass the stack through block params
- Avoided redundant slot loads and stores for parameters of blocks with just a single predecessor
- SlotSSA calculates join point block argument types from the consuming slot load ops (instead of the slot store ops)
- TestSmallCorpus now performs triple round stability verification and actual numbers are: >99% of methods is stable, no exceptions, no verification errors

Remaining instability of ~130 methods is related to nested try blocks.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/babylon.git pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/215.diff">https://git.openjdk.org/babylon/pull/215.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/215#issuecomment-2291281390)