### PR TITLE
Initial prep for swapping callgraphs for Op.Module

### DIFF
--- a/hat/backends/ptx/src/main/java/hat/backend/PTXCodeBuilder.java
+++ b/hat/backends/ptx/src/main/java/hat/backend/PTXCodeBuilder.java
@@ -386,7 +386,7 @@ public class PTXCodeBuilder extends CodeBuilder<PTXCodeBuilder> {
                     st().dot().param().paramType(op.operandNAsValue(i).type()).space().osbrace().param().intVal(i).csbrace().commaSpace().reg(op.operandNAsValue(i)).ptxNl();
                 }
                 dot().param().space().paramType(op.resultType()).space().retVal().ptxNl();
-                call().uni().space().oparen().retVal().cparen().commaSpace().append(op.method().getName()).commaSpace();
+                call().uni().space().oparen().retVal().cparen().commaSpace().append(op.methodNoLookup().getName()).commaSpace();
                 final int[] counter = {0};
                 paren(_ -> commaSeparated(op.operands(), _ -> param().intVal(counter[0]++))).ptxNl();
                 ld().dot().param().paramType(op.resultType()).space().resultReg(op, getResultType(op.resultType())).commaSpace().osbrace().retVal().csbrace();

--- a/hat/hat/src/main/java/hat/Accelerator.java
+++ b/hat/hat/src/main/java/hat/Accelerator.java
@@ -149,7 +149,7 @@ public class Accelerator implements BufferAllocator {
     public void compute(QuotableComputeContextConsumer quotableComputeContextConsumer) {
         Quoted quoted = quotableComputeContextConsumer.quoted();
         LambdaOpWrapper lambda = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op());
-        Method method = lambda.getQuotableTargetMethod();
+        Method method = lambda.getQuotableTargetMethod(this.lookup);
 
         // Create (or get cached) a compute context which closes over compute entryppint and reachable kernels.
         // The models of all compute and kernel methods are passed to the backend during creation

--- a/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -28,6 +28,7 @@ import hat.ComputeContext;
 import hat.buffer.Buffer;
 import hat.buffer.KernelContext;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.Block;
 import java.lang.reflect.code.Value;
@@ -89,7 +90,7 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
         return javaReturnType().equals(JavaType.VOID);
     }
 
-    public Method method() {
+    public Method methodNoLookup() {
         Class<?> declaringClass = javaRefClass().orElseThrow();
         // TODO this is just matching the name....
         Optional<Method> declaredMethod = Stream.of(declaringClass.getDeclaredMethods())
@@ -105,6 +106,15 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
             return nonDeclaredMethod.get();
         } else {
             throw new IllegalStateException("what were we looking for ?"); // getClass causes this
+        }
+    }
+    public Method method(MethodHandles.Lookup lookup) {
+        Method invokedMethod = null;
+        try {
+            invokedMethod = methodRef().resolveToMethod(lookup);
+            return invokedMethod;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -135,14 +145,14 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
         return isIfaceAccessor() ? IfaceBufferAccess.Access : isIfaceMutator() ? IfaceBufferAccess.Mutate : IfaceBufferAccess.None;
     }
 
-
     public String name() {
         return op().invokeDescriptor().name();
     }
 
     public Optional<Class<?>> javaRefClass() {
         try {
-            String className = javaRefType().toString();
+            JavaType refType = javaRefType();
+            String className = refType.toString();
             Class<?> javaRefClass = Class.forName(className);
             return Optional.of(javaRefClass);
         } catch (ClassNotFoundException e) {

--- a/hat/hat/src/main/java/hat/optools/LambdaOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/LambdaOpWrapper.java
@@ -26,6 +26,7 @@ package hat.optools;
 
 import hat.util.Result;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.Quoted;
@@ -53,8 +54,8 @@ public class LambdaOpWrapper extends OpWrapper<CoreOp.LambdaOp> {
         return op().operands();
     }
 
-    public Method getQuotableTargetMethod() {
-        return getQuotableTargetInvokeOpWrapper().method();
+    public Method getQuotableTargetMethod(MethodHandles.Lookup lookup) {
+        return getQuotableTargetInvokeOpWrapper().method(lookup);
     }
 
     public InvokeOpWrapper getQuotableTargetInvokeOpWrapper() {

--- a/hat/hat/src/main/java/hat/optools/ModuleOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/ModuleOpWrapper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.optools;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.code.CopyContext;
+import java.lang.reflect.code.Op;
+import java.lang.reflect.code.Value;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.reflect.code.type.MethodRef;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
+public class ModuleOpWrapper extends OpWrapper<CoreOp.ModuleOp> {
+    ModuleOpWrapper(CoreOp.ModuleOp op) {
+        super(op);
+    }
+
+    record MethodRefToEntryFuncOpCall(MethodRef methodRef, CoreOp.FuncOp funcOp) {
+    }
+
+    record Closure(Deque<MethodRefToEntryFuncOpCall> work, LinkedHashSet<MethodRef> funcsVisited,
+                   List<CoreOp.FuncOp> moduleFuncOps) {
+    }
+
+    public static ModuleOpWrapper createTransitiveInvokeModule(MethodHandles.Lookup lookup,
+                                                               Method entryPoint) {
+        Optional<CoreOp.FuncOp> codeModel = entryPoint.getCodeModel();
+        if (codeModel.isPresent()) {
+            return OpWrapper.wrap(createTransitiveInvokeModule(lookup, MethodRef.method(entryPoint), codeModel.get()));
+        } else {
+            return OpWrapper.wrap(CoreOp.module(List.of()));
+        }
+    }
+   /* static Method resolveToMethod(MethodHandles.Lookup lookup, MethodRef invokedMethodRef){
+        Method invokedMethod = null;
+        try {
+            invokedMethod = invokedMethodRef.resolveToMethod(lookup);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        return invokedMethod;
+    } */
+
+    static CoreOp.ModuleOp createTransitiveInvokeModule(MethodHandles.Lookup lookup,
+                                                        MethodRef methodRef, CoreOp.FuncOp entryFuncOp) {
+        Closure closure = new Closure(new ArrayDeque<>(), new LinkedHashSet<>(), new ArrayList<>());
+        closure.work.push(new MethodRefToEntryFuncOpCall(methodRef, entryFuncOp));
+        while (!closure.work.isEmpty()) {
+            MethodRefToEntryFuncOpCall methodRefToEntryFuncOpCall = closure.work.pop();
+            if (closure.funcsVisited.add(methodRefToEntryFuncOpCall.methodRef)) {
+                CoreOp.FuncOp tf = methodRefToEntryFuncOpCall.funcOp.transform(
+                        methodRefToEntryFuncOpCall.methodRef.toString(), (blockBuilder, op) -> {
+                            if (op instanceof CoreOp.InvokeOp invokeOp && OpWrapper.wrap(invokeOp) instanceof InvokeOpWrapper invokeOpWrapper) {
+                                Method invokedMethod = invokeOpWrapper.method(lookup);
+                                Optional<CoreOp.FuncOp> optionalInvokedFuncOp = invokedMethod.getCodeModel();
+                                if (optionalInvokedFuncOp.isPresent() && OpWrapper.wrap(optionalInvokedFuncOp.get()) instanceof FuncOpWrapper funcOpWrapper) {
+                                    MethodRefToEntryFuncOpCall call =
+                                            new MethodRefToEntryFuncOpCall(invokeOpWrapper.methodRef(), funcOpWrapper.op());
+                                    closure.work.push(call);
+                                    CopyContext copyContext = blockBuilder.context();
+                                    List<Value> operands = copyContext.getValues(invokeOp.operands());
+                                    CoreOp.FuncCallOp replacementCall = CoreOp.funcCall(
+                                            call.methodRef.toString(),
+                                            call.funcOp.invokableType(),
+                                            operands);
+                                    Op.Result replacementResult = blockBuilder.op(replacementCall);
+                                    copyContext.mapValue(invokeOp.result(), replacementResult);
+                                    // System.out.println("replaced " + call);
+                                } else {
+                                    // System.out.println("We have no code model for " + invokeOpWrapper.methodRef());
+                                    blockBuilder.op(invokeOp);
+                                }
+                            } else {
+                                blockBuilder.op(op);
+                            }
+                            return blockBuilder;
+                        });
+                closure.moduleFuncOps.add(tf);
+            }
+        }
+
+        return CoreOp.module(closure.moduleFuncOps);
+    }
+}

--- a/hat/hat/src/main/java/hat/optools/OpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/OpWrapper.java
@@ -44,6 +44,7 @@ public class OpWrapper<T extends Op> {
     @SuppressWarnings("unchecked")
     public static <O extends Op, OW extends OpWrapper<O>> OW wrap(O op) {
         // We have one special case
+        // This is possibly a premature optimization. But it allows us to treat vardeclarations differently from params.
         if (op instanceof CoreOp.VarOp varOp) {
             // this gets called a lot and we can't wrap yet or we recurse so we
             // use the raw model. Basically we want a different wrapper for VarDeclations
@@ -56,6 +57,7 @@ public class OpWrapper<T extends Op> {
             }
         }
         return switch (op) {
+            case CoreOp.ModuleOp $ -> (OW) new ModuleOpWrapper($);
             case ExtendedOp.JavaForOp $ -> (OW) new ForOpWrapper($);
             case ExtendedOp.JavaWhileOp $ -> (OW) new WhileOpWrapper($);
             case ExtendedOp.JavaIfOp $ -> (OW) new IfOpWrapper($);


### PR DESCRIPTION
These are initial steps towards swapping existing callgraph implementation with CoreOp.ModuleOp

Basically adding ModuleOpWrapper

I also took the opportunity of cleanup up some code for converting MethodRef -> Method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/236/head:pull/236` \
`$ git checkout pull/236`

Update a local copy of the PR: \
`$ git checkout pull/236` \
`$ git pull https://git.openjdk.org/babylon.git pull/236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 236`

View PR using the GUI difftool: \
`$ git pr show -t 236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/236.diff">https://git.openjdk.org/babylon/pull/236.diff</a>

</details>
