### PR TITLE
Captured constants in variables

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -544,18 +544,19 @@ public class ReflectMethods extends TreeTranslator {
 
             // add captured variables mappings
             for (int i = 0 ; i < capturedSymbols.size() ; i++) {
-                var capturedArg = top.block.parameters().get(blockParamOffset + i);
                 Symbol capturedSymbol = capturedSymbols.get(i);
+                var capturedArg = top.block.parameters().get(blockParamOffset + i);
                 top.localToOp.put(capturedSymbol,
                         append(CoreOp.var(capturedSymbol.name.toString(), capturedArg)));
             }
 
             // add captured constant mappings
             for (Map.Entry<Symbol, Object> constantCapture : lambdaCaptureScanner.constantCaptures.entrySet()) {
-                Symbol constantCaptureSym = constantCapture.getKey();
-                Object constantCaptureValue = constantCapture.getValue();
-                top.localToOp.put(constantCaptureSym,
-                        append(CoreOp.constant(typeToTypeElement(constantCaptureSym.type), constantCaptureValue)));
+                Symbol capturedSymbol = constantCapture.getKey();
+                var capturedArg = append(CoreOp.constant(typeToTypeElement(capturedSymbol.type),
+                        constantCapture.getValue()));
+                top.localToOp.put(capturedSymbol,
+                        append(CoreOp.var(capturedSymbol.name.toString(), capturedArg)));
             }
 
             bodyTarget = tree.target.getReturnType();

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -67,7 +67,7 @@ public class TestCaptureQuotable {
         Iterator<Object> it = quoted.capturedValues().values().iterator();
         assertEquals(it.next(), this);
         assertEquals(((Var)it.next()).value(), hello);
-        assertEquals(it.next(), x);
+        assertEquals(((Var)it.next()).value(), x);
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
         assertEquals(res, x + 1 + hashCode() + hello.length());

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
@@ -83,7 +83,7 @@ public class TestCaptureQuoted {
         Iterator<Object> it = quoted.capturedValues().values().iterator();
         assertEquals(it.next(), this);
         assertEquals(((Var)it.next()).value(), hello);
-        assertEquals(it.next(), x);
+        assertEquals(((Var)it.next()).value(), x);
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
                 quoted.capturedValues(), 1);
         assertEquals(res, x + 1 + hashCode() + hello.length());


### PR DESCRIPTION
Tweak the modeling of captured constants to model as variables initialized with the constants. This makes the modeling more uniform and preserves the variable name. Which in turn fixes an issue in HAT that relies on this uniformity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/250/head:pull/250` \
`$ git checkout pull/250`

Update a local copy of the PR: \
`$ git checkout pull/250` \
`$ git pull https://git.openjdk.org/babylon.git pull/250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 250`

View PR using the GUI difftool: \
`$ git pr show -t 250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/250.diff">https://git.openjdk.org/babylon/pull/250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/250#issuecomment-2397739920)