### PR TITLE
Change the model of the default label of switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1544,8 +1544,8 @@ public class ReflectMethods extends TreeTranslator {
                 bodies.add(defaultBody);
             } else if (isDefaultCaseNeeded) {
                 // label
-                pushBody(tree, FunctionType.VOID);
-                append(CoreOp._yield());
+                pushBody(tree, FunctionType.functionType(JavaType.BOOLEAN));
+                append(CoreOp._yield(append(CoreOp.constant(JavaType.BOOLEAN, true))));
                 bodies.add(stack.body);
                 popBody();
 
@@ -1651,9 +1651,9 @@ public class ReflectMethods extends TreeTranslator {
                 popBody();
             } else if (headCl instanceof JCTree.JCDefaultCaseLabel) {
                 // @@@ Do we need to model the default label body?
-                pushBody(headCl, FunctionType.VOID);
+                pushBody(headCl, FunctionType.functionType(JavaType.BOOLEAN));
 
-                append(CoreOp._yield());
+                append(CoreOp._yield(append(CoreOp.constant(JavaType.BOOLEAN, true))));
                 body = stack.body;
 
                 // Pop label

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1528,7 +1528,7 @@ public class ReflectMethods extends TreeTranslator {
             for (JCTree.JCCase c : cases) {
 
                 Body.Builder caseLabel = visitCaseLabel(tree, selector, target, c);
-                Body.Builder caseBody = visitCaseBody(c, caseBodyType);
+                Body.Builder caseBody = visitCaseBody(tree, c, caseBodyType);
 
                 if (c.labels.head instanceof JCTree.JCDefaultCaseLabel) {
                     defaultLabel = caseLabel;
@@ -1665,10 +1665,10 @@ public class ReflectMethods extends TreeTranslator {
             return body;
         }
 
-        private Body.Builder visitCaseBody(JCTree.JCCase c, FunctionType caseBodyType) {
+        private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, FunctionType caseBodyType) {
 
             Body.Builder body = null;
-            Type yieldType = typeElementToType(caseBodyType.returnType());
+            Type yieldType = tree.type != null ? adaptBottom(tree.type) : null;
 
             JCTree.JCCaseLabel headCl = c.labels.head;
             switch (c.caseKind) {

--- a/test/langtools/tools/javac/reflect/BoxingConversionTest.java
+++ b/test/langtools/tools/javac/reflect/BoxingConversionTest.java
@@ -308,8 +308,9 @@ public class BoxingConversionTest {
                         %11 : int = invoke %10 @"java.lang.Integer::intValue()int";
                         yield %11;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()int -> {
                         %12 : int = constant @"0";
@@ -342,8 +343,9 @@ public class BoxingConversionTest {
                         %10 : int = constant @"1";
                         yield %10;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()int -> {
                         %11 : java.lang.Integer = var.load %4;
@@ -377,8 +379,9 @@ public class BoxingConversionTest {
                         %9 : java.lang.Integer = invoke %8 @"java.lang.Integer::valueOf(int)java.lang.Integer";
                         yield %9;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.Integer -> {
                         %10 : int = constant @"0";
@@ -413,8 +416,9 @@ public class BoxingConversionTest {
                         %11 : int = invoke %10 @"java.lang.Integer::intValue()int";
                         java.yield %11;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()int -> {
                         %12 : int = constant @"0";
@@ -447,8 +451,9 @@ public class BoxingConversionTest {
                         %10 : int = constant @"1";
                         java.yield %10;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()int -> {
                         %11 : java.lang.Integer = var.load %4;
@@ -482,8 +487,9 @@ public class BoxingConversionTest {
                         %9 : java.lang.Integer = invoke %8 @"java.lang.Integer::valueOf(int)java.lang.Integer";
                         java.yield %9;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.Integer -> {
                         %10 : int = constant @"0";

--- a/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
+++ b/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
@@ -228,8 +228,9 @@ public class ImplicitConversionTest {
                         %8 : long = constant @"1";
                         yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()long -> {
                         %9 : int = constant @"0";
@@ -263,8 +264,9 @@ public class ImplicitConversionTest {
                         %9 : long = conv %8;
                         yield %9;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()long -> {
                         %10 : long = constant @"0";
@@ -297,8 +299,9 @@ public class ImplicitConversionTest {
                         %9 : long = conv %8;
                         yield %9;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()long -> {
                         %10 : int = constant @"0";
@@ -331,8 +334,9 @@ public class ImplicitConversionTest {
                         %8 : long = constant @"1";
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()long -> {
                         %9 : int = constant @"0";
@@ -366,8 +370,9 @@ public class ImplicitConversionTest {
                         %9 : long = conv %8;
                         java.yield %9;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()long -> {
                         %10 : long = constant @"0";
@@ -400,8 +405,9 @@ public class ImplicitConversionTest {
                         %9 : long = conv %8;
                         java.yield %9;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()long -> {
                         %10 : int = constant @"0";

--- a/test/langtools/tools/javac/reflect/NullTest.java
+++ b/test/langtools/tools/javac/reflect/NullTest.java
@@ -173,8 +173,9 @@ public class NullTest {
                         %8 : java.lang.String = constant @"";
                         yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.String -> {
                         %9 : java.lang.String = constant @null;
@@ -205,8 +206,9 @@ public class NullTest {
                         %8 : java.lang.String = constant @null;
                         yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.String -> {
                         %9 : java.lang.String = constant @"";
@@ -237,8 +239,9 @@ public class NullTest {
                         %8 : java.lang.String = constant @null;
                         yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.String -> {
                         %9 : java.lang.String = constant @null;
@@ -269,8 +272,9 @@ public class NullTest {
                         %8 : java.lang.Object = constant @null;
                         yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.Object -> {
                         %9 : java.lang.Object = constant @null;
@@ -302,8 +306,9 @@ public class NullTest {
                         %8 : java.lang.String = constant @"";
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.String -> {
                         %9 : java.lang.String = constant @null;
@@ -334,8 +339,9 @@ public class NullTest {
                         %8 : java.lang.String = constant @null;
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.String -> {
                         %9 : java.lang.String = constant @"";
@@ -366,8 +372,9 @@ public class NullTest {
                         %8 : java.lang.String = constant @null;
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.String -> {
                         %9 : java.lang.String = constant @null;
@@ -398,8 +405,9 @@ public class NullTest {
                         %8 : java.lang.Object = constant @null;
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.Object -> {
                         %9 : java.lang.Object = constant @null;

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
@@ -69,8 +69,9 @@ public class SwitchExpressionTest {
                         %15 : java.lang.String = constant @"FOO";
                         yield %15;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.Object -> {
                         %16 : java.lang.String = constant @"";
@@ -117,8 +118,9 @@ public class SwitchExpressionTest {
                         %12 : java.lang.String = constant @"FOO";
                         yield %12;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %14 : boolean = constant @"true";
+                        yield %14;
                     }
                     ()java.lang.Object -> {
                         %13 : java.lang.String = constant @"";
@@ -169,8 +171,9 @@ public class SwitchExpressionTest {
                         %15 : java.lang.String = constant @"FOO";
                         java.yield %15;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.Object -> {
                         %16 : java.lang.String = constant @"";
@@ -217,8 +220,9 @@ public class SwitchExpressionTest {
                         %12 : java.lang.String = constant @"FOO";
                         java.yield %12;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.Object -> {
                         java.block ()void -> {
@@ -261,8 +265,9 @@ public class SwitchExpressionTest {
                         };
                         unreachable;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %11 : boolean = constant @"true";
+                        yield %11;
                     }
                     ()java.lang.Object -> {
                         %10 : java.lang.String = constant @"";
@@ -303,8 +308,9 @@ public class SwitchExpressionTest {
                         };
                         java.switch.fallthrough;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %10 : boolean = constant @"true";
+                        yield %10;
                     }
                     ()java.lang.Object -> {
                         %9 : java.lang.String = constant @"";
@@ -368,8 +374,9 @@ public class SwitchExpressionTest {
                         %18 : java.lang.String = var.load %6;
                         java.yield %18;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %10 : boolean = constant @"true";
+                        yield %10;
                     }
                     ()java.lang.Object -> {
                         %19 : java.lang.String = constant @"";
@@ -475,8 +482,9 @@ public class SwitchExpressionTest {
                         %35 : java.lang.String = var.load %8;
                         java.yield %35;
                     }
-                    ^defaultCaseLabel()void -> {
-                        yield;
+                    ^defaultCaseLabel()boolean -> {
+                        %37 : boolean = constant @"true";
+                        yield %37;
                     }
                     ()java.lang.Object -> {
                         %36 : java.lang.String = constant @"";

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
@@ -41,8 +41,9 @@ public class SwitchExpressionTest2 {
                         %15 : java.lang.String = constant @"FOO";
                         yield %15;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.String -> {
                         %16 : java.lang.String = constant @"";
@@ -93,8 +94,9 @@ public class SwitchExpressionTest2 {
                         %15 : java.lang.String = constant @"FOO";
                         java.yield %15;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.String -> {
                         %16 : java.lang.String = constant @"";
@@ -153,8 +155,9 @@ public class SwitchExpressionTest2 {
                         %15 : java.lang.String = constant @"FOO";
                         java.yield %15;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()java.lang.String -> {
                         %16 : java.lang.String = constant @"";
@@ -212,8 +215,9 @@ public class SwitchExpressionTest2 {
                         %17 : java.lang.String = constant @"vowel";
                         java.yield %17;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %19 : boolean = constant @"true";
+                        yield %19;
                     }
                     ()java.lang.String -> {
                         %18 : java.lang.String = constant @"consonant";
@@ -255,8 +259,9 @@ public class SwitchExpressionTest2 {
                         %13 : java.lang.String = constant @"NINE";
                         yield %13;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %15 : boolean = constant @"true";
+                        yield %15;
                     }
                     ()java.lang.String -> {
                         %14 : java.lang.String = constant @"An integer";
@@ -288,8 +293,9 @@ public class SwitchExpressionTest2 {
                         %7 : java.lang.String = constant @"null";
                         yield %7;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %9 : boolean = constant @"true";
+                        yield %9;
                     }
                     ()java.lang.String -> {
                         %8 : java.lang.String = constant @"non null";
@@ -338,8 +344,9 @@ public class SwitchExpressionTest2 {
                         %10 : java.lang.String = constant @"A or B";
                         java.yield %10;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %12 : boolean = constant @"true";
+                        yield %12;
                     }
                     ()java.lang.String -> {
                         %11 : java.lang.String = constant @"Neither A nor B";
@@ -426,8 +433,9 @@ public class SwitchExpressionTest2 {
                         %27 : int = constant @"9";
                         yield %27;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %29 : boolean = constant @"true";
+                        yield %29;
                     }
                     ()int -> {
                         %28 : java.lang.MatchException = new @"func<java.lang.MatchException>";
@@ -607,8 +615,9 @@ public class SwitchExpressionTest2 {
                         %82 : java.lang.String = constant @"13";
                         yield %82;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %84 : boolean = constant @"true";
+                        yield %84;
                     }
                     ()java.lang.String -> {
                         %83 : java.lang.String = constant @"an int";
@@ -680,8 +689,9 @@ public class SwitchExpressionTest2 {
                         %23 : java.lang.String = constant @"two";
                         yield %23;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %25 : boolean = constant @"true";
+                        yield %25;
                     }
                     ()java.lang.String -> {
                         %24 : java.lang.String = constant @"default";
@@ -731,8 +741,9 @@ public class SwitchExpressionTest2 {
                         %17 : java.lang.String = constant @"two";
                         yield %17;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %19 : boolean = constant @"true";
+                        yield %19;
                     }
                     ()java.lang.String -> {
                         %18 : java.lang.String = constant @"default";
@@ -776,8 +787,9 @@ public class SwitchExpressionTest2 {
                         %11 : java.lang.String = constant @"g";
                         yield %11;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %13 : boolean = constant @"true";
+                        yield %13;
                     }
                     ()java.lang.String -> {
                         %12 : java.lang.MatchException = new @"func<java.lang.MatchException>";
@@ -881,8 +893,9 @@ public class SwitchExpressionTest2 {
                         %17 : java.lang.String = constant @"C";
                         yield %17;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %19 : boolean = constant @"true";
+                        yield %19;
                     }
                     ()java.lang.String -> {
                         %18 : java.lang.MatchException = new @"func<java.lang.MatchException>";
@@ -922,8 +935,9 @@ public class SwitchExpressionTest2 {
                         %12 : java.lang.String = constant @"Aow";
                         yield %12;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %13 : boolean = constant @"true";
+                        yield %13;
                     }
                     ()java.lang.String -> {
                         %4 : java.lang.String = constant @"else";

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -54,8 +54,9 @@ public class SwitchStatementTest {
                           var.store %3 %22;
                           yield;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %26 : boolean = constant @"true";
+                          yield %26;
                       }
                       ()void -> {
                           %23 : java.lang.String = var.load %3;
@@ -123,8 +124,9 @@ public class SwitchStatementTest {
                           var.store %3 %22;
                           yield;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %26 : boolean = constant @"true";
+                          yield %26;
                       }
                       ()void -> {
                           %23 : java.lang.String = var.load %3;
@@ -200,8 +202,9 @@ public class SwitchStatementTest {
                           var.store %3 %22;
                           java.break;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %26 : boolean = constant @"true";
+                          yield %26;
                       }
                       ()void -> {
                           %23 : java.lang.String = var.load %3;
@@ -277,8 +280,9 @@ public class SwitchStatementTest {
                         var.store %3 %20;
                         java.break;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %24 : boolean = constant @"true";
+                        yield %24;
                     }
                     ()void -> {
                         %21 : java.lang.String = var.load %3;
@@ -334,8 +338,9 @@ public class SwitchStatementTest {
                         var.store %3 %16;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %17 : java.lang.String = var.load %3;
@@ -378,8 +383,9 @@ public class SwitchStatementTest {
                         var.store %3 %10;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %11 : java.lang.String = var.load %3;
@@ -440,8 +446,9 @@ public class SwitchStatementTest {
                           var.store %3 %13;
                           java.break;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %17 : boolean = constant @"true";
+                          yield %17;
                       }
                       ()void -> {
                           %14 : java.lang.String = var.load %3;
@@ -783,8 +790,9 @@ public class SwitchStatementTest {
                         var.store %3 %120;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %121 : java.lang.String = var.load %3;
@@ -871,8 +879,9 @@ public class SwitchStatementTest {
                           var.store %9 %30;
                           yield;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %17 : boolean = constant @"true";
+                          yield %17;
                       }
                       ()void -> {
                           %31 : java.lang.String = var.load %9;
@@ -936,8 +945,9 @@ public class SwitchStatementTest {
                         var.store %6 %22;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %23 : java.lang.String = var.load %6;
@@ -1054,8 +1064,9 @@ public class SwitchStatementTest {
                           var.store %3 %24;
                           yield;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %17 : boolean = constant @"true";
+                          yield %17;
                       }
                       ()void -> {
                           %25 : java.lang.MatchException = new @"func<java.lang.MatchException>";
@@ -1128,8 +1139,9 @@ public class SwitchStatementTest {
                         var.store %3 %22;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %23 : java.lang.MatchException = new @"func<java.lang.MatchException>";
@@ -1252,8 +1264,9 @@ public class SwitchStatementTest {
                           var.store %3 %22;
                           yield;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %17 : boolean = constant @"true";
+                          yield %17;
                       }
                       ()void -> {
                           %23 : java.lang.String = var.load %3;
@@ -1326,8 +1339,9 @@ public class SwitchStatementTest {
                           var.store %3 %22;
                           yield;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %17 : boolean = constant @"true";
+                          yield %17;
                       }
                       ()void -> {
                           %23 : java.lang.String = var.load %3;
@@ -1406,8 +1420,9 @@ public class SwitchStatementTest {
                           var.store %3 %22;
                           java.break;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %17 : boolean = constant @"true";
+                          yield %17;
                       }
                       ()void -> {
                           %23 : java.lang.String = var.load %3;
@@ -1482,8 +1497,9 @@ public class SwitchStatementTest {
                         var.store %3 %20;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %21 : java.lang.String = var.load %3;
@@ -1604,8 +1620,9 @@ public class SwitchStatementTest {
                           var.store %3 %39;
                           yield;
                       }
-                      ()void -> {
-                          yield;
+                      ()boolean -> {
+                          %17 : boolean = constant @"true";
+                          yield %17;
                       }
                       ()void -> {
                           %40 : java.lang.String = var.load %3;
@@ -1764,8 +1781,9 @@ public class SwitchStatementTest {
                         var.store %3 %58;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %59 : java.lang.String = var.load %3;
@@ -1823,8 +1841,9 @@ public class SwitchStatementTest {
                         var.store %3 %14;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %15 : java.lang.String = var.load %3;
@@ -1923,8 +1942,9 @@ public class SwitchStatementTest {
                         var.store %3 %37;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %38 : java.lang.String = var.load %3;
@@ -1979,8 +1999,9 @@ public class SwitchStatementTest {
                         var.store %3 %16;
                         yield;
                     }
-                    ()void -> {
-                        yield;
+                    ()boolean -> {
+                        %17 : boolean = constant @"true";
+                        yield %17;
                     }
                     ()void -> {
                         %17 : java.lang.String = var.load %3;


### PR DESCRIPTION
Model the default label of switch as a body that yield true, this makes the modeling consistent for all labels.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/babylon.git pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/223.diff">https://git.openjdk.org/babylon/pull/223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/223#issuecomment-2333479031)