### PR TITLE
Model synchronized statements

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -910,6 +910,14 @@ public final class BytecodeGenerator {
                                 toClassDesc(op.operands().get(1).type()))));
                         push(op.result());
                     }
+                    case MonitorOp.MonitorEnterOp op -> {
+                        processFirstOperand(op);
+                        cob.monitorenter();
+                    }
+                    case MonitorOp.MonitorExitOp op -> {
+                        processFirstOperand(op);
+                        cob.monitorexit();
+                    }
                     default ->
                         throw new UnsupportedOperationException("Unsupported operation: " + ops.get(i));
                 }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
@@ -784,8 +784,14 @@ public final class BytecodeLift {
                             throw new UnsupportedOperationException("Unsupported stack instruction: " + inst);
                     }
                 }
-                case MonitorInstruction _ -> {
-                    stack.pop(); // @@@ lift monitorenter and monitorexit ?
+                case MonitorInstruction inst -> {
+                    var monitor = stack.pop();
+                    switch (inst.opcode()) {
+                        case MONITORENTER -> op(CoreOp.monitorEnter(monitor));
+                        case MONITOREXIT -> op(CoreOp.monitorExit(monitor));
+                        default ->
+                                throw new UnsupportedOperationException("Unsupported stack instruction: " + inst);
+                    }
                 }
                 case NopInstruction _ -> {}
                 case PseudoInstruction _ -> {}

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSynchronizedOp.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSynchronizedOp.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @run testng TestSynchronizedOp
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.MonitorInstruction;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.bytecode.BytecodeGenerator;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.runtime.CodeReflection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TestSynchronizedOp {
+
+    @CodeReflection
+    static int f(Object o, int i, int[] a) {
+        synchronized (o) {
+            if (i < 0) {
+                throw new RuntimeException();
+            }
+            a[0] = ++i;
+        }
+        return i;
+    }
+
+    @Test
+    public void testInstructions() {
+        CoreOp.FuncOp f = getFuncOp("f");
+        f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+
+        byte[] classdata = BytecodeGenerator.generateClassData(MethodHandles.lookup(), f);
+        CodeModel cmf = ClassFile.of().parse(classdata).methods().stream()
+                .filter(mm -> mm.methodName().equalsString("f"))
+                .findFirst().flatMap(MethodModel::code).orElseThrow();
+        Map<Opcode, Long> monitorCount = cmf.elementStream().<Opcode>mapMulti((i, c) -> {
+            if (i instanceof MonitorInstruction mi) {
+                c.accept(mi.opcode());
+            }
+        }).collect(Collectors.groupingBy(oc -> oc, Collectors.counting()));
+        Assert.assertEquals(monitorCount, Map.of(
+                Opcode.MONITORENTER, 1L,
+                Opcode.MONITOREXIT, 2L));
+    }
+
+    @Test
+    public void testExecution() throws Throwable {
+        CoreOp.FuncOp f = getFuncOp("f");
+        f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+
+        MethodHandle mf = BytecodeGenerator.generate(MethodHandles.lookup(), f);
+
+        Object monitor = new Object();
+        int[] a = new int[1];
+        Assert.assertEquals((int) mf.invoke(monitor, 0, a), 1);
+        a[0] = 0;
+        Assert.assertThrows(RuntimeException.class, () -> {
+            int i = (int) mf.invoke(monitor, -1, a);
+        });
+        Assert.assertEquals(a[0], 0);
+    }
+
+    static CoreOp.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestSynchronizedOp.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}

--- a/test/jdk/java/lang/reflect/code/lower/TestSynchronized.java
+++ b/test/jdk/java/lang/reflect/code/lower/TestSynchronized.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary test lowering of synchronized blocks
+ * @build TestSynchronized
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester TestSynchronized
+ */
+
+import java.lang.runtime.CodeReflection;
+
+public class TestSynchronized {
+
+    @CodeReflection
+    @LoweredModel(value = """
+            func @"test1" (%0 : java.lang.Object, %1 : int)int -> {
+                %2 : Var<java.lang.Object> = var %0 @"m";
+                %3 : Var<int> = var %1 @"i";
+                %4 : java.lang.Object = var.load %2;
+                branch ^block_1(%4);
+
+              ^block_1(%5 : java.lang.Object):
+                monitor.enter %5;
+                %6 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_2 ^block_4;
+
+              ^block_2:
+                %7 : int = var.load %3;
+                %8 : int = constant @"1";
+                %9 : int = add %7 %8;
+                var.store %3 %9;
+                monitor.exit %5;
+                exception.region.exit %6 ^block_3;
+
+              ^block_3:
+                %10 : int = var.load %3;
+                return %10;
+
+              ^block_4(%11 : java.lang.Throwable):
+                %12 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_5 ^block_4;
+
+              ^block_5:
+                monitor.exit %5;
+                exception.region.exit %12 ^block_6;
+
+              ^block_6:
+                throw %11;
+            };
+            """, ssa = false)
+    static int test1(Object m, int i) {
+        synchronized (m) {
+            i++;
+        }
+        return i;
+    }
+
+
+    @CodeReflection
+    @LoweredModel(value = """
+            func @"test2" (%0 : java.lang.Object, %1 : int)int -> {
+                %2 : Var<java.lang.Object> = var %0 @"m";
+                %3 : Var<int> = var %1 @"i";
+                %4 : java.lang.Object = var.load %2;
+                branch ^block_1(%4);
+
+              ^block_1(%5 : java.lang.Object):
+                monitor.enter %5;
+                %6 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_2 ^block_8;
+
+              ^block_2:
+                %7 : int = var.load %3;
+                %8 : int = constant @"0";
+                %9 : boolean = gt %7 %8;
+                cbranch %9 ^block_3 ^block_5;
+
+              ^block_3:
+                %10 : int = constant @"-1";
+                monitor.exit %5;
+                exception.region.exit %6 ^block_4;
+
+              ^block_4:
+                return %10;
+
+              ^block_5:
+                branch ^block_6;
+
+              ^block_6:
+                %11 : int = var.load %3;
+                %12 : int = constant @"1";
+                %13 : int = add %11 %12;
+                var.store %3 %13;
+                monitor.exit %5;
+                exception.region.exit %6 ^block_7;
+
+              ^block_7:
+                %14 : int = var.load %3;
+                return %14;
+
+              ^block_8(%15 : java.lang.Throwable):
+                %16 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_9 ^block_8;
+
+              ^block_9:
+                monitor.exit %5;
+                exception.region.exit %16 ^block_10;
+
+              ^block_10:
+                throw %15;
+            };
+            """, ssa = false)
+    static int test2(Object m, int i) {
+        synchronized (m) {
+            if (i > 0) {
+                return -1;
+            }
+            i++;
+        }
+        return i;
+    }
+
+}

--- a/test/langtools/tools/javac/reflect/SynchronizedTest.java
+++ b/test/langtools/tools/javac/reflect/SynchronizedTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Smoke test for code reflection with synchronized blocks.
+ * @build SynchronizedTest
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester SynchronizedTest
+ */
+
+import java.lang.runtime.CodeReflection;
+
+public class SynchronizedTest {
+    @CodeReflection
+    @IR("""
+            func @"test1" (%0 : SynchronizedTest, %1 : int)int -> {
+                %2 : Var<int> = var %1 @"i";
+                java.synchronized
+                    ()SynchronizedTest -> {
+                        yield %0;
+                    }
+                    ()void -> {
+                        %3 : int = var.load %2;
+                        %4 : int = constant @"1";
+                        %5 : int = add %3 %4;
+                        var.store %2 %5;
+                        yield;
+                    };
+                %6 : int = var.load %2;
+                return %6;
+            };
+            """)
+    int test1(int i) {
+        synchronized (this) {
+            i++;
+        }
+        return i;
+    }
+
+    static Object m() {
+        return null;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test2" (%0 : SynchronizedTest, %1 : int)int -> {
+                %2 : Var<int> = var %1 @"i";
+                java.synchronized
+                    ()java.lang.Object -> {
+                        %3 : java.lang.Object = invoke @"SynchronizedTest::m()java.lang.Object";
+                        yield %3;
+                    }
+                    ()void -> {
+                        %4 : int = var.load %2;
+                        %5 : int = constant @"1";
+                        %6 : int = add %4 %5;
+                        var.store %2 %6;
+                        yield;
+                    };
+                %7 : int = var.load %2;
+                return %7;
+            };
+            """)
+    int test2(int i) {
+        synchronized (m()) {
+            i++;
+        }
+        return i;
+    }
+
+}


### PR DESCRIPTION
Model synchronized statements.

A synchronized op has two bodies one for the expression yielding the monitor and one for the synchronized block that covers the monitor enter and exit.

The lowering of synchronized op produces a model containing monitor enter and exit operations and operations covered by exception regions, ensuring that a monitor exits under exceptional circumstances. 

The interpreter has been updated, but locking is currently on a best effort basis using `ReentrantLock` instances thus we cannot consistently apply synchronization on objects across interpretation, executing in a single thread, and bytecode executing in one or more other threads.  We would need to update the interpreter to use native methods that invoke the JNI `MonitorEnter` and `MonitorExit` methods, although it is not clear if those can be mixed in a nested manner with JVM execution of monitor enter and exit bytecode instructions.

A simple test for generated bytecode has been included that tests for the expected number of monitor enter and exit instructions, and single threaded execution for non-exceptional and exceptional cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/babylon.git pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/217.diff">https://git.openjdk.org/babylon/pull/217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/217#issuecomment-2305614136)