### PR TITLE
Unify common code of SwitchStatementOp and SwitchExpressionOp

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -970,7 +970,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 exit = b;
             } else {
                 exit = b.block(resultType());
-                if (resultType() != VOID) {
+                if (this instanceof JavaSwitchExpressionOp) {
                     exit.context().mapValue(result(), exit.parameters().get(0));
                 }
             }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -895,192 +895,12 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
         }
     }
 
-    /**
-     * The switch expression operation, that can model Java language switch expressions.
-     */
-    @OpFactory.OpDeclaration(JavaSwitchExpressionOp.NAME)
-    public static final class JavaSwitchExpressionOp extends ExtendedOp
-            implements Op.Nested, Op.Lowerable, JavaExpression {
-        public static final String NAME = "java.switch.expression";
-
-        final TypeElement resultType;
-        final List<Body> bodies;
-
-        public JavaSwitchExpressionOp(ExternalizedOp def) {
-            super(def);
-
-            if (def.operands().size() != 1) {
-                throw new IllegalStateException("Operation must have one operand");
-            }
-
-            // @@@ Validate
-
-            this.bodies = def.bodyDefinitions().stream().map(bd -> bd.build(this)).toList();
-            this.resultType = def.resultType();
-        }
-
-        JavaSwitchExpressionOp(JavaSwitchExpressionOp that, CopyContext cc, OpTransformer ot) {
-            super(that, cc);
-
-            // Copy body
-            this.bodies = that.bodies.stream()
-                    .map(b -> b.transform(cc, ot).build(this)).toList();
-            this.resultType = that.resultType;
-        }
-
-        @Override
-        public JavaSwitchExpressionOp transform(CopyContext cc, OpTransformer ot) {
-            return new JavaSwitchExpressionOp(this, cc, ot);
-        }
-
-        JavaSwitchExpressionOp(TypeElement resultType, Value target, List<Body.Builder> bodyCs) {
-            super(NAME, List.of(target));
-
-            // Each case is modelled as a contiguous pair of bodies
-            // The first body models the case labels, and the second models the case expression or statements
-            // The labels body has a parameter whose type is target operand's type and returns a boolean value
-            // The statements/expression body has no parameters and returns the result whose type is the result of
-            // the switch expression
-            this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
-            // @@@ when resultType is null, we assume statements/expressions bodies have the same yieldType
-            this.resultType = resultType == null ? bodies.get(1).yieldType() : resultType;
-        }
-
-        @Override
-        public List<Body> bodies() {
-            return bodies;
-        }
-
-        @Override
-        public TypeElement resultType() {
-            return resultType;
-        }
-
-        private boolean haveNullCase() {
-            /*
-            case null is modeled like this:
-            (%4 : T)boolean -> {
-                %5 : java.lang.Object = constant @null;
-                %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                yield %6;
-            }
-            * */
-            for (int i = 0; i < bodies().size() - 2; i+=2) {
-                Body labelBody = bodies().get(i);
-                if (labelBody.blocks().size() != 1) {
-                    continue; // we skip, for now
-                }
-                Op terminatingOp = bodies().get(i).entryBlock().terminatingOp();
-                //@@@ when op pattern matching is ready, we can use it
-                if (terminatingOp instanceof YieldOp yieldOp &&
-                        yieldOp.yieldValue() instanceof Op.Result opr &&
-                        opr.op() instanceof InvokeOp invokeOp &&
-                        invokeOp.invokeDescriptor().equals(MethodRef.method(Objects.class, "equals", boolean.class, Object.class, Object.class)) &&
-                        invokeOp.operands().stream().anyMatch(o -> o instanceof Op.Result r && r.op() instanceof ConstantOp cop && cop.value() == null)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Block.Builder lower(Block.Builder b, OpTransformer opT) {
-
-            Value selectorExpression = b.context().getValue(operands().get(0));
-
-            if (!(selectorExpression.type() instanceof PrimitiveType) && !haveNullCase()) {
-                Block.Builder throwBlock = b.block();
-                throwBlock.op(_throw(
-                        throwBlock.op(_new(FunctionType.functionType(JavaType.type(NullPointerException.class))))
-                ));
-
-                Block.Builder continueBlock = b.block();
-
-                Result p = b.op(invoke(MethodRef.method(Objects.class, "equals", boolean.class, Object.class, Object.class),
-                        selectorExpression, b.op(constant(J_L_OBJECT, null))));
-                b.op(conditionalBranch(p, throwBlock.successor(), continueBlock.successor()));
-
-                b = continueBlock;
-            }
-
-            final int n = bodies().size();
-
-            List<Block.Builder> blocks = new ArrayList<>();
-            for (int i = 0; i < n; i++) {
-                Block.Builder bb = b.block();
-                if (i == 0) {
-                    bb = b;
-                }
-                blocks.add(bb);
-            }
-
-            Block.Builder exit;
-            if (bodies().isEmpty()) {
-                exit = b;
-            } else {
-                exit = b.block(resultType());
-                exit.context().mapValue(result(), exit.parameters().get(0));
-            }
-
-            setBranchTarget(b.context(), this, new BranchTarget(exit, null));
-            // map expr body to nextExprBlock
-            // this mapping will be used for lowering SwitchFallThroughOp
-            for (int i = 1; i < n - 2; i+=2) {
-                setBranchTarget(b.context(), bodies().get(i), new BranchTarget(null, blocks.get(i + 2)));
-            }
-
-            for (int i = 0; i < n; i++) {
-                boolean isLabelBody = i % 2 == 0;
-                Block.Builder curr = blocks.get(i);
-                if (isLabelBody) {
-                    Block.Builder expression = blocks.get(i + 1);
-                    boolean isLastLabel = i == n - 2;
-                    Block.Builder nextLabel = isLastLabel ? null : blocks.get(i + 2);
-                    curr.transformBody(bodies().get(i), List.of(selectorExpression), opT.andThen((block, op) -> {
-                        switch (op) {
-                            case YieldOp yop -> {
-                                if (isLastLabel) {
-                                    block.op(branch(expression.successor()));
-                                } else {
-                                    block.op(conditionalBranch(
-                                            block.context().getValue(yop.yieldValue()),
-                                            expression.successor(),
-                                            nextLabel.successor()
-                                    ));
-                                }
-                            }
-                            case Lowerable lop -> block = lop.lower(block);
-                            default -> block.op(op);
-                        }
-                        return block;
-                    }));
-                } else { // expression body
-                    curr.transformBody(bodies().get(i), blocks.get(i).parameters(), opT.andThen((block, op) -> {
-                        switch (op) {
-                            case YieldOp yop -> block.op(branch(exit.successor(block.context().getValue(yop.yieldValue()))));
-                            case Lowerable lop -> block = lop.lower(block);
-                            default -> block.op(op);
-                        }
-                        return block;
-                    }));
-                }
-            }
-
-            return exit;
-        }
-    }
-
-    /**
-     * The switch statement operation, that can model Java language switch statement.
-     */
-    @OpFactory.OpDeclaration(JavaSwitchStatementOp.NAME)
-    public static final class JavaSwitchStatementOp extends ExtendedOp
-            implements Op.Nested, JavaStatement, Op.Lowerable {
-        public static final String NAME = "java.switch.statement";
+    abstract static sealed class JavaSwitch extends ExtendedOp implements Op.Nested, Op.Lowerable
+            permits JavaSwitchStatementOp, JavaSwitchExpressionOp {
 
         final List<Body> bodies;
 
-        public JavaSwitchStatementOp(ExternalizedOp def) {
+        public JavaSwitch(ExternalizedOp def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -1091,7 +911,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             this.bodies = def.bodyDefinitions().stream().map(bd -> bd.build(this)).toList();
         }
 
-        JavaSwitchStatementOp(JavaSwitchStatementOp that, CopyContext cc, OpTransformer ot) {
+        JavaSwitch(JavaSwitch that, CopyContext cc, OpTransformer ot) {
             super(that, cc);
 
             // Copy body
@@ -1099,13 +919,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     .map(b -> b.transform(cc, ot).build(this)).toList();
         }
 
-        @Override
-        public JavaSwitchStatementOp transform(CopyContext cc, OpTransformer ot) {
-            return new JavaSwitchStatementOp(this, cc, ot);
-        }
-
-        JavaSwitchStatementOp(Value target, List<Body.Builder> bodyCs) {
-            super(NAME, List.of(target));
+        JavaSwitch(String name, Value target, List<Body.Builder> bodyCs) {
+            super(name, List.of(target));
 
             // Each case is modelled as a contiguous pair of bodies
             // The first body models the case labels, and the second models the case statements
@@ -1117,11 +932,6 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
         @Override
         public List<Body> bodies() {
             return bodies;
-        }
-
-        @Override
-        public TypeElement resultType() {
-            return VOID;
         }
 
         @Override
@@ -1156,10 +966,13 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             }
 
             Block.Builder exit;
-            if (bodies.isEmpty()) {
+            if (bodies().isEmpty()) {
                 exit = b;
             } else {
-                exit = b.block();
+                exit = b.block(resultType());
+                if (result() != null) { // i.e. resultType not void
+                    exit.context().mapValue(result(), exit.parameters().get(0));
+                }
             }
 
             setBranchTarget(b.context(), this, new BranchTarget(exit, null));
@@ -1192,7 +1005,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 } else { // statement body
                     curr.transformBody(bodies().get(i), blocks.get(i).parameters(), opT.andThen((block, op) -> {
                         switch (op) {
-                            case YieldOp yop -> block.op(branch(exit.successor()));
+                            case YieldOp yop when yop.operands().isEmpty() -> block.op(branch(exit.successor()));
+                            case YieldOp yop -> block.op(branch(exit.successor(block.context().getValue(yop.yieldValue()))));
                             case Lowerable lop -> block = lop.lower(block);
                             default -> block.op(op);
                         }
@@ -1204,7 +1018,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             return exit;
         }
 
-        private boolean haveNullCase() {
+        boolean haveNullCase() {
             /*
             case null is modeled like this:
             (%4 : T)boolean -> {
@@ -1229,6 +1043,76 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 }
             }
             return false;
+        }
+    }
+
+    /**
+     * The switch expression operation, that can model Java language switch expressions.
+     */
+    @OpFactory.OpDeclaration(JavaSwitchExpressionOp.NAME)
+    public static final class JavaSwitchExpressionOp extends JavaSwitch
+            implements JavaExpression {
+        public static final String NAME = "java.switch.expression";
+
+        final TypeElement resultType;
+
+        public JavaSwitchExpressionOp(ExternalizedOp def) {
+            super(def);
+
+            this.resultType = def.resultType();
+        }
+
+        JavaSwitchExpressionOp(JavaSwitchExpressionOp that, CopyContext cc, OpTransformer ot) {
+            super(that, cc, ot);
+
+            this.resultType = that.resultType;
+        }
+
+        @Override
+        public JavaSwitchExpressionOp transform(CopyContext cc, OpTransformer ot) {
+            return new JavaSwitchExpressionOp(this, cc, ot);
+        }
+
+        JavaSwitchExpressionOp(TypeElement resultType, Value target, List<Body.Builder> bodyCs) {
+            super(NAME, target, bodyCs);
+
+            this.resultType = resultType == null ? bodies.get(1).yieldType() : resultType;
+        }
+
+        @Override
+        public TypeElement resultType() {
+            return resultType;
+        }
+    }
+
+    /**
+     * The switch statement operation, that can model Java language switch statement.
+     */
+    @OpFactory.OpDeclaration(JavaSwitchStatementOp.NAME)
+    public static final class JavaSwitchStatementOp extends JavaSwitch
+            implements JavaStatement {
+        public static final String NAME = "java.switch.statement";
+
+        public JavaSwitchStatementOp(ExternalizedOp def) {
+            super(def);
+        }
+
+        JavaSwitchStatementOp(JavaSwitchStatementOp that, CopyContext cc, OpTransformer ot) {
+            super(that, cc, ot);
+        }
+
+        @Override
+        public JavaSwitchStatementOp transform(CopyContext cc, OpTransformer ot) {
+            return new JavaSwitchStatementOp(this, cc, ot);
+        }
+
+        JavaSwitchStatementOp(Value target, List<Body.Builder> bodyCs) {
+            super(NAME, target, bodyCs);
+        }
+
+        @Override
+        public TypeElement resultType() {
+            return VOID;
         }
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -970,7 +970,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 exit = b;
             } else {
                 exit = b.block(resultType());
-                if (result() != null) { // i.e. resultType not void
+                if (resultType() != VOID) {
                     exit.context().mapValue(result(), exit.parameters().get(0));
                 }
             }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -991,7 +991,9 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     Block.Builder nextLabel = isLastLabel ? null : blocks.get(i + 2);
                     curr.transformBody(bodies().get(i), List.of(selectorExpression), opT.andThen((block, op) -> {
                         switch (op) {
-                            case YieldOp yop when yop.operands().isEmpty() -> block.op(branch(statement.successor()));
+                            case YieldOp yop when isLastLabel && this instanceof JavaSwitchExpressionOp -> {
+                                block.op(branch(statement.successor()));
+                            }
                             case YieldOp yop -> block.op(conditionalBranch(
                                     block.context().getValue(yop.yieldValue()),
                                     statement.successor(),

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -1005,8 +1005,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 } else { // statement body
                     curr.transformBody(bodies().get(i), blocks.get(i).parameters(), opT.andThen((block, op) -> {
                         switch (op) {
-                            case YieldOp yop when yop.operands().isEmpty() -> block.op(branch(exit.successor()));
-                            case YieldOp yop -> block.op(branch(exit.successor(block.context().getValue(yop.yieldValue()))));
+                            case YieldOp yop when this instanceof JavaSwitchStatementOp -> block.op(branch(exit.successor()));
+                            case YieldOp yop when this instanceof JavaSwitchExpressionOp -> block.op(branch(exit.successor(block.context().getValue(yop.yieldValue()))));
                             case Lowerable lop -> block = lop.lower(block);
                             default -> block.op(op);
                         }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -895,12 +895,12 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
         }
     }
 
-    abstract static sealed class JavaSwitch extends ExtendedOp implements Op.Nested, Op.Lowerable
+    public abstract static sealed class JavaSwitchOp extends ExtendedOp implements Op.Nested, Op.Lowerable
             permits JavaSwitchStatementOp, JavaSwitchExpressionOp {
 
         final List<Body> bodies;
 
-        public JavaSwitch(ExternalizedOp def) {
+        public JavaSwitchOp(ExternalizedOp def) {
             super(def);
 
             if (def.operands().size() != 1) {
@@ -911,7 +911,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             this.bodies = def.bodyDefinitions().stream().map(bd -> bd.build(this)).toList();
         }
 
-        JavaSwitch(JavaSwitch that, CopyContext cc, OpTransformer ot) {
+        JavaSwitchOp(JavaSwitchOp that, CopyContext cc, OpTransformer ot) {
             super(that, cc);
 
             // Copy body
@@ -919,7 +919,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     .map(b -> b.transform(cc, ot).build(this)).toList();
         }
 
-        JavaSwitch(String name, Value target, List<Body.Builder> bodyCs) {
+        JavaSwitchOp(String name, Value target, List<Body.Builder> bodyCs) {
             super(name, List.of(target));
 
             // Each case is modelled as a contiguous pair of bodies
@@ -1050,7 +1050,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
      * The switch expression operation, that can model Java language switch expressions.
      */
     @OpFactory.OpDeclaration(JavaSwitchExpressionOp.NAME)
-    public static final class JavaSwitchExpressionOp extends JavaSwitch
+    public static final class JavaSwitchExpressionOp extends JavaSwitchOp
             implements JavaExpression {
         public static final String NAME = "java.switch.expression";
 
@@ -1089,7 +1089,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
      * The switch statement operation, that can model Java language switch statement.
      */
     @OpFactory.OpDeclaration(JavaSwitchStatementOp.NAME)
-    public static final class JavaSwitchStatementOp extends JavaSwitch
+    public static final class JavaSwitchStatementOp extends JavaSwitchOp
             implements JavaStatement {
         public static final String NAME = "java.switch.statement";
 


### PR DESCRIPTION
Unify common code of SwitchStatementOp and SwitchExpressionOp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.org/babylon.git pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/222.diff">https://git.openjdk.org/babylon/pull/222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/222#issuecomment-2333215148)