### PR TITLE
Cleanup cmake handoff from maven and from bldr

### DIFF
--- a/hat/.gitignore
+++ b/hat/.gitignore
@@ -1,3 +1,4 @@
+thirdparty/
 build/
 target/
 maven-build/

--- a/hat/backends/CMakeLists.txt
+++ b/hat/backends/CMakeLists.txt
@@ -1,14 +1,20 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(backends)
+set(CMAKE_CXX_STANDARD 14)
 
-add_custom_target(copy_libs)
+if ("${HAT_TARGET}EMPTY" STREQUAL "EMPTY")
+    message("HAT_TARGET is empty")
+else ()
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${HAT_TARGET})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${HAT_TARGET})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${HAT_TARGET})
+    message("Binaries in ${HAT_TARGET} HAT_TARGET")
+endif ()
 
 if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
     set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/shared")
     message("SHARED_BACKEND=${SHARED_BACKEND}")
 endif()
-
-set(CMAKE_CXX_STANDARD 14)
 
 include_directories(
     ${SHARED_BACKEND}/include

--- a/hat/backends/cuda/CMakeLists.txt
+++ b/hat/backends/cuda/CMakeLists.txt
@@ -6,20 +6,21 @@ set(CMAKE_CXX_STANDARD 14)
 find_package(CUDAToolkit)
 if(CUDAToolkit_FOUND)
     message("CUDA")
+
     if ("${CUDA_BACKEND}EMPTY" STREQUAL "EMPTY")
 	    set (CUDA_BACKEND "${CMAKE_SOURCE_DIR}")
 	    message("CUDA_BACKEND=${CUDA_BACKEND}")
     endif()
+
     if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
         set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
         message("SHARED_BACKEND=${SHARED_BACKEND}")
     endif()
 
-
     include_directories(
             ${CUDAToolkit_INCLUDE_DIR}
-	    ${SHARED_BACKEND}/include
-	    ${CUDA_BACKEND}/include
+	        ${SHARED_BACKEND}/include
+	        ${CUDA_BACKEND}/include
     )
 
     link_directories(
@@ -46,11 +47,4 @@ if(CUDAToolkit_FOUND)
             -lcudart
             -lcuda
     )
-    add_custom_target(cuda_natives DEPENDS cuda_info cuda_backend)
-
-    add_custom_target(copy_cuda_libs DEPENDS cuda_info cuda_backend
-        COMMAND cp ${CMAKE_BINARY_DIR}/cuda/libcuda_backend.* ${HAT_TARGET}
-        COMMAND cp ${CMAKE_BINARY_DIR}/cuda/cuda_info ${HAT_TARGET}
-   )
-   add_dependencies(copy_libs copy_cuda_libs)
 endif()

--- a/hat/backends/mock/CMakeLists.txt
+++ b/hat/backends/mock/CMakeLists.txt
@@ -3,11 +3,13 @@ project(opencl_backend)
 
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(OpenCL)
+#find_package(OpenCL)
+
 if ("${MOCK_BACKEND}EMPTY" STREQUAL "EMPTY")
     set (MOCK_BACKEND "${CMAKE_SOURCE_DIR}")
     message("MOCK_BACKEND=${MOCK_BACKEND}")
 endif()
+
 if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
     set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
     message("SHARED_BACKEND=${SHARED_BACKEND}")
@@ -38,12 +40,7 @@ add_executable(mock_info
 target_link_libraries(mock_info
     mock_backend
 )
-add_custom_target(mock_natives DEPENDS mock_info mock_backend)
-add_custom_target(copy_mock_libs DEPENDS mock_info mock_backend
-    COMMAND cp ${CMAKE_BINARY_DIR}/mock/libmock_backend.* ${HAT_TARGET}
-    COMMAND cp ${CMAKE_BINARY_DIR}/mock/mock_info ${HAT_TARGET}
-)
-add_dependencies(copy_libs copy_mock_libs)
+
 
 
 

--- a/hat/backends/opencl/CMakeLists.txt
+++ b/hat/backends/opencl/CMakeLists.txt
@@ -10,6 +10,7 @@ if(OPENCL_FOUND)
         set (OPENCL_BACKEND "${CMAKE_SOURCE_DIR}")
         message("OPENCL_BACKEND=${OPENCL_BACKEND}")
     endif()
+
     if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
         set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
         message("SHARED_BACKEND=${SHARED_BACKEND}")
@@ -48,11 +49,5 @@ if(OPENCL_FOUND)
         opencl_backend
         ${OPENCL_LIB}
     )
-    add_custom_target(opencl_natives DEPENDS opencl_info opencl_backend)
-    add_custom_target(copy_opencl_libs DEPENDS opencl_info opencl_backend
-       COMMAND cp ${CMAKE_BINARY_DIR}/opencl/libopencl_backend.*  ${HAT_TARGET}
-       COMMAND cp ${CMAKE_BINARY_DIR}/opencl/opencl_info ${HAT_TARGET}
-    )
-    add_dependencies(copy_libs copy_opencl_libs)
 
 endif()

--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -82,22 +82,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                    </arguments>
                 </configuration>
              </execution>
-              <execution>
-                <id>cmake_install_copy_libs</id>
-                <phase>install</phase>
-                <goals>
-                   <goal>exec</goal>
-                </goals>
-                <configuration>
-                   <executable>cmake</executable>
-                   <arguments>
-                      <argument>--build</argument>
-                      <argument>cmake-build-debug</argument>
-                      <argument>--target</argument>
-                      <argument>copy_libs</argument>
-                   </arguments>
-                </configuration>
-             </execution>
 
              <execution>
                 <id>cmake_clean</id>

--- a/hat/backends/ptx/CMakeLists.txt
+++ b/hat/backends/ptx/CMakeLists.txt
@@ -15,7 +15,6 @@ if(CUDAToolkit_FOUND)
         message("SHARED_BACKEND=${SHARED_BACKEND}")
     endif()
 
-
     include_directories(
             ${CUDAToolkit_INCLUDE_DIR}
 	    ${SHARED_BACKEND}/include
@@ -46,13 +45,7 @@ if(CUDAToolkit_FOUND)
             -lcudart
             -lcuda
     )
-    add_custom_target(ptx_natives DEPENDS ptx_info ptx_backend)
 
-    add_custom_target(copy_ptx_libs DEPENDS ptx_info ptx_backend
-        COMMAND cp ${CMAKE_BINARY_DIR}/ptx/libptx_backend.* ${HAT_TARGET}
-        COMMAND cp ${CMAKE_BINARY_DIR}/ptx/ptx_info ${HAT_TARGET}
-    ) 
-    add_dependencies(copy_libs copy_ptx_libs)
 endif()
 
 

--- a/hat/backends/spirv/CMakeLists.txt
+++ b/hat/backends/spirv/CMakeLists.txt
@@ -3,11 +3,11 @@ project(spirv_backend)
 
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(OpenCL)
 if ("${SPIRV_BACKEND}EMPTY" STREQUAL "EMPTY")
     set (SPIRV_BACKEND "${CMAKE_SOURCE_DIR}")
     message("SPIRV_BACKEND=${SPIRV_BACKEND}")
 endif()
+
 if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
     set (SHARED_BACKEND "${CMAKE_SOURCE_DIR}/../shared")
     message("SHARED_BACKEND=${SHARED_BACKEND}")
@@ -29,7 +29,6 @@ add_library(spirv_backend SHARED
     ${SPIRV_BACKEND}/cpp/spirv_backend.cpp
 )
 
-
 add_executable(spirv_info
     ${SPIRV_BACKEND}/cpp/info.cpp
 )
@@ -37,13 +36,5 @@ add_executable(spirv_info
 target_link_libraries(spirv_info
     spirv_backend
 )
-
-add_custom_target(spirv_natives DEPENDS spirv_info spirv_backend)
-
-add_custom_target(copy_spirv_libs DEPENDS spirv_info spirv_backend
-   COMMAND cp ${CMAKE_BINARY_DIR}/spirv/libspirv_backend.* ${HAT_TARGET}
-   COMMAND cp ${CMAKE_BINARY_DIR}/spirv/spirv_info ${HAT_TARGET}
-)
-add_dependencies(copy_libs copy_spirv_libs)
 
 

--- a/hat/bld
+++ b/hat/bld
@@ -1,4 +1,4 @@
-#!/usr/bin/env java --enable-preview --source 24 
+#!/usr/bin/env java --enable-preview --source 24 --class-path bldr/classes
 /*
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -25,226 +25,69 @@
  */
 
 import module java.compiler;
-
-
-static String join(List<Path> paths, char separator){
-   StringBuilder sb = new StringBuilder();
-   paths.forEach(path -> {
-      if (!sb.isEmpty()) {
-         sb.append(separator);
-      }
-      sb.append(path);
-   });
-   return sb.toString();
-}
-
-static void addEntry(JarOutputStream jarStream, Path root, Path path){
-    try{
-       var attributes = Files.readAttributes(path, PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-       var entry = new JarEntry(root.relativize(path).toString()+(attributes.isDirectory()?"/":""));
-       entry.setTime(attributes.lastModifiedTime().toMillis());
-       jarStream.putNextEntry(entry);
-       if (attributes.isRegularFile()){
-          Files.newInputStream(path).transferTo(jarStream);
-       }
-       jarStream.closeEntry();
-    }catch(IOException ioe){
-      println(ioe);
-    }
-}
-
-
-static Path javacjar(Path jar, Path classesDir, List<Path> sourcePath, List<Path> classPath, List<Path> resourcePath) throws IOException{
-     var src = new ArrayList<Path>();
-     sourcePath.forEach(path->{
-         try{
-            Files.walk(path).forEach(s->{if (s.toString().endsWith(".java")){src.add(s);}});
-         }catch(IOException ioe){
-            println(ioe);
-         }
-     });
-
-     if (Files.exists(classesDir)) {
-       Files.walk(classesDir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-     }
-     Files.createDirectories(classesDir);
-     DiagnosticListener<JavaFileObject> dl = (diagnostic)-> System.out.println(diagnostic.getKind() + " " + diagnostic.getMessage(null));
-
-     var opts = new ArrayList<String>(List.of(
-         "--source","24",
-         "--enable-preview",
-         "--add-exports=java.base/jdk.internal=ALL-UNNAMED",
-         "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
-         "-d", classesDir.toString(),
-         "--source-path", join(sourcePath,':')
-     ));
-     if (!classPath.isEmpty()){ 
-        opts.addAll(List.of(
-           "--class-path", join(classPath,':')
-        ));
-     }
-     //println(opts);
-     
-     List<Path> pathsToJar = new ArrayList<>();
-     JavaCompiler javac = javax.tools.ToolProvider.getSystemJavaCompiler();
-     ((com.sun.source.util.JavacTask) javac.getTask(new PrintWriter(System.err), javac.getStandardFileManager(dl, null, null), dl, opts, null,
-        src.stream().map(path->
-             new SimpleJavaFileObject(path.toUri(),JavaFileObject.Kind.SOURCE){
-                public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                   try {
-                     return Files.readString(Path.of(toUri()));
-                   } catch (IOException e) {
-                      throw new RuntimeException(e);
-                  }
-             }
-          }).toList()
-     )).generate().forEach(fileObject->pathsToJar.add(Path.of(fileObject.toUri())));
-
-     var jarStream = new JarOutputStream(Files.newOutputStream(jar));
-     var setOfDirs = new HashSet<Path>();
-     pathsToJar.stream().sorted().forEach(path -> {
-          var parentDir = path.getParent();
-          if (!setOfDirs.contains(parentDir)){
-             setOfDirs.add(parentDir);
-             addEntry(jarStream, classesDir, parentDir);
-          }
-          addEntry(jarStream, classesDir, path);
-     });
-     resourcePath.stream().sorted().forEach(resourceDir->{
-          if (Files.isDirectory(resourceDir)){
-             //println("Trying "+resourceDir);
-             try{
-               Files.walk(resourceDir).filter(path->Files.isRegularFile(path)).forEach(path->{
-                 var parentDir = path.getParent();
-                 if (!setOfDirs.contains(parentDir)){
-                    setOfDirs.add(parentDir);
-                    addEntry(jarStream, resourceDir, parentDir);
-                 }
-                 addEntry(jarStream, resourceDir, path);
-               });
-             }catch(IOException ioe){
-               println(ioe);
-             } 
-          //}else{
-          // println("no resources "+resourceDir);
-          }
-        }
-     );
-     jarStream.finish();
-     jarStream.close();
-     return jar;
-}
-static Path javacjar(Path jar, Path classesDir, List<Path> sourcePath, List<Path> classPath) throws IOException{
-    return javacjar(jar, classesDir, sourcePath, classPath, List.of( /*resources*/));
-}
-static Path javacjar(Path jar, Path classesDir, List<Path> sourcePath) throws IOException{
-    return javacjar(jar, classesDir, sourcePath, List.of( /*classpath*/));
-}
-
-static Path path(String name){
-   return Path.of(name);
-}
-
-static List<Path> paths(Path ...paths){
-     List<Path> selectedPaths = new ArrayList<>();
-     Arrays.asList(paths).forEach(path->{
-        if (Files.isDirectory(path)){
-           selectedPaths.add(path);
-        }
-     });
-     return selectedPaths;
-}
-
+import static bldr.Bldr.*;
 void main(String[] args) throws IOException, InterruptedException {
-     var hatDir = path("/Users/grfrost/github/babylon-grfrost-fork/hat");
+       var hatDir = Path.of(System.getProperty("user.dir"));
+        var licensePattern = Pattern.compile("^.*Copyright.*202[4-9].*(Intel|Oracle).*$");
+        var eolws = Pattern.compile("^.* $");
+        var tab = Pattern.compile("^.*\\t.*");
 
-     Set.of("hat", "examples", "backends").forEach(dirName->{
-         try{
-            Files.walk(Paths.get(dirName)).filter(p->{
-              var name = p.toString();
-              return !name.contains("cmake-build-debug")
-                && !name.contains("rleparser")
-                && ( name.endsWith(".java") || name.endsWith(".cpp") || name.endsWith(".h"));
-              }).forEach(path->{
-                try{
-                   boolean license = false;
-                   for (String line: Files.readAllLines(path,  StandardCharsets.UTF_8)){
-                      if (line.contains("\t")){
-                        System.err.println("ERR TAB "+path+":"+line);
-                      }
-                      if (line.endsWith(" ")) {
-                        System.err.println("ERR TRAILING WHITESPACE "+path+":"+line);
-                      }
-                      if (Pattern.matches("^  *(package|import).*$",line)) { // I saw this a few times....?
-                        System.err.println("ERR WEIRD INDENT "+path+":"+line);
-                      }
-                      if (Pattern.matches("^.*Copyright.*202[4-9].*Intel.*$",line)) { // not foolproof I know
-                        license = true;
-                      }
-                      if (Pattern.matches("^.*Copyright.*202[4-9].*Oracle.*$",line)) { // not foolproof I know
-                        license = true;
-                      }
-                   }
-                   if (!license){
-                      System.err.println("ERR MISSING LICENSE "+path);
-                   }
-                } catch(IOException ioe){
-                  System.err.println(ioe);
+        paths(hatDir, "hat", "examples", "backends").forEach(dir -> {
+            paths(dir, path -> !Pattern.matches("^.*(-debug|rleparser).*$", path.toString())
+                       && Pattern.matches("^.*\\.(java|cpp|h|hpp)$", path.toString())
+            ).stream().map(path -> new TextFile(path)).forEach(textFile -> {
+                if (!textFile.grep(licensePattern)){
+                    System.err.println("ERR MISSING LICENSE " + textFile.path());
                 }
+                textFile.lines().forEach(line -> {
+                    if (line.grep(tab)) {
+                        System.err.println("ERR TAB " + textFile.path() + ":" + line.line() + "#" + line.num());
+                    }
+                    if (line.grep(eolws)) {
+                        System.err.println("ERR TRAILING WHITESPACE " + textFile.path() + ":" + line.line() + "#" + line.num());
+                    }
+                });
             });
-         } catch(IOException ioe){
-           System.err.println(ioe);
-         }
-      });
+        });
 
-     
-     var target = hatDir.resolve("build");
+        var target = mkdir(rmdir(path(hatDir, "build")));
+        var hatJavacOpts = List.of(
+                "--source", "24",
+                "--enable-preview",
+                "--add-exports=java.base/jdk.internal=ALL-UNNAMED",
+                "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+        );
 
-     var hatJar = javacjar(
-         target.resolve("hat-1.0.jar"),
-         target.resolve("hat-1.0.jar.classes"),
-         List.of(hatDir.resolve("hat/src/main/java"))
-     );
-     println(hatJar);
+        var hatJarResult = javacjar($ -> $
+                .opts(hatJavacOpts)
+                .jar(path(target, "hat-1.0.jar"))
+                .source_path(path(hatDir, "hat/src/main/java"))
+        );
+        println(hatJarResult.jar);
+        for (var exampleDir : paths(path(hatDir, "examples"), "mandel", "squares", "heal", "violajones", "life")) {
+            javacjar($ -> $
+                    .opts(hatJavacOpts)
+                    .jar(path(target, "hat-example-" + exampleDir.getFileName() + "-1.0.jar"))
+                    .source_path(path(exampleDir, "src/main/java"))
+                    .class_path(hatJarResult.jar)
+                    .resource_path(path(exampleDir, "src/main/resources"))
+            );
+        }
+        var backendsDir = path(hatDir, "backends");
+        for (var backendDir : paths(backendsDir, "opencl", "ptx")) {
+            javacjar($ -> $
+                    .opts(hatJavacOpts)
+                    .jar(path(target, "hat-backend-" + backendDir.getFileName() + "-1.0.jar"))
+                    .source_path(path(backendDir, "src/main/java"))
+                    .class_path(hatJarResult.jar)
+                    .resource_path(path(backendDir, "src/main/resources"))
+            );
+        }
 
-     for (var example: List.of("mandel", "squares", "heal", "violajones", "life")){
-       var exampleJar = javacjar(
-         target.resolve("hat-example-"+example+"-1.0.jar"),
-         target.resolve("hat-example-"+example+"-1.0.jar.classes"),
-         List.of(hatDir.resolve("examples/"+example+"/src/main/java")),
-         List.of(hatJar),
-         List.of(hatDir.resolve("examples/"+example+"/src/main/resources"))
-       );
-       println(exampleJar);
-     }
-     var backendsDir = hatDir.resolve("backends");
-     for (var backend: List.of("opencl")){
-       var backendDir = backendsDir.resolve(backend);
-       var backendJar = javacjar(
-         target.resolve("hat-backend-"+backend+"-1.0.jar"),
-         target.resolve("hat-backend-"+backend+"-1.0.jar.classes"),
-         List.of(backendDir.resolve("src/main/java")),
-         List.of(hatJar),
-         List.of(backendDir.resolve("src/main/resources"))
-       );
-       println(backendJar);
-     }
-  
-     var cmakeBldDebugDir = backendsDir.resolve("bld-debug");
-     Files.createDirectories(cmakeBldDebugDir);
-     var cmakeInit  = new ProcessBuilder()
-        .directory(backendsDir.toFile())
-        .inheritIO()
-        .command("cmake","-B", cmakeBldDebugDir.getFileName().toString(), "-DHAT_TARGET="+target)
-        .start();
-    cmakeInit.waitFor();
-
-     var cmakeBuild  = new ProcessBuilder()
-        .directory(backendsDir.toFile())
-        .inheritIO()
-        .command("cmake","--build", cmakeBldDebugDir.getFileName().toString(),"--target", "copy_libs")
-        .start();
-     cmakeBuild.waitFor();
-
-}
-
+        var cmakeBldDebugDir = backendsDir.resolve("bld-debug");
+        if (!existingDir(cmakeBldDebugDir)) {
+            mkdir(cmakeBldDebugDir);
+            cmake($ -> $.cwd(backendsDir)._B(cmakeBldDebugDir).opts("-DHAT_TARGET=" + target));
+        }
+        cmake($ -> $.cwd(backendsDir).__build(cmakeBldDebugDir));
+  } 

--- a/hat/bldr/.gitignore
+++ b/hat/bldr/.gitignore
@@ -1,0 +1,1 @@
+classes

--- a/hat/bldr/src/main/java/bldr/Bldr.java
+++ b/hat/bldr/src/main/java/bldr/Bldr.java
@@ -1,0 +1,701 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package bldr;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.io.IO.println;
+
+public class Bldr {
+    public record OS(String arch, String name, String version) {
+    }
+
+    public static OS os = new OS(System.getProperty("os.arch"), System.getProperty("os.name"), System.getProperty("os.version"));
+
+    public record Java(String version, File home) {
+    }
+
+    public static Java java = new Java(System.getProperty("java.version"), new File(System.getProperty("java.home")));
+
+    public record User(File home, File pwd) {
+    }
+
+    public static User user = new User(new File(System.getProperty("user.home")), new File(System.getProperty("user.dir")));
+
+
+    public static class XMLNode {
+        org.w3c.dom.Element element;
+        List<XMLNode> children = new ArrayList<>();
+        Map<String, String> attrMap = new HashMap<>();
+
+        XMLNode(org.w3c.dom.Element element) {
+            this.element = element;
+            this.element.normalize();
+            for (int i = 0; i < this.element.getChildNodes().getLength(); i++) {
+                if (this.element.getChildNodes().item(i) instanceof org.w3c.dom.Element e) {
+                    this.children.add(new XMLNode(e));
+                }
+            }
+            for (int i = 0; i < element.getAttributes().getLength(); i++) {
+                if (element.getAttributes().item(i) instanceof org.w3c.dom.Attr attr) {
+                    this.attrMap.put(attr.getName(), attr.getValue());
+                }
+            }
+        }
+
+        public boolean hasAttr(String name) {
+            return attrMap.containsKey(name);
+        }
+
+        public String attr(String name) {
+            return attrMap.get(name);
+        }
+
+        XMLNode(File file) throws Throwable {
+            this(javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file).getDocumentElement());
+        }
+
+        XMLNode(URL url) throws Throwable {
+            this(javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(url.openStream()).getDocumentElement());
+        }
+
+        void write(File file) throws Throwable {
+            var transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+            transformer.transform(new DOMSource(element.getOwnerDocument()), new StreamResult(file));
+        }
+
+        XPathExpression xpath(String expression) throws XPathExpressionException {
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            return xpath.compile(expression);
+        }
+
+        Node node(XPathExpression xPathExpression) throws XPathExpressionException {
+            return (Node) xPathExpression.evaluate(this.element, XPathConstants.NODE);
+        }
+
+        String string(XPathExpression xPathExpression) throws XPathExpressionException {
+            return (String) xPathExpression.evaluate(this.element, XPathConstants.STRING);
+        }
+
+        NodeList nodeList(XPathExpression xPathExpression) throws XPathExpressionException {
+            return (NodeList) xPathExpression.evaluate(this.element, XPathConstants.NODESET);
+        }
+    }
+
+    static class POM {
+
+        static Pattern varPattern = Pattern.compile("\\$\\{([^}]*)\\}");
+
+        static public String varExpand(Map<String, String> props, String value) { // recurse
+            String result = value;
+            if (varPattern.matcher(value) instanceof Matcher matcher && matcher.find()) {
+                var v = matcher.group(1);
+                result = varExpand(props, value.substring(0, matcher.start())
+                        + (v.startsWith("env")
+                        ? System.getenv(v.substring(4))
+                        : props.get(v))
+                        + value.substring(matcher.end()));
+                //out.println("incomming ='"+value+"'  v= '"+v+"' value='"+value+"'->'"+result+"'");
+            }
+            return result;
+        }
+
+        POM(Path dir) throws Throwable {
+            var topPom = new XMLNode(new File(dir.toFile(), "pom.xml"));
+            var babylonDirKey = "babylon.dir";
+            var spirvDirKey = "beehive.spirv.toolkit.dir";
+            var hatDirKey = "hat.dir";
+            var interestingKeys = Set.of(spirvDirKey, babylonDirKey, hatDirKey);
+            var requiredDirKeys = Set.of(babylonDirKey, hatDirKey);
+            var dirKeyToDirMap = new HashMap<String, File>();
+            var props = new HashMap<String, String>();
+
+            topPom.children.stream().filter(e -> e.element.getNodeName().equals("properties")).forEach(properties ->
+                    properties.children.stream().forEach(property -> {
+                        var key = property.element.getNodeName();
+                        var value = varExpand(props, property.element.getTextContent());
+                        props.put(key, value);
+                        if (interestingKeys.contains(key)) {
+                            var file = new File(value);
+                            if (requiredDirKeys.contains(key) && !file.exists()) {
+                                System.err.println("ERR pom.xml has property '" + key + "' with value '" + value + "' but that dir does not exists!");
+                                System.exit(1);
+                            }
+                            dirKeyToDirMap.put(key, file);
+                        }
+                    })
+            );
+            for (var key : requiredDirKeys) {
+                if (!props.containsKey(key)) {
+                    System.err.println("ERR pom.xml expected to have property '" + key + "' ");
+                    System.exit(1);
+                }
+            }
+        }
+    }
+
+    public static String pathCharSeparated(List<Path> paths) {
+        StringBuilder sb = new StringBuilder();
+        paths.forEach(path -> {
+            if (!sb.isEmpty()) {
+                sb.append(File.pathSeparatorChar);
+            }
+            sb.append(path);
+        });
+        return sb.toString();
+    }
+
+    public static Path rmdir(Path path) {
+        try {
+            if (Files.exists(path)) {
+                Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+        } catch (IOException ioe) {
+            System.out.println(ioe);
+        }
+        return path;
+    }
+
+
+    public static class JavaJarConfig {
+        public Path jar;
+        public List<String> opts = new ArrayList<>();
+        public Path classesDir;
+        public List<Path> sourcePath;
+        public List<Path> classPath;
+        public List<Path> resourcePath;
+
+        public JavaJarConfig jar(Path jar) {
+            this.jar = jar;
+            return this;
+        }
+
+        public JavaJarConfig opts(List<String> opts) {
+            this.opts.addAll(opts);
+            return this;
+        }
+
+        public JavaJarConfig opts(String... opts) {
+            opts(Arrays.asList(opts));
+            return this;
+        }
+
+        public JavaJarConfig source_path(Path... sourcePaths) {
+            this.sourcePath = new ArrayList<>(Arrays.asList(sourcePaths));
+            return this;
+        }
+
+        public JavaJarConfig class_path(Path... classPaths) {
+            this.classPath = new ArrayList<>(Arrays.asList(classPaths));
+            return this;
+        }
+
+        public JavaJarConfig resource_path(Path... resourcePaths) {
+            this.resourcePath = new ArrayList<>(Arrays.asList(resourcePaths));
+            return this;
+        }
+
+        public JavaJarConfig resourcepathIgnoreIfNon(Path... resourcePaths) {
+            this.resourcePath = new ArrayList<>(Arrays.asList(resourcePaths));
+            return this;
+        }
+    }
+
+    public static JavaJarConfig javacjar(Consumer<JavaJarConfig> jjb) throws IOException {
+        JavaJarConfig builder = new JavaJarConfig();
+        jjb.accept(builder);
+        if (builder.classesDir == null) {
+            builder.classesDir = builder.jar.resolveSibling(builder.jar.getFileName().toString() + ".classes");
+        }
+        builder.opts.addAll(List.of("-d", builder.classesDir.toString()));
+        mkdir(rmdir(builder.classesDir));
+
+        if (builder.classPath != null) {
+            builder.opts.addAll(List.of("--class-path", pathCharSeparated(builder.classPath)));
+        }
+
+        builder.opts.addAll(List.of("--source-path", pathCharSeparated(builder.sourcePath)));
+        var src = new ArrayList<Path>();
+        builder.sourcePath.forEach(entry ->
+                src.addAll(paths(entry, path -> path.toString().endsWith(".java")))
+        );
+        if (builder.resourcePath == null) {
+            builder.resourcePath = new ArrayList<>();
+        }
+        DiagnosticListener<JavaFileObject> dl = (diagnostic) -> {
+            if (!diagnostic.getKind().equals(Diagnostic.Kind.NOTE)) {
+                System.out.println(diagnostic.getKind()
+                        + " " + diagnostic.getLineNumber() + ":" + diagnostic.getColumnNumber() + " " + diagnostic.getMessage(null));
+            }
+        };
+
+        // System.out.println(builder.opts);
+        record RootAndPath(Path root, Path path) {
+            Path relativize() {
+                return root().relativize(path());
+            }
+        }
+        List<RootAndPath> pathsToJar = new ArrayList<>();
+        JavaCompiler javac = javax.tools.ToolProvider.getSystemJavaCompiler();
+        ((com.sun.source.util.JavacTask) javac.getTask(new PrintWriter(System.err), javac.getStandardFileManager(dl, null, null), dl, builder.opts, null,
+                src.stream().map(path ->
+                        new SimpleJavaFileObject(path.toUri(), JavaFileObject.Kind.SOURCE) {
+                            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                                try {
+                                    return Files.readString(Path.of(toUri()));
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                        }).toList()
+        )).generate().forEach(fileObject -> pathsToJar.add(new RootAndPath(builder.classesDir, Path.of(fileObject.toUri()))));
+
+        var jarStream = new JarOutputStream(Files.newOutputStream(builder.jar));
+        var setOfDirs = new HashSet<Path>();
+        builder.resourcePath.stream().sorted().forEach(resourceDir -> {
+                    if (Files.isDirectory(resourceDir)) {
+                        paths(resourceDir, Files::isRegularFile).forEach(path -> pathsToJar.add(new RootAndPath(resourceDir, path)));
+                    }
+                }
+        );
+
+        pathsToJar.stream().sorted((l, r) -> l.path().compareTo(r.path)).forEach(rootAndPath -> {
+            var parentDir = rootAndPath.path().getParent();
+            try {
+                if (!setOfDirs.contains(parentDir)) {
+                    setOfDirs.add(parentDir);
+                    PosixFileAttributes attributes = Files.readAttributes(rootAndPath.path(), PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                    var entry = new JarEntry(rootAndPath.relativize() + "/");
+                    entry.setTime(attributes.lastModifiedTime().toMillis());
+                    jarStream.putNextEntry(entry);
+                    jarStream.closeEntry();
+                }
+                PosixFileAttributes attributes = Files.readAttributes(rootAndPath.path(), PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                var entry = new JarEntry(rootAndPath.relativize().toString());
+                entry.setTime(attributes.lastModifiedTime().toMillis());
+                jarStream.putNextEntry(entry);
+                if (attributes.isRegularFile()) {
+                    Files.newInputStream(rootAndPath.path()).transferTo(jarStream);
+                }
+                jarStream.closeEntry();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        jarStream.finish();
+        jarStream.close();
+        return builder;
+    }
+
+    public static Path path(String name) {
+        return Path.of(name);
+    }
+
+    public static Path path(Path parent, String name) {
+        return parent.resolve(name);
+    }
+
+    public static List<Path> paths(Path... paths) {
+        List<Path> selectedPaths = new ArrayList<>();
+        Arrays.asList(paths).forEach(path -> {
+            if (Files.isDirectory(path)) {
+                selectedPaths.add(path);
+            }
+        });
+        return selectedPaths;
+    }
+
+    public static List<Path> paths(Path parent, String... names) {
+        List<Path> selectedPaths = new ArrayList<>();
+        Arrays.asList(names).forEach(name -> {
+            Path path = path(parent, name);
+            if (Files.isDirectory(path)) {
+                selectedPaths.add(path);
+            }
+        });
+        return selectedPaths;
+    }
+
+    public static List<Path> paths(Path path, Predicate<Path> predicate) {
+        try {
+            return Files.walk(path).filter(predicate).toList();
+        } catch (IOException ioe) {
+            throw new IllegalStateException(ioe);
+        }
+    }
+
+    public static class CMakeConfig {
+        public List<String> opts = new ArrayList<>(List.of("cmake"));
+        public Path cmakeBldDebugDir;
+        public Path cwd;
+
+        public CMakeConfig _B(Path cmakeBldDebugDir) {
+            this.cmakeBldDebugDir = cmakeBldDebugDir;
+            opts.addAll(List.of("-B", cmakeBldDebugDir.getFileName().toString()));
+            return this;
+        }
+
+        public CMakeConfig __build(Path cmakeBldDebugDir) {
+            this.cmakeBldDebugDir = cmakeBldDebugDir;
+            opts.addAll(List.of("--build", cmakeBldDebugDir.getFileName().toString()));
+            return this;
+        }
+
+        public CMakeConfig cwd(Path cwd) {
+            this.cwd = cwd;
+            return this;
+        }
+
+        public CMakeConfig opts(String... opts) {
+            this.opts.addAll(Arrays.asList(opts));
+            return this;
+        }
+    }
+
+    public static void cmake(Consumer<CMakeConfig> cMakeConfigConsumer) {
+        CMakeConfig cmakeConfig = new CMakeConfig();
+        cMakeConfigConsumer.accept(cmakeConfig);
+        try {
+            Files.createDirectories(cmakeConfig.cmakeBldDebugDir);
+            //System.out.println(cmakeConfig.opts);
+            var cmakeInit = new ProcessBuilder()
+                    .directory(cmakeConfig.cwd.toFile())
+                    .inheritIO()
+                    .command(cmakeConfig.opts)
+                    .start();
+            cmakeInit.waitFor();
+        } catch (InterruptedException ie) {
+            System.out.println(ie);
+        } catch (IOException ioe) {
+            System.out.println(ioe);
+        }
+    }
+
+    public static boolean existingDir(Path dir) {
+        return Files.exists(dir);
+    }
+
+    public static Path mkdir(Path path) {
+        try {
+            return Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public record TextFile(Path path) {
+        public Stream<Line> lines() {
+            try {
+                int num[] = new int[]{1};
+                return Files.readAllLines(path(), StandardCharsets.UTF_8).stream().map(line -> new Line(line, num[0]++));
+            } catch (IOException ioe) {
+                System.out.println(ioe);
+                return new ArrayList<Line>().stream();
+            }
+        }
+
+        public boolean grep(Pattern pattern) {
+            return lines().anyMatch(line -> pattern.matcher(line.line).matches());
+        }
+    }
+
+    public record Line(String line, int num) {
+        public boolean grep(Pattern pattern) {
+            return pattern.matcher(line()).matches();
+        }
+    }
+
+    record GroupArtifactVersion(String group, String artifact, String version) {
+
+    }
+
+    interface RepoNode {
+        XMLNode xmlNode();
+
+        default GroupArtifactVersion groupArtifactVersion() {
+            try {
+                var groupIdXPath = xmlNode().xpath("groupId/text()");
+                var group = xmlNode().string(groupIdXPath);
+                var artifactIdXPath = xmlNode().xpath("artifactId/text()");
+                var artifact = xmlNode().string(artifactIdXPath);
+                var versionXPath = xmlNode().xpath("version/text()");
+                var version = xmlNode().string(versionXPath);
+                return new GroupArtifactVersion(group, artifact, version);
+            } catch (XPathExpressionException xPathExpressionException) {
+                throw new RuntimeException(xPathExpressionException);
+            }
+        }
+
+        default String location() {
+            GroupArtifactVersion groupArtifactVersion = groupArtifactVersion();
+            return "https://repo1.maven.org/maven2/" + groupArtifactVersion.group().replace('.', '/') + "/" + groupArtifactVersion().artifact() + "/" + groupArtifactVersion.version();
+        }
+
+        default String name(String suffix) {
+            GroupArtifactVersion groupArtifactVersion = groupArtifactVersion();
+            return groupArtifactVersion.artifact() + "-" + groupArtifactVersion.version + "." + suffix;
+        }
+
+        default URL url(String suffix) {
+            try {
+                return new URI(location() + "/" + name(suffix)).toURL();
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        default void downloadTo(Path thirdPartyDir, String suffix) {
+            var thirdPartyFile = thirdPartyDir.resolve(name(suffix));
+            try {
+                println("Downloading " + name(suffix) + "->" + thirdPartyDir);
+                url(suffix).openStream().transferTo(Files.newOutputStream(thirdPartyFile));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    record Dependency(XMLNode xmlNode) implements RepoNode {
+        public URL pomURL() {
+            try {
+                GroupArtifactVersion groupArtifactVersion = groupArtifactVersion();
+                return new URI("https://repo1.maven.org/maven2/" + groupArtifactVersion.group().replace('.', '/') + "/" + groupArtifactVersion.artifact() + "/" + groupArtifactVersion.version() + "/"
+                        + groupArtifactVersion.artifact() + "-" + groupArtifactVersion.version() + ".pom").toURL();
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    record RepoPom(XMLNode xmlNode) implements RepoNode {
+        List<Dependency> dependencies() {
+            List<Dependency> dependencies = new ArrayList<>();
+            try {
+                var dependenciesXPath = xmlNode().xpath("/project/dependencies/dependency");
+                var nodeList = xmlNode().nodeList(dependenciesXPath);
+                for (int i = 0; i < nodeList.getLength(); i++) {
+                    var node = nodeList.item(i);
+                    dependencies.add(new Dependency(new XMLNode((Element) node)));
+                }
+                return dependencies;
+            } catch (XPathExpressionException xPathExpressionException) {
+                throw new RuntimeException(xPathExpressionException);
+            }
+        }
+    }
+
+    public static class Repo {
+        Path dir;
+
+        Repo(Path dir) {
+            this.dir = dir;
+        }
+
+        Map<GroupArtifactVersion, Path> map = new HashMap<>();
+
+        RepoPom get(String groupId, String artifactId, String version) {
+            try {
+                var pom = new RepoPom(new XMLNode(new URI("https://repo1.maven.org/maven2/" + groupId.replace('.', '/') + "/"
+                        + artifactId + "/" + version + "/"
+                        + artifactId + "-" + version + ".pom").toURL()));
+                return pom;
+            } catch (Throwable exception) {
+                throw new RuntimeException(exception);
+            }
+
+        }
+
+    }
+
+    //  https://stackoverflow.com/questions/23272861/how-to-call-testng-xml-from-java-main-method
+    public static void main(String[] args) throws Throwable {
+
+        var hatDir = path("/Users/grfrost/github/babylon-grfrost-fork/hat");
+        var repo = new Repo(mkdir(rmdir(hatDir.resolve("thirdparty"))));
+        GroupArtifactVersion g= new GroupArtifactVersion("org.testng", "testng", "7.1.0");
+        GroupArtifactVersion aparapi = new GroupArtifactVersion("com.aparapi","aparapi","3.0.2");
+        GroupArtifactVersion aparapi_jni = new GroupArtifactVersion("com.aparapi","aparapi-jni","1.4.3");
+        GroupArtifactVersion aparapi_examples = new GroupArtifactVersion("com.aparapi","aparapi-examples","3.0.0");
+        RepoPom testng = repo.get("org.testng", "testng", "7.1.0");
+
+        //  var url = new URI("https://repo1.maven.org/maven2/org/testng/testng/7.1.0/testng-7.1.0.pom").toURL();
+        //  var node = new XMLNode(url);
+        //  RepoPom testng = new RepoPom(new XMLNode(new URI("https://repo1.maven.org/maven2/org/testng/testng/7.1.0/testng-7.1.0.pom").toURL()));
+        testng.downloadTo(repo.dir, "jar");
+        // testng.dependencies().stream().forEach(dependency->println(dependency.group()));
+        // testng.dependencies().stream().forEach(dependency->println(dependency.pomURL()));
+
+        // https://repo1.maven.org/maven2/org/testng/testng/7.1.0/testng-7.1.0.jar
+        /*
+        <project>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>7.1.0</version>
+          <name>testng</name>
+          <description>Testing framework for Java</description>
+          <url>https://testng.org</url>
+
+          <dependencies>
+             <dependency>
+                <groupId>com.beust</groupId>
+                <artifactId>jcommander</artifactId>
+                <version>1.72</version>
+                <scope>compile</scope>
+             </dependency>
+<dependency>
+<groupId>com.google.inject</groupId>
+<artifactId>guice</artifactId>
+<version>4.1.0</version>
+<classifier>no_aop</classifier>
+<scope>compile</scope>
+</dependency>
+<dependency>
+<groupId>org.yaml</groupId>
+<artifactId>snakeyaml</artifactId>
+<version>1.21</version>
+<scope>compile</scope>
+</dependency>
+</dependencies>
+</project>
+         */
+        // var hatDir = path("/Users/grfrost/github/babylon-grfrost-fork/hat");
+        var licensePattern = Pattern.compile("^.*Copyright.*202[4-9].*(Intel|Oracle).*$");
+        var eolws = Pattern.compile("^.* $");
+        var tab = Pattern.compile("^.*\\t.*");
+
+        paths(hatDir, "hat", "examples", "backends").forEach(dir -> {
+            paths(dir, path -> !Pattern.matches("^.*(-debug|rleparser).*$", path.toString())
+                    && Pattern.matches("^.*\\.(java|cpp|h|hpp)$", path.toString())
+            ).stream().map(path -> new TextFile(path)).forEach(textFile -> {
+                if (!textFile.grep(licensePattern)) {
+                    System.err.println("ERR MISSING LICENSE " + textFile.path());
+                }
+                textFile.lines().forEach(line -> {
+                    if (line.grep(tab)) {
+                        System.err.println("ERR TAB " + textFile.path() + ":" + line.line() + "#" + line.num());
+                    }
+                    if (line.grep(eolws)) {
+                        System.err.println("ERR TRAILING WHITESPACE " + textFile.path() + ":" + line.line() + "#" + line.num());
+                    }
+                });
+            });
+        });
+
+        var target = mkdir(rmdir(path(hatDir, "build")));
+        var hatJavacOpts = List.of(
+                "--source", "24",
+                "--enable-preview",
+                "--add-exports=java.base/jdk.internal=ALL-UNNAMED",
+                "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+        );
+
+        var hatJarResult = javacjar($ -> $
+                .opts(hatJavacOpts)
+                .jar(path(target, "hat-1.0.jar"))
+                .source_path(path(hatDir, "hat/src/main/java"))
+        );
+        println(hatJarResult.jar);
+        for (var exampleDir : paths(path(hatDir, "examples"), "mandel", "squares", "heal", "violajones", "life")) {
+            javacjar($ -> $
+                    .opts(hatJavacOpts)
+                    .jar(path(target, "hat-example-" + exampleDir.getFileName() + "-1.0.jar"))
+                    .source_path(path(exampleDir, "src/main/java"))
+                    .class_path(hatJarResult.jar)
+                    .resource_path(path(exampleDir, "src/main/resources"))
+            );
+        }
+        var backendsDir = path(hatDir, "backends");
+        for (var backendDir : paths(backendsDir, "opencl", "ptx")) {
+            javacjar($ -> $
+                    .opts(hatJavacOpts)
+                    .jar(path(target, "hat-backend-" + backendDir.getFileName() + "-1.0.jar"))
+                    .source_path(path(backendDir, "src/main/java"))
+                    .class_path(hatJarResult.jar)
+                    .resource_path(path(backendDir, "src/main/resources"))
+            );
+        }
+
+        var cmakeBldDebugDir = backendsDir.resolve("bld-debug");
+        if (!existingDir(cmakeBldDebugDir)) {
+            mkdir(cmakeBldDebugDir);
+            cmake($ -> $.cwd(backendsDir)._B(cmakeBldDebugDir).opts("-DHAT_TARGET=" + target));
+        }
+        cmake($ -> $.cwd(backendsDir).__build(cmakeBldDebugDir).opts("--target", "copy_libs"));
+    }
+}

--- a/hat/hatrun.bash
+++ b/hat/hatrun.bash
@@ -31,10 +31,10 @@ function example(){
    backend=$2
    example=$3
    shift 3
-   if test -d maven-build; then 
+   if test -d maven-build; then
       echo using trad maven-build
       build_dir=maven-build
-   elif test -d build; then 
+   elif test -d build; then
       echo using new build dir
       build_dir=build
    else

--- a/hat/intellij/.idea/modules.xml
+++ b/hat/intellij/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/hat.iml" filepath="$PROJECT_DIR$/hat.iml" />
+      <module fileurl="file://$PROJECT_DIR$/bldr.iml" filepath="$PROJECT_DIR$/bldr.iml" />
       <module fileurl="file://$PROJECT_DIR$/backend_cuda.iml" filepath="$PROJECT_DIR$/backend_cuda.iml" />
       <module fileurl="file://$PROJECT_DIR$/backend_mock.iml" filepath="$PROJECT_DIR$/backend_mock.iml" />
       <module fileurl="file://$PROJECT_DIR$/backend_ptx.iml" filepath="$PROJECT_DIR$/backend_ptx.iml" />

--- a/hat/intellij/bldr.iml
+++ b/hat/intellij/bldr.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../bldr/">
+      <sourceFolder url="file://$MODULE_DIR$/../bldr/src/main/java" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/hat/mkbldr
+++ b/hat/mkbldr
@@ -1,0 +1,73 @@
+#!/usr/bin/env java --enable-preview --source 24 
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import module java.compiler;
+
+void main(String[] args) throws IOException, InterruptedException {
+     var pwdDir = Path.of(System.getProperty("user.dir"));
+     var toolsDir = pwdDir.resolve("bldr");
+     var classesDir = toolsDir.resolve("classes");
+     var sourcePath = toolsDir.resolve("src/main/java");
+
+     if (Files.exists(classesDir)) {
+        Files.walk(classesDir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+     }
+     Files.createDirectories(classesDir);
+
+     var src = new ArrayList<Path>();
+     Files.walk(sourcePath).forEach(s->{if (s.toString().endsWith(".java")){src.add(s);}});
+
+     DiagnosticListener<JavaFileObject> dl = (diagnostic)-> System.out.println(diagnostic.getKind() + " " + diagnostic.getMessage(null));
+  
+     var opts = List.of(
+           "--source","24",
+           "--enable-preview",
+           "-d", classesDir.toString(),
+           "--source-path", sourcePath.toString()
+     );
+       
+     JavaCompiler javac = javax.tools.ToolProvider.getSystemJavaCompiler();
+     var javacTask = javac.getTask(
+          new PrintWriter(System.err),
+          javac.getStandardFileManager(dl, null, null),
+          dl,
+          opts,
+          null,
+          src.stream().map(path->
+               new SimpleJavaFileObject(path.toUri(),JavaFileObject.Kind.SOURCE){
+                  public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                     try {
+                       return Files.readString(Path.of(toUri()));
+                     } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+               }
+           }).toList()
+     );
+     ((com.sun.source.util.JavacTask)javacTask).generate();
+
+}
+


### PR DESCRIPTION
Previously cmake would build, and we have a special copy_libs target added to each sub project to copy to maven-build or build

Now we just pass in the required output directly and so cmake writes to desired dir. We avoid the extra copy

The new 'all java' and 'maven free' bldr 'bld' also uses this mechanism.

We need to chmod +x mkbldr bld it seems we can't commit scripts with execute bit set.    