### PR TITLE
Ensure exception region exits are generated

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -2551,9 +2551,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             OpTransformer tryExitTransformer;
             if (finalizer != null) {
                 tryExitTransformer = opT.compose((block, op) -> {
-                    if (op instanceof CoreOp.ReturnOp) {
-                        return inlineFinalizer(block, tryExceptionRegion, opT);
-                    } else if (op instanceof ExtendedOp.JavaLabelOp lop && ifExitFromTry(lop)) {
+                    if (op instanceof CoreOp.ReturnOp ||
+                            (op instanceof ExtendedOp.JavaLabelOp lop && ifExitFromTry(lop))) {
                         return inlineFinalizer(block, tryExceptionRegion, opT);
                     } else {
                         return block;
@@ -2561,9 +2560,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 });
             } else {
                 tryExitTransformer = opT.compose((block, op) -> {
-                    // @@@ break and continue
-                    // when target break/continue is enclosing the try
-                    if (op instanceof CoreOp.ReturnOp) {
+                    if (op instanceof CoreOp.ReturnOp ||
+                            (op instanceof ExtendedOp.JavaLabelOp lop && ifExitFromTry(lop))) {
                         Block.Builder tryRegionReturnExit = block.block();
                         block.op(exceptionRegionExit(tryExceptionRegion, tryRegionReturnExit.successor()));
                         return tryRegionReturnExit;


### PR DESCRIPTION
Ensure exception region exits are generated for break and continue instructions that exit a try block with only catch blocks (no finally block).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.org/babylon.git pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/252.diff">https://git.openjdk.org/babylon/pull/252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/252#issuecomment-2403636253)