### PR TITLE
Implementation of a HAT Spirv backend

### DIFF
--- a/hat/backends/spirv/pom.xml
+++ b/hat/backends/spirv/pom.xml
@@ -45,6 +45,16 @@ questions.
             <version>1.0</version>
             <artifactId>hat</artifactId>
         </dependency>
+        <dependency>
+            <groupId>beehive-lab</groupId>
+            <version>0.0.4</version>
+            <artifactId>beehive-spirv-lib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>oneapi</groupId>
+            <version>0.0.1</version>
+            <artifactId>levelzero</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -90,8 +100,8 @@ questions.
                         </goals>
                         <configuration>
                             <sources>
-                                <source>${babylon.dir}/cr-examples/spirv/src/main/java/</source>
-                                <source>${beehive.spirv.toolkit.dir}/lib/src/main/java/</source>
+                                <!-- <source>${babylon.dir}/cr-examples/spirv/src/main/java/</source> -->
+                                <!-- <source>${beehive.spirv.toolkit.dir}/lib/src/main/java/</source> -->
                             </sources>
                         </configuration>
                     </execution>

--- a/hat/backends/spirv/scripts/build-beehive-spirv-toolkit.sh
+++ b/hat/backends/spirv/scripts/build-beehive-spirv-toolkit.sh
@@ -1,3 +1,5 @@
 git clone https://github.com/beehive-lab/beehive-spirv-toolkit.git
 cd beehive-spirv-toolkit
 mvn clean install
+cd ..
+cp beehive-spirv-toolkit/lib/target/beehive-spirv-lib-0.0.4.jar ../../../maven-build/

--- a/hat/backends/spirv/scripts/build-behive-spirv-toolkit.sh
+++ b/hat/backends/spirv/scripts/build-behive-spirv-toolkit.sh
@@ -1,0 +1,3 @@
+git clone https://github.com/beehive-lab/beehive-spirv-toolkit.git
+cd beehive-spirv-toolkit
+mvn clean install

--- a/hat/backends/spirv/scripts/build-level-zero.sh
+++ b/hat/backends/spirv/scripts/build-level-zero.sh
@@ -1,0 +1,7 @@
+git clone https://github.com/oneapi-src/level-zero.git
+cd level-zero
+mkdir build
+cd build
+cmake .. -D CMAKE_BUILD_TYPE=Release
+cmake --build . --target package
+cmake --build . --target install

--- a/hat/backends/spirv/scripts/generate-level-zero-binding.sh
+++ b/hat/backends/spirv/scripts/generate-level-zero-binding.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+$JEXTRACT_DIR/bin/jextract --output src/gen/java -I /usr/include -t oneapi.levelzero level-zero/include/ze_api.h
+$JAVA_HOME/bin/javac -cp target/classes -d target/classes src/gen/java/oneapi/levelzero/*.java
+$JAVA_HOME/bin/jar cf levelzero.jar -C target/classes/ .
+mvn install:install-file -Dfile=levelzero.jar -DgroupId=oneapi -DartifactId=levelzero -Dversion=0.0.1 -Dpackaging=jar

--- a/hat/backends/spirv/scripts/generate-level-zero-binding.sh
+++ b/hat/backends/spirv/scripts/generate-level-zero-binding.sh
@@ -4,3 +4,4 @@ $JEXTRACT_DIR/bin/jextract --output src/gen/java -I /usr/include -t oneapi.level
 $JAVA_HOME/bin/javac -cp target/classes -d target/classes src/gen/java/oneapi/levelzero/*.java
 $JAVA_HOME/bin/jar cf levelzero.jar -C target/classes/ .
 mvn install:install-file -Dfile=levelzero.jar -DgroupId=oneapi -DartifactId=levelzero -Dversion=0.0.1 -Dpackaging=jar
+cp levelzero.jar ../../../maven-build/

--- a/hat/backends/spirv/src/main/java/hat/backend/TestIt.java
+++ b/hat/backends/spirv/src/main/java/hat/backend/TestIt.java
@@ -26,7 +26,7 @@
 package hat.backend;
 
 import intel.code.spirv.SpirvModuleGenerator;
-import intel.code.spirv.SpirvOps;
+import intel.code.spirv.SpirvOp;
 import intel.code.spirv.TranslateToSpirvModel;
 
 import java.lang.foreign.MemorySegment;
@@ -57,7 +57,7 @@ public class TestIt {
             //  Method method = Mand.class.getDeclaredMethod(methodName, float[].class, float[].class, float[].class, int.class);
 
             CoreOp.FuncOp javaFunc = method.getCodeModel().get();
-            SpirvOps.FuncOp spirvFunc = TranslateToSpirvModel.translateFunction(javaFunc);
+            SpirvOp.FuncOp spirvFunc = TranslateToSpirvModel.translateFunction(javaFunc);
             MemorySegment spirvBinary = SpirvModuleGenerator.generateModule(methodName, spirvFunc);
 
             System.out.println("\n------- Java Model -------");

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/LevelZero.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/LevelZero.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import oneapi.levelzero.ze_api_h;
+import static oneapi.levelzero.ze_api_h.*;
+import oneapi.levelzero.ze_context_desc_t;
+import oneapi.levelzero.ze_kernel_desc_t;
+import oneapi.levelzero.ze_command_queue_desc_t;
+import oneapi.levelzero.ze_command_list_desc_t;
+import oneapi.levelzero.ze_command_queue_group_properties_t;
+import oneapi.levelzero.ze_event_pool_desc_t;
+import oneapi.levelzero.ze_event_desc_t;
+import oneapi.levelzero.ze_fence_desc_t;
+import oneapi.levelzero.ze_module_desc_t;
+import oneapi.levelzero.ze_group_count_t;
+import oneapi.levelzero.ze_host_mem_alloc_desc_t;
+import oneapi.levelzero.ze_device_mem_alloc_desc_t;
+import oneapi.levelzero.ze_device_properties_t;
+import oneapi.levelzero.ze_driver_properties_t;
+import oneapi.levelzero.ze_driver_extension_properties_t;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.Block;
+import java.lang.reflect.code.Value;
+import hat.ComputeContext;
+import hat.KernelContext;
+import hat.NDRange;
+import hat.buffer.Buffer;
+import hat.callgraph.KernelEntrypoint;
+import hat.callgraph.KernelCallGraph;
+import intel.code.spirv.SpirvModuleGenerator;
+import intel.code.spirv.SpirvOp;
+import intel.code.spirv.TranslateToSpirvModel;
+import intel.code.spirv.UsmArena;
+import java.lang.invoke.MethodHandles;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.AddressLayout;
+import static java.lang.foreign.ValueLayout.*;
+
+public class LevelZero {
+    static {
+        System.loadLibrary("ze_loader");
+    }
+
+    public static final AddressLayout driver_handle_t = AddressLayout.ADDRESS;
+    public static final AddressLayout context_handle_t = AddressLayout.ADDRESS;
+    public static final AddressLayout device_handle_t = AddressLayout.ADDRESS;
+    public static final AddressLayout command_queue_handle_t = AddressLayout.ADDRESS;
+
+    private final Arena lzArena;
+    private final Arena backendArena;
+    private final MemorySegment driverHandle;
+    private final MemorySegment contextHandle;
+    private final MemorySegment deviceHandle;
+    private final MemorySegment queueHandle;
+    private final MemorySegment eventPoolDescription;
+
+    public static LevelZero create(Arena javaArena) {
+        return new LevelZero(javaArena);
+    }
+
+    LevelZero(Arena javaArena) {
+        lzArena = javaArena;
+        // get driver
+        check(zeInit(ZE_INIT_FLAG_GPU_ONLY()));
+        int[] numDrivers = new int[1];
+        MemorySegment pNumDrivers = lzArena.allocate(JAVA_INT);
+        check(zeDriverGet(pNumDrivers, MemorySegment.NULL));
+        MemorySegment driverCount = lzArena.allocate(Integer.BYTES);
+        check(zeDriverGet(driverCount, MemorySegment.NULL));
+        debug("driverCount = %d", driverCount.get(JAVA_INT, 0));
+        MemorySegment driverHandles = lzArena.allocate(driverCount.get(JAVA_INT, 0) * driver_handle_t.byteSize(), 8);
+        check(zeDriverGet(driverCount, driverHandles));
+        driverHandle = driverHandles.get(ADDRESS, 0);
+
+        // create context
+        MemorySegment pContextDesc = lzArena.allocate(ze_context_desc_t.layout());
+        ze_context_desc_t.stype(pContextDesc, ZE_STRUCTURE_TYPE_CONTEXT_DESC());
+        MemorySegment pContextHandle = lzArena.allocate(context_handle_t);
+        check(zeContextCreate(driverHandle, pContextDesc, pContextHandle));
+        contextHandle = pContextHandle.get(ADDRESS, 0);
+
+        // get device
+        MemorySegment pDeviceCount = lzArena.allocate(Integer.BYTES);
+        check(zeDeviceGet(driverHandle, pDeviceCount, MemorySegment.NULL));
+        int deviceCount = pDeviceCount.get(JAVA_INT, 0);
+        assert deviceCount > 0;
+        debug("deviceCount = %d", deviceCount);
+        MemorySegment deviceHandles = lzArena.allocate(deviceCount * device_handle_t.byteSize(), 8);
+        check(zeDeviceGet(driverHandle, pDeviceCount, deviceHandles));
+        for (int i = 0; i < deviceCount; i++) {
+            debug("device #%d: %s", i, deviceHandles.get(device_handle_t, i * device_handle_t.byteSize()));
+        }
+        assert deviceCount == 1;
+        deviceHandle = deviceHandles.get(ADDRESS, 0);
+        MemorySegment pDeviceProperties = lzArena.allocate(ze_device_properties_t.layout());
+        ze_device_properties_t.stype(pDeviceProperties, ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES());
+        check(zeDeviceGetProperties(deviceHandle, pDeviceProperties));
+        debug("deviceProperties:\n\ttype = %d\n\tvendorId = %d\n\tmaxMemAllocSize = %d",
+            ze_device_properties_t.type(pDeviceProperties),
+            ze_device_properties_t.vendorId(pDeviceProperties),
+            ze_device_properties_t.maxMemAllocSize(pDeviceProperties));
+
+        // create queue
+        MemorySegment pNumQueueGroups = lzArena.allocate(JAVA_INT, 1);
+        check(zeDeviceGetCommandQueueGroupProperties(deviceHandle, pNumQueueGroups, MemorySegment.NULL));
+        assert pNumQueueGroups.get(JAVA_INT, 0) == 1;
+        MemorySegment pGroupProperties = lzArena.allocate(ze_command_queue_group_properties_t.layout());
+        check(zeDeviceGetCommandQueueGroupProperties(deviceHandle, pNumQueueGroups, pGroupProperties));
+
+        MemorySegment pQueueDesc = lzArena.allocate(ze_command_queue_desc_t.layout());
+        ze_command_queue_desc_t.stype(pQueueDesc, ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC());
+        ze_command_queue_desc_t.index(pQueueDesc, 0);
+        ze_command_queue_desc_t.mode(pQueueDesc, ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS());
+        ze_command_queue_desc_t.ordinal(pQueueDesc, 0);
+        MemorySegment pQueueHandle = lzArena.allocate(command_queue_handle_t);
+        check(zeCommandQueueCreate(contextHandle, deviceHandle, pQueueDesc, pQueueHandle));
+        queueHandle = pQueueHandle.get(ADDRESS, 0);
+
+        // create event pool (may not use events if use in-order queue)
+        eventPoolDescription = lzArena.allocate(ze_event_pool_desc_t.layout().byteSize());
+        ze_event_pool_desc_t.stype(eventPoolDescription, ZE_STRUCTURE_TYPE_EVENT_POOL_DESC());
+        ze_event_pool_desc_t.count(eventPoolDescription, 20);
+        ze_event_pool_desc_t.flags(eventPoolDescription, ZE_EVENT_POOL_FLAG_HOST_VISIBLE());
+
+        backendArena = new UsmArena(contextHandle, deviceHandle);
+    }
+
+    public Arena arena() {
+        return backendArena;
+    }
+
+    public void dispatchKernel(KernelCallGraph kernelCallGraph, NDRange ndRange, Object... args) {
+        KernelEntrypoint kernelEntrypoint = kernelCallGraph.entrypoint;
+        CoreOp.FuncOp funcOp = kernelEntrypoint.funcOpWrapper().op();
+        String kernelName = funcOp.funcName();
+        // System.out.println(funcOp.toText());
+        MemorySegment spirvBinary = SpirvModuleGenerator.generateModule(kernelName, kernelCallGraph);
+        String path = "/home/steve/spirv_binaries/" + kernelName + ".spv";
+        SpirvModuleGenerator.writeModuleToFile(spirvBinary, path);
+        // System.out.println("generated module \n" + SpirvModuleGenerator.disassembleModule(spirvBinary));
+        args[0] = ndRange.kid;
+        List<Arg> kernelArgs = collectArgs(funcOp, args);
+        int[] globalSizes = new int[] {ndRange.kid.maxX, 1, 1};
+        int[] localSizes = new int[] {512, 1, 1};
+        KernelGeometry geometry = new KernelGeometry(globalSizes, localSizes);
+        MemorySegment commandListHandle = createCommandList(spirvBinary, kernelName, geometry, kernelArgs);
+        executeCommandList(commandListHandle);
+        check(zeCommandQueueSynchronize(queueHandle, -1L));
+        for (int i = 1; i < kernelArgs.size(); i++) {
+            copyArgToHost(kernelArgs.get(i), contextHandle);
+        }
+    }
+
+    private static void check(int result) {
+        if (result != ZE_RESULT_SUCCESS()) {
+            throw new RuntimeException(String.format("Call failed: 0x%x (%d)", result, result));
+        }
+    }
+
+    public static void debug(String message, Object... args) {
+        System.out.println(String.format(message, args));
+    }
+
+    private List<Arg> collectArgs(CoreOp.FuncOp kernelMethod, Object[] values) {
+        List<Arg> args = new ArrayList<>();
+        List<Block.Parameter> params = kernelMethod.body().entryBlock().parameters();
+        for (int i = 0; i < params.size(); i++) {
+            args.add(Arg.createArg(this, "arg" + i, params.get(i), values[i]));
+        }
+        return args;
+    }
+
+    void provisionArg(Arg arg) {
+        MemorySegment deviceMemAllocDesc = lzArena.allocate(ze_device_mem_alloc_desc_t.layout());
+        ze_device_mem_alloc_desc_t.stype(deviceMemAllocDesc, ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC());
+        ze_device_mem_alloc_desc_t.ordinal(deviceMemAllocDesc, 0);
+        MemorySegment hostMemAllocDesc = lzArena.allocate(ze_host_mem_alloc_desc_t.layout());
+        ze_host_mem_alloc_desc_t.stype(hostMemAllocDesc, ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC());
+        if (arg.value() instanceof Buffer buff) {
+            arg.setNeedsCleanup(false);
+            arg.setDataSegment(Buffer.getMemorySegment(buff));
+            arg.setSize(8);
+        }
+        else if (arg.cls() == Short.class) {
+            arg.setSize(2);
+        }
+        else if (arg.cls() == Integer.class || arg.cls() == Float.class || arg.cls() == Boolean.class) {
+            arg.setSize(4);
+        }
+        else if (arg.cls() == Long.class) {
+            arg.setSize(8);
+        }
+        else if (arg.cls() == KernelContext.class) {
+            KernelContext kc = (KernelContext)arg.value();
+            MemorySegment segment = lzArena.allocate(8, 8);
+            segment.set(JAVA_INT, 0, kc.maxX);
+            segment.set(JAVA_INT, 4, kc.x);
+            arg.setDataSegment(segment);
+            arg.setSize(8);
+        }
+        else if (arg.cls() == NDRange.class) {
+            NDRange kc = (NDRange)arg.value();
+            MemorySegment segment = lzArena.allocate(8, 8);
+            arg.setDataSegment(segment);
+            arg.setSize(8);
+        }
+        else throw new RuntimeException("unsupported type: " + arg.cls());
+    }
+
+    void copyArgToHost(Arg arg, MemorySegment contextHandle) {
+        // currently using shared memory
+    }
+
+    private MemorySegment createCommandList(MemorySegment spirvModule, String kernelName, KernelGeometry geometry, List<Arg> args) {
+        Arena arena = Arena.ofShared();
+        MemorySegment pCommandListHandle = lzArena.allocate(ze_command_list_handle_t);
+        MemorySegment commandListDesc = lzArena.allocate(ze_command_list_desc_t.layout());
+        ze_command_list_desc_t.stype(eventPoolDescription, ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC());
+        ze_command_list_desc_t.commandQueueGroupOrdinal(commandListDesc, 0);
+        check(zeCommandListCreate(contextHandle, deviceHandle, commandListDesc, pCommandListHandle));
+        MemorySegment commandListHandle = pCommandListHandle.get(ADDRESS, 0);
+        MemorySegment moduleHandle = createModule(kernelName);
+        MemorySegment kernelHandle = createKernel(moduleHandle, kernelName, geometry);
+        for (int i = 0; i < args.size(); i++) {
+            Arg arg = args.get(i);
+            setKernelArg(arg, i, commandListHandle, kernelHandle);
+        }
+        MemorySegment groupCount = lzArena.allocate(ze_group_count_t.layout());
+        ze_group_count_t.groupCountX(groupCount, geometry.globalSizes()[0] / geometry.localSizes()[0]);
+        ze_group_count_t.groupCountY(groupCount, geometry.globalSizes()[1] / geometry.localSizes()[1]);
+        ze_group_count_t.groupCountZ(groupCount, geometry.globalSizes()[2] / geometry.localSizes()[2]);
+        MemorySegment pKernelWaitHandles = MemorySegment.NULL;
+        check(zeCommandListAppendLaunchKernel(commandListHandle, kernelHandle, groupCount, MemorySegment.NULL, 0, pKernelWaitHandles));
+        check(zeCommandListClose(commandListHandle));
+        return commandListHandle;
+    }
+
+    private MemorySegment executeCommandList(MemorySegment commandListHandle) {
+        MemorySegment fenceDesc = lzArena.allocate(ze_fence_desc_t.layout());
+        ze_module_desc_t.stype(fenceDesc, ZE_STRUCTURE_TYPE_FENCE_DESC());
+        ze_fence_desc_t.flags(fenceDesc, ZE_FENCE_FLAG_SIGNALED());
+        MemorySegment pFenceHandle = lzArena.allocate(ze_fence_handle_t);
+        check(zeFenceCreate(queueHandle, fenceDesc, pFenceHandle));
+        MemorySegment fenceHandle = pFenceHandle.get(ADDRESS, 0);
+        MemorySegment pCommandListHandle = lzArena.allocate(ze_command_list_handle_t);
+        pCommandListHandle.set(ADDRESS, 0, commandListHandle);
+        check(zeCommandQueueExecuteCommandLists(queueHandle, 1, pCommandListHandle, fenceHandle));
+        check(zeCommandQueueSynchronize(queueHandle, -1L));
+        return fenceHandle;
+    }
+
+    private MemorySegment createKernel(MemorySegment moduleHandle, String kernelNameString, KernelGeometry geometry) {
+        MemorySegment kernelDesc = lzArena.allocate(ze_kernel_desc_t.layout());
+        MemorySegment kernelName = lzArena.allocateFrom(kernelNameString);
+        ze_kernel_desc_t.stype(kernelDesc, ZE_STRUCTURE_TYPE_KERNEL_DESC());
+        ze_kernel_desc_t.pKernelName(kernelDesc, kernelName);
+        MemorySegment pKernelHandle = lzArena.allocate(ze_kernel_handle_t);
+        check(zeKernelCreate(moduleHandle, kernelDesc, pKernelHandle));
+        int[] globalSizes = geometry.globalSizes();
+        int[] localSizes = geometry.localSizes();
+        MemorySegment pGroupSizeX = lzArena.allocate(JAVA_INT, localSizes[0]);
+        MemorySegment pGroupSizeY = lzArena.allocate(JAVA_INT, localSizes[1]);
+        MemorySegment pGroupSizeZ = lzArena.allocate(JAVA_INT, localSizes[2]);
+        MemorySegment kernelHandle = pKernelHandle.get(ADDRESS, 0);
+        check(zeKernelSuggestGroupSize(kernelHandle, globalSizes[0], globalSizes[1], globalSizes[2], pGroupSizeX, pGroupSizeY, pGroupSizeZ));
+        geometry.localSizes()[0] = pGroupSizeX.get(JAVA_INT, 0);
+        geometry.localSizes()[1] = pGroupSizeY.get(JAVA_INT, 0);
+        geometry.localSizes()[2] = pGroupSizeZ.get(JAVA_INT, 0);
+        check(zeKernelSetGroupSize(kernelHandle, pGroupSizeX.get(JAVA_INT, 0), pGroupSizeY.get(JAVA_INT, 0), pGroupSizeZ.get(JAVA_INT, 0)));
+        return kernelHandle;
+    }
+
+    private void setKernelArg(Arg arg, int ordinal, MemorySegment commandListHandle, MemorySegment kernelHandle) {
+        MemorySegment dataSegment = arg.dataSegment();
+        Class<?> cls = arg.cls();
+        if (cls == Short.class) {
+            MemorySegment pArgValue = lzArena.allocateFrom(JAVA_SHORT, (short)arg.value());
+            check(zeKernelSetArgumentValue(kernelHandle, ordinal, Short.BYTES, pArgValue));
+        }
+        else if (cls == Integer.class || cls == Boolean.class /*|| VectorSpecies.class.isAssignableFrom(cls)*/) {
+            MemorySegment pArgValue = lzArena.allocateFrom(JAVA_INT, (int)arg.value());
+            check(zeKernelSetArgumentValue(kernelHandle, ordinal, Integer.BYTES, pArgValue));
+        }
+        else if (cls == Long.class) {
+            MemorySegment pArgValue = lzArena.allocateFrom(JAVA_LONG, (long)arg.value());
+            check(zeKernelSetArgumentValue(kernelHandle, ordinal, Long.BYTES, pArgValue));
+        }
+        else if (cls == Float.class) {
+            MemorySegment pArgValue = lzArena.allocateFrom(JAVA_LONG, Float.floatToIntBits((float)arg.value()));
+            check(zeKernelSetArgumentValue(kernelHandle, ordinal, Float.BYTES, pArgValue));
+        }
+        else if (arg.value() instanceof Buffer) {
+            MemorySegment pDataSegment = lzArena.allocateFrom(ADDRESS, dataSegment);
+            check(zeKernelSetArgumentValue(kernelHandle, ordinal, ADDRESS.byteSize(), pDataSegment));
+        }
+        else if (arg.value() instanceof KernelContext) {
+            MemorySegment pDataSegment = lzArena.allocateFrom(ADDRESS, dataSegment);
+            check(zeKernelSetArgumentValue(kernelHandle, ordinal, ADDRESS.byteSize(), pDataSegment));
+        }
+        else throw new RuntimeException("unsupported type: " + cls);
+    }
+
+    private MemorySegment createModule(String moduleName, MemorySegment spirvCode) {
+        MemorySegment pModuleHandle = lzArena.allocate(ze_module_handle_t);
+        MemorySegment moduleDesc = lzArena.allocate(ze_module_desc_t.layout());
+        ze_module_desc_t.stype(moduleDesc, ZE_STRUCTURE_TYPE_MODULE_DESC());
+        ze_module_desc_t.format(moduleDesc, ZE_MODULE_FORMAT_IL_SPIRV());
+        ze_module_desc_t.pInputModule(moduleDesc, spirvCode);
+        ze_module_desc_t.inputSize(moduleDesc, spirvCode.byteSize());
+        ze_module_desc_t.pBuildFlags(moduleDesc, lzArena.allocateFrom(""));
+        MemorySegment buildLogHandle = lzArena.allocate(ze_module_build_log_handle_t);
+        check(zeModuleCreate(contextHandle, deviceHandle, moduleDesc, pModuleHandle, buildLogHandle));
+        MemorySegment moduleHandle = pModuleHandle.get(ADDRESS, 0);
+        return moduleHandle;
+    }
+
+    private MemorySegment createModule(String moduleName)
+    {
+        try
+        {
+            MemorySegment codeBytes = MemorySegment.ofArray(Files.readAllBytes(Paths.get("/home/steve/spirv_binaries/" + moduleName + ".spv")));
+            MemorySegment spirvCode = lzArena.allocate(codeBytes.byteSize());
+            MemorySegment.copy(codeBytes, 0, spirvCode, 0, spirvCode.byteSize());
+            MemorySegment pModuleHandle = lzArena.allocate(ze_module_handle_t);
+            MemorySegment moduleDesc = lzArena.allocate(ze_module_desc_t.layout());
+            ze_module_desc_t.stype(moduleDesc, ZE_STRUCTURE_TYPE_MODULE_DESC());
+            ze_module_desc_t.format(moduleDesc, ZE_MODULE_FORMAT_IL_SPIRV());
+            ze_module_desc_t.pInputModule(moduleDesc, spirvCode);
+            ze_module_desc_t.inputSize(moduleDesc, spirvCode.byteSize());
+            ze_module_desc_t.pBuildFlags(moduleDesc, lzArena.allocateFrom(""));
+            MemorySegment buildLogHandle = lzArena.allocate(ze_module_build_log_handle_t);
+            check(zeModuleCreate(contextHandle, deviceHandle, moduleDesc, pModuleHandle, buildLogHandle));
+            MemorySegment moduleHandle = pModuleHandle.get(ADDRESS, 0);
+            return moduleHandle;
+        }
+        catch (IOException ioe) {throw new RuntimeException(ioe);}
+    }
+
+    private static record KernelGeometry(int[] globalSizes, int[] localSizes) {
+        public KernelGeometry() {
+            this(new int[3], new int[] {512, 1, 1});
+        }
+
+        @Override
+        public String toString() {
+            return String.format("global: %s, local: %s", Arrays.toString(globalSizes), Arrays.toString(localSizes));
+        }
+    }
+
+    public static class Arg {
+        private final String name;
+        private final Value crValue;
+        private final Object value;
+        private final Class<?> cls;
+        private int size;
+        private boolean needsCleanup;
+        private MemorySegment dataSegment;
+
+        public static Arg createArg(LevelZero levelZero, String name, Value crValue, Object value) {
+            Arg arg = new Arg(name, crValue, value);
+            levelZero.provisionArg(arg);
+            return arg;
+        }
+
+        private Arg(String name, Value crValue, Object value) {
+            this.name = name;
+            this.crValue = crValue;
+            this.cls = value.getClass();
+            this.value = value;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public Object value() {
+            return value;
+        }
+
+        public Object crValue() {
+            return crValue;
+        }
+
+        public Class<?> cls() {
+            return cls;
+        }
+
+        public void setSize(int size) {
+            this.size = size;
+        }
+
+        public int size() {
+            return size;
+        }
+
+        public void setDataSegment(MemorySegment segment) {
+            dataSegment = segment;
+        }
+
+        public MemorySegment dataSegment() {
+            return dataSegment;
+        }
+
+        public void setNeedsCleanup(boolean needsCleanup) {
+            this.needsCleanup = needsCleanup;
+        }
+
+        public boolean needsCleanup() {
+            return needsCleanup;
+        }
+
+        public int hashCode() {
+            return crValue.hashCode();
+        }
+
+        public boolean equals(Object other) {
+            return other instanceof Arg arg && arg.crValue.equals(arg.crValue);
+        }
+
+        public String toString() {
+            return String.format("name = %s, hash = %d, cls = %s", name, crValue.hashCode(), cls);
+        }
+    }
+}

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/LevelZero.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/LevelZero.java
@@ -135,7 +135,8 @@ public class LevelZero {
         MemorySegment pNumQueueGroups = lzArena.allocate(JAVA_INT, 1);
         check(zeDeviceGetCommandQueueGroupProperties(deviceHandle, pNumQueueGroups, MemorySegment.NULL));
         assert pNumQueueGroups.get(JAVA_INT, 0) == 1;
-        MemorySegment pGroupProperties = lzArena.allocate(ze_command_queue_group_properties_t.layout());
+        MemorySegment pGroupProperties = lzArena.allocate(ze_command_queue_group_properties_t.layout(),
+                                                          pNumQueueGroups.get(JAVA_INT, 0));
         check(zeDeviceGetCommandQueueGroupProperties(deviceHandle, pNumQueueGroups, pGroupProperties));
 
         MemorySegment pQueueDesc = lzArena.allocate(ze_command_queue_desc_t.layout());
@@ -166,7 +167,7 @@ public class LevelZero {
         String kernelName = funcOp.funcName();
         // System.out.println(funcOp.toText());
         MemorySegment spirvBinary = SpirvModuleGenerator.generateModule(kernelName, kernelCallGraph);
-        String path = "/home/steve/spirv_binaries/" + kernelName + ".spv";
+        String path = "/tmp/" + kernelName + ".spv";
         SpirvModuleGenerator.writeModuleToFile(spirvBinary, path);
         // System.out.println("generated module \n" + SpirvModuleGenerator.disassembleModule(spirvBinary));
         args[0] = ndRange.kid;
@@ -349,7 +350,7 @@ public class LevelZero {
     {
         try
         {
-            MemorySegment codeBytes = MemorySegment.ofArray(Files.readAllBytes(Paths.get("/home/steve/spirv_binaries/" + moduleName + ".spv")));
+            MemorySegment codeBytes = MemorySegment.ofArray(Files.readAllBytes(Paths.get("/tmp/" + moduleName + ".spv")));
             MemorySegment spirvCode = lzArena.allocate(codeBytes.byteSize());
             MemorySegment.copy(codeBytes, 0, spirvCode, 0, spirvCode.byteSize());
             MemorySegment pModuleHandle = lzArena.allocate(ze_module_handle_t);

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/PointerType.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/PointerType.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.lang.reflect.code.TypeElement;
+import java.util.Objects;
+import java.util.List;
+
+public final class PointerType extends SpirvType {
+    static final String NAME = "spirv.pointer";
+    private final TypeElement referentType;
+    private final TypeElement storageType;
+
+    public PointerType(TypeElement referentType, TypeElement storageType)
+    {
+        this.referentType = referentType;
+        this.storageType = storageType;
+    }
+
+    public TypeElement referentType()
+    {
+        return referentType;
+    }
+
+    public TypeElement storageType()
+    {
+        return storageType;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == null || obj.getClass() != PointerType.class) return false;
+        PointerType pt = (PointerType)obj;
+        return pt.referentType().equals(referentType) && pt.storageType.equals(storageType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(referentType, storageType);
+    }
+
+    @Override
+    public ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(NAME, List.of(referentType.externalize(), storageType.externalize()));
+    }
+
+    @Override
+    public String toString() {
+        return externalize().toString();
+    }
+}

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvModuleGenerator.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvModuleGenerator.java
@@ -1,0 +1,1144 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.function.Function;
+import java.io.IOException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.math.BigInteger;
+import java.lang.invoke.MethodHandles;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.reflect.code.Block;
+import java.lang.reflect.code.Body;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.Value;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.MethodRef;
+import java.lang.reflect.code.type.ClassType;
+import java.lang.reflect.code.type.JavaType;
+import java.lang.reflect.code.type.FunctionType;
+import hat.callgraph.CallGraph;
+import hat.callgraph.KernelCallGraph;
+import hat.callgraph.KernelEntrypoint;
+import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVHeader;
+import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVModule;
+import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVFunction;
+import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVBlock;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.*;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.*;
+import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.Disassembler;
+import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.SPIRVDisassemblerOptions;
+import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.SPVByteStreamReader;
+import intel.code.spirv.SpirvOp.PhiOp;
+
+public class SpirvModuleGenerator {
+    private final String moduleName;
+    private final SPIRVModule module;
+    private final Symbols symbols;
+
+    public static SpirvModuleGenerator create(String moduleName) {
+        return new SpirvModuleGenerator(moduleName);
+    }
+
+    public static MemorySegment generateModule(String moduleName, KernelCallGraph callGraph) {
+        SpirvModuleGenerator generator = SpirvModuleGenerator.create(moduleName);
+        for (CallGraph.MethodCall call : callGraph.calls) {
+            if (call.targetMethodRef != null) {
+                try {
+                    Optional<CoreOp.FuncOp> ofo = call.targetMethodRef.codeModel(MethodHandles.lookup());
+                    if (ofo.isPresent()) {
+                        CoreOp.FuncOp fo = ofo.get();
+                        SpirvOp.FuncOp spirvFunc = TranslateToSpirvModel.translateFunction(fo);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        KernelEntrypoint kernelEntrypoint = callGraph.entrypoint;
+        CoreOp.FuncOp funcOp = kernelEntrypoint.funcOpWrapper().op();
+        String kernelName = funcOp.funcName();
+        SpirvOp.FuncOp spirvFunc = TranslateToSpirvModel.translateFunction(funcOp);
+        generator.generateFunction(funcOp.funcName(), spirvFunc, true);
+        return generator.finalizeModule();
+    }
+
+    public static MemorySegment generateModule(String moduleName, CoreOp.FuncOp func) {
+        SpirvOp.FuncOp spirvFunc = TranslateToSpirvModel.translateFunction(func);
+        MemorySegment moduleSegment = SpirvModuleGenerator.generateModule(moduleName, spirvFunc);
+        return moduleSegment;
+    }
+
+    public static MemorySegment generateModule(String moduleName, SpirvOp.FuncOp func) {
+        SpirvModuleGenerator generator = new SpirvModuleGenerator(moduleName);
+        MemorySegment moduleSegment = generator.generateModuleInternal(func);
+        return moduleSegment;
+    }
+
+    public static void writeModuleToFile(MemorySegment module, String filepath)  {
+        ByteBuffer buffer = module.asByteBuffer();
+        File out = new File(filepath);
+        try (FileChannel channel = new FileOutputStream(out, false).getChannel()) {
+            channel.write(buffer);
+            channel.close();
+        }
+        catch (IOException e)  {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void writeModuleToFile(SPIRVModule module, String filepath)
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(module.getByteCount());
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        module.close().write(buffer);
+        buffer.flip();
+        File out = new File(filepath);
+        try (FileChannel channel = new FileOutputStream(out, false).getChannel())
+        {
+            channel.write(buffer);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String disassembleModule(MemorySegment module) {
+        SPVByteStreamReader input = new SPVByteStreamReader(new ByteArrayInputStream(module.toArray(ValueLayout.JAVA_BYTE)));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(out))  {
+            SPIRVDisassemblerOptions options = new SPIRVDisassemblerOptions(false, false, false, false, true);
+            Disassembler dis = new Disassembler(input, ps, options);
+            dis.run();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return new String(out.toByteArray());
+    }
+
+    public MemorySegment finalizeModule() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(module.getByteCount());
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        module.close().write(buffer);
+        buffer.flip();
+        return MemorySegment.ofBuffer(buffer);
+    }
+
+    private record SpirvResult(SPIRVId type, SPIRVId address, SPIRVId value) {}
+
+    private SpirvModuleGenerator(String moduleName) {
+        this.moduleName = moduleName;
+        this.module = new SPIRVModule(new SPIRVHeader(1, 2, 32, 0, 0));
+        this.symbols = new Symbols();
+        initModule();
+    }
+
+    private MemorySegment generateModuleInternal(SpirvOp.FuncOp func) {
+        generateFunction(moduleName, func, true);
+        return finalizeModule();
+    }
+
+    private SPIRVId generateFunction(String fnName, SpirvOp.FuncOp func, boolean isEntryPoint) {
+        TypeElement returnType = func.invokableType().returnType();
+        SPIRVId functionId = nextId(fnName);
+        String signature = func.invokableType().returnType().toString();
+        List<TypeElement> paramTypes = func.invokableType().parameterTypes();
+        // build signature string
+        for (int i = 0; i < paramTypes.size(); i++) {
+            signature += "_" + paramTypes.get(i).toString();
+        }
+        // declare function type if not already present
+        SPIRVId functionSig = getIdOrNull(signature);
+        if (functionSig == null) {
+            SPIRVId[] typeIdsArray = new SPIRVId[paramTypes.size()];
+            for (int i = 0; i < paramTypes.size(); i++) {
+                typeIdsArray[i] = spirvType(paramTypes.get(i).toString());
+            }
+            functionSig = nextId(fnName + "Signature");
+            module.add(new SPIRVOpTypeFunction(functionSig, spirvType(returnType.toString()), new SPIRVMultipleOperands<>(typeIdsArray)));
+            addId(signature, functionSig);
+        }
+        SPIRVId spirvReturnType = spirvType(returnType.toString());
+        SPIRVFunction function = (SPIRVFunction)module.add(new SPIRVOpFunction(spirvReturnType, functionId, SPIRVFunctionControl.DontInline(), functionSig));
+        SPIRVOpLabel entryLabel = new SPIRVOpLabel(nextId());
+        SPIRVBlock entryBlock = (SPIRVBlock)function.add(entryLabel);
+        SPIRVMultipleOperands<SPIRVId> operands = new SPIRVMultipleOperands<>(getId("globalInvocationId"), getId("globalSize"), getId("subgroupSize"), getId("subgroupId"));
+        if (isEntryPoint) {
+            module.add(new SPIRVOpEntryPoint(SPIRVExecutionModel.Kernel(), functionId, new SPIRVLiteralString(fnName), operands));
+        }
+        translateBody(func.body(), function, entryBlock);
+        function.add(new SPIRVOpFunctionEnd());
+        return functionId;
+    }
+
+    private void translateBody(Body body, SPIRVFunction function, SPIRVBlock entryBlock) {
+        int labelNumber = 0;
+        SPIRVBlock spirvBlock = entryBlock;
+        for (int bi = 1; bi < body.blocks().size(); bi++)  {
+            Block block = body.blocks().get(bi);
+            SPIRVOpLabel blockLabel = new SPIRVOpLabel(nextId());
+            SPIRVBlock newBlock = (SPIRVBlock)function.add(blockLabel);
+            symbols.putBlock(block, newBlock);
+            symbols.putLabel(block, blockLabel);
+            for (int i = 0; i < block.parameters().size(); i++) {
+                Value param = block.parameters().get(i);
+                SPIRVId paramId = nextId();
+                addResult(param, new SpirvResult(spirvType(param.type().toString()), null, paramId));
+            }
+        }
+        for (int bi = 0; bi < body.blocks().size(); bi++)  {
+            Block block = body.blocks().get(bi);
+            if (bi > 0) {
+                spirvBlock = symbols.getBlock(block);
+            }
+            for (Op op : block.ops()) {
+                switch (op)  {
+                    case SpirvOp.PhiOp phop -> {
+                        List<PhiOp.Predecessor> inPredecessors = phop.predecessors();
+                        SPIRVPairIdRefIdRef[] outPredecessors = new SPIRVPairIdRefIdRef[inPredecessors.size()];
+                        for (int i = 0; i < inPredecessors.size(); i++) {
+                            PhiOp.Predecessor predecessor = inPredecessors.get(i);
+                            SPIRVId label = symbols.getLabel(predecessor.block().targetBlock()).getResultId();
+                            SPIRVId value = getResult(predecessor.value()).value();
+                            outPredecessors[i] = new SPIRVPairIdRefIdRef(value, label);
+                        }
+                        SPIRVId result = nextId();
+                        SPIRVId type = spirvType(phop.resultType().toString());
+                        SPIRVOpPhi phiOp = new SPIRVOpPhi(spirvType(phop.resultType().toString()), result, new SPIRVMultipleOperands<>(outPredecessors));
+                        spirvBlock.add(phiOp);
+                        addResult(phop.result(), new SpirvResult(type, null, result));
+                    }
+                    case SpirvOp.VariableOp vop -> {
+                        String typeName = vop.varType().toString();
+                        SPIRVId type = spirvType(typeName);
+                        SPIRVId varType = spirvVariableType(type);
+                        SPIRVId var = nextId(vop.varName());
+                        spirvBlock.add(new SPIRVOpVariable(varType, var, SPIRVStorageClass.Function(), new SPIRVOptionalOperand<>()));
+                        addResult(vop.result(), new SpirvResult(varType, var, null));
+                    }
+                    case SpirvOp.FunctionParameterOp fpo -> {
+                        SPIRVId result = nextId();
+                        SPIRVId type = spirvType(fpo.resultType().toString());
+                        function.add(new SPIRVOpFunctionParameter(type, result));
+                        module.add(new SPIRVOpDecorate(result, SPIRVDecoration.Alignment(new SPIRVLiteralInteger(8))));
+                        addResult(fpo.result(), new SpirvResult(type, null, result));
+                    }
+                    case SpirvOp.LoadOp lo -> {
+                        SPIRVId type = spirvType(lo.resultType().toString());
+                        SpirvResult toLoad = getResult(lo.operands().get(0));
+                        SPIRVId varAddr = toLoad.address();
+                        SPIRVId result = nextId();
+                        spirvBlock.add(new SPIRVOpLoad(type, result, varAddr, align(type.getName())));
+                        addResult(lo.result(), new SpirvResult(type, varAddr, result));
+                    }
+                    case SpirvOp.StoreOp so -> {
+                        SpirvResult var = getResult(so.operands().get(0));
+                        SPIRVId varAddr = var.address();
+                        SPIRVId value = getResult(so.operands().get(1)).value();
+                        spirvBlock.add(new SPIRVOpStore(varAddr, value, align(var.type().getName())));
+                    }
+                    case SpirvOp.IAddOp _, SpirvOp.FAddOp _ -> {
+                        SPIRVId intType = getType("int");
+                        SPIRVId longType = getType("long");
+                        SPIRVId floatType = getType("float");
+                        SPIRVId lhs = getResult(op.operands().get(0)).value();
+                        SPIRVId rhs = getResult(op.operands().get(1)).value();
+                        SPIRVId lhsType = spirvType(op.resultType().toString());
+                        SPIRVId ans = nextId();
+                        if (lhsType == intType) spirvBlock.add(new SPIRVOpIAdd(intType, ans, lhs, rhs));
+                        else if (lhsType == longType) spirvBlock.add(new SPIRVOpIAdd(longType, ans, lhs, rhs));
+                        else if (lhsType == floatType) spirvBlock.add(new SPIRVOpFAdd(floatType, ans, lhs, rhs));
+                        else unsupported("type", lhsType.getName());
+                        addResult(op.result(), new SpirvResult(lhsType, null, ans));
+                    }
+                    case SpirvOp.ISubOp _, SpirvOp.FSubOp _ -> {
+                        SPIRVId intType = getType("int");
+                        SPIRVId longType = getType("long");
+                        SPIRVId floatType = getType("float");
+                        SPIRVId lhs = getResult(op.operands().get(0)).value();
+                        SPIRVId rhs = getResult(op.operands().get(1)).value();
+                        SPIRVId lhsType = spirvType(op.resultType().toString());
+                        SPIRVId ans = nextId();
+                        if (lhsType == intType) spirvBlock.add(new SPIRVOpISub(intType, ans, lhs, rhs));
+                        else if (lhsType == longType) spirvBlock.add(new SPIRVOpISub(longType, ans, lhs, rhs));
+                        else if (lhsType == floatType) spirvBlock.add(new SPIRVOpFSub(floatType, ans, lhs, rhs));
+                        else unsupported("type", lhsType.getName());
+                        addResult(op.result(), new SpirvResult(lhsType, null, ans));
+                    }
+                    case SpirvOp.IMulOp _, SpirvOp.FMulOp _, SpirvOp.IDivOp _, SpirvOp.FDivOp _ -> {
+                        SPIRVId intType = getType("int");
+                        SPIRVId longType = getType("long");
+                        SPIRVId floatType = getType("float");
+                        SPIRVId lhs = getResult(op.operands().get(0)).value();
+                        SPIRVId rhs = getResult(op.operands().get(1)).value();
+                        SPIRVId lhsType = spirvType(op.resultType().toString());
+                        SPIRVId rhsType = getResult(op.operands().get(1)).type();
+                        SPIRVId ans = nextId();
+                        if (lhsType == intType) {
+                            if (op instanceof SpirvOp.IMulOp) spirvBlock.add(new SPIRVOpIMul(intType, ans, lhs, rhs));
+                            else if (op instanceof SpirvOp.IDivOp) spirvBlock.add(new SPIRVOpSDiv(intType, ans, lhs, rhs));
+                        }
+                        else if (lhsType == longType) {
+                            SPIRVId rhsId = rhsType == intType ? nextId() : rhs;
+                            if (rhsType == intType) spirvBlock.add(new SPIRVOpSConvert(longType, rhsId, rhs));
+                            if (op instanceof SpirvOp.IMulOp) spirvBlock.add(new SPIRVOpIMul(longType, ans, lhs, rhsId));
+                            else if (op instanceof SpirvOp.IDivOp) spirvBlock.add(new SPIRVOpSDiv(longType, ans, lhs, rhs));
+                        }
+                        else if (lhsType == floatType) {
+                            if (op instanceof SpirvOp.FMulOp) spirvBlock.add(new SPIRVOpFMul(floatType, ans, lhs, rhs));
+                            else if (op instanceof SpirvOp.FDivOp) spirvBlock.add(new SPIRVOpFDiv(floatType, ans, lhs, rhs));
+                        }
+                        else unsupported("type", lhsType);
+                        addResult(op.result(), new SpirvResult(lhsType, null, ans));
+                    }
+                    case SpirvOp.ModOp mop -> {
+                        SPIRVId type = getType(mop.operands().get(0).type().toString());
+                        SPIRVId lhs = getResult(mop.operands().get(0)).value();
+                        SPIRVId rhs = getResult(mop.operands().get(1)).value();
+                        SPIRVId result = nextId();
+                        spirvBlock.add(new SPIRVOpUMod(type, result, lhs, rhs));
+                        addResult(mop.result(), new SpirvResult(type, null, result));
+                    }
+                    case SpirvOp.IEqualOp eqop -> {
+                        SPIRVId boolType = getType("bool");
+                        SPIRVId intType = getType("int");
+                        SPIRVId longType = getType("long");
+                        SPIRVId floatType = getType("float");
+                        SPIRVId lhs = getResult(op.operands().get(0)).value();
+                        SPIRVId rhs = getResult(op.operands().get(1)).value();
+                        SPIRVId lhsType = spirvType(op.resultType().toString());
+                        SPIRVId ans = nextId();
+                        if (lhsType == intType) spirvBlock.add(new SPIRVOpIEqual(boolType, ans, lhs, rhs));
+                        else if (lhsType == longType) spirvBlock.add(new SPIRVOpIEqual(boolType, ans, lhs, rhs));
+                        else unsupported("type", lhsType.getName());
+                        addResult(op.result(), new SpirvResult(lhsType, null, ans));
+                    }
+                    case SpirvOp.GeOp eqop -> {
+                        SPIRVId boolType = getType("bool");
+                        SPIRVId lhs = getResult(op.operands().get(0)).value();
+                        SPIRVId rhs = getResult(op.operands().get(1)).value();
+                        SPIRVId lhsType = spirvType(op.resultType().toString());
+                        SPIRVId ans = nextId();
+                        spirvBlock.add(new SPIRVOpSGreaterThanEqual(boolType, ans, lhs, rhs));
+                        addResult(op.result(), new SpirvResult(lhsType, null, ans));
+                    }
+                    case SpirvOp.PtrNotEqualOp neqop -> {
+                        SPIRVId boolType = getType("bool");
+                        SPIRVId longType = getType("long");
+                        SPIRVId lhs = getResult(neqop.operands().get(0)).value();
+                        SPIRVId rhs = getResult(neqop.operands().get(1)).value();
+                        SPIRVId ans = nextId();
+                        SPIRVId lhsLong = nextId();
+                        SPIRVId rhsLong = nextId();
+                        spirvBlock.add(new SPIRVOpConvertPtrToU(longType, lhsLong, lhs));
+                        spirvBlock.add(new SPIRVOpConvertPtrToU(longType, rhsLong, rhs));
+                        spirvBlock.add(new SPIRVOpIEqual(boolType, ans, lhsLong, rhsLong));
+                        addResult(op.result(), new SpirvResult(boolType, null, ans));
+                    }
+                    case SpirvOp.CallOp call -> {
+                        MethodRef methodRef = call.callDescriptor();
+                        if (methodRef.equals(MethodRef.ofString("hat.buffer.S32Array::array(long)int")))
+                        {
+                            SPIRVId longType = getType("long");
+                            String arrayTypeName = call.operands().get(0).type().toString();
+                            SpirvResult arrayResult = getResult(call.operands().get(0));
+                            SPIRVId arrayAddr = arrayResult.address();
+                            SPIRVId arrayType = spirvType(arrayTypeName);
+                            SPIRVId elementType = spirvElementType(arrayTypeName);
+                            int nIndexes = call.operands().size() - 1;
+                            SPIRVId indexX = getResult(call.operands().get(1)).value();
+                            SPIRVId array = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(arrayType, array, arrayAddr, align(arrayType.getName())));
+                            SPIRVId temp1 = nextId();
+                            SPIRVId temp2 = nextId();
+                            spirvBlock.add(new SPIRVOpConvertPtrToU(longType, temp1, array));
+                            spirvBlock.add(new SPIRVOpIAdd(longType, temp2, temp1, getConst("long", 4)));
+                            SPIRVId elementBase = nextId();
+                            spirvBlock.add(new SPIRVOpConvertUToPtr(arrayType, elementBase, temp2));
+                            SPIRVId resultAddr = nextId();
+                            spirvBlock.add(new SPIRVOpInBoundsPtrAccessChain(arrayType, resultAddr, elementBase, indexX, new SPIRVMultipleOperands<>()));
+                            SPIRVId result = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(elementType, result, resultAddr, align(elementType.getName())));
+                            addResult(call.result(), new SpirvResult(elementType, resultAddr, result));
+                        }
+                        else if (methodRef.equals(MethodRef.ofString("hat.buffer.S32Array2D::array(long)int")) ||
+                                 methodRef.equals(MethodRef.ofString("hat.buffer.F32Array2D::array(long)float")))
+                        {
+                            SPIRVId longType = getType("long");
+                            String arrayTypeName = call.operands().get(0).type().toString();
+                            SpirvResult arrayResult = getResult(call.operands().get(0));
+                            SPIRVId arrayAddr = arrayResult.address();
+                            SPIRVId arrayType = spirvType(arrayTypeName);
+                            SPIRVId elementType = spirvElementType(arrayTypeName);
+                            int nIndexes = call.operands().size() - 1;
+                            SPIRVId indexX = getResult(call.operands().get(1)).value();
+                            SPIRVId array = nextId();
+                            SPIRVId temp1 = nextId();
+                            SPIRVId temp2 = nextId();
+                            spirvBlock.add(new SPIRVOpConvertPtrToU(longType, temp1, array));
+                            spirvBlock.add(new SPIRVOpIAdd(longType, temp2, temp1, getConst("long", 4)));
+                            SPIRVId elementBase = nextId();
+                            spirvBlock.add(new SPIRVOpConvertUToPtr(arrayType, elementBase, temp2));
+                            spirvBlock.add(new SPIRVOpLoad(arrayType, array, arrayAddr, align(arrayType.getName())));
+                            SPIRVId resultAddr = nextId();
+                            spirvBlock.add(new SPIRVOpInBoundsPtrAccessChain(arrayType, resultAddr, elementBase, indexX, new SPIRVMultipleOperands<>()));
+                            SPIRVId result = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(elementType, result, resultAddr, align(elementType.getName())));
+                            addResult(call.result(), new SpirvResult(elementType, resultAddr, result));
+                        }
+                        else if (methodRef.equals(MethodRef.ofString("hat.buffer.S32Array::array(long, int)void"))) {
+                            SPIRVId longType = getType("long");
+                            String arrayTypeName = call.operands().get(0).type().toString();
+                            SpirvResult arrayResult = getResult(call.operands().get(0));
+                            SPIRVId arrayAddr = arrayResult.address();
+                            SPIRVId arrayType = spirvType(arrayTypeName);
+                            SPIRVId elementType = spirvElementType(arrayTypeName);
+                            int nIndexes = call.operands().size() - 2;
+                            int valueIndex = nIndexes + 1;
+                            SPIRVId indexX = getResult(call.operands().get(1)).value();
+                            SPIRVId array = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(arrayType, array, arrayAddr, align(arrayType.getName())));
+                            SPIRVId temp1 = nextId();
+                            SPIRVId temp2 = nextId();
+                            spirvBlock.add(new SPIRVOpConvertPtrToU(longType, temp1, array));
+                            spirvBlock.add(new SPIRVOpIAdd(longType, temp2, temp1, getConst("long", 4)));
+                            SPIRVId elementBase = nextId();
+                            spirvBlock.add(new SPIRVOpConvertUToPtr(arrayType, elementBase, temp2));
+                            SPIRVId dest = nextId();
+                            spirvBlock.add(new SPIRVOpInBoundsPtrAccessChain(arrayType, dest, elementBase, indexX, new SPIRVMultipleOperands<>()));
+                            SPIRVId value = getResult(call.operands().get(valueIndex)).value();
+                            spirvBlock.add(new SPIRVOpStore(dest, value, align(elementType.getName())));
+                        }
+                        else if (methodRef.equals(MethodRef.ofString("hat.buffer.S32Array2D::array(long, int)void")) ||
+                                 methodRef.equals(MethodRef.ofString("hat.buffer.F32Array2D::array(long, float)void"))) {
+                            SPIRVId longType = getType("long");
+                            String arrayTypeName = call.operands().get(0).type().toString();
+                            SpirvResult arrayResult = getResult(call.operands().get(0));
+                            SPIRVId arrayAddr = arrayResult.address();
+                            SPIRVId arrayType = spirvType(arrayTypeName);
+                            SPIRVId elementType = spirvElementType(arrayTypeName);
+                            int nIndexes = call.operands().size() - 2;
+                            int valueIndex = nIndexes + 1;
+                            SPIRVId indexX = getResult(call.operands().get(1)).value();
+                            SPIRVId array = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(arrayType, array, arrayAddr, align(arrayType.getName())));
+                            SPIRVId temp1 = nextId();
+                            SPIRVId temp2 = nextId();
+                            spirvBlock.add(new SPIRVOpConvertPtrToU(longType, temp1, array));
+                            spirvBlock.add(new SPIRVOpIAdd(longType, temp2, temp1, getConst("long", 8)));
+                            SPIRVId elementBase = nextId();
+                            spirvBlock.add(new SPIRVOpConvertUToPtr(arrayType, elementBase, temp2));
+                            SPIRVId dest = nextId();
+                            spirvBlock.add(new SPIRVOpInBoundsPtrAccessChain(arrayType, dest, elementBase, indexX, new SPIRVMultipleOperands<>()));
+                            SPIRVId value = getResult(call.operands().get(valueIndex)).value();
+                            spirvBlock.add(new SPIRVOpStore(dest, value, align(elementType.getName())));
+                        }
+                        else if (methodRef.equals(MethodRef.ofString("hat.buffer.S32Array::length()int")) ||
+                                 methodRef.equals(MethodRef.ofString("hat.buffer.S32Array2D::width()int"))||
+                                 methodRef.equals(MethodRef.ofString("hat.buffer.F32Array2D::width()int"))) {
+                            SPIRVId intType = getType("int");
+                            String arrayTypeName = call.operands().get(0).type().toString();
+                            SpirvResult arrayResult = getResult(call.operands().get(0));
+                            SPIRVId arrayAddr = arrayResult.address();
+                            SPIRVId arrayType = spirvType(arrayTypeName);
+                            SPIRVId array = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(arrayType, array, arrayAddr, align(arrayType.getName())));
+                            SPIRVId resultAddr = nextId();
+                            spirvBlock.add(new SPIRVOpInBoundsPtrAccessChain(arrayType, resultAddr, array, getConst("int", 0), new SPIRVMultipleOperands<>()));
+                            SPIRVId result = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(intType, result, resultAddr, align(arrayType.getName())));
+                            addResult(call.result(), new SpirvResult(intType, resultAddr, result));
+                        }
+                        else if (methodRef.equals(MethodRef.ofString("hat.buffer.S32Array2D::height()int")) ||
+                                 methodRef.equals(MethodRef.ofString("hat.buffer.F32Array2D::height()int"))) {
+                            SPIRVId intType = getType("int");
+                            String arrayTypeName = call.operands().get(0).type().toString();
+                            SpirvResult arrayResult = getResult(call.operands().get(0));
+                            SPIRVId arrayAddr = arrayResult.address();
+                            SPIRVId arrayType = spirvType(arrayTypeName);
+                            SPIRVId array = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(arrayType, array, arrayAddr, align(arrayType.getName())));
+                            SPIRVId resultAddr = nextId();
+                            spirvBlock.add(new SPIRVOpInBoundsPtrAccessChain(arrayType, resultAddr, array, getConst("int", 1), new SPIRVMultipleOperands<>()));
+                            SPIRVId result = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(intType, result, resultAddr, align(arrayType.getName())));
+                            addResult(call.result(), new SpirvResult(intType, resultAddr, result));
+                        }
+                        else if (methodRef.equals(MethodRef.ofString("java.lang.Math::sqrt(double)double"))) {
+                            SPIRVId floatType = getType("float");
+                            SPIRVId result = nextId();
+                            SPIRVId operand = getResult(call.operands().get(0)).value();
+                            spirvBlock.add(new SPIRVOpExtInst(floatType, result, getId("oclExtension"), new SPIRVLiteralExtInstInteger(61, "sqrt"), new SPIRVMultipleOperands<>(operand)));
+                            addResult(call.result(), new SpirvResult(floatType, null, result));
+                        }
+                        else {
+                            SPIRVId fnId = getFunctionId(methodRef);
+                            if (fnId == null) {
+                                unsupported("method", methodRef);
+                            }
+                            else {
+                                FunctionType fnType = methodRef.type();
+                                SPIRVId[] args = new SPIRVId[call.operands().size()];
+                                for (int i = 0; i < args.length; i++) {
+                                    SPIRVId argId = getResult(call.operands().get(i)).value();
+                                    args[i] = argId;
+                                }
+                                SPIRVId returnType = spirvType(fnType.returnType().toString());
+                                SPIRVId callResult = nextId();
+                                spirvBlock.add(new SPIRVOpFunctionCall(returnType, callResult, fnId, new SPIRVMultipleOperands<>(args)));
+                                addResult(call.result(), new SpirvResult(returnType, null, callResult));
+                            }
+                        }
+                    }
+                    case SpirvOp.ConstantOp cop -> {
+                        SPIRVId type = spirvType(cop.resultType().toString());
+                        SPIRVId result = nextId();
+                        Object value = cop.value();
+                        if (type == getType("int")) {
+                            module.add(new SPIRVOpConstant(type, result, new SPIRVContextDependentInt(new BigInteger(String.valueOf(value)))));
+                        }
+                        else if (type == getType("long")) {
+                            module.add(new SPIRVOpConstant(type, result, new SPIRVContextDependentLong(new BigInteger(String.valueOf(value)))));
+                        }
+                        else if (type == getType("float")) {
+                            module.add(new SPIRVOpConstant(type, result, new SPIRVContextDependentFloat((float)value)));
+                        }
+                        else if (type == getType("bool")) {
+                            module.add(((boolean)value) ? new SPIRVOpConstantTrue(type, result) : new SPIRVOpConstantFalse(type, result));
+                        }
+                        else if (type == getType("java.lang.Object")) {
+                            module.add(new SPIRVOpConstantNull(type, result));
+                        }
+                        else if (type == getType("int[]")) {
+                            module.add(new SPIRVOpConstantNull(type, result));
+                        }
+                        else unsupported("type", cop.resultType());
+                        addResult(cop.result(), new SpirvResult(type, null, result));
+                    }
+                    case SpirvOp.ConvertOp scop -> {
+                        SPIRVId toType = spirvType(scop.resultType().toString());
+                        SPIRVId to = nextId();
+                        SpirvResult valueResult = getResult(scop.operands().get(0));
+                        SPIRVId from = valueResult.value();
+                        SPIRVId fromType = valueResult.type();
+                        if (isIntegerType(fromType)) {
+                            if (isIntegerType(toType)) {
+                                spirvBlock.add(new SPIRVOpSConvert(toType, to, from));
+                            }
+                            else if (isFloatType(toType)) {
+                                spirvBlock.add(new SPIRVOpConvertSToF(toType, to, from));
+                            }
+                            else unsupported("conversion type", scop.resultType());
+                        }
+                        else if (isFloatType(fromType)) {
+                            if (isIntegerType(toType)) {
+                                spirvBlock.add(new SPIRVOpConvertFToS(toType, to, from));
+                            }
+                            else if (isFloatType(toType)) {
+                                spirvBlock.add(new SPIRVOpFConvert(toType, to, from));
+                            }
+                            else unsupported("conversion type", scop.resultType());
+                        }
+                        else unsupported("conversion type", scop.operands().get(0));
+                        addResult(scop.result(), new SpirvResult(toType, null, to));
+                    }
+                    case SpirvOp.InBoundsAccessChainOp iacop -> {
+                        SPIRVId type = spirvType(iacop.resultType().toString());
+                        SPIRVId result = nextId();
+                        SPIRVId object = getResult(iacop.operands().get(0)).value();
+                        SPIRVId index = getResult(iacop.operands().get(1)).value();
+                        spirvBlock.add(new SPIRVOpInBoundsPtrAccessChain(type, result, object, index, new SPIRVMultipleOperands<>()));
+                        addResult(iacop.result(), new SpirvResult(type, result, null));
+                    }
+                    case SpirvOp.FieldLoadOp flo -> {
+                        if (flo.operands().size() > 0 && (flo.operands().get(0).type().equals(JavaType.ofString("hat.KernelContext")))) {
+                            SpirvResult result;
+                            int group = -1;
+                            int index = -1;
+                            String fieldName = flo.fieldDescriptor().name();
+                            switch (fieldName) {
+                                case "x": group = 0; index = 0; break;
+                                case "y": group = 0; index = 1; break;
+                                case "z": group = 0; index = 2; break;
+                                case "maxX": group = 1; index = 0; break;
+                                case "maxY": group = 1; index = 1; break;
+                                case "maxZ": group = 1; index = 2; break;
+                            }
+                            switch (group) {
+                                case 0: result = globalId(index, spirvBlock); break;
+                                case 1: result = globalSize(index, spirvBlock); break;
+                                default: throw new RuntimeException("Unknown Index field: " + fieldName);
+                            }
+                            addResult(flo.result(), result);
+                        }
+                        else if (flo.operands().get(0).type().equals(JavaType.ofString("hat.KernelContext"))) {
+                            String fieldName = flo.fieldDescriptor().name();
+                            SPIRVId fieldIndex = switch (fieldName) {
+                                case "x" -> getConst("long", 0);
+                                case "maxX" -> getConst("long", 1);
+                                default -> throw new RuntimeException("Unknown field: " + fieldName);
+                            };
+                            SPIRVId intType = getType("int");
+                            String contextTypeName = flo.operands().get(0).type().toString();
+                            SpirvResult kernalContext = getResult(flo.operands().get(0));
+                            SPIRVId contextAddr = kernalContext.address();
+                            SPIRVId contextType = spirvType(contextTypeName);
+                            SPIRVId context = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(contextType, context, contextAddr, align(contextType.getName())));
+                            SPIRVId fieldType = intType;
+                            SPIRVId resultAddr = nextId();
+                            spirvBlock.add(new SPIRVOpInBoundsAccessChain(getType("ptrInt"), resultAddr, context, new SPIRVMultipleOperands<>(fieldIndex)));
+                            SPIRVId result = nextId();
+                            spirvBlock.add(new SPIRVOpLoad(intType, result, resultAddr, align("int")));
+                            addResult(flo.result(), new SpirvResult(intType, resultAddr, result));
+                        }
+                        else if (flo.fieldDescriptor().refType().equals(JavaType.type(ByteOrder.class))) {
+                            // currently ignored
+                        }
+                        else unsupported("field load", ((ClassType)flo.fieldDescriptor().refType()).toClassName() + "." + flo.fieldDescriptor().name());
+                    }
+                    case SpirvOp.BranchOp bop -> {
+                        SPIRVId label = symbols.getLabel(bop.branch().targetBlock()).getResultId();
+                        Block.Reference target = bop.branch();
+                        spirvBlock.add(new SPIRVOpBranch(label));
+                    }
+                    case SpirvOp.ConditionalBranchOp cbop -> {
+                        SPIRVId test = getResult(cbop.operands().get(0)).value();
+                        SPIRVId trueLabel = symbols.getLabel(cbop.trueBranch().targetBlock()).getResultId();
+                        SPIRVId falseLabel = symbols.getLabel(cbop.falseBranch().targetBlock()).getResultId();
+                        spirvBlock.add(new SPIRVOpBranchConditional(test, trueLabel, falseLabel, new SPIRVMultipleOperands<SPIRVLiteralInteger>()));
+                    }
+                    case SpirvOp.LtOp ltop -> {
+                        SpirvResult lhs = getResult(ltop.operands().get(0));
+                        SpirvResult rhs = getResult(ltop.operands().get(1));
+                        SPIRVId boolType = getType("bool");
+                        SPIRVId result = nextId();
+                        String operandType = lhs.type().getName();
+                        SPIRVInstruction sop = switch (operandType) {
+                            case "float" -> new SPIRVOpFUnordLessThan(boolType, result, lhs.value(), rhs.value());
+                            case "int" -> new SPIRVOpSLessThan(boolType, result, lhs.value(), rhs.value());
+                            case "long" -> new SPIRVOpSLessThan(boolType, result, lhs.value(), rhs.value());
+                            default -> throw new RuntimeException("Unsupported type: " + lhs.type().getName());
+                        };
+                        spirvBlock.add(sop);
+                        addResult(ltop.result(), new SpirvResult(boolType, null, result));
+                    }
+                    case SpirvOp.ReturnOp rop -> {
+                        spirvBlock.add(new SPIRVOpReturn());
+                    }
+                    case SpirvOp.ReturnValueOp rop -> {
+                        SPIRVId returnValue = getResult(rop.operands().get(0)).value();
+                        spirvBlock.add(new SPIRVOpReturnValue(returnValue));
+                    }
+                    default -> unsupported("op", op.getClass());
+                }
+            }
+        } // end bi
+    }
+
+    private SPIRVId getFunctionId(MethodRef methodRef) {
+        SPIRVId fnId = symbols.getId(methodRef.toString());
+        if (fnId == null) {
+            try {
+                Optional<CoreOp.FuncOp> optJFuncOp = methodRef.codeModel(MethodHandles.lookup());
+                if (optJFuncOp.isPresent()) {
+                    CoreOp.FuncOp jFuncOp = optJFuncOp.get();
+                    SpirvOp.FuncOp sFuncOp = TranslateToSpirvModel.translateFunction(jFuncOp);
+                    fnId = generateFunction(jFuncOp.funcName(), sFuncOp, false);
+                    symbols.putId(methodRef.toString(), fnId);
+                }
+            }
+            catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return fnId;
+    }
+
+    private void initModule() {
+        module.add(new SPIRVOpCapability(SPIRVCapability.Addresses()));
+        module.add(new SPIRVOpCapability(SPIRVCapability.Linkage()));
+        module.add(new SPIRVOpCapability(SPIRVCapability.Kernel()));
+        module.add(new SPIRVOpCapability(SPIRVCapability.Int8()));
+        module.add(new SPIRVOpCapability(SPIRVCapability.Int64()));
+        module.add(new SPIRVOpMemoryModel(SPIRVAddressingModel.Physical64(), SPIRVMemoryModel.OpenCL()));
+
+        // OpenCL extension provides built-in variables suitable for kernel programming
+        // Import extension and declare four variables
+        SPIRVId oclExtension = nextId("oclExtension");
+        module.add(new SPIRVOpExtInstImport(oclExtension, new SPIRVLiteralString("OpenCL.std")));
+        symbols.putId("oclExtension", oclExtension);
+
+        SPIRVId globalInvocationId = nextId("globalInvocationId");
+        SPIRVId globalSize = nextId("globalSize");
+        SPIRVId subgroupSize = nextId("subgroupSize");
+        SPIRVId subgroupId = nextId("subgroupId");
+
+        module.add(new SPIRVOpDecorate(globalInvocationId, SPIRVDecoration.BuiltIn(SPIRVBuiltIn.GlobalInvocationId())));
+        module.add(new SPIRVOpDecorate(globalInvocationId, SPIRVDecoration.Constant()));
+        module.add(new SPIRVOpDecorate(globalInvocationId, SPIRVDecoration.LinkageAttributes(new SPIRVLiteralString("spirv_BuiltInGlobalInvocationId"), SPIRVLinkageType.Import())));
+        module.add(new SPIRVOpDecorate(globalSize, SPIRVDecoration.BuiltIn(SPIRVBuiltIn.GlobalSize())));
+        module.add(new SPIRVOpDecorate(globalSize, SPIRVDecoration.Constant()));
+        module.add(new SPIRVOpDecorate(globalSize, SPIRVDecoration.LinkageAttributes(new SPIRVLiteralString("spirv_BuiltInGlobalSize"), SPIRVLinkageType.Import())));
+        module.add(new SPIRVOpDecorate(subgroupSize, SPIRVDecoration.BuiltIn(SPIRVBuiltIn.SubgroupSize())));
+        module.add(new SPIRVOpDecorate(subgroupSize, SPIRVDecoration.Constant()));
+        module.add(new SPIRVOpDecorate(subgroupSize, SPIRVDecoration.LinkageAttributes(new SPIRVLiteralString("spirv_BuiltInSubgroupSize"), SPIRVLinkageType.Import())));
+        module.add(new SPIRVOpDecorate(subgroupId, SPIRVDecoration.BuiltIn(SPIRVBuiltIn.SubgroupId())));
+        module.add(new SPIRVOpDecorate(subgroupId, SPIRVDecoration.Constant()));
+        module.add(new SPIRVOpDecorate(subgroupId, SPIRVDecoration.LinkageAttributes(new SPIRVLiteralString("spirv_BuiltInSubgroupId"), SPIRVLinkageType.Import())));
+
+        module.add(new SPIRVOpVariable(getType("ptrV3long"), globalInvocationId, SPIRVStorageClass.Input(), new SPIRVOptionalOperand<>()));
+        module.add(new SPIRVOpVariable(getType("ptrV3long"), globalSize, SPIRVStorageClass.Input(), new SPIRVOptionalOperand<>()));
+        module.add(new SPIRVOpVariable(getType("ptrV3long"), subgroupSize, SPIRVStorageClass.Input(), new SPIRVOptionalOperand<>()));
+        module.add(new SPIRVOpVariable(getType("ptrV3long"), subgroupId, SPIRVStorageClass.Input(), new SPIRVOptionalOperand<>()));
+    }
+
+    private SPIRVId spirvType(String inputType) {
+        String javaType = inputType.replaceAll("\\$", ".");
+        SPIRVId ans = switch(javaType) {
+            case "byte" -> getType("byte");
+            case "short" -> getType("short");
+            case "int" -> getType("int");
+            case "long" -> getType("long");
+            case "float" -> getType("float");
+            case "double" -> getType("double");
+            case "byte[]" -> getType("byte[]");
+            case "int[]" -> getType("int[]");
+            case "float[]" -> getType("float[]");
+            case "double[]" -> getType("double[]");
+            case "long[]" -> getType("long[]");
+            case "bool" -> getType("bool");
+            case "boolean" -> getType("bool");
+            case "java.lang.Object" -> getType("java.lang.Object");
+            case "hat.buffer.S32Array" -> getType("int[]");
+            case "hat.buffer.S32Array2D" -> getType("int[]");
+            case "hat.buffer.F32Array2D" -> getType("float[]");
+            case "void" -> getType("void");
+            case "hat.KernelContext" -> getType("ptrKernelContext");
+            case "java.lang.foreign.MemorySegment" -> getType("ptrByte");
+            default -> null;
+        };
+        if (ans == null) unsupported("type", javaType);
+        return ans;
+    }
+
+    private SPIRVId spirvElementType(String inputType) {
+        String javaType = inputType.replaceAll("\\$", ".");
+        SPIRVId ans = switch(javaType) {
+            case "byte[]" -> getType("byte");
+            case "short[]" -> getType("short");
+            case "int[]" -> getType("int");
+            case "long[]" -> getType("long");
+            case "float[]" -> getType("float");
+            case "double[]" -> getType("double");
+            case "boolean[]" -> getType("bool");
+            case "hat.buffer.S32Array" -> getType("int");
+            case "hat.buffer.S32Array2D" -> getType("int");
+            case "hat.buffer.F32Array2D" -> getType("float");
+            case "java.lang.foreign.MemorySegment" -> getType("byte");
+            default -> null;
+        };
+        if (ans == null) unsupported("type", javaType);
+        return ans;
+    }
+
+    private SPIRVId vectorElementType(SPIRVId type) {
+        SPIRVId ans = switch(type.getName()) {
+            case "v8int" -> getType("int");
+            case "v16int" -> getType("int");
+            case "v8long" -> getType("long");
+            case "v8float" -> getType("float");
+            case "v16float" -> getType("float");
+            default -> null;
+        };
+        if (ans == null) unsupported("type", type.getName());
+        return ans;
+    }
+
+    private SPIRVId spirvVariableType(SPIRVId spirvType) {
+        SPIRVId ans = switch(spirvType.getName()) {
+            case "bool" -> getType("ptrBool");
+            case "byte" -> getType("ptrByte");
+            case "short" -> getType("ptrShort");
+            case "int" -> getType("ptrInt");
+            case "long" -> getType("ptrLong");
+            case "float" -> getType("ptrFloat");
+            case "double" -> getType("ptrDouble");
+            case "boolean" -> getType("ptrBool");
+            case "byte[]" -> getType("ptrByte[]");
+            case "int[]" -> getType("ptrInt[]");
+            case "long[]" -> getType("ptrLong[]");
+            case "float[]" -> getType("ptrFloat[]");
+            case "double[]" -> getType("ptrDouble[]");
+            case "v8int" -> getType("ptrV8int");
+            case "v16int" -> getType("ptrV16int");
+            case "v8long" -> getType("ptrV8long");
+            case "v8float" -> getType("ptrV8float");
+            case "v16float" -> getType("ptrV16float");
+            case "ptrKernelContext" -> getType("ptrPtrKernelContext");
+            case "hat.KernelContext" -> getType("ptrKernelContext");
+            case "ptrByte" -> getType("ptrPtrByte");
+            default -> null;
+        };
+        if (ans == null) unsupported("type", spirvType.getName());
+        return ans;
+    }
+
+    private SPIRVId spirvVectorType(String javaVectorType, int vectorLength) {
+        String prefix = "v" + vectorLength;
+        String elementType = spirvElementType(javaVectorType).getName();
+        return getType(prefix + elementType);
+    }
+
+    private int alignment(String inputType) {
+        String spirvType = inputType.replaceAll("\\$", ".");
+        int ans = switch(spirvType) {
+            case "bool" -> 1;
+            case "byte" -> 1;
+            case "short" -> 2;
+            case "int" -> 4;
+            case "long" -> 8;
+            case "float" -> 4;
+            case "double" -> 8;
+            case "boolean" -> 1;
+            case "v8int" -> 32;
+            case "v16int" -> 64;
+            case "v8long" -> 64;
+            case "v8float" -> 32;
+            case "v16float" -> 64;
+            case "hat.KernelContext" -> 32;
+            case "ptrKernelContext" -> 32;
+            case "byte[]" -> 8;
+            case "int[]" -> 8;
+            case "long[]" -> 8;
+            case "float[]" -> 8;
+            case "double[]" -> 8;
+            case "ptrBool" -> 8;
+            case "ptrByte" -> 8;
+            case "ptrInt" -> 8;
+            case "ptrByte[]" -> 8;
+            case "ptrInt[]" -> 8;
+            case "ptrLong" -> 8;
+            case "ptrLong[]" -> 8;
+            case "ptrFloat" -> 8;
+            case "ptrFloat[]" -> 8;
+            case "ptrV8int" -> 8;
+            case "ptrV8float" -> 8;
+            case "ptrPtrKernelContext" -> 8;
+            default -> 0;
+        };
+        if (ans == 0) unsupported("type", spirvType);
+        return ans;
+    }
+
+    private Set<String> moduleTypes = new HashSet<>();
+
+    private SPIRVId getType(String inputName) {
+        String name = inputName.replaceAll("\\$", ".");
+        if (!moduleTypes.contains(name)) {
+            switch (name) {
+                case "void" -> module.add(new SPIRVOpTypeVoid(nextId(name)));
+                case "bool" -> module.add(new SPIRVOpTypeBool(nextId(name)));
+                case "boolean" -> module.add(new SPIRVOpTypeBool(nextId(name)));
+                case "byte" -> module.add(new SPIRVOpTypeInt(nextId(name), new SPIRVLiteralInteger(8), new SPIRVLiteralInteger(0)));
+                case "short" -> module.add(new SPIRVOpTypeInt(nextId(name), new SPIRVLiteralInteger(16), new SPIRVLiteralInteger(0)));
+                case "int" -> module.add(new SPIRVOpTypeInt(nextId(name), new SPIRVLiteralInteger(32), new SPIRVLiteralInteger(0)));
+                case "long" -> module.add(new SPIRVOpTypeInt(nextId(name), new SPIRVLiteralInteger(64), new SPIRVLiteralInteger(0)));
+                case "float" -> module.add(new SPIRVOpTypeFloat(nextId(name), new SPIRVLiteralInteger(32)));
+                case "double" -> module.add(new SPIRVOpTypeFloat(nextId(name), new SPIRVLiteralInteger(64)));
+                case "ptrBool" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("bool")));
+                case "ptrByte" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("byte")));
+                case "ptrInt" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("int")));
+                case "ptrLong" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("long")));
+                case "ptrFloat" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("float")));
+                case "byte[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("byte")));
+                case "short[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("short")));
+                case "int[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("int")));
+                case "long[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("long")));
+                case "float[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("float")));
+                case "double[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("double")));
+                case "boolean[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("boolean")));
+                case "ptrByte[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("byte[]")));
+                case "ptrInt[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("int[]")));
+                case "ptrLong[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("long[]")));
+                case "ptrFloat[]" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("float[]")));
+                case "java.lang.Object" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("void")));
+                case "hat.KernelContext" -> module.add(new SPIRVOpTypeStruct(nextId(name), new SPIRVMultipleOperands<>(getType("int"), getType("int"))));
+                case "ptrKernelContext" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("hat.KernelContext")));
+                case "ptrCrossGroupByte"-> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.CrossWorkgroup(), getType("byte")));
+                case "ptrPtrKernelContext" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrKernelContext")));
+                case "ptrPtrByte" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrByte")));
+                case "ptrPtrInt" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrInt")));
+                case "ptrPtrFloat" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrFloat")));
+                case "v3long" -> module.add(new SPIRVOpTypeVector(nextId(name), getType("long"), new SPIRVLiteralInteger(3)));
+                case "v8int" -> module.add(new SPIRVOpTypeVector(nextId(name), getType("int"), new SPIRVLiteralInteger(8)));
+                case "v8long" -> module.add(new SPIRVOpTypeVector(nextId(name), getType("long"), new SPIRVLiteralInteger(8)));
+                case "v16int" -> module.add(new SPIRVOpTypeVector(nextId(name), getType("int"), new SPIRVLiteralInteger(16)));
+                case "v8float" -> module.add(new SPIRVOpTypeVector(nextId(name), getType("float"), new SPIRVLiteralInteger(8)));
+                case "v16float" -> module.add(new SPIRVOpTypeVector(nextId(name), getType("float"), new SPIRVLiteralInteger(16)));
+                case "ptrV3long" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Input(), getType("v3long")));
+                case "ptrV8long" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("v8long")));
+                case "ptrV8int" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("v8int")));
+                case "ptrV16int" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("v16int")));
+                case "ptrV8float" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("v8float")));
+                case "ptrV16float" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("v16float")));
+                case "ptrPtrV8int" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrV8int")));
+                case "ptrPtrV16int" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrV16int")));
+                case "ptrPtrV8float" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrV8float")));
+                case "ptrPtrV16float" -> module.add(new SPIRVOpTypePointer(nextId(name), SPIRVStorageClass.Function(), getType("ptrV16float")));
+                default -> unsupported("type", name);
+            }
+            moduleTypes.add(name);
+        }
+        return getId(name);
+    }
+
+    private Set<String> moduleConstants = new HashSet<>();
+
+    private SPIRVId getConst(String typeName, long value) {
+        String name = typeName + "_" + value;
+        if (!moduleConstants.contains(name)) {
+            String valueStr = String.valueOf(value);
+            switch (typeName) {
+                case "int" -> module.add(new SPIRVOpConstant(getType(typeName), nextId(name), new SPIRVContextDependentInt(new BigInteger(valueStr))));
+                case "long" -> module.add(new SPIRVOpConstant(getType(typeName), nextId(name), new SPIRVContextDependentLong(new BigInteger(valueStr))));
+                case "boolean" -> module.add(value == 0 ? new SPIRVOpConstantFalse(getType(typeName), nextId(name)) : new SPIRVOpConstantTrue(getType(typeName), nextId(name)));
+                default -> unsupported("constant", name);
+            };
+            moduleConstants.add(name);
+        }
+        return getId(name);
+    }
+
+    private SPIRVOptionalOperand<SPIRVMemoryAccess> align(int align) {
+        return new SPIRVOptionalOperand<>(SPIRVMemoryAccess.Aligned(new SPIRVLiteralInteger(align)));
+    }
+
+    private SPIRVOptionalOperand<SPIRVMemoryAccess> align(String type) {
+        return align(alignment(type));
+    }
+
+    private SPIRVMultipleOperands<SPIRVId> spirvOperands(SPIRVId value, int count) {
+        SPIRVId[] values = new SPIRVId[count];
+        Arrays.fill(values, value);
+        return new SPIRVMultipleOperands<>(values);
+    }
+
+    private SPIRVOptionalOperand<SPIRVMemoryAccess> none() {
+        return new SPIRVOptionalOperand<>();
+    }
+
+    private SpirvResult globalSize(int index, SPIRVBlock spirvBlock) {
+        SPIRVId intType = getType("int");
+        SPIRVId longType = getType("long");
+        SPIRVId v3long = getId("v3long");
+        SPIRVId globalSizeId = getId("globalSize");
+        SPIRVId globalSizes = nextId();
+        spirvBlock.add(new SPIRVOpLoad(v3long, globalSizes, globalSizeId, align(32)));
+        SPIRVId longSize = nextId();
+        SPIRVId globalSize = nextId();
+        spirvBlock.add(new SPIRVOpCompositeExtract(longType, longSize, globalSizes, new SPIRVMultipleOperands<>(new SPIRVLiteralInteger(index))));
+        spirvBlock.add(new SPIRVOpSConvert(intType, globalSize, longSize));
+        return new SpirvResult(intType, null, globalSize);
+    }
+
+    private SpirvResult globalId(int index, SPIRVBlock spirvBlock) {
+        SPIRVId intType = getType("int");
+        SPIRVId longType = getType("long");
+        SPIRVId v3long = getId("v3long");
+        SPIRVId globalInvocationId = getId("globalInvocationId");
+        SPIRVId globalIds = nextId();
+        spirvBlock.add(new SPIRVOpLoad(v3long, globalIds, globalInvocationId, align(32)));
+        SPIRVId longIndex = nextId();
+        SPIRVId globalIndex = nextId();
+        spirvBlock.add(new SPIRVOpCompositeExtract(longType, longIndex, globalIds, new SPIRVMultipleOperands<>(new SPIRVLiteralInteger(index))));
+        spirvBlock.add(new SPIRVOpSConvert(intType, globalIndex, longIndex));
+        return new SpirvResult(intType, null, globalIndex);
+    }
+
+   private SpirvResult flatIndex(SPIRVId sizeX, SPIRVId sizeY, SPIRVId sizeZ, SPIRVId indexX, SPIRVId indexY, SPIRVId indexZ, SPIRVBlock spirvBlock)
+    {
+        SPIRVId longType = getType("long");
+        SPIRVId xTerm0 = nextId();
+        SPIRVId xTerm1 = nextId();
+        SPIRVId yTerm = nextId();
+        SPIRVId flat0 = nextId();
+        SPIRVId flat1 = nextId();
+        spirvBlock.add(new SPIRVOpIMul(longType, xTerm0, sizeY, sizeZ));
+        spirvBlock.add(new SPIRVOpIMul(longType, xTerm1, xTerm0, indexX));
+        spirvBlock.add(new SPIRVOpIMul(longType, yTerm, sizeZ, indexY));
+        spirvBlock.add(new SPIRVOpIAdd(longType, flat0, xTerm1, yTerm));
+        spirvBlock.add(new SPIRVOpIAdd(longType, flat1, flat0, indexZ));
+        return new SpirvResult(longType, null, flat1);
+    }
+
+    private SPIRVId nextId() {
+        return module.getNextId();
+    }
+
+    private SPIRVId nextId(String name) {
+        SPIRVId ans = nextId();
+        ans.setName(name);
+        symbols.putId(name, ans);
+        module.add(new SPIRVOpName(ans, new SPIRVLiteralString(name)));
+        return ans;
+    }
+
+    private static int counter = 0;
+
+    private String nextTempTag() {
+        counter++;
+        return "temp_" + counter + "_";
+    }
+
+    private boolean isIntegerType(SPIRVId type) {
+        String name = type.getName();
+        return name.equals("byte") || name.equals("short") || name.equals("int") || name.equals("long");
+    }
+
+    private boolean isFloatType(SPIRVId type) {
+        String name = type.getName();
+        return name.equals("float") || name.equals("double");
+    }
+
+    private boolean isVectorSpecies(String javaType) {
+        return javaType.equals("VectorSpecies");
+    }
+
+    private boolean isVectorType(String javaType) {
+        return javaType.equals("IntVector") || javaType.equals("FloatVector");
+    }
+
+    private void addId(String name, SPIRVId id) {
+        symbols.putId(name, id);
+    }
+
+    private SPIRVId getId(String name) {
+        SPIRVId ans = symbols.getId(name);
+        assert ans != null : name + " not found";
+        return ans;
+    }
+
+    private SPIRVId getIdOrNull(String name) {
+        return symbols.getId(name);
+    }
+
+    private static Object map(Function<Object, Boolean> test, Object... args) {
+        int len = args.length;
+        assert len >= 2 && len % 2 == 0;
+        int pairs = len / 2;
+        for (int i = 0; i < pairs; i++) {
+            if (test.apply(args[i])) return args[i + pairs];
+        }
+        throw new RuntimeException("No match: " + args[0]);
+    }
+
+    private void unsupported(String message, Object value) {
+        throw new RuntimeException("Unsupported " + message + ": " + value);
+    }
+
+    private void addResult(Value value, SpirvResult result) {
+        assert symbols.getResult(value) == null : "result already present";
+        symbols.putResult(value, result);
+    }
+
+    private SpirvResult getResult(Value value) {
+        return symbols.getResult(value);
+    }
+
+    private static class Symbols {
+        private final HashMap<Value, SpirvResult> results;
+        private final HashMap<String, SPIRVId> ids;
+        private final HashMap<Block, SPIRVBlock> blocks;
+        private final HashMap<Block, SPIRVOpLabel> labels;
+
+        public Symbols() {
+            this.results = new HashMap<>();
+            this.ids = new HashMap<>();
+            this.blocks = new HashMap<>();
+            this.labels = new HashMap<>();
+        }
+
+        public void putId(String name, SPIRVId id) {
+            ids.put(name, id);
+        }
+
+        public SPIRVId getId(String name) {
+            return ids.get(name);
+        }
+
+        public void putBlock(Block block, SPIRVBlock spirvBlock) {
+            blocks.put(block, spirvBlock);
+        }
+
+        public SPIRVBlock getBlock(Block block) {
+            return blocks.get(block);
+        }
+
+        public void putLabel(Block block, SPIRVOpLabel spirvLabel) {
+            labels.put(block, spirvLabel);
+        }
+
+        public SPIRVOpLabel getLabel(Block block) {
+            return labels.get(block);
+        }
+
+        public void putResult(Value value, SpirvResult result) {
+            results.put(value, result);
+        }
+
+        public SpirvResult getResult(Value value) {
+            return results.get(value);
+        }
+
+        public String toString() {
+            return String.format("results %s\n\nids %s\n\nblocks %s\nlabels %s\n", results.keySet(), ids.keySet(), blocks.keySet(), labels.keySet());
+        }
+    }
+
+    public static void debug(String message, Object... args) {
+        System.out.println(String.format(message, args));
+    }
+}

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvOp.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvOp.java
@@ -1,0 +1,873 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.op.ExternalizableOp;
+import java.lang.reflect.code.Value;
+import java.lang.reflect.code.CopyContext;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.Block;
+import java.lang.reflect.code.Body;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.type.MethodRef;
+import java.lang.reflect.code.type.FieldRef;
+import java.lang.reflect.code.type.FunctionType;
+import java.lang.reflect.code.type.JavaType;
+
+public abstract class SpirvOp extends ExternalizableOp {
+    static final String NAME_PREFIX = "spirv.";
+    private final TypeElement type;
+    private final Map<String, Object> attributes;
+
+    SpirvOp(String opName) {
+        super(opName, List.of());
+        this.type = JavaType.VOID;
+        this.attributes = new HashMap<>();
+    }
+
+    SpirvOp(String opName, TypeElement type, List<Value> operands) {
+        super(opName, operands);
+        this.type = type;
+        this.attributes = new HashMap<>();
+    }
+
+    SpirvOp(String opName, TypeElement type, List<Value> operands, Map<String, Object> attributes) {
+        super(opName, operands);
+        this.type = type;
+        this.attributes = new HashMap<>();
+    }
+
+    SpirvOp(SpirvOp that, CopyContext cc) {
+        super(that, cc);
+        this.type = that.type;
+        this.attributes = new HashMap<>();
+    }
+
+    @Override
+    public TypeElement resultType() {
+        return type;
+    }
+
+    @Override
+    public Map<String, Object> attributes() {
+        return attributes;
+    }
+
+    public static final class ModuleOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "module";
+
+        private final String name;
+
+        public ModuleOp(String moduleName) {
+            super(OPNAME);
+            this.name = moduleName;
+        }
+
+        public ModuleOp(ModuleOp that, CopyContext cc) {
+            super(that, cc);
+            this.name = that.name;
+        }
+
+        @Override
+        public ModuleOp transform(CopyContext cc, OpTransformer ot) {
+            return new ModuleOp(this, cc);
+        }
+    }
+
+    public static final class PhiOp extends SpirvOp {
+        public static record Predecessor(Block.Reference block, Value value) {}
+
+        public static final String OPNAME = NAME_PREFIX + "phi";
+        private final List<Predecessor> predecessors;
+
+
+        public PhiOp(TypeElement resultType, List<Predecessor> predecessors) {
+            super(OPNAME, resultType, List.of());
+            this.predecessors = predecessors;
+            this.attributes().put("predecessors", predecessors);
+        }
+
+        public PhiOp(PhiOp that, CopyContext cc) {
+            super(that, cc);
+            List<Predecessor> thisPredecessors = List.of();
+            for (var predecessor : that.predecessors) {
+                thisPredecessors.add(new Predecessor(cc.getSuccessorOrCreate(predecessor.block), predecessor.value()));
+            }
+            this.predecessors = thisPredecessors;
+            this.attributes().put("predecessors", predecessors);
+        }
+
+        @Override
+        public PhiOp transform(CopyContext cc, OpTransformer ot) {
+            return new PhiOp(this, cc);
+        }
+
+        public List<Predecessor> predecessors() {
+            return predecessors;
+        }
+    }
+
+    public static final class LoadOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "load";
+
+        public LoadOp(TypeElement resultType, List<Value> operands) {
+            super(OPNAME, resultType, operands);
+        }
+
+        public LoadOp(LoadOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public LoadOp transform(CopyContext cc, OpTransformer ot) {
+            return new LoadOp(this, cc);
+        }
+    }
+
+    public static final class FieldLoadOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "fieldload";
+        private final FieldRef fieldDesc;
+
+        public FieldLoadOp(TypeElement resultType, FieldRef fieldRef, List<Value> operands) {
+            super(OPNAME, resultType, operands);
+            this.fieldDesc = fieldRef;
+        }
+
+        public FieldLoadOp(FieldLoadOp that, CopyContext cc) {
+            super(that, cc);
+            this.fieldDesc = that.fieldDesc;
+        }
+
+        @Override
+        public FieldLoadOp transform(CopyContext cc, OpTransformer ot) {
+            return new FieldLoadOp(this, cc);
+        }
+
+        public FieldRef fieldDescriptor() {
+            return fieldDesc;
+        }
+    }
+
+    public static final class StoreOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "store";
+
+        public StoreOp(Value dest, Value value) {
+            super(NAME, JavaType.VOID, List.of(dest, value));
+        }
+
+        public StoreOp(List<Value> operands) {
+            this(operands.get(0), operands.get(1));
+        }
+
+        public StoreOp(StoreOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public StoreOp transform(CopyContext cc, OpTransformer ot) {
+            return new StoreOp(this, cc);
+        }
+    }
+
+    public static final class CallOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "call";
+        private MethodRef descriptor;
+
+        public CallOp(MethodRef descriptor, List<Value> operands) {
+            super(nameString(descriptor), descriptor.type().returnType(), operands);
+            this.descriptor = descriptor;
+        }
+
+        public CallOp(CallOp that, CopyContext cc) {
+            super(that, cc);
+            this.descriptor = that.descriptor;
+        }
+
+        @Override
+        public CallOp transform(CopyContext cc, OpTransformer ot) {
+            return new CallOp(this, cc);
+        }
+
+        public MethodRef callDescriptor() {
+            return descriptor;
+        }
+
+        private static String nameString(MethodRef descriptor) {
+            return OPNAME + " @" + descriptor.refType() + "::" + descriptor.name();
+        }
+    }
+
+    public static final class ArrayLengthOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "arraylength";
+
+        public ArrayLengthOp(TypeElement resultType, List<Value> operands) {
+            super(NAME, resultType, operands);
+        }
+
+        public ArrayLengthOp(ArrayLengthOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public ArrayLengthOp transform(CopyContext cc, OpTransformer ot) {
+            return new ArrayLengthOp(this, cc);
+        }
+    }
+
+    public static final class ConstantOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "constant";
+        private final Object value;
+
+        public ConstantOp(TypeElement resultType, Object value) {
+                super(OPNAME, resultType, List.of());
+                this.value = value;
+        }
+
+        public ConstantOp(ConstantOp that, CopyContext cc) {
+            super(that, cc);
+            this.value = that.value;  // TODO: need to copy
+        }
+
+        @Override
+        public ConstantOp transform(CopyContext cc, OpTransformer ot) {
+            return new ConstantOp(this, cc);
+        }
+
+        public Object value() {
+            return value;
+        }
+    }
+
+    public static final class ConvertOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "sconvert";
+
+        public ConvertOp(TypeElement resultType, List<Value> operands) {
+                super(OPNAME, resultType, operands);
+        }
+
+        public ConvertOp(ConvertOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public ConvertOp transform(CopyContext cc, OpTransformer ot) {
+            return new ConvertOp(this, cc);
+        }
+    }
+
+    public static final class BitwiseAndOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "and";
+
+        public BitwiseAndOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public BitwiseAndOp(BitwiseAndOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public BitwiseAndOp transform(CopyContext cc, OpTransformer ot) {
+            return new BitwiseAndOp(this, cc);
+        }
+    }
+
+
+    public static final class IAddOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "iadd";
+
+        public IAddOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public IAddOp(IAddOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public IAddOp transform(CopyContext cc, OpTransformer ot) {
+            return new IAddOp(this, cc);
+        }
+    }
+
+    public static final class FAddOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "fadd";
+
+        public FAddOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public FAddOp(FAddOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FAddOp transform(CopyContext cc, OpTransformer ot) {
+            return new FAddOp(this, cc);
+        }
+    }
+
+    public static final class ISubOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "isub";
+
+        public ISubOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public ISubOp(ISubOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public ISubOp transform(CopyContext cc, OpTransformer ot) {
+            return new ISubOp(this, cc);
+        }
+    }
+
+    public static final class FSubOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "fsub";
+
+        public FSubOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public FSubOp(FSubOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FSubOp transform(CopyContext cc, OpTransformer ot) {
+            return new FSubOp(this, cc);
+        }
+    }
+
+    public static final class IMulOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "imul";
+
+        public IMulOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public IMulOp(IMulOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public IMulOp transform(CopyContext cc, OpTransformer ot) {
+            return new IMulOp(this, cc);
+        }
+    }
+
+    public static final class FMulOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "fmul";
+
+        public FMulOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public FMulOp(FMulOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FMulOp transform(CopyContext cc, OpTransformer ot) {
+            return new FMulOp(this, cc);
+        }
+    }
+
+    public static final class IDivOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "idiv";
+
+        public IDivOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public IDivOp(IDivOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public IDivOp transform(CopyContext cc, OpTransformer ot) {
+            return new IDivOp(this, cc);
+        }
+    }
+
+    public static final class FDivOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "fdiv";
+
+        public FDivOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public FDivOp(FDivOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FDivOp transform(CopyContext cc, OpTransformer ot) {
+            return new FDivOp(this, cc);
+        }
+    }
+
+    public static final class ModOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "mod";
+
+        public ModOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public ModOp(ModOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public ModOp transform(CopyContext cc, OpTransformer ot) {
+            return new ModOp(this, cc);
+        }
+    }
+
+    public static final class SNegateOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "sneg";
+
+        public SNegateOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public SNegateOp(SNegateOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public SNegateOp transform(CopyContext cc, OpTransformer ot) {
+            return new SNegateOp(this, cc);
+        }
+    }
+
+    public static final class FNegateOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "fneg";
+
+        public FNegateOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public FNegateOp(FNegateOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FNegateOp transform(CopyContext cc, OpTransformer ot) {
+            return new FNegateOp(this, cc);
+        }
+    }
+
+    public static final class IEqualOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "iequal";
+
+        public IEqualOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public IEqualOp(IEqualOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public IEqualOp transform(CopyContext cc, OpTransformer ot) {
+            return new IEqualOp(this, cc);
+        }
+    }
+
+    public static final class FEqualOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "fequal";
+
+        public FEqualOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public FEqualOp(FEqualOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FEqualOp transform(CopyContext cc, OpTransformer ot) {
+            return new FEqualOp(this, cc);
+        }
+    }
+
+    public static final class INotEqualOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "inotequal";
+
+        public INotEqualOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public INotEqualOp(INotEqualOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public INotEqualOp transform(CopyContext cc, OpTransformer ot) {
+            return new INotEqualOp(this, cc);
+        }
+    }
+
+
+    public static final class FNotEqualOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "fnotequal";
+
+        public FNotEqualOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public FNotEqualOp(FNotEqualOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FNotEqualOp transform(CopyContext cc, OpTransformer ot) {
+            return new FNotEqualOp(this, cc);
+        }
+    }
+
+    public static final class PtrNotEqualOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "ptrnotequal";
+
+        public PtrNotEqualOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public PtrNotEqualOp(PtrNotEqualOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public PtrNotEqualOp transform(CopyContext cc, OpTransformer ot) {
+            return new PtrNotEqualOp(this, cc);
+        }
+    }
+
+    public static final class LtOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "lt";
+
+        public LtOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public LtOp(LtOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public LtOp transform(CopyContext cc, OpTransformer ot) {
+            return new LtOp(this, cc);
+        }
+    }
+
+    public static final class GtOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "gt";
+
+        public GtOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public GtOp(GtOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public GtOp transform(CopyContext cc, OpTransformer ot) {
+            return new GtOp(this, cc);
+        }
+    }
+
+    public static final class GeOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "ge";
+
+        public GeOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public GeOp(GeOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public GeOp transform(CopyContext cc, OpTransformer ot) {
+            return new GeOp(this, cc);
+        }
+    }
+
+    public static final class BranchOp extends SpirvOp implements Op.BlockTerminating {
+        public static final String NAME = NAME_PREFIX + "br";
+        private final Block.Reference successor;
+
+        public BranchOp(Block.Reference successor) {
+            super(NAME, JavaType.VOID, List.of());
+            this.successor = successor;
+        }
+
+        public BranchOp(BranchOp that, CopyContext cc) {
+            super(that, cc);
+            this.successor = cc.getSuccessorOrCreate(that.successor);
+        }
+
+        @Override
+        public BranchOp transform(CopyContext cc, OpTransformer ot) {
+            return new BranchOp(this, cc);
+        }
+
+        public Block.Reference branch() {
+            return successor;
+        }
+
+        @Override
+        public List<Block.Reference> successors() {
+            return List.of(successor);
+        }
+    }
+
+    public static final class ConditionalBranchOp extends SpirvOp implements Op.BlockTerminating {
+        public static final String NAME = NAME_PREFIX + "brcond";
+        private final Block.Reference trueBlock;
+        private final Block.Reference falseBlock;
+
+        public ConditionalBranchOp(Block.Reference trueBlock, Block.Reference falseBlock, List<Value> operands) {
+                super(NAME, JavaType.VOID, operands);
+                this.trueBlock = trueBlock;
+                this.falseBlock = falseBlock;
+        }
+
+        public ConditionalBranchOp(ConditionalBranchOp that, CopyContext cc) {
+            super(that, cc);
+            this.trueBlock = cc.getSuccessorOrCreate(that.trueBlock);
+            this.falseBlock = cc.getSuccessorOrCreate(that.falseBlock);
+        }
+
+        @Override
+        public ConditionalBranchOp transform(CopyContext cc, OpTransformer ot) {
+            return new ConditionalBranchOp(this, cc);
+        }
+
+        public Block.Reference trueBranch() {
+            return trueBlock;
+        }
+
+        public Block.Reference falseBranch() {
+            return falseBlock;
+        }
+
+        @Override
+        public List<Block.Reference> successors() {
+            return List.of(trueBlock, falseBlock);
+        }
+    }
+
+    public static final class VariableOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "variable";
+        private final String varName;
+        private final TypeElement varType;
+
+        public VariableOp(String varName, TypeElement type, TypeElement varType) {
+            super(OPNAME + " @" + varName, type, List.of());
+            this.varName = varName;
+            this.varType = varType;
+        }
+
+        public VariableOp(VariableOp that, CopyContext cc) {
+            super(that, cc);
+            this.varName = that.varName;
+            this.varType = that.varType;
+        }
+
+        @Override
+        public VariableOp transform(CopyContext cc, OpTransformer ot) {
+            return new VariableOp(this, cc);
+        }
+
+        public TypeElement varType() {
+            return varType;
+        }
+
+        public String varName() {
+            return varName;
+        }
+    }
+
+    public static final class CompositeExtractOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "compositeExtract";
+
+        public CompositeExtractOp(TypeElement resultType, List<Value> operands) {
+                super(OPNAME, resultType, operands);
+        }
+
+        public CompositeExtractOp(CompositeExtractOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public CompositeExtractOp transform(CopyContext cc, OpTransformer ot) {
+            return new CompositeExtractOp(this, cc);
+        }
+    }
+
+    public static final class InBoundsAccessChainOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "inBoundsAccessChain";
+
+        public InBoundsAccessChainOp(TypeElement resultType, List<Value> operands) {
+                super(OPNAME, resultType, operands);
+        }
+
+        public InBoundsAccessChainOp(InBoundsAccessChainOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public InBoundsAccessChainOp transform(CopyContext cc, OpTransformer ot) {
+            return new InBoundsAccessChainOp(this, cc);
+        }
+    }
+
+    public static final class ReturnOp extends SpirvOp implements Op.Terminating {
+        public static final String OPNAME = "return";
+
+        public ReturnOp(TypeElement resultType) {
+            super(OPNAME, resultType, List.of());
+        }
+
+        public ReturnOp(ReturnOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public ReturnOp transform(CopyContext cc, OpTransformer ot) {
+            return new ReturnOp(this, cc);
+        }
+    }
+
+    public static final class ReturnValueOp extends SpirvOp implements Op.Terminating {
+        public static final String OPNAME = "return";
+
+        public ReturnValueOp(TypeElement resultType, List<Value> operands) {
+            super(OPNAME, resultType, operands);
+        }
+
+        public ReturnValueOp(ReturnValueOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public ReturnValueOp transform(CopyContext cc, OpTransformer ot) {
+            return new ReturnValueOp(this, cc);
+        }
+    }
+
+    public static final class FunctionParameterOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "function parameter";
+
+        public FunctionParameterOp(TypeElement resultType, List<Value> operands) {
+            super(OPNAME, resultType, operands);
+        }
+
+        public FunctionParameterOp(FunctionParameterOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public FunctionParameterOp transform(CopyContext cc, OpTransformer ot) {
+            return new FunctionParameterOp(this, cc);
+        }
+    }
+
+    public static final class FuncOp extends SpirvOp implements Op.Invokable {
+        public static enum Control {
+            INLINE,
+            DONTINLINE,
+            PURE,
+            CONST,
+            NONE
+        }
+
+        public static final String OPNAME = NAME_PREFIX + "function";
+        private final String functionName;
+        private final FunctionType functionType;
+        private final Body body;
+
+
+        public FuncOp(String name, FunctionType functionType, Body.Builder builder) {
+            super(OPNAME + "_" + name);
+            this.functionName = name;
+            this.functionType = functionType;
+            this.body = builder.build(this);
+        }
+
+        public FuncOp(FuncOp that, CopyContext cc) {
+            super(that, cc);
+            this.functionName = that.functionName;
+            this.functionType = that.functionType;
+            this.body = that.body;
+        }
+
+        public FuncOp transform(OpTransformer ot) {
+            return transform(CopyContext.create(), ot);
+        }
+
+        @Override
+        public FuncOp transform(CopyContext cc, OpTransformer ot) {
+            return new FuncOp(this, this.functionName, cc, ot);
+        }
+
+        FuncOp(FuncOp that, String functionName, CopyContext cc, OpTransformer ot) {
+            super(that, cc);
+            this.functionType = that.functionType;
+            this.functionName = functionName;
+            Body.Builder bb = that.body.transform(cc, ot);
+            this.body = bb.build(this);
+        }
+
+        @Override
+        public Body body() {
+            return body;
+        }
+
+        public String functionName() {
+            return functionName;
+        }
+
+        @Override
+        public List<Body> bodies() {
+            return List.of(body);
+        }
+
+        @Override
+        public FunctionType invokableType() {
+            return functionType;
+        }
+    }
+}

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvType.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.lang.reflect.code.TypeElement;
+
+public abstract sealed class SpirvType implements TypeElement permits PointerType, StorageType {
+}

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/StorageType.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/StorageType.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.util.List;
+import java.util.Objects;
+
+public sealed abstract class StorageType extends SpirvType
+    permits StorageType.Input, StorageType.Workgroup, StorageType.CrossWorkgroup, StorageType.Private, StorageType.Function {
+
+    public static final Input INPUT = new Input();
+    public static final Workgroup WORKGROUP = new Workgroup();
+    public static final CrossWorkgroup CROSSWORKGROUP= new CrossWorkgroup();
+    public static final Private PRIVATE = new Private();
+    public static final Function FUNCTION = new Function();
+
+    protected final String NAME;
+
+    protected StorageType(String name) {
+        this.NAME = name;
+    }
+
+    static final class Input extends StorageType {
+        protected Input(){
+            super("Input");
+        }
+    }
+
+    static final class Workgroup extends StorageType {
+        protected Workgroup() {
+            super("Workgroup");
+        }
+    }
+
+    static final class CrossWorkgroup extends StorageType
+    {
+        protected CrossWorkgroup() {
+            super("CrossWorkgroup");
+        }
+    }
+
+    static final class Private extends StorageType
+    {
+        protected Private() {
+            super("Private");
+        }
+    }
+
+    static final class Function extends StorageType
+    {
+        protected Function() {
+            super("Function");
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && obj.getClass() != this.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(NAME);
+    }
+
+    @Override
+    public ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(NAME, List.of());
+    }
+
+    @Override
+    public String toString() {
+        return externalize().toString();
+    }
+}

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.lang.reflect.code.Block;
+import java.lang.reflect.code.Body;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.Value;
+import java.lang.reflect.code.CopyContext;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.TypeElement;
+import java.lang.reflect.code.type.JavaType;
+import intel.code.spirv.SpirvOp.PhiOp;
+
+public class TranslateToSpirvModel  {
+    private Map<Block, Block.Builder> blockMap;    // Java block to spirv block builder
+    private Map<Value, Value> valueMap;            // Java model Value to Spirv model Value
+
+    public static SpirvOp.FuncOp translateFunction(CoreOp.FuncOp func) {
+        CoreOp.FuncOp lowFunc = lowerMethod(func);
+        TranslateToSpirvModel instance = new TranslateToSpirvModel();
+        Body.Builder bodyBuilder = instance.translateBody(lowFunc.body(), lowFunc, null);
+        SpirvOp.FuncOp tempFunc = new SpirvOp.FuncOp(lowFunc.funcName(), lowFunc.invokableType(), bodyBuilder);
+        SpirvOp.FuncOp spirvFunc = instance.addPhiOps(tempFunc);
+        return spirvFunc;
+    }
+
+    public TranslateToSpirvModel() {
+        blockMap = new HashMap<>();
+        valueMap = new HashMap<>();
+    }
+
+    private PhiMap buildPhiMap(SpirvOp.FuncOp func) {
+        PhiMap phiMap = PhiMap.create(); // Map<Block, List<List<PhiMap.Predecessor>>>>
+        // populate map with (predecessor, parameter value) pairs for each block parameter
+        for (Block block : func.body().blocks()) {
+            for (Op op : block.ops()) {
+                switch (op) {
+                    case SpirvOp.BranchOp bop: {
+                        Block targetBlock = bop.branch().targetBlock();
+                        for (int i = 0; i < bop.branch().arguments().size(); i++) {
+                            Value arg = bop.branch().arguments().get(i);
+                            phiMap.addPredecessor(targetBlock, i, new PhiMap.Predecessor(bop.parent(), arg));
+                        }
+                        break;
+                    }
+                    case SpirvOp.ConditionalBranchOp cbop: {
+                        Block trueBlock = cbop.trueBranch().targetBlock();
+                        Block falseBlock = cbop.falseBranch().targetBlock();
+                        for (int i = 0; i < cbop.trueBranch().arguments().size(); i++) {
+                            Value arg = cbop.trueBranch().arguments().get(i);
+                            phiMap.addPredecessor(trueBlock, i, new PhiMap.Predecessor(cbop.parent(), arg));
+                        }
+                        for (int i = 0; i < cbop.falseBranch().arguments().size(); i++) {
+                            Value arg = cbop.falseBranch().arguments().get(i);
+                            phiMap.addPredecessor(falseBlock, i, new PhiMap.Predecessor(cbop.parent(), arg));
+                        }
+                        break;
+                    }
+                    default:
+                }
+            }
+        }
+        return phiMap;
+    }
+
+    private SpirvOp.FuncOp addPhiOps(SpirvOp.FuncOp func) {
+        PhiMap phiMap = buildPhiMap(func);
+        SpirvOp.FuncOp tfunc = func.transform((builder, op) -> {
+            Block block = op.parent();
+            if (phiMap.containsBlock(block)) {
+                for (int i = 0; i < block.parameters().size(); i++) {
+                    List<PhiMap.Predecessor> inPredecessors = phiMap.getPredecessors(block, i);
+                    List<PhiOp.Predecessor> outPredecessors = new ArrayList<>();
+                    Block.Parameter param = block.parameters().get(i);
+                    for (PhiMap.Predecessor predecessor : inPredecessors) {
+                        Block.Builder sourceBuilder = builder.context().getBlock(predecessor.block());
+                        Block.Reference sourceRef = sourceBuilder.isEntryBlock() ? null : sourceBuilder.successor();
+                        outPredecessors.add(new PhiOp.Predecessor(sourceRef, builder.context().getValue(predecessor.value())));
+                    }
+                    Op.Result phiResult = builder.op(new SpirvOp.PhiOp(param.type(), outPredecessors));
+                    builder.context().mapValue(param, phiResult);
+                }
+                phiMap.removeBlock(block);
+            }
+            builder.op(op);
+            return builder;
+        });
+        return tfunc;
+    }
+
+    private Body.Builder translateBody(Body body, Op parentOp, Body.Builder ancestorBody) {
+        Body.Builder bodyBuilder = Body.Builder.of(ancestorBody, body.bodyType());
+        Block.Builder spirvBlock = bodyBuilder.entryBlock();
+        blockMap.put(body.entryBlock(), spirvBlock);
+        List<Block> blocks = body.blocks();
+        // map Java blocks to spirv blocks
+        for (Block b : blocks.subList(1, blocks.size()))  {
+            Block.Builder loweredBlock = spirvBlock.block();
+            for (TypeElement paramType : b.parameterTypes()) {
+                loweredBlock.parameter(paramType);
+            }
+            spirvBlock = loweredBlock;
+            for (int i = 0; i < b.parameters().size(); i++) {
+                Block.Parameter param = b.parameters().get(i);
+                valueMap.put(param, spirvBlock.parameters().get(i));
+            }
+            blockMap.put(b, spirvBlock);
+        }
+        // map entry block parameters to spirv function parameter
+        spirvBlock = bodyBuilder.entryBlock();
+        List<SpirvOp> paramOps = new ArrayList<>();
+        Block entryBlock = body.entryBlock();
+        int paramCount = entryBlock.parameters().size();
+        for (int i = 0; i < paramCount; i++) {
+            Block.Parameter bp = entryBlock.parameters().get(i);
+            assert entryBlock.ops().get(i) instanceof CoreOp.VarOp;
+            SpirvOp funcParam = new SpirvOp.FunctionParameterOp(bp.type(), List.of());
+            spirvBlock.op(funcParam);
+            valueMap.put(bp, funcParam.result());
+            paramOps.add(funcParam);
+        }
+        // emit all SpirvOp.VariableOps as first ops in entry block
+        for (Block block : body.blocks()) {
+            for (Op op : block.ops()) {
+                if (op instanceof CoreOp.VarOp jvop) {
+                    TypeElement resultType = new PointerType(jvop.varValueType(), StorageType.CROSSWORKGROUP);
+                    SpirvOp.VariableOp svop = new SpirvOp.VariableOp((String)jvop.attributes().get(""), resultType, jvop.varValueType());
+                    bodyBuilder.entryBlock().op(svop);
+                    valueMap.put(jvop.result(), svop.result());
+                }
+            }
+        }
+        for (Block block : body.blocks()) {
+            spirvBlock = blockMap.get(block);
+            for (Op op : block.ops()) {
+                switch (op) {
+                    case CoreOp.VarOp vop -> {
+                        Value dest = valueMap.get(vop.result());
+                        Value value = valueMap.get(vop.operands().get(0));
+                        // init variable here; declaration has been moved to top of function
+                        SpirvOp.StoreOp store = new SpirvOp.StoreOp(dest, value);
+                        spirvBlock.op(store);
+                    }
+                    case CoreOp.ReturnOp rop -> {
+                        if (rop.operands().size() > 0) {
+                            spirvBlock.op(new SpirvOp.ReturnValueOp(rop.resultType(), mapOperands(rop)));
+                        }
+                        else {
+                            spirvBlock.op(new SpirvOp.ReturnOp(rop.resultType()));
+                        }
+                    }
+                    case CoreOp.VarAccessOp.VarLoadOp vlo -> {
+                        List<Value> operands = mapOperands(vlo);
+                        Op.Result loadResult = spirvBlock.op(new SpirvOp.LoadOp(vlo.resultType(), operands));
+                        valueMap.put(vlo.result(), loadResult);
+                    }
+                    case CoreOp.VarAccessOp.VarStoreOp vso -> {
+                        Value dest = valueMap.get(vso.varOp().result());
+                        Value value = valueMap.get(vso.operands().get(1));
+                        spirvBlock.op(new SpirvOp.StoreOp(dest, value));
+                    }
+                    case CoreOp.ArrayAccessOp.ArrayLoadOp alo -> {
+                        Value array = valueMap.get(alo.operands().get(0));
+                        Value index = valueMap.get(alo.operands().get(1));
+                        TypeElement arrayType = array.type();
+                        SpirvOp.ConvertOp convert = new SpirvOp.ConvertOp(JavaType.type(long.class), List.of(index));
+                        spirvBlock.op(new SpirvOp.LoadOp(arrayType, List.of(array)));
+                        spirvBlock.op(convert);
+                        SpirvOp ibac = new SpirvOp.InBoundsAccessChainOp(arrayType, List.of(array, convert.result()));
+                        spirvBlock.op(ibac);
+                        Op.Result loadResult = spirvBlock.op(new SpirvOp.LoadOp(alo.resultType(), List.of(ibac.result())));
+                        valueMap.put(alo.result(), loadResult);
+                    }
+                    case CoreOp.ArrayAccessOp.ArrayStoreOp aso -> {
+                        Value array = valueMap.get(aso.operands().get(0));
+                        Value index = valueMap.get(aso.operands().get(1));
+                        TypeElement arrayType = array.type();
+                        SpirvOp ibac = new SpirvOp.InBoundsAccessChainOp(arrayType, List.of(array, index));
+                        spirvBlock.op(ibac);
+                        SpirvOp.StoreOp store = new SpirvOp.StoreOp(ibac.result(), valueMap.get(aso.operands().get(2)));
+                        spirvBlock.op(store);
+                    }
+                    case CoreOp.ArrayLengthOp alo -> {
+                        Op len = new SpirvOp.ArrayLengthOp(JavaType.INT, List.of(valueMap.get(alo.operands().get(0))));
+                        spirvBlock.op(len);
+                        valueMap.put(alo.result(), len.result());
+                    }
+                    case CoreOp.AndOp andop -> {
+                        TypeElement type = andop.operands().get(0).type();
+                        List<Value> operands = mapOperands(andop);
+                        SpirvOp saop = new SpirvOp.BitwiseAndOp(type, operands);
+                        spirvBlock.op(saop);
+                        valueMap.put(andop.result(), saop.result());
+                     }
+                    case CoreOp.AddOp aop -> {
+                        TypeElement type = aop.operands().get(0).type();
+                        List<Value> operands = mapOperands(aop);
+                        SpirvOp addOp;
+                        if (isIntegerType(type)) addOp = new SpirvOp.IAddOp(type, operands);
+                        else if (isFloatType(type)) addOp = new SpirvOp.FAddOp(type, operands);
+                        else throw unsupported("type", type);
+                        spirvBlock.op(addOp);
+                        valueMap.put(aop.result(), addOp.result());
+                     }
+                    case CoreOp.SubOp sop -> {
+                        TypeElement  type = sop.operands().get(0).type();
+                        List<Value> operands = mapOperands(sop);
+                        SpirvOp subOp;
+                        if (isIntegerType(type)) subOp = new SpirvOp.ISubOp(type, operands);
+                        else if (isFloatType(type)) subOp = new SpirvOp.FSubOp(type, operands);
+                        else throw unsupported("type", type);
+                        spirvBlock.op(subOp);
+                        valueMap.put(sop.result(), subOp.result());
+                     }
+                    case CoreOp.MulOp mop -> {
+                        TypeElement type = mop.operands().get(0).type();
+                        List<Value> operands = mapOperands(mop);
+                        SpirvOp mulOp;
+                        if (isIntegerType(type)) mulOp = new SpirvOp.IMulOp(type, operands);
+                        else if (isFloatType(type)) mulOp = new SpirvOp.FMulOp(type, operands);
+                        else throw unsupported("type", type);
+                        spirvBlock.op(mulOp);
+                        valueMap.put(mop.result(), mulOp.result());
+                    }
+                    case CoreOp.DivOp dop -> {
+                        TypeElement type = dop.operands().get(0).type();
+                        List<Value> operands = mapOperands(dop);
+                        SpirvOp divOp;
+                        if (isIntegerType(type)) divOp = new SpirvOp.IDivOp(type, operands);
+                        else if (isFloatType(type)) divOp = new SpirvOp.FDivOp(type, operands);
+                        else throw unsupported("type", type);
+                        spirvBlock.op(divOp);
+                        valueMap.put(dop.result(), divOp.result());
+                    }
+                    case CoreOp.ModOp mop -> {
+                        TypeElement type = mop.operands().get(0).type();
+                        List<Value> operands = mapOperands(mop);
+                        SpirvOp modOp = new SpirvOp.ModOp(type, operands);
+                        spirvBlock.op(modOp);
+                        valueMap.put(mop.result(), modOp.result());
+                    }
+                    case CoreOp.NegOp negop -> {
+                        TypeElement type = negop.operands().get(0).type();
+                        List<Value> operands = mapOperands(negop);
+                        SpirvOp snegop;
+                        if (isIntegerType(type)) snegop = new SpirvOp.SNegateOp(type, operands);
+                        else if (isFloatType(type)) snegop = new SpirvOp.FNegateOp(type, operands);
+                        else throw unsupported("type", type);
+                        spirvBlock.op(snegop);
+                        valueMap.put(negop.result(), snegop.result());
+                    }
+                    case CoreOp.EqOp eqop -> {
+                        TypeElement type = eqop.operands().get(0).type();
+                        List<Value> operands = mapOperands(eqop);
+                        SpirvOp seqop;
+                        if (isIntegerType(type)) seqop = new SpirvOp.IEqualOp(type, operands);
+                        else if (isFloatType(type)) seqop = new SpirvOp.FEqualOp(type, operands);
+                        else throw unsupported("type", type);
+                        spirvBlock.op(seqop);
+                        valueMap.put(eqop.result(), seqop.result());
+                    }
+                    case CoreOp.NeqOp neqop -> {
+                        TypeElement type = neqop.operands().get(0).type();
+                        List<Value> operands = mapOperands(neqop);
+                        SpirvOp sneqop;
+                        if (isIntegerType(type)) sneqop = new SpirvOp.INotEqualOp(type, operands);
+                        else if (isFloatType(type)) sneqop = new SpirvOp.FNotEqualOp(type, operands);
+                        else if (isObjectType(type)) sneqop = new SpirvOp.PtrNotEqualOp(type, operands);
+                        else throw unsupported("type", type);
+                        spirvBlock.op(sneqop);
+                        valueMap.put(neqop.result(), sneqop.result());
+                    }
+                    case CoreOp.LtOp ltop -> {
+                        TypeElement type = ltop.operands().get(0).type();
+                        List<Value> operands = mapOperands(ltop);
+                        SpirvOp sltop = new SpirvOp.LtOp(type, operands);
+                        spirvBlock.op(sltop);
+                        valueMap.put(ltop.result(), sltop.result());
+                    }
+                    case CoreOp.GtOp gtop -> {
+                        TypeElement type = gtop.operands().get(0).type();
+                        List<Value> operands = mapOperands(gtop);
+                        SpirvOp sgtop = new SpirvOp.LtOp(type, operands);
+                        spirvBlock.op(sgtop);
+                        valueMap.put(gtop.result(), sgtop.result());
+                    }
+                    case CoreOp.GeOp geop -> {
+                        TypeElement type = geop.operands().get(0).type();
+                        List<Value> operands = mapOperands(geop);
+                        SpirvOp sgeop = new SpirvOp.GeOp(type, operands);
+                        spirvBlock.op(sgeop);
+                        valueMap.put(geop.result(), sgeop.result());
+                    }
+                    case CoreOp.InvokeOp inv -> {
+                        List<Value> operands = mapOperands(inv);
+                        SpirvOp spirvCall = new SpirvOp.CallOp(inv.invokeDescriptor(), operands);
+                        spirvBlock.op(spirvCall);
+                        valueMap.put(inv.result(), spirvCall.result());
+                    }
+                    case CoreOp.ConstantOp cop -> {
+                        SpirvOp scop = new SpirvOp.ConstantOp(cop.resultType(), cop.value());
+                        spirvBlock.op(scop);
+                        valueMap.put(cop.result(), scop.result());
+                    }
+                    case CoreOp.ConvOp cop -> {
+                        List<Value> operands = mapOperands(cop);
+                        SpirvOp scop = new SpirvOp.ConvertOp(cop.resultType(), operands);
+                        spirvBlock.op(scop);
+                        valueMap.put(cop.result(), scop.result());
+                    }
+                    case CoreOp.FieldAccessOp.FieldLoadOp flo -> {
+                        SpirvOp load = new SpirvOp.FieldLoadOp(flo.resultType(), flo.fieldDescriptor(), mapOperands(flo));
+                        spirvBlock.op(load);
+                        valueMap.put(flo.result(), load.result());
+                    }
+                    case CoreOp.BranchOp bop -> {
+                        Block branchBlock = bop.branch().targetBlock();
+                        List<Value> sargs = new ArrayList<>();
+                        for (Value arg : bop.branch().arguments()) {
+                            sargs.add(valueMap.get(arg));
+                        }
+                        Block.Reference spvTargetBlock = blockMap.get(branchBlock).successor(sargs);
+                        spirvBlock.op(new SpirvOp.BranchOp(spvTargetBlock));
+                    }
+                    case CoreOp.ConditionalBranchOp cbop -> {
+                        Block trueBlock = cbop.trueBranch().targetBlock();
+                        List<Value> targs = new ArrayList<>();
+                        for (Value targ : cbop.trueBranch().arguments()) {
+                            targs.add(valueMap.get(targ));
+                        }
+                        Block falseBlock = cbop.falseBranch().targetBlock();
+                        List<Value> fargs = new ArrayList<>();
+                        for (Value farg : cbop.falseBranch().arguments()) {
+                            fargs.add(valueMap.get(farg));
+                        }
+                        Block.Reference spvTrueBlock = blockMap.get(trueBlock).successor(targs);
+                        Block.Reference spvFalseBlock = blockMap.get(falseBlock).successor(fargs);
+                        spirvBlock.op(new SpirvOp.ConditionalBranchOp(spvTrueBlock, spvFalseBlock, mapOperands(cbop)));
+                    }
+                    default -> throw unsupported("op", op.getClass());
+                }
+            } //ops
+        } // blocks
+        return bodyBuilder;
+    }
+
+    private RuntimeException unsupported(String message, Object value) {
+        return new RuntimeException("Unsupported " + message + ": " + value);
+    }
+
+    private static CoreOp.FuncOp lowerMethod(CoreOp.FuncOp fop) {
+        CoreOp.FuncOp lfop = fop.transform((block, op) -> {
+            if (op instanceof Op.Lowerable lop)  {
+                return lop.lower(block);
+            }
+            else {
+                block.op(op);
+                return block;
+            }
+        });
+        return lfop;
+    }
+
+    private List<Value> mapOperands(Op op) {
+        List<Value> operands = new ArrayList<>();
+        for (Value javaValue : op.operands()) {
+            Value spirvValue = valueMap.get(javaValue);
+            assert spirvValue != null : "no value mapping from %s" + javaValue;
+            if (spirvValue == null) throw new RuntimeException("no value mapping from %s" + javaValue);
+            operands.add(spirvValue);
+        }
+        return operands;
+    }
+
+    private boolean isIntegerType(TypeElement type) {
+        return type.equals(JavaType.INT) || type.equals(JavaType.LONG);
+    }
+
+    private boolean isFloatType(TypeElement type) {
+        return type.equals(JavaType.FLOAT) || type.equals(JavaType.DOUBLE);
+    }
+
+    private boolean isObjectType(TypeElement type) {
+        // TODO: not correct
+        return !isIntegerType(type) && !isFloatType(type);
+    }
+
+    private static class PhiMap {
+        public static record Predecessor(Block block, Value value) {}
+
+        private Map<Block, List<List<Predecessor>>> data;
+
+        private PhiMap() {
+            data = new HashMap<>();
+        }
+
+        public static PhiMap create() {
+            return new PhiMap();
+        }
+
+        private void addBlock(Block block) {
+            data.putIfAbsent(block, new ArrayList<>());
+        }
+
+        private void addParameter(Block block, int index) {
+            addBlock(block);
+            int paramCount = data.get(block).size();
+            if (paramCount <= index) {
+                data.get(block).add(new ArrayList<>());
+            }
+        }
+
+        public void addPredecessor(Block block, int paramIndex, Predecessor predecessor) {
+            addBlock(block);
+            addParameter(block, paramIndex);
+            data.get(block).get(paramIndex).add(predecessor);
+        }
+
+        public boolean containsBlock(Block block) {
+            return data.containsKey(block);
+        }
+
+        public List<Predecessor> getPredecessors(Block block, int paramIndex) {
+            return data.get(block).get(paramIndex);
+        }
+
+        public void removeBlock(Block block) {
+            data.remove(block);
+        }
+
+        public String toString() {
+            return data.toString();
+        }
+    }
+}

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/UsmArena.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/UsmArena.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package intel.code.spirv;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment.Scope;
+import static java.lang.foreign.ValueLayout.*;
+import oneapi.levelzero.ze_api_h;
+import static oneapi.levelzero.ze_api_h.*;
+import oneapi.levelzero.ze_device_mem_alloc_desc_t;
+import oneapi.levelzero.ze_host_mem_alloc_desc_t;
+
+public final class UsmArena implements Arena {
+    private final Arena lzArena;
+    private final MemorySegment contextHandle;
+    private final MemorySegment deviceHandle;
+
+    public UsmArena(MemorySegment contextHandle, MemorySegment deviceHandle) {
+        lzArena = Arena.global();
+        this.contextHandle = contextHandle;
+        this.deviceHandle = deviceHandle;
+    }
+
+    public MemorySegment allocate(long byteSize, long byteAlignment) {
+        MemorySegment pDeviceMemAllocDesc = lzArena.allocate(ze_device_mem_alloc_desc_t.layout());
+        ze_device_mem_alloc_desc_t.stype(pDeviceMemAllocDesc, ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC());
+        ze_device_mem_alloc_desc_t.ordinal(pDeviceMemAllocDesc, 0);
+        MemorySegment pHostMemAllocDesc = lzArena.allocate(ze_host_mem_alloc_desc_t.layout());
+        ze_host_mem_alloc_desc_t.stype(pHostMemAllocDesc, ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC());
+        MemorySegment pBuffer = lzArena.allocate(ADDRESS);
+        check(zeMemAllocShared(contextHandle, pDeviceMemAllocDesc, pHostMemAllocDesc, byteSize, byteAlignment, deviceHandle, pBuffer));
+        long address = pBuffer.get(JAVA_LONG, 0);
+        return MemorySegment.ofAddress(address).reinterpret(byteSize);
+    }
+
+    public void close() {
+    }
+
+    public MemorySegment.Scope scope() {
+        return null;
+    }
+
+    public void freeSegment(MemorySegment segment) {
+        check(zeMemFree(contextHandle, segment));
+    }
+
+    private static void check(int result) {
+        if (result != ZE_RESULT_SUCCESS()) {
+            throw new RuntimeException(String.format("Call failed: 0x%x (%d)", result, result));
+        }
+    }
+}

--- a/hat/hatrun.bash
+++ b/hat/hatrun.bash
@@ -43,9 +43,9 @@ function example(){
       if test -f ${example_jar} ; then
          ${JAVA_HOME}/bin/java \
             --enable-preview --enable-native-access=ALL-UNNAMED \
-            --class-path maven-build/hat-1.0.jar:${example_jar}:${backend_jar} \
+            --class-path maven-build/hat-1.0.jar:${example_jar}:${backend_jar}:maven-build/levelzero.jar:maven-build/beehive-spirv-lib-0.0.4.jar \
             --add-exports=java.base/jdk.internal=ALL-UNNAMED \
-            -Djava.library.path=maven-build\
+            -Djava.library.path=maven-build:/usr/local/lib \
             -Dheadless=${headless} \
             ${example}.Main
       else


### PR DESCRIPTION
## A HAT SPIR-V backend 

Implements an initial version of a HAT SPIR-V backend. It extends JavaBackend and includes no native code. It is complete enough to run the HAT Mandel example and some other simple examples.  It lacks generalized data structure support and so will not yet run, e.g., the BlackScholes or ViolaJones examples.

The backend currently only supports Linux and requires an Intel GPU to run.  Examples of compatible Intel GPU hardware are:

  * Integrated Intel GPU such as:
    * Iris Xe or UHD graphics in 11th generation or later CPUs (Rocket Lake, Alder Lake, Raptor Lake, ...) 
    * Arc graphics available with the latest CPUs, e.g., Meteor Lake
  * Discrete Intel GPU such as Arc 580, 750, 770
    * these are available on Amazon, search, e.g., "Intel Arc 580" or "Intel Arc 770"

Linux drivers for the above hardware have been included in some major Linux distros (e.g. Ubuntu) in time corresponding to the release of the hardware.  Drivers for the discrete Arc cards are included in, e.g., Ubuntu 23.10.  Ubuntu drivers for Arc discrete GPUs can also be downloaded separately.  See https://www.intel.com/content/www/us/en/download/747008/intel-arc-graphics-driver-ubuntu.html 

## Dependencies
Software-wise, the backend has several dependencies outside of the Babylon repo:

	1. The Intel Level Zero library, a low level native library used to access the GPU
	2. A Java binding to the Level Zero library, generated using the OpenJDK jextract tool
	3. The Beehive Labs Java SPIR-V toolkit, used to construct a SPIR-V binary module

Currently these dependencies are not automatically built.  Below is information on how to build and install the three items above.


### Intel Level Zero library 

A build-levelzero.sh script is included in the hat/backends/spirv/scripts directory.  Superuser privileges may be required when running this script.  Execute the script with the scripts directory as the current directory:
```
cd backends/spirv/scripts
sh build-level-zero.sh
```
This will build and install the Level Zero ze_loader.so to /usr/local/lib.  This path must be include in java.library.path or LD_LIBRARY_PATH when running using the spirv backend.

### OpenJDK jextract tool and generated binding to Level Zero

An early-access binary of the jextract tool can be found at: 

	https://jdk.java.net/jextract/

- expand the archive 
- set a JEXTRACT_DIR environment variable to point at the jextract directory.

A generate-level-zero-binding.sh script is included in the hat/backends/spirv/scripts directory.  The script will reference the JEXTRACT_DIR variable set earlier.  Execute the script with the scripts directory as the current directory:

```
cd backends/spirv/scripts
sh generate-level-zero-binding.sh
```

This will generate a Java FFM-based binding to LevelZero, as levelzero.jar, and install the jar in your local Maven repo to satisfy a Maven dependency in the spirv backend pom file.  This jar must be on the Java classpath when running using the spirv backend.


### Beehive Labs Java SPIR-V toolkit

A build-beehive-spirv-toolkit.sh script is included in the hat/backends/spirv/scripts directory.   Note that this project will not currently compile with the babylon JDK, please temporarily set your JAVA_HOME to JDK 22.  Execute the script with the scripts directory as the current directory:

```
cd backends/spirv/scripts
export JAVA_HOME = <path to JDK 22>
sh build-beehive-spirv-toolkit.sh
```

This will build a beehive_spirv_lib.0.0.4.jar and install it in your local maven repo to satisfy a Maven dependency in the spirv backend pom file.  This jar must be on the Java classpath when running the spirv backend.

## Note:

These three dependencies (Level Zero library, Level Zero Java binding, Beehive SPIR-V Toolkit) must be built and installed prior to building and using the 'spirv' backend.  Because these dependencies are not yet built automatically, the spirv backend is current not built by default.  To enable building and use of the spirv backend, after manually running these scripts, change one line of the 'modules' section in hat/backends/pom.xml:

```
<modules>
     <module>opencl</module>
     <module>cuda</module>
     <module>mock</module>
     <module>ptx</module>
     <!--<module>spirv</module>-->
</modules>

```
to: 

```
<modules>
     <module>opencl</module>
     <module>cuda</module>
     <module>mock</module>
     <module>ptx</module>
     <module>spirv</module>
</modules>
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Gary Frost](https://openjdk.org/census#gfrost) (@grfrost - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.org/babylon.git pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/229.diff">https://git.openjdk.org/babylon/pull/229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/229#issuecomment-2347375412)