### PR TITLE
BytecodeLift with NormalizerBlockTransformer + fix + ExceptionTableCompactor

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeLift.java
@@ -74,6 +74,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.lang.classfile.attribute.StackMapFrameInfo.SimpleVerificationTypeInfo.*;
+import java.lang.reflect.code.analysis.NormalizeBlocksTransformer;
 
 public final class BytecodeLift {
 
@@ -275,12 +276,12 @@ public final class BytecodeLift {
         if (!methodModel.flags().has(AccessFlag.STATIC)) {
             mDesc = mDesc.insertParameterTypes(0, classModel.thisClass().asSymbol());
         }
-        return CoreOp.func(
-                methodModel.methodName().stringValue(),
-                MethodRef.ofNominalDescriptor(mDesc)).body(entryBlock ->
-                        new BytecodeLift(entryBlock,
-                                         classModel,
-                                         methodModel.code().orElseThrow()).liftBody());
+        return NormalizeBlocksTransformer.transform(
+                CoreOp.func(methodModel.methodName().stringValue(),
+                            MethodRef.ofNominalDescriptor(mDesc)).body(entryBlock ->
+                                    new BytecodeLift(entryBlock,
+                                                     classModel,
+                                                     methodModel.code().orElseThrow()).liftBody()));
     }
 
     private Block.Builder newBlock(List<Block.Parameter> otherBlockParams) {

--- a/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
+++ b/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
@@ -211,6 +211,46 @@ public class TestNormalizeBlocksTransformer {
             };
             """;
 
+    static final String TEST5_INPUT = """
+            func @"f" ()void -> {
+                %0 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_1 ^block_4;
+
+              ^block_1:
+                invoke @"A::m()void";
+                branch ^block_2;
+
+              ^block_2:
+                exception.region.exit %0 ^block_3;
+
+              ^block_3:
+                branch ^block_5;
+
+              ^block_4(%1 : java.lang.Throwable):
+                branch ^block_5;
+
+              ^block_5:
+                return;
+            };
+            """;
+    static final String TEST5_EXPECTED = """
+            func @"f" ()void -> {
+                %0 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_1 ^block_3;
+
+              ^block_1:
+                invoke @"A::m()void";
+                exception.region.exit %0 ^block_2;
+
+              ^block_2:
+                branch ^block_4;
+
+              ^block_3(%1 : java.lang.Throwable):
+                branch ^block_4;
+
+              ^block_4:
+                return;
+            };
+            """;
+
     @DataProvider
     static Object[][] testModels() {
         return new Object[][]{
@@ -218,6 +258,7 @@ public class TestNormalizeBlocksTransformer {
                 parse(TEST2_INPUT, TEST2_EXPECTED),
                 parse(TEST3_INPUT, TEST3_EXPECTED),
                 parse(TEST4_INPUT, TEST4_EXPECTED),
+                parse(TEST5_INPUT, TEST5_EXPECTED),
         };
     }
 


### PR DESCRIPTION
Minor fix of `NormalizerBlockTransformer` to skip exception handlers.
`NormalizerBlockTransformer` plugged into `BytecodeLift`.
Implementation of `ExceptionTableCompactor` plugged into `BytecodeGenerator`.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [5ce104a7](https://git.openjdk.org/babylon/pull/242/files/5ce104a765802bc23b771a4fbbefa396db1b95da)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.org/babylon.git pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/242.diff">https://git.openjdk.org/babylon/pull/242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/242#issuecomment-2378610168)