### PR TITLE
Bitwise complement op

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -579,6 +579,22 @@ public final class BytecodeGenerator {
                         }
                         push(op.result());
                     }
+                    case ComplOp op -> {
+                        // Lower to x ^ -1
+                        processFirstOperand(op);
+                        switch (rvt) {
+                            case IntType, BooleanType, ByteType, ShortType, CharType -> {
+                                cob.iconst_m1();
+                                cob.ixor();
+                            }
+                            case LongType -> {
+                                cob.ldc(-1L);
+                                cob.lxor();
+                            }
+                            default -> throw new IllegalArgumentException("Bad type: " + op.resultType());
+                        }
+                        push(op.result());
+                    }
                     case NotOp op -> {
                         processFirstOperand(op);
                         cob.ifThenElse(CodeBuilder::iconst_0, CodeBuilder::iconst_1);

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
@@ -51,6 +51,10 @@ final class InvokableLeafOps {
         return -l;
     }
 
+    public static int compl(int l) {
+        return ~l;
+    }
+
     public static int add(int l, int r) {
         return l + r;
     }
@@ -137,6 +141,10 @@ final class InvokableLeafOps {
         return (byte) -l;
     }
 
+    public static byte compl(byte l) {
+        return (byte) ~l;
+    }
+
     public static byte add(byte l, byte r) {
         return (byte) (l + r);
     }
@@ -193,6 +201,10 @@ final class InvokableLeafOps {
 
     public static short neg(short l) {
         return (short) -l;
+    }
+
+    public static short compl(short l) {
+        return (short) ~l;
     }
 
     public static short add(short l, short r) {
@@ -257,6 +269,10 @@ final class InvokableLeafOps {
         return (char) -l;
     }
 
+    public static char compl(char l) {
+        return (char) ~l;
+    }
+
     public static char add(char l, char r) {
         return (char) (l + r);
     }
@@ -317,6 +333,10 @@ final class InvokableLeafOps {
 
     public static long neg(long l) {
         return -l;
+    }
+
+    public static long compl(long l) {
+        return ~l;
     }
 
     public static long add(long l, long r) {

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
@@ -2994,7 +2994,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
-     * The bitwise complement neg operation, that can model the Java language unary {@code ~} operator for integral types
+     * The bitwise complement operation, that can model the Java language unary {@code ~} operator for integral types
      */
     @OpFactory.OpDeclaration(ComplOp.NAME)
     public static final class ComplOp extends UnaryOp {

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
@@ -2994,6 +2994,31 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
+     * The bitwise complement neg operation, that can model the Java language unary {@code ~} operator for integral types
+     */
+    @OpFactory.OpDeclaration(ComplOp.NAME)
+    public static final class ComplOp extends UnaryOp {
+        public static final String NAME = "compl";
+
+        public ComplOp(ExternalizedOp opdef) {
+            super(opdef);
+        }
+
+        ComplOp(ComplOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public ComplOp transform(CopyContext cc, OpTransformer ot) {
+            return new ComplOp(this, cc);
+        }
+
+        ComplOp(Value v) {
+            super(NAME, v);
+        }
+    }
+
+    /**
      * The not operation, that can model the Java language unary {@code !} operator for boolean types
      */
     @OpFactory.OpDeclaration(NotOp.NAME)
@@ -3980,6 +4005,16 @@ public sealed abstract class CoreOp extends ExternalizableOp {
      */
     public static UnaryOp neg(Value v) {
         return new NegOp(v);
+    }
+
+    /**
+     * Creates a bitwise complement operation.
+     *
+     * @param v the operand
+     * @return the bitwise complement operation
+     */
+    public static UnaryOp compl(Value v) {
+        return new ComplOp(v);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -450,8 +450,6 @@ public class ReflectMethods extends TreeTranslator {
         private static final EnumSet<JCTree.Tag> UNSUPPORTED_TAGS = EnumSet.of(
                 // statements
                 Tag.SWITCH, Tag.SYNCHRONIZED,
-                // operators
-                Tag.COMPL,
 
                 // the nodes below are not as relevant, either because they have already
                 // been handled by an earlier compiler pass, or because they are typically
@@ -463,6 +461,8 @@ public class ReflectMethods extends TreeTranslator {
                 Tag.TOPLEVEL, Tag.PACKAGEDEF, Tag.IMPORT, Tag.METHODDEF,
                 // modules (likely outside the scope for code models)
                 Tag.MODULEDEF, Tag.EXPORTS, Tag.OPENS, Tag.PROVIDES, Tag.REQUIRES, Tag.USES,
+                // classes, ignore local class definitions (allows access to but does not model the definition)
+                // Tag.CLASSDEF,
                 // switch labels (these are handled by the enclosing construct, SWITCH or SWITCH_EXPRESSION)
                 Tag.CASE, Tag.DEFAULTCASELABEL, Tag.CONSTANTCASELABEL, Tag.PATTERNCASELABEL,
                 // patterns (these are handled by the enclosing construct, like IF, SWITCH_EXPRESSION, TYPETEST)
@@ -2124,6 +2124,10 @@ public class ReflectMethods extends TreeTranslator {
                 case NOT -> {
                     Value rhs = toValue(tree.arg, tree.type);
                     result = append(CoreOp.not(rhs));
+                }
+                case COMPL -> {
+                    Value rhs = toValue(tree.arg, tree.type);
+                    result = append(CoreOp.compl(rhs));
                 }
                 case POS -> {
                     // Result is value of the operand

--- a/test/jdk/java/lang/reflect/code/TestBinops.java
+++ b/test/jdk/java/lang/reflect/code/TestBinops.java
@@ -54,6 +54,34 @@ public class TestBinops {
     }
 
     @CodeReflection
+    public static int neg(int a) {
+        return -a;
+    }
+
+    @Test
+    public void testNeg() {
+        CoreOp.FuncOp f = getFuncOp("neg");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, 42), neg(42));
+    }
+
+    @CodeReflection
+    public static int compl(int a) {
+        return ~a;
+    }
+
+    @Test
+    public void testCompl() {
+        CoreOp.FuncOp f = getFuncOp("compl");
+
+        f.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(f, 42), compl(42));
+    }
+
+    @CodeReflection
     public static int mod(int a, int b) {
         return a % b;
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -117,27 +117,27 @@ public class TestBytecode {
 
     @CodeReflection
     static int intBitOps(int i, int j, int k) {
-        return i & j | k ^ j;
+        return ~(i & j | k ^ j);
     }
 
     @CodeReflection
     static byte byteBitOps(byte i, byte j, byte k) {
-        return (byte) (i & j | k ^ j);
+        return (byte) ~(i & j | k ^ j);
     }
 
     @CodeReflection
     static short shortBitOps(short i, short j, short k) {
-        return (short) (i & j | k ^ j);
+        return (short) ~(i & j | k ^ j);
     }
 
     @CodeReflection
     static char charBitOps(char i, char j, char k) {
-        return (char) (i & j | k ^ j);
+        return (char) ~(i & j | k ^ j);
     }
 
     @CodeReflection
     static long longBitOps(long i, long j, long k) {
-        return i & j | k ^ j;
+        return ~(i & j | k ^ j);
     }
 
     @CodeReflection

--- a/test/langtools/tools/javac/reflect/UnaryopTest.java
+++ b/test/langtools/tools/javac/reflect/UnaryopTest.java
@@ -85,4 +85,17 @@ public class UnaryopTest {
     static Integer test4(Integer v) {
         return +v;
     }
+
+    @CodeReflection
+    @IR("""
+            func @"test5" (%0 : int)int -> {
+                %1 : Var<int> = var %0 @"v" ;
+                %2 : int = var.load %1 ;
+                %3 : int = compl %2 ;
+                return %3 ;
+            };
+            """)
+    static int test5(int v) {
+        return ~v;
+    }
 }


### PR DESCRIPTION
Lowering `~x` to bytecode generates the equivalent of `x ^ -1`, so the first lift and generation cycle will result in different bytecode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [74587625](https://git.openjdk.org/babylon/pull/216/files/745876259ef9720fe4cb82880cc68f3030b72a32)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/216/head:pull/216` \
`$ git checkout pull/216`

Update a local copy of the PR: \
`$ git checkout pull/216` \
`$ git pull https://git.openjdk.org/babylon.git pull/216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 216`

View PR using the GUI difftool: \
`$ git pr show -t 216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/216.diff">https://git.openjdk.org/babylon/pull/216.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/216#issuecomment-2290075250)