### PR TITLE
Include boolean in primitive type conversions.

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/InvokableLeafOps.java
@@ -548,6 +548,9 @@ final class InvokableLeafOps {
     static byte conv_byte(double i) {
         return (byte) i;
     }
+    static boolean conv_boolean(double i) {
+        return ((int)i & 1) == 1;
+    }
 
     // float conversion
     static double conv_double(float i) {
@@ -570,6 +573,9 @@ final class InvokableLeafOps {
     }
     static byte conv_byte(float i) {
         return (byte) i;
+    }
+    static boolean conv_boolean(float i) {
+        return ((int)i & 1) == 1;
     }
 
     // long conversion
@@ -594,6 +600,9 @@ final class InvokableLeafOps {
     static byte conv_byte(long i) {
         return (byte) i;
     }
+    static boolean conv_boolean(long i) {
+        return (i & 1) == 1;
+    }
 
     // int conversion
     static double conv_double(int i) {
@@ -616,6 +625,9 @@ final class InvokableLeafOps {
     }
     static byte conv_byte(int i) {
         return (byte) i;
+    }
+    static boolean conv_boolean(int i) {
+        return (i & 1) == 1;
     }
 
     // short conversion
@@ -640,6 +652,9 @@ final class InvokableLeafOps {
     static byte conv_byte(short i) {
         return (byte) i;
     }
+    static boolean conv_boolean(short i) {
+        return (i & 1) == 1;
+    }
 
     // char conversion
     static double conv_double(char i) {
@@ -663,6 +678,9 @@ final class InvokableLeafOps {
     static byte conv_byte(char i) {
         return (byte) i;
     }
+    static boolean conv_boolean(char i) {
+        return (i & 1) == 1;
+    }
 
     // byte conversion
     static double conv_double(byte i) {
@@ -684,6 +702,35 @@ final class InvokableLeafOps {
         return (char) i;
     }
     static byte conv_byte(byte i) {
+        return i;
+    }
+    static boolean conv_boolean(byte i) {
+        return (i & 1) == 1;
+    }
+
+    // boolean conversion
+    static double conv_double(boolean i) {
+        return i ? 1d : 0d;
+    }
+    static float conv_float(boolean i) {
+        return i ? 1f : 0f;
+    }
+    static long conv_long(boolean i) {
+        return i ? 1l : 0l;
+    }
+    static int conv_int(boolean i) {
+        return i ? 1 : 0;
+    }
+    static short conv_short(boolean i) {
+        return i ? (short)1 : 0;
+    }
+    static char conv_char(boolean i) {
+        return i ? (char)1 : 0;
+    }
+    static byte conv_byte(boolean i) {
+        return i ? (byte)1 : 0;
+    }
+    static boolean conv_boolean(boolean i) {
         return i;
     }
 }


### PR DESCRIPTION
There is a big difference in `boolean` role in JLS and JVMS. While in JLS it is not allowed to cast between `boolean` and other primitive numeric types (obviously because it is not  a numeric type). On the other side in the bytecode it is very hard to differentiate between `byte`, `boolean`, `short`, `char` and `int`. `BytecodeLift` actually inserts an explicit `ConvOp` in the situations where the sub-int type detection failed and it needs to by adjusted on the fly. Explicit `ConvOp` works for conversions between primitive numeric types according to JLS, however `Interpreter` fails on `ConvOp` from and to booleans. `BytecodeGenerator` accepts such conversions (as Class-File API also directly supports conversions between all primitive types, see `CodeBuilder::conversion`).

I'm proposing to add `boolean` into the matrix of supported types for `ConvOp`.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.org/babylon.git pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/232.diff">https://git.openjdk.org/babylon/pull/232.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/232#issuecomment-2354757918)