### PR TITLE
Bytecode round 12

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -361,7 +361,7 @@ public final class BytecodeGenerator {
         return !op.resultType().equals(JavaType.J_L_CLASS);
     }
 
-    // Singl-use var or var with a single-use entry block parameter operand can be deferred
+    // Single-use var or var with a single-use entry block parameter operand can be deferred
     private static boolean canDefer(VarOp op) {
         return !moreThanOneUse(op.result())
             || op.operands().getFirst() instanceof Block.Parameter bp && bp.declaringBlock().isEntryBlock() && !moreThanOneUse(bp)

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -370,17 +370,15 @@ public final class BytecodeGenerator {
     }
 
     // Detection of var declaration in a dominant block, initialized with a redundant default value
-    // Combo of ConstantOp and VarOp can be deferred if all its VarLoadOp are dominated by VarStoreOp
+    // Combo of ConstantOp and VarOp can be deferred if all its VarLoadOps are dominated by VarStoreOp
     private static boolean canDeferVarCombo(VarOp op) {
         if (op.initOperand() instanceof Op.Result or && or.op() instanceof ConstantOp cop && canDefer(cop)) {
             Set<Op.Result> allUses = op.result().uses();
-            Set<Op.Result> storeResults = allUses.stream().filter(r -> r.op() instanceof VarAccessOp.VarStoreOp).collect(Collectors.toSet());
-            // All VarLoadOp must be dominated by a VarStoreOp
-            for (Op.Result loadResult : allUses) {
-                if (loadResult.op() instanceof VarAccessOp.VarLoadOp) {
-                    if (!isDominatedBy(loadResult, storeResults)) {
-                        return false;
-                    }
+            Set<Op.Result> stores = allUses.stream().filter(r -> r.op() instanceof VarAccessOp.VarStoreOp).collect(Collectors.toSet());
+            // All VarLoadOps must be dominated by a VarStoreOp
+            for (Op.Result load : allUses) {
+                if (load.op() instanceof VarAccessOp.VarLoadOp && !isDominatedBy(load, stores)) {
+                    return false;
                 }
             }
             return true;

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
@@ -325,7 +325,7 @@ public final class BytecodeLift {
                 if (sl.var.isSingleValue) {
                     sl.var.value = initLocalValues.get(i);
                 } else {
-                    sl.var.value = op(CoreOp.var("slot#" + i, sl.var.type(), initLocalValues.get(i)));
+                    sl.var.value = op(CoreOp.var("slot#" + i, sl.var.type(), i < initLocalValues.size() ? initLocalValues.get(i) : liftConstant(sl.var.defaultValue())));
                 }
             }
         }
@@ -902,6 +902,9 @@ public final class BytecodeLift {
                     yield op(CoreOp.invoke(bsmRef, bootstrapArgs));
                 }
                 case Boolean b -> op(CoreOp.constant(JavaType.BOOLEAN, b));
+                case Byte b -> op(CoreOp.constant(JavaType.BYTE, b));
+                case Short s -> op(CoreOp.constant(JavaType.SHORT, s));
+                case Character ch -> op(CoreOp.constant(JavaType.CHAR, ch));
                 default -> throw new UnsupportedOperationException(c.getClass().toString());
             };
             constantCache.put(c, res);

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/LocalsTypeMapper.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/LocalsTypeMapper.java
@@ -188,9 +188,6 @@ final class LocalsTypeMapper {
                     }
                 }
                 if (initialSlots.size() > 1) {
-                    if (var.isSingleValue) {
-                        System.out.println("wat?");
-                    }
                     // Add synthetic dominant slot, which needs to be initialized with a default value
                     Slot initialSlot = new Slot();
                     initialSlot.var = var;

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -97,8 +97,8 @@ public class TestSmallCorpus {
             stats.getValue().entrySet().stream().sorted((e1, e2) -> Integer.compare(e2.getValue(), e1.getValue())).forEach(e -> System.out.println(e.getValue() +"x " + e.getKey() + "\n"));
         }
 
-        // Roundtrip is >98% stable, no exceptions, no verification errors
-        Assert.assertTrue(stable > 64410 && unstable < 940 && errorStats.isEmpty(), String.format("""
+        // Roundtrip is >99% stable, no exceptions, no verification errors
+        Assert.assertTrue(stable > 65240 && unstable < 110 && errorStats.isEmpty(), String.format("""
 
                     stable: %d
                     unstable: %d

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -172,13 +172,12 @@ public class TestSmallCorpus {
             for (Block block : body.blocks()) {
                 for (Op op : block.ops()) {
                     for (Value v : op.operands()) {
-                        // Verify operands accessibility
-                        Block declaringBlock = v.declaringBlock();
-                        if (!block.isDominatedBy(declaringBlock)) {
+                        // Verify operands dominance
+                        if (!op.result().isDominatedBy(v)) {
                             if (naming == null) {
                                 naming = OpWriter.CodeItemNamerOption.of(OpWriter.computeGlobalNames(func));
                             }
-                            error(category, "block_" + block.index() + " " + OpWriter.toText(op, naming) + " is not dominated by its operand declaration in block_" + declaringBlock.index());
+                            error(category, "block_" + block.index() + " " + OpWriter.toText(op, naming) + " is not dominated by its operand declaration in block_" + v.declaringBlock().index());
                         }
                     }
                 }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -97,8 +97,8 @@ public class TestSmallCorpus {
             stats.getValue().entrySet().stream().sorted((e1, e2) -> Integer.compare(e2.getValue(), e1.getValue())).forEach(e -> System.out.println(e.getValue() +"x " + e.getKey() + "\n"));
         }
 
-        // Roundtrip is >99% stable, no exceptions, no verification errors
-        Assert.assertTrue(stable > 65230 && unstable < 120 && errorStats.isEmpty(), String.format("""
+        // Roundtrip is >98% stable, no exceptions, no verification errors
+        Assert.assertTrue(stable > 64410 && unstable < 940 && errorStats.isEmpty(), String.format("""
 
                     stable: %d
                     unstable: %d

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -307,7 +307,6 @@ public class TestSmallCorpus {
     }
 
     private void error(String category, String msg) {
-        System.out.println("!!! " + msg);
         errorStats.computeIfAbsent(category, _ -> new HashMap<>())
                   .compute(msg, (_, i) -> i == null ? 1 : i + 1);
     }


### PR DESCRIPTION
- Added test for operand values dominance revealed a bug in the BytecodeLift.
- Fixed BytecodeLift revealed regression in the roundtrip stability.
- Roundtrip instability was caused by a bug in the LocalsTypeMapper.

All the above is fixed and the roundtrip stability is restored.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/219/head:pull/219` \
`$ git checkout pull/219`

Update a local copy of the PR: \
`$ git checkout pull/219` \
`$ git pull https://git.openjdk.org/babylon.git pull/219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 219`

View PR using the GUI difftool: \
`$ git pr show -t 219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/219.diff">https://git.openjdk.org/babylon/pull/219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/219#issuecomment-2321392589)