### PR TITLE
Fix method resolution on invoke op wrapper

### DIFF
--- a/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/hat/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -111,7 +111,7 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
     public Method method(MethodHandles.Lookup lookup) {
         Method invokedMethod = null;
         try {
-            invokedMethod = methodRef().resolveToMethod(lookup);
+            invokedMethod = methodRef().resolveToMethod(lookup, op().invokeKind());
             return invokedMethod;
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Changes in the modeling of invoke expressions broke HAT. This PR fixes that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/243/head:pull/243` \
`$ git checkout pull/243`

Update a local copy of the PR: \
`$ git checkout pull/243` \
`$ git pull https://git.openjdk.org/babylon.git pull/243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 243`

View PR using the GUI difftool: \
`$ git pr show -t 243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/243.diff">https://git.openjdk.org/babylon/pull/243.diff</a>

</details>
