### PR TITLE
Avoid boxing when concatenating a string with a primitive

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -830,7 +830,13 @@ public class ReflectMethods extends TreeTranslator {
             // Capture applying rhs and operation
             Function<Value, Value> scanRhs = (lhs) -> {
                 Type unboxedType = types.unboxedTypeOrType(tree.type);
-                Value rhs = toValue(tree.rhs, unboxedType);
+                // if string concat and rhs is primitive, toValue(rhs)
+                Value rhs;
+                if (tree.operator.opcode == ByteCodes.string_add && tree.rhs.type.isPrimitive()) {
+                    rhs = toValue(tree.rhs);
+                } else {
+                    rhs = toValue(tree.rhs, unboxedType);
+                }
                 lhs = unboxIfNeeded(lhs);
 
                 Value assignOpResult = switch (tree.getTag()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -830,7 +830,6 @@ public class ReflectMethods extends TreeTranslator {
             // Capture applying rhs and operation
             Function<Value, Value> scanRhs = (lhs) -> {
                 Type unboxedType = types.unboxedTypeOrType(tree.type);
-                // if string concat and rhs is primitive, toValue(rhs)
                 Value rhs;
                 if (tree.operator.opcode == ByteCodes.string_add && tree.rhs.type.isPrimitive()) {
                     rhs = toValue(tree.rhs);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -844,7 +844,6 @@ public class ReflectMethods extends TreeTranslator {
                     // Arithmetic operations
                     case PLUS_ASG -> {
                         if (tree.operator.opcode == ByteCodes.string_add) {
-                            // @@@ avoid boxing of rhs when it's a primitive value
                             yield append(CoreOp.concat(lhs, rhs));
                         } else {
                             yield append(CoreOp.add(lhs, rhs));

--- a/test/langtools/tools/javac/reflect/StringConcatTest.java
+++ b/test/langtools/tools/javac/reflect/StringConcatTest.java
@@ -1,0 +1,61 @@
+import java.lang.runtime.CodeReflection;
+
+/*
+ * @test
+ * @build StringConcatTest
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester StringConcatTest
+ */
+public class StringConcatTest {
+
+    @IR("""
+            func @"test1" (%0 : java.lang.String, %1 : int)java.lang.String -> {
+                %2 : Var<java.lang.String> = var %0 @"a";
+                %3 : Var<int> = var %1 @"b";
+                %4 : java.lang.String = var.load %2;
+                %5 : int = var.load %3;
+                %6 : java.lang.String = concat %4 %5;
+                return %6;
+            };
+            """)
+    @CodeReflection
+    static String test1(String a, int b) {
+        return a + b;
+    }
+
+    @IR("""
+            func @"test2" (%0 : java.lang.String, %1 : char)java.lang.String -> {
+                %2 : Var<java.lang.String> = var %0 @"a";
+                %3 : Var<char> = var %1 @"b";
+                %4 : java.lang.String = var.load %2;
+                %5 : char = var.load %3;
+                %6 : java.lang.String = concat %4 %5;
+                var.store %2 %6;
+                %7 : java.lang.String = var.load %2;
+                return %7;
+            };
+            """)
+    @CodeReflection
+    static String test2(String a, char b) {
+        a += b;
+        return a;
+    }
+
+    @IR("""
+            func @"test3" (%0 : java.lang.String, %1 : float)java.lang.String -> {
+                %2 : Var<java.lang.String> = var %0 @"a";
+                %3 : Var<float> = var %1 @"b";
+                %4 : java.lang.String = var.load %2;
+                %5 : float = var.load %3;
+                %6 : java.lang.String = concat %4 %5;
+                var.store %2 %6;
+                %7 : java.lang.String = var.load %2;
+                return %7;
+            };
+            """)
+    @CodeReflection
+    static String test3(String a, float b) {
+        a = a + b;
+        return a;
+    }
+}


### PR DESCRIPTION
Avoid boxing when concatenating a string with a primitive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [bf55c1c0](https://git.openjdk.org/babylon/pull/226/files/bf55c1c0bda68c8d388e7b95860cd52edebb76cb)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/babylon.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/226.diff">https://git.openjdk.org/babylon/pull/226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/226#issuecomment-2339553004)