### PR TITLE
Simplify code generation for quotable lambdas not to require duplicate capture argument lists

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -74,10 +74,6 @@ import static sun.invoke.util.Wrapper.isWrapperType;
                                               // intermediate representation (can be null).
     final MethodHandleInfo quotableOpFieldInfo;  // Info about the quotable getter method handle (can be null).
 
-    final MethodType quotableOpType;          // The type of the quotable lambda's associated
-                                              // intermediate representation (can be null).
-
-
     /**
      * Meta-factory constructor.
      *
@@ -192,18 +188,6 @@ import static sun.invoke.util.Wrapper.isWrapperType;
         this.altInterfaces = altInterfaces;
         this.altMethods = altMethods;
         this.quotableOpField = reflectiveField;
-        if (reflectiveField != null) {
-            // infer the method type associated with the intermediate representation of the
-            // quotable lambda. Since {@code factoryType} contains all the captured args
-            // we need to subtract the captured args that are required to invoke the lambda's
-            // bytecode. The type of {@code implementation} is useful here, as it corresponds to
-            // the signature of the emitted javac lambda implementation. From there, we need to
-            // drop all the dynamic arguments, which are obtained from {@code interfaceMethodType}.
-            this.quotableOpType = factoryType.dropParameterTypes(0,
-                    implementation.type().parameterCount() - interfaceMethodType.parameterCount());
-        } else {
-            quotableOpType = null;
-        }
 
         if (interfaceMethodName.isEmpty() ||
                 interfaceMethodName.indexOf('.') >= 0 ||
@@ -263,7 +247,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
     void validateMetafactoryArgs() throws LambdaConversionException {
         // Check arity: captured + SAM == impl
         final int implArity = implMethodType.parameterCount();
-        final int capturedArity = factoryType.parameterCount() - reflectiveCaptureCount();
+        final int capturedArity = factoryType.parameterCount();
         final int samArity = interfaceMethodType.parameterCount();
         final int dynamicArity = dynamicMethodType.parameterCount();
         if (implArity != capturedArity + samArity) {
@@ -352,10 +336,6 @@ import static sun.invoke.util.Wrapper.isWrapperType;
         for (MethodType bridgeMT : altMethods) {
             checkDescriptor(bridgeMT);
         }
-    }
-
-    int reflectiveCaptureCount() {
-        return quotableOpType == null ? 0 : quotableOpType.parameterCount();
     }
 
     /** Validate that the given descriptor's types are compatible with {@code dynamicMethodType} **/

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -470,16 +470,16 @@ import sun.invoke.util.Wrapper;
 
         // load captured args in array
 
-        cob.loadConstant(quotableOpType.parameterCount())
+        int capturedArity = factoryType.parameterCount();
+        cob.loadConstant(capturedArity)
            .anewarray(CD_Object);
-        int capturedArity = factoryType.parameterCount() - reflectiveCaptureCount();
         // initialize quoted captures
-        for (int i = 0; i < reflectiveCaptureCount(); i++) {
+        for (int i = 0; i < capturedArity; i++) {
             cob.dup()
                .loadConstant(i)
                .aload(0)
-               .getfield(lambdaClassEntry.asSymbol(), argNames[capturedArity + i], argDescs[capturedArity + i]);
-            TypeConvertingMethodAdapter.boxIfTypePrimitive(cob, TypeKind.from(argDescs[capturedArity + i]));
+               .getfield(lambdaClassEntry.asSymbol(), argNames[i], argDescs[i]);
+            TypeConvertingMethodAdapter.boxIfTypePrimitive(cob, TypeKind.from(argDescs[i]));
             cob.aastore();
         }
 
@@ -605,7 +605,7 @@ import sun.invoke.util.Wrapper;
                     cob.ldc(cp.constantDynamicEntry(cp.bsmEntry(cp.methodHandleEntry(BSM_CLASS_DATA_AT), List.of(cp.intEntry(0))),
                                                     cp.nameAndTypeEntry(DEFAULT_NAME, CD_MethodHandle)));
                 }
-                for (int i = 0; i < argNames.length - reflectiveCaptureCount(); i++) {
+                for (int i = 0; i < argNames.length ; i++) {
                     cob.aload(0)
                        .getfield(pool.fieldRefEntry(lambdaClassEntry, pool.nameAndTypeEntry(argNames[i], argDescs[i])));
                 }
@@ -635,7 +635,7 @@ import sun.invoke.util.Wrapper;
 
     private void convertArgumentTypes(CodeBuilder cob, MethodType samType) {
         int samParametersLength = samType.parameterCount();
-        int captureArity = factoryType.parameterCount() - reflectiveCaptureCount();
+        int captureArity = factoryType.parameterCount();
         for (int i = 0; i < samParametersLength; i++) {
             Class<?> argType = samType.parameterType(i);
             cob.loadLocal(TypeKind.from(argType), cob.parameterSlot(i));

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -956,17 +956,11 @@ public final class BytecodeGenerator {
                                     .map(Value::type).map(BytecodeGenerator::toClassDesc).toArray(ClassDesc[]::new);
                             int lambdaIndex = lambdaSink.size();
                             if (Quotable.class.isAssignableFrom(intfClass)) {
-                                // @@@ double the captured values to enable LambdaMetafactory.FLAG_QUOTABLE
-                                for (Value cv : op.capturedValues()) {
-                                    load(cv);
-                                }
                                 cob.invokedynamic(DynamicCallSiteDesc.of(
                                         DMHD_LAMBDA_ALT_METAFACTORY,
                                         funcIntfMethodName(intfClass),
-                                        // @@@ double the descriptor parameters
                                         MethodTypeDesc.of(intfType.toNominalDescriptor(),
-                                                          Stream.concat(Stream.of(captureTypes),
-                                                                        Stream.of(captureTypes)).toList()),
+                                                          captureTypes),
                                         mtd,
                                         MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC,
                                                                   className,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -5404,4 +5404,30 @@ public class Types {
     public boolean isQuoted(Type type) {
         return type.tsym == syms.quotedType.tsym;
     }
+
+    public enum FunctionalExpressionKind {
+        QUOTED_STRUCTURAL(true), // this is transitional
+        QUOTABLE(true),
+        NOT_QUOTED(false);
+
+        final boolean isQuoted;
+
+        FunctionalExpressionKind(boolean isQuoted) {
+            this.isQuoted = isQuoted;
+        }
+
+        public boolean isQuoted() {
+            return isQuoted;
+        }
+    }
+
+    public FunctionalExpressionKind functionalKind(Type target) {
+        if (target.hasTag(TypeTag.METHOD)) {
+            return FunctionalExpressionKind.QUOTED_STRUCTURAL;
+        } else if (asSuper(target, syms.quotableType.tsym) != null) {
+            return FunctionalExpressionKind.QUOTABLE;
+        } else {
+            return FunctionalExpressionKind.NOT_QUOTED;
+        }
+    }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -5404,30 +5404,4 @@ public class Types {
     public boolean isQuoted(Type type) {
         return type.tsym == syms.quotedType.tsym;
     }
-
-    public enum FunctionalExpressionKind {
-        QUOTED_STRUCTURAL(true), // this is transitional
-        QUOTABLE(true),
-        NOT_QUOTED(false);
-
-        final boolean isQuoted;
-
-        FunctionalExpressionKind(boolean isQuoted) {
-            this.isQuoted = isQuoted;
-        }
-
-        public boolean isQuoted() {
-            return isQuoted;
-        }
-    }
-
-    public FunctionalExpressionKind functionalKind(Type target) {
-        if (target.hasTag(TypeTag.METHOD)) {
-            return FunctionalExpressionKind.QUOTED_STRUCTURAL;
-        } else if (asSuper(target, syms.quotableType.tsym) != null) {
-            return FunctionalExpressionKind.QUOTABLE;
-        } else {
-            return FunctionalExpressionKind.NOT_QUOTED;
-        }
-    }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -421,9 +421,7 @@ public class LambdaToMethod extends TreeTranslator {
 
         //add quotable captures
         if (isQuotable(tree)) {
-            for (JCExpression capturedArg : tree.codeReflectionInfo.capturedArgs()) {
-                syntheticInits.append(capturedArg);
-            }
+            syntheticInits.appendList(syntheticInits);
         }
 
         //then, determine the arguments to the indy call
@@ -522,9 +520,7 @@ public class LambdaToMethod extends TreeTranslator {
 
         // add quotable captures
         if (isQuotable(tree)) {
-            for (JCExpression capturedArg : tree.codeReflectionInfo.capturedArgs()) {
-                indy_args = indy_args.append(capturedArg);
-            }
+            indy_args = indy_args.appendList(indy_args);
         }
 
         //build a sam instance using an indy call to the meta-factory
@@ -893,7 +889,7 @@ public class LambdaToMethod extends TreeTranslator {
                 }
             }
             if (isQuotable) {
-                VarSymbol reflectField = (VarSymbol)tree.codeReflectionInfo.quotedField();
+                VarSymbol reflectField = (VarSymbol)tree.codeModel;
                 staticArgs = staticArgs.append(reflectField.asMethodHandle(true));
             }
             if (isSerializable) {
@@ -963,7 +959,7 @@ public class LambdaToMethod extends TreeTranslator {
     }
 
     boolean isQuotable(JCFunctionalExpression tree) {
-        return tree.codeReflectionInfo != null;
+        return tree.codeModel != null;
     }
 
     void dumpStats(JCFunctionalExpression tree, boolean needsAltMetafactory, Symbol sym) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -419,11 +419,6 @@ public class LambdaToMethod extends TreeTranslator {
             syntheticInits.append(captured_local);
         }
 
-        //add quotable captures
-        if (isQuotable(tree)) {
-            syntheticInits.appendList(syntheticInits);
-        }
-
         //then, determine the arguments to the indy call
         List<JCExpression> indy_args = translate(syntheticInits.toList());
 
@@ -517,11 +512,6 @@ public class LambdaToMethod extends TreeTranslator {
 
         List<JCExpression> indy_args = (init == null) ?
                 List.nil() : translate(List.of(init));
-
-        // add quotable captures
-        if (isQuotable(tree)) {
-            indy_args = indy_args.appendList(indy_args);
-        }
 
         //build a sam instance using an indy call to the meta-factory
         result = makeMetafactoryIndyCall(tree, refSym.asHandle(), refSym, indy_args);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1221,60 +1221,6 @@ public class LambdaToMethod extends TreeTranslator {
             return types.erasure(tree.getDescriptorType(types));
         }
 
-        /**
-         * Compute the set of local variables captured by this lambda expression.
-         * Also determines whether this lambda expression captures the enclosing 'this'.
-         */
-        class LambdaCaptureScanner extends CaptureScanner {
-            boolean capturesThis;
-            Set<ClassSymbol> seenClasses = new HashSet<>();
-
-            LambdaCaptureScanner(JCLambda ownerTree) {
-                super(ownerTree);
-            }
-
-            @Override
-            public void visitClassDef(JCClassDecl tree) {
-                seenClasses.add(tree.sym);
-                super.visitClassDef(tree);
-            }
-
-            @Override
-            public void visitIdent(JCIdent tree) {
-                if (!tree.sym.isStatic() &&
-                        tree.sym.owner.kind == TYP &&
-                        (tree.sym.kind == VAR || tree.sym.kind == MTH) &&
-                        !seenClasses.contains(tree.sym.owner)) {
-                    if ((tree.sym.flags() & LOCAL_CAPTURE_FIELD) != 0) {
-                        // a local, captured by Lower - re-capture!
-                        addFreeVar((VarSymbol) tree.sym);
-                    } else {
-                        // a reference to an enclosing field or method, we need to capture 'this'
-                        capturesThis = true;
-                    }
-                } else {
-                    // might be a local capture
-                    super.visitIdent(tree);
-                }
-            }
-
-            @Override
-            public void visitSelect(JCFieldAccess tree) {
-                if (tree.sym.kind == VAR &&
-                        (tree.sym.name == names._this ||
-                                tree.sym.name == names._super) &&
-                        !seenClasses.contains(tree.sym.type.tsym)) {
-                    capturesThis = true;
-                }
-                super.visitSelect(tree);
-            }
-
-            @Override
-            public void visitAnnotation(JCAnnotation tree) {
-                // do nothing (annotation values look like captured instance fields)
-            }
-        }
-
         /*
          * These keys provide mappings for various translated lambda symbols
          * and the prevailing order must be maintained.
@@ -1283,6 +1229,60 @@ public class LambdaToMethod extends TreeTranslator {
             PARAM,          // original to translated lambda parameters
             LOCAL_VAR,      // original to translated lambda locals
             CAPTURED_VAR;   // variables in enclosing scope to translated synthetic parameters
+        }
+    }
+
+    /**
+     * Compute the set of local variables captured by this lambda expression.
+     * Also determines whether this lambda expression captures the enclosing 'this'.
+     */
+    class LambdaCaptureScanner extends CaptureScanner {
+        boolean capturesThis;
+        Set<ClassSymbol> seenClasses = new HashSet<>();
+
+        LambdaCaptureScanner(JCLambda ownerTree) {
+            super(ownerTree);
+        }
+
+        @Override
+        public void visitClassDef(JCClassDecl tree) {
+            seenClasses.add(tree.sym);
+            super.visitClassDef(tree);
+        }
+
+        @Override
+        public void visitIdent(JCIdent tree) {
+            if (!tree.sym.isStatic() &&
+                    tree.sym.owner.kind == TYP &&
+                    (tree.sym.kind == VAR || tree.sym.kind == MTH) &&
+                    !seenClasses.contains(tree.sym.owner)) {
+                if ((tree.sym.flags() & LOCAL_CAPTURE_FIELD) != 0) {
+                    // a local, captured by Lower - re-capture!
+                    addFreeVar((VarSymbol) tree.sym);
+                } else {
+                    // a reference to an enclosing field or method, we need to capture 'this'
+                    capturesThis = true;
+                }
+            } else {
+                // might be a local capture
+                super.visitIdent(tree);
+            }
+        }
+
+        @Override
+        public void visitSelect(JCFieldAccess tree) {
+            if (tree.sym.kind == VAR &&
+                    (tree.sym.name == names._this ||
+                            tree.sym.name == names._super) &&
+                    !seenClasses.contains(tree.sym.type.tsym)) {
+                capturesThis = true;
+            }
+            super.visitSelect(tree);
+        }
+
+        @Override
+        public void visitAnnotation(JCAnnotation tree) {
+            // do nothing (annotation values look like captured instance fields)
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -529,7 +529,7 @@ public class ReflectMethods extends TreeTranslator {
             ListBuffer<Type> capturedTypes = new ListBuffer<>();
             if (lambdaCaptureScanner.capturesThis) {
                 capturedTypes.add(currentClassSym.type);
-                blockArgOffset++;
+                blockParamOffset++;
             }
             for (Symbol s : capturedSymbols) {
                 capturedTypes.add(s.type);
@@ -544,7 +544,7 @@ public class ReflectMethods extends TreeTranslator {
 
             // add captured variables mappings
             for (int i = 0 ; i < capturedSymbols.size() ; i++) {
-                var capturedArg = top.block.parameters().get(blockArgOffset + i);
+                var capturedArg = top.block.parameters().get(blockParamOffset + i);
                 Symbol capturedSymbol = capturedSymbols.get(i);
                 top.localToOp.put(capturedSymbol,
                         append(CoreOp.var(capturedSymbol.name.toString(), capturedArg)));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -91,9 +91,7 @@ import java.lang.constant.ClassDesc;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
-import static com.sun.tools.javac.code.Flags.LOCAL_CAPTURE_FIELD;
 import static com.sun.tools.javac.code.Flags.NOOUTERTHIS;
 import static com.sun.tools.javac.code.Flags.PARAMETER;
 import static com.sun.tools.javac.code.Flags.SYNTHETIC;
@@ -126,7 +124,6 @@ public class ReflectMethods extends TreeTranslator {
     private final Gen gen;
     private final Log log;
     private final Lower lower;
-    private final LambdaToMethod lambdaToMethod;
     private final boolean dumpIR;
     private final boolean lineDebugInfo;
 
@@ -151,7 +148,6 @@ public class ReflectMethods extends TreeTranslator {
         gen = Gen.instance(context);
         log = Log.instance(context);
         lower = Lower.instance(context);
-        lambdaToMethod = LambdaToMethod.instance(context);
     }
 
     // Cannot compute within constructor due to circular dependencies on bootstrap compilation

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -524,7 +524,7 @@ public class ReflectMethods extends TreeTranslator {
                     new QuotableLambdaCaptureScanner(tree);
 
             List<VarSymbol> capturedSymbols = lambdaCaptureScanner.analyzeCaptures();
-            int blockArgOffset = 0;
+            int blockParamOffset = 0;
 
             ListBuffer<Type> capturedTypes = new ListBuffer<>();
             if (lambdaCaptureScanner.capturesThis) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -623,6 +623,14 @@ public class ReflectMethods extends TreeTranslator {
             }
 
             @Override
+            public void visitNewClass(JCNewClass tree) {
+                if (tree.type.tsym.owner.kind == MTH &&
+                    !seenClasses.contains(tree.type.tsym)) {
+                    throw unsupported(tree);
+                }
+            }
+
+            @Override
             public void visitAnnotation(JCAnnotation tree) {
                 // do nothing (annotation values look like captured instance fields)
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -682,7 +682,7 @@ public class TransTypes extends TreeTranslator {
                 slam.owner = tree.owner;
                 slam.type = tree.type;
                 slam.pos = tree.pos;
-                slam.codeReflectionInfo = tree.codeReflectionInfo;
+                slam.codeModel = tree.codeModel;
                 slam.wasMethodReference = true;
                 if (receiverExpression != null) {
                     // use a let expression so that the receiver expression is evaluated eagerly

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -38,7 +38,6 @@ import com.sun.tools.javac.code.*;
 import com.sun.tools.javac.code.Directive.RequiresDirective;
 import com.sun.tools.javac.code.Scope.*;
 import com.sun.tools.javac.code.Symbol.*;
-import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.util.*;
 import com.sun.tools.javac.util.DefinedBy.Api;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
@@ -809,10 +808,10 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
 
         /** list of target types inferred for this functional expression. */
         public Type target;
-        /** code reflection specific metadata. */
-        public CodeReflectionInfo codeReflectionInfo;
         /** The owner of this functional expression. */
         public Symbol owner;
+        /** code reflection specific metadata. */
+        public Symbol codeModel;
 
         public Type getDescriptorType(Types types) {
             if (target == null) {
@@ -824,8 +823,6 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
                 return types.findDescriptorType(target);
             }
         }
-
-        public record CodeReflectionInfo(Symbol quotedField, List<JCExpression> capturedArgs) { }
     }
 
     /**

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -63,9 +63,10 @@ public class TestCaptureQuotable {
         String hello = "hello";
         Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + hello.length() + x;
         Quoted quoted = quotable.quoted();
-        assertEquals(quoted.capturedValues().size(), 1);
+        assertEquals(quoted.capturedValues().size(), 2);
         Iterator<Object> it = quoted.capturedValues().values().iterator();
         assertEquals(((Var)it.next()).value(), hello);
+        assertEquals(it.next(), x);
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
         assertEquals(res, x + 1 + hello.length());

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -63,10 +63,9 @@ public class TestCaptureQuotable {
         String hello = "hello";
         Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + hello.length() + x;
         Quoted quoted = quotable.quoted();
-        assertEquals(quoted.capturedValues().size(), 2);
+        assertEquals(quoted.capturedValues().size(), 1);
         Iterator<Object> it = quoted.capturedValues().values().iterator();
         assertEquals(((Var)it.next()).value(), hello);
-        assertEquals(((Var)it.next()).value(), x);
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
         assertEquals(res, x + 1 + hello.length());

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -58,18 +58,19 @@ public class TestCaptureQuotable {
     }
 
     @Test
-    public void testCaptureRefAndIntConstant() {
+    public void testCaptureThisRefAndIntConstant() {
         final int x = 100;
         String hello = "hello";
-        Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + hello.length() + x;
+        Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + hashCode() + hello.length() + x;
         Quoted quoted = quotable.quoted();
-        assertEquals(quoted.capturedValues().size(), 2);
+        assertEquals(quoted.capturedValues().size(), 3);
         Iterator<Object> it = quoted.capturedValues().values().iterator();
+        assertEquals(it.next(), this);
         assertEquals(((Var)it.next()).value(), hello);
         assertEquals(it.next(), x);
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
-        assertEquals(res, x + 1 + hello.length());
+        assertEquals(res, x + 1 + hashCode() + hello.length());
     }
 
     @Test

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
@@ -27,11 +27,14 @@
  * @run testng TestCaptureQuoted
  */
 
+import java.lang.reflect.code.Quotable;
 import java.lang.reflect.code.op.CoreOp.Var;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.Quoted;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
+import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
 
 import org.testng.annotations.*;
@@ -69,6 +72,21 @@ public class TestCaptureQuoted {
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
         assertEquals(res, x + 1);
+    }
+
+    @Test
+    public void testCaptureThisRefAndIntConstant() {
+        final int x = 100;
+        String hello = "hello";
+        Quoted quoted = (Integer y) -> y.intValue() + hashCode() + hello.length() + x;
+        assertEquals(quoted.capturedValues().size(), 3);
+        Iterator<Object> it = quoted.capturedValues().values().iterator();
+        assertEquals(it.next(), this);
+        assertEquals(((Var)it.next()).value(), hello);
+        assertEquals(it.next(), x);
+        int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
+                quoted.capturedValues(), 1);
+        assertEquals(res, x + 1 + hashCode() + hello.length());
     }
 
     @DataProvider(name = "ints")


### PR DESCRIPTION
When translating quotable lambdas/method references, we generate two captured argument lists:

* the captured arguments to be used by the functional interface implementation;
* the captured arguments to be used by the quotable implementation

In most cases these two captured lists are identical, except for cosmetic differences.
This is even more true after the backend of javac underwent significant rearchitecture, to better support the Flexible Constructor Bodies feature.

This PR simplifies `ReflectMethods` so that a visitor now computes all the required captured variables upfront.
The captured variables are then inserted in the quoted block, so that the rest of `BodyScanner` will be able to resolve references to such variables w/o the need for ad-hoc logic.

One complication is that, under this new regime, we can no longer afford to treat captured variables whose value is constant (e.g. `final int k = 100`) as if they were true captures.
This is because neither `Lower` nor `LambdaToMethod` capture constant variables. Since we're reusing the same dynamic arguments as `LambdaToMethod` we need to make sure that `ReflectMethods` also does not capture constant arguments.
Special logic to avoid capture of constant arguments is baked into the new visitor.

I have also added a check in the visitor, so that if, inside a quotable lambda, we see a creation of a local class that is declared outside the lambda, an unsupported exception is thrown.

I will followup with a separate fix to deal with these cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [1ae6a58c](https://git.openjdk.org/babylon/pull/249/files/1ae6a58c74c82e8e379476676fef55fb52f26578)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.org/babylon.git pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/249.diff">https://git.openjdk.org/babylon/pull/249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/249#issuecomment-2394146546)