### PR TITLE
Super expressions

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -101,7 +101,7 @@ public final class BytecodeGenerator {
 
         MethodHandles.Lookup hcl;
         try {
-            hcl = l.defineHiddenClass(classBytes, true);
+            hcl = l.defineHiddenClass(classBytes, true, MethodHandles.Lookup.ClassOption.NESTMATE);
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
@@ -815,7 +815,14 @@ public final class BytecodeGenerator {
                         Opcode invokeOpcode;
                         if (isInstance) {
                             if (isSuper) {
-                                invokeOpcode = Opcode.INVOKESPECIAL;
+                                // @@@ We cannot generate an invokespecial as it will result in a verify error,
+                                //     since the owner is not assignable to generated hidden class
+                                // @@@ Construct method handle via lookup.findSpecial
+                                //     using the lookup's class as the specialCaller and
+                                //     add that method handle to the to be defined hidden class's constant data
+                                //     Use and ldc+constant dynamic to access the class data,
+                                //     extract the method handle and then invoke it
+                                throw new UnsupportedOperationException("invoke super unsupported: " + op.invokeDescriptor());
                             } else if (isInterface) {
                                 invokeOpcode = Opcode.INVOKEINTERFACE;
                             } else {

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
@@ -415,6 +415,7 @@ public final class Interpreter {
         } else if (o instanceof CoreOp.InvokeOp co) {
             MethodType target = resolveToMethodType(l, o.opType());
             MethodHandle mh;
+            // @@@ This does not work for vararg methods
 //            if (co.hasReceiver()) {
 //                if (co instanceof CoreOp.InvokeOp.InvokeSuperOp) {
 //                    MethodHandles.Lookup in = l.in(target.parameterType(0));
@@ -425,11 +426,11 @@ public final class Interpreter {
 //            } else {
 //                mh = resolveToMethodHandle(l, co.invokeDescriptor(), MethodRef.ResolveKind.invokeClass);
 //            }
-
             if (co instanceof CoreOp.InvokeOp.InvokeSuperOp) {
                 MethodHandles.Lookup in = l.in(target.parameterType(0));
                 mh = resolveToMethodHandle(in, co.invokeDescriptor(), MethodRef.ResolveKind.invokeSuper);
             } else {
+                // @@@ resolves to class or instance method handle
                 mh = resolveToMethodHandle(l, co.invokeDescriptor());
             }
 
@@ -624,14 +625,6 @@ public final class Interpreter {
         } catch (NoSuchMethodException | IllegalAccessException e) {
             throw interpreterException(e);
         }
-    }
-
-    static MethodHandle methodStaticHandle(MethodHandles.Lookup l, MethodRef d) {
-        return resolveToMethodHandle(l, d, MethodRef.ResolveKind.invokeClass);
-    }
-
-    static MethodHandle methodHandle(MethodHandles.Lookup l, MethodRef d) {
-        return resolveToMethodHandle(l, d, MethodRef.ResolveKind.invokeInstance);
     }
 
     static MethodHandle constructorHandle(MethodHandles.Lookup l, FunctionType ft) {

--- a/src/java.base/share/classes/java/lang/reflect/code/parser/impl/Tokens.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/parser/impl/Tokens.java
@@ -68,8 +68,6 @@ public final class Tokens {
         ERROR(),
         IDENTIFIER(Token.Tag.NAMED),
         VALUE_IDENTIFIER(Token.Tag.NAMED),
-        EXTENDS("extends", Token.Tag.NAMED),
-        SUPER("super", Token.Tag.NAMED),
         INTLITERAL(Token.Tag.NUMERIC),
         LONGLITERAL(Token.Tag.NUMERIC),
         FLOATLITERAL(Token.Tag.NUMERIC),

--- a/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
@@ -53,8 +53,10 @@ public sealed interface MethodRef extends TypeVarRef.Owner permits MethodRefImpl
 
     // Resolutions to methods and method handles
 
+    // Resolve using ResolveKind.invokeClass, on failure resolve using ResolveKind.invokeInstance
     Method resolveToMethod(MethodHandles.Lookup l) throws ReflectiveOperationException;
 
+    // Resolve using ResolveKind.invokeClass, on failure resolve using ResolveKind.invokeInstance
     MethodHandle resolveToHandle(MethodHandles.Lookup l) throws ReflectiveOperationException;
 
     enum ResolveKind {
@@ -65,9 +67,10 @@ public sealed interface MethodRef extends TypeVarRef.Owner permits MethodRefImpl
 
     Method resolveToMethod(MethodHandles.Lookup l, ResolveKind kind) throws ReflectiveOperationException;
 
+    // For ResolveKind.invokeSuper the specialCaller == l.lookupClass() for Lookup::findSpecial
     MethodHandle resolveToHandle(MethodHandles.Lookup l, ResolveKind kind) throws ReflectiveOperationException;
 
-        // Factories
+    // Factories
 
     static MethodRef method(Executable e) {
         return method(e.getDeclaringClass(), e.getName(),

--- a/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/MethodRef.java
@@ -43,14 +43,6 @@ import static java.lang.reflect.code.type.FunctionType.functionType;
 /**
  * The symbolic reference to a Java method.
  */
-// @@@ require invoke kind:
-//    special, static, virtual
-//    interface_special, interface_static, interface_virtual
-//  Otherwise it is not possible to generate correct bytecode invoke instruction with
-//  a symbolic reference to a method or an interface method, specifically a
-//  constant pool entry of CONSTANT_Methodref_info or CONSTANT_InterfaceMethodref_info.
-//
-//  We can infer the kind, if we can resolve the types and lookup the declared method
 public sealed interface MethodRef extends TypeVarRef.Owner permits MethodRefImpl {
 
     TypeElement refType();
@@ -59,15 +51,23 @@ public sealed interface MethodRef extends TypeVarRef.Owner permits MethodRefImpl
 
     FunctionType type();
 
-    // Resolutions and model access
+    // Resolutions to methods and method handles
 
-    Executable resolveToMember(MethodHandles.Lookup l) throws ReflectiveOperationException;
+    Method resolveToMethod(MethodHandles.Lookup l) throws ReflectiveOperationException;
 
     MethodHandle resolveToHandle(MethodHandles.Lookup l) throws ReflectiveOperationException;
 
-    Optional<CoreOp.FuncOp> codeModel(MethodHandles.Lookup l) throws ReflectiveOperationException;
+    enum ResolveKind {
+        invokeClass,
+        invokeInstance,
+        invokeSuper
+    }
 
-    // Factories
+    Method resolveToMethod(MethodHandles.Lookup l, ResolveKind kind) throws ReflectiveOperationException;
+
+    MethodHandle resolveToHandle(MethodHandles.Lookup l, ResolveKind kind) throws ReflectiveOperationException;
+
+        // Factories
 
     static MethodRef method(Executable e) {
         return method(e.getDeclaringClass(), e.getName(),

--- a/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
@@ -51,6 +51,7 @@ public final class TypeVarRef implements JavaType {
     public Type resolve(Lookup lookup) throws ReflectiveOperationException {
         TypeVariable<?>[] typeVariables = switch (owner) {
             case MethodRef methodRef -> {
+                // @@@ resolves to class or instance method
                 Method method = ((MethodRef)owner).resolveToMethod(lookup);
                 yield method.getTypeParameters();
             }

--- a/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/TypeVarRef.java
@@ -27,7 +27,7 @@ package java.lang.reflect.code.type;
 
 import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles.Lookup;
-import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.List;
@@ -51,7 +51,7 @@ public final class TypeVarRef implements JavaType {
     public Type resolve(Lookup lookup) throws ReflectiveOperationException {
         TypeVariable<?>[] typeVariables = switch (owner) {
             case MethodRef methodRef -> {
-                Executable method = ((MethodRef)owner).resolveToMember(lookup);
+                Method method = ((MethodRef)owner).resolveToMethod(lookup);
                 yield method.getTypeParameters();
             }
             case JavaType type -> {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -960,7 +960,7 @@ public class ReflectMethods extends TreeTranslator {
                 case LOCAL_VARIABLE, RESOURCE_VARIABLE, BINDING_VARIABLE, PARAMETER, EXCEPTION_PARAMETER ->
                     result = loadVar(sym);
                 case FIELD, ENUM_CONSTANT -> {
-                    if (sym.name.equals(names._this)) {
+                    if (sym.name.equals(names._this) || sym.name.equals(names._super)) {
                         result = thisValue();
                     } else {
                         FieldRef fr = symbolToFieldRef(sym, symbolSiteType(sym));
@@ -1020,13 +1020,17 @@ public class ReflectMethods extends TreeTranslator {
                 Symbol sym = tree.sym;
                 switch (sym.getKind()) {
                     case FIELD, ENUM_CONSTANT -> {
-                        FieldRef fr = symbolToFieldRef(sym, qualifierTarget.hasTag(NONE) ?
-                                tree.selected.type : qualifierTarget);
-                        TypeElement resultType = typeToTypeElement(types.memberType(tree.selected.type, sym));
-                        if (sym.isStatic()) {
-                            result = append(CoreOp.fieldLoad(resultType, fr));
+                        if (sym.name.equals(names._this) || sym.name.equals(names._super)) {
+                            result = thisValue();
                         } else {
-                            result = append(CoreOp.fieldLoad(resultType, fr, receiver));
+                            FieldRef fr = symbolToFieldRef(sym, qualifierTarget.hasTag(NONE) ?
+                                    tree.selected.type : qualifierTarget);
+                            TypeElement resultType = typeToTypeElement(types.memberType(tree.selected.type, sym));
+                            if (sym.isStatic()) {
+                                result = append(CoreOp.fieldLoad(resultType, fr));
+                            } else {
+                                result = append(CoreOp.fieldLoad(resultType, fr, receiver));
+                            }
                         }
                     }
                     case INTERFACE, CLASS, ENUM -> {
@@ -1089,15 +1093,27 @@ public class ReflectMethods extends TreeTranslator {
 
                     Symbol sym = access.sym;
                     List<Value> args = new ArrayList<>();
+                    boolean isSuper;
                     if (!sym.isStatic()) {
                         args.add(receiver);
+                        isSuper = switch (access.selected) {
+                            case JCIdent i when i.sym.name.equals(names._super) -> true;
+                            case JCFieldAccess fa when fa.sym.name.equals(names._super) -> true;
+                            default -> false;
+                        };
+                    } else {
+                        isSuper = false;
                     }
 
                     args.addAll(scanMethodArguments(tree.args, tree.meth.type, tree.varargsElement));
 
                     MethodRef mr = symbolToErasedMethodRef(sym, qualifierTarget.hasTag(NONE) ?
                             access.selected.type : qualifierTarget);
-                    Value res = append(CoreOp.invoke(typeToTypeElement(meth.type.getReturnType()), mr, args));
+                    JavaType returnType = typeToTypeElement(meth.type.getReturnType());
+                    CoreOp.InvokeOp iop = isSuper
+                            ? CoreOp.invokeSuper(returnType, mr, args)
+                            : CoreOp.invoke(returnType, mr, args);
+                    Value res = append(iop);
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;
                     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1092,6 +1092,7 @@ public class ReflectMethods extends TreeTranslator {
                     boolean isSuper;
                     if (!sym.isStatic()) {
                         args.add(receiver);
+                        // @@@ expr.super(...) for inner class super constructor calls
                         isSuper = switch (access.selected) {
                             case JCIdent i when i.sym.name.equals(names._super) -> true;
                             case JCFieldAccess fa when fa.sym.name.equals(names._super) -> true;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1061,10 +1061,6 @@ public class ReflectMethods extends TreeTranslator {
 
             // @@@ this.xyz(...) calls in a constructor
 
-            // @@@ super.xyz(...) calls
-            // Modeling with a call operation would result in the receiver type differing from that
-            // in the method reference, perhaps that is sufficient?
-
             JCTree meth = TreeInfo.skipParens(tree.meth);
             switch (meth.getTag()) {
                 case IDENT: {

--- a/test/jdk/java/lang/reflect/code/TestInvokeSuper.java
+++ b/test/jdk/java/lang/reflect/code/TestInvokeSuper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestInvokeSuper
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class TestInvokeSuper {
+
+    interface I {
+        default String f() { return "I"; }
+    }
+    static class A {
+        String f() { return "A"; }
+    }
+
+    static class B extends A implements I {
+        final boolean invokeClass;
+
+        public B(boolean invokeClass) {
+            this.invokeClass = invokeClass;
+        }
+
+        @CodeReflection
+        public String f() {
+            return invokeClass ? super.f() : I.super.f();
+        }
+    }
+
+    @Test
+    public void testInvokeSuper() {
+        CoreOp.FuncOp f = getFuncOp(B.class, "f");
+        f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        f.writeTo(System.out);
+
+        for (boolean invokeClass : new boolean[] {true, false}) {
+            B b = new B(invokeClass);
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, b), b.f());
+        }
+    }
+
+    static CoreOp.FuncOp getFuncOp(Class<?> c, String name) {
+        Optional<Method> om = Stream.of(c.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}

--- a/test/jdk/java/lang/reflect/code/TestTransitiveInvokeModule.java
+++ b/test/jdk/java/lang/reflect/code/TestTransitiveInvokeModule.java
@@ -108,9 +108,9 @@ public class TestTransitiveInvokeModule {
             CoreOp.FuncOp tf = rf.f.transform(rf.r.toString(), (block, op) -> {
                 if (op instanceof CoreOp.InvokeOp iop) {
                     MethodRef r = iop.invokeDescriptor();
-                    Executable em = null;
+                    Method em = null;
                     try {
-                        em = r.resolveToMember(l);
+                        em = r.resolveToMethod(l);
                     } catch (ReflectiveOperationException _) {
                     }
                     if (em instanceof Method m) {

--- a/test/jdk/java/lang/reflect/code/bytecode/TestInvokeSuper.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestInvokeSuper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestInvokeSuper
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.bytecode.BytecodeGenerator;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class TestInvokeSuper {
+
+    interface I {
+        default String f() { return "I"; }
+    }
+    static class A {
+        String f() { return "A"; }
+    }
+
+    static class B extends A implements I {
+        final boolean invokeClass;
+
+        public B(boolean invokeClass) {
+            this.invokeClass = invokeClass;
+        }
+
+        @CodeReflection
+        public String f() {
+            return invokeClass ? super.f() : I.super.f();
+        }
+    }
+
+    @Ignore
+    @Test
+    public void testInvokeSuper() throws Throwable {
+        CoreOp.FuncOp f = getFuncOp(B.class, "f");
+        MethodHandle mh = generate(f);
+
+        for (boolean invokeClass : new boolean[] {true, false}) {
+            B b = new B(invokeClass);
+            Assert.assertEquals(mh.invoke(b), b.f());
+        }
+    }
+
+    static MethodHandle generate(CoreOp.FuncOp f) {
+        f.writeTo(System.out);
+
+        CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        return BytecodeGenerator.generate(MethodHandles.lookup().in(B.class), lf);
+    }
+
+    static CoreOp.FuncOp getFuncOp(Class<?> c, String name) {
+        Optional<Method> om = Stream.of(c.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}

--- a/test/jdk/java/lang/reflect/code/type/TestReferences.java
+++ b/test/jdk/java/lang/reflect/code/type/TestReferences.java
@@ -97,15 +97,4 @@ public class TestReferences {
         RecordTypeRef rtr = RecordTypeRef.ofString(rtds);
         Assert.assertEquals(rtr.toString(), rtds);
     }
-
-
-    @CodeReflection
-    static void x() {}
-
-    @Test
-    public void testAccessCodeModel() throws ReflectiveOperationException {
-        MethodRef xr = MethodRef.method(TestReferences.class, "x", void.class);
-        Optional<CoreOp.FuncOp> m = xr.codeModel(MethodHandles.lookup());
-        Assert.assertTrue(m.isPresent());
-    }
 }

--- a/test/langtools/tools/javac/reflect/FieldAccessTest.java
+++ b/test/langtools/tools/javac/reflect/FieldAccessTest.java
@@ -113,6 +113,29 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
+            func @"test2_3" (%0 : FieldAccessTest)void -> {
+                %1 : int = constant @"1";
+                field.store %0 %1 @"FieldAccessTest::f()int";
+                return;
+            };
+            """)
+    void test2_3() {
+        FieldAccessTest.this.f = 1;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test2_4" (%0 : FieldAccessTest)int -> {
+                %1 : int = field.load %0 @"FieldAccessTest::f()int";
+                return %1;
+            };
+            """)
+    int test2_4() {
+        return FieldAccessTest.this.f;
+    }
+
+    @CodeReflection
+    @IR("""
             func @"test3" (%0 : FieldAccessTest)int -> {
                 %1 : int = field.load @"FieldAccessTest::s_f()int";
                 %2 : int = field.load %0 @"FieldAccessTest::f()int";

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -66,6 +66,17 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
+            func @"test2_1" (%0 : MethodCallTest)void -> {
+                invoke %0 @"MethodCallTest::m()void";
+                return;
+            };
+            """)
+    void test2_1() {
+        MethodCallTest.this.m();
+    }
+
+    @CodeReflection
+    @IR("""
             func @"test3" (%0 : MethodCallTest)int -> {
                 %1 : int = invoke %0 @"MethodCallTest::m_int()int";
                 return %1;

--- a/test/langtools/tools/javac/reflect/SuperTest.java
+++ b/test/langtools/tools/javac/reflect/SuperTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.runtime.CodeReflection;
+
+/*
+ * @test
+ * @summary Smoke test for code reflection with super qualified expressions.
+ * @build SuperTest
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester SuperTest
+ */
+
+public class SuperTest extends SuperClass implements SuperInterface {
+    static int sf;
+    int f;
+
+    @Override
+    public void get() {}
+    static void sget() {}
+
+    @CodeReflection
+    @IR("""
+            func @"superClassFieldAccess" (%0 : SuperTest)void -> {
+                %1 : int = field.load %0 @"SuperClass::f()int";
+                %2 : Var<int> = var %1 @"i";
+                %3 : int = constant @"1";
+                field.store %0 %3 @"SuperClass::f()int";
+                %4 : int = field.load %0 @"SuperClass::f()int";
+                var.store %2 %4;
+                %5 : int = constant @"1";
+                field.store %0 %5 @"SuperClass::f()int";
+                %6 : int = field.load @"SuperClass::sf()int";
+                var.store %2 %6;
+                %7 : int = constant @"1";
+                field.store %7 @"SuperClass::sf()int";
+                %8 : int = field.load @"SuperClass::sf()int";
+                var.store %2 %8;
+                %9 : int = constant @"1";
+                field.store %9 @"SuperClass::sf()int";
+                return;
+            };
+            """)
+    public void superClassFieldAccess() {
+        int i = super.f;
+        super.f = 1;
+        i = SuperTest.super.f;
+        SuperTest.super.f = 1;
+
+        i = super.sf;
+        super.sf = 1;
+        i = SuperTest.super.sf;
+        SuperTest.super.sf = 1;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"superClassMethodInvocation" (%0 : SuperTest)void -> {
+                invoke.super %0 @"SuperClass::get()void";
+                invoke.super %0 @"SuperClass::get()void";
+                invoke @"SuperClass::sget()void";
+                invoke @"SuperClass::sget()void";
+                return;
+            };
+            """)
+    public void superClassMethodInvocation() {
+        super.get();
+        SuperTest.super.get();
+
+        super.sget();
+        SuperTest.super.sget();
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"superInterfaceMethodInvocation" (%0 : SuperTest)void -> {
+                invoke.super %0 @"SuperInterface::get()void";
+                return;
+            };
+            """)
+    public void superInterfaceMethodInvocation() {
+        SuperInterface.super.get();
+    }
+}
+
+class SuperClass {
+    static int sf;
+    int f;
+
+    void get() {}
+    static void sget() {}
+}
+
+interface SuperInterface {
+    default void get() {}
+}

--- a/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
+++ b/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
@@ -61,6 +61,8 @@ import javax.tools.ToolProvider;
 public class TestIRFromAnnotation {
 
     static final Set<String> EXCLUDED_TEST = Set.of(
+            "SuperTest.java",                   // @@@ Might be issue referencing auxiliary interface
+                                                // in method superInterfaceMethodInvocation
             "LocalClassTest.java",              // name of local classes is not stable at annotation processing time
             "TestLocalCapture.java",            // plain testng test
             "TestCaptureQuoted.java",           // plain testng test


### PR DESCRIPTION
Support super expressions.

The work in the bytecode generator is not complete, and a disabled test has been added. Currently when it encounters an invoke super operation it will throw. We cannot generate invokespecial instructions as this will create invalid bytecode (the calling class is not related to the referenced class). Instead, in a subsequent PR, we need to dynamically generate method handles, pass them as class data to the defined hidden class, so they can be loaded as constants and invoked (and therefore emulating the invokespecial instruction). That subsequent PR should also address the lifting of invokespecial instructions.

This work has shown deficiencies in the modeling of invocation expressions and the resolution of `MethodRef`s. The latter has been partially addressed by providing additional information for resolution, namely the kind of invocation.

Invocation operations do not fully model invocation to vararg methods and this means we cannot reliably determine in all cases if the invocation has a receiver operand or not (a class or instance invocation). This should be fixed in a subsequent PR. The fix might require the following:
- explicit modeling of class and instance and invocation; and
- modeling var args as a prefix (sublist) of the operand list

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [e1e1e0ed](https://git.openjdk.org/babylon/pull/221/files/e1e1e0ed322f88ff08169452fe8e14f93ccbb695)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/babylon.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/221.diff">https://git.openjdk.org/babylon/pull/221.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/221#issuecomment-2332818877)