### PR TITLE
Bldr provides access to jextract

### DIFF
--- a/hat/bld
+++ b/hat/bld
@@ -27,67 +27,111 @@
 import module java.compiler;
 import static bldr.Bldr.*;
 void main(String[] args) throws IOException, InterruptedException {
-       var hatDir = Path.of(System.getProperty("user.dir"));
-        var licensePattern = Pattern.compile("^.*Copyright.*202[4-9].*(Intel|Oracle).*$");
-        var eolws = Pattern.compile("^.* $");
-        var tab = Pattern.compile("^.*\\t.*");
+   var hatDir = Path.of(System.getProperty("user.dir"));
+   var licensePattern = Pattern.compile("^.*Copyright.*202[4-9].*(Intel|Oracle).*$");
+   var eolws = Pattern.compile("^.* $");
+   var tab = Pattern.compile("^.*\\t.*");
 
-        paths(hatDir, "hat", "examples", "backends").forEach(dir -> {
-            paths(dir, path -> !Pattern.matches("^.*(-debug|rleparser).*$", path.toString())
-                       && Pattern.matches("^.*\\.(java|cpp|h|hpp)$", path.toString())
-            ).stream().map(path -> new TextFile(path)).forEach(textFile -> {
-                if (!textFile.grep(licensePattern)){
-                    System.err.println("ERR MISSING LICENSE " + textFile.path());
-                }
-                textFile.lines().forEach(line -> {
-                    if (line.grep(tab)) {
-                        System.err.println("ERR TAB " + textFile.path() + ":" + line.line() + "#" + line.num());
-                    }
-                    if (line.grep(eolws)) {
-                        System.err.println("ERR TRAILING WHITESPACE " + textFile.path() + ":" + line.line() + "#" + line.num());
-                    }
-                });
-            });
-        });
+   paths(hatDir, "hat", "examples", "backends").forEach(dir -> {
+         paths(dir, path -> !Pattern.matches("^.*(-debug|rleparser).*$", path.toString())
+               && Pattern.matches("^.*\\.(java|cpp|h|hpp)$", path.toString())
+              ).stream().map(path -> new TextFile(path)).forEach(textFile -> {
+                 if (!textFile.grep(licensePattern)){
+                 System.err.println("ERR MISSING LICENSE " + textFile.path());
+                 }
+                 textFile.lines().forEach(line -> {
+                       if (line.grep(tab)) {
+                          System.err.println("ERR TAB " + textFile.path() + ":" + line.line() + "#" + line.num());
+                       }
+                       if (line.grep(eolws)) {
+                          System.err.println("ERR TRAILING WHITESPACE " + textFile.path() + ":" + line.line() + "#" + line.num());
+                       }
+                 });
+              });
+   });
 
-        var target = mkdir(rmdir(path(hatDir, "build")));
-        var hatJavacOpts = List.of(
-                "--source", "24",
-                "--enable-preview",
-                "--add-exports=java.base/jdk.internal=ALL-UNNAMED",
-                "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
-        );
+   var target = mkdir(rmdir(path(hatDir, "build")));
+   var hatJavacOpts = List.of(
+         "--source", "24",
+         "--enable-preview",
+         "--add-exports=java.base/jdk.internal=ALL-UNNAMED",
+         "--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
+         );
 
-        var hatJarResult = javacjar($ -> $
-                .opts(hatJavacOpts)
-                .jar(path(target, "hat-1.0.jar"))
-                .source_path(path(hatDir, "hat/src/main/java"))
-        );
-        println(hatJarResult.jar);
-        for (var exampleDir : paths(path(hatDir, "examples"), "mandel", "squares", "heal", "violajones", "life")) {
-            javacjar($ -> $
-                    .opts(hatJavacOpts)
-                    .jar(path(target, "hat-example-" + exampleDir.getFileName() + "-1.0.jar"))
-                    .source_path(path(exampleDir, "src/main/java"))
-                    .class_path(hatJarResult.jar)
-                    .resource_path(path(exampleDir, "src/main/resources"))
+   var hatJarResult = javacjar($ -> $
+         .opts(hatJavacOpts)
+         .jar(path(target, "hat-1.0.jar"))
+         .source_path(path(hatDir, "hat/src/main/java"))
+         );
+   println(hatJarResult.jar);
+   for (var exampleDir : paths(path(hatDir, "examples"), "mandel", "squares", "heal", "violajones", "life")) {
+      javacjar($ -> $
+            .opts(hatJavacOpts)
+            .jar(path(target, "hat-example-" + exampleDir.getFileName() + "-1.0.jar"))
+            .source_path(path(exampleDir, "src/main/java"))
+            .class_path(hatJarResult.jar)
+            .resource_path(path(exampleDir, "src/main/resources"))
             );
-        }
-        var backendsDir = path(hatDir, "backends");
-        for (var backendDir : paths(backendsDir, "opencl", "ptx")) {
-            javacjar($ -> $
-                    .opts(hatJavacOpts)
-                    .jar(path(target, "hat-backend-" + backendDir.getFileName() + "-1.0.jar"))
-                    .source_path(path(backendDir, "src/main/java"))
-                    .class_path(hatJarResult.jar)
-                    .resource_path(path(backendDir, "src/main/resources"))
+   }
+   var backendsDir = path(hatDir, "backends");
+   for (var backendDir : paths(backendsDir, "opencl", "ptx")) {
+      javacjar($ -> $
+            .opts(hatJavacOpts)
+            .jar(path(target, "hat-backend-" + backendDir.getFileName() + "-1.0.jar"))
+            .source_path(path(backendDir, "src/main/java"))
+            .class_path(hatJarResult.jar)
+            .resource_path(path(backendDir, "src/main/resources"))
             );
-        }
+   }
+   var hattricksDir = path(hatDir, "hattricks");
+   if (Files.exists(hattricksDir)){
+      for (var hattrickDir : paths(hattricksDir, "chess", "view")) {
+         javacjar($ -> $
+               .opts(hatJavacOpts)
+               .jar(path(target, "hat-example-" + hattrickDir.getFileName() + "-1.0.jar"))
+               .source_path(path(hattrickDir, "src/main/java"))
+               .class_path(hatJarResult.jar)
+               .resource_path(path(hattrickDir, "src/main/resources"))
+               );
+      }
+      for (var hattrickDir : paths(hattricksDir, "nbody")) {
 
-        var cmakeBldDebugDir = backendsDir.resolve("bld-debug");
-        if (!existingDir(cmakeBldDebugDir)) {
-            mkdir(cmakeBldDebugDir);
-            cmake($ -> $.cwd(backendsDir)._B(cmakeBldDebugDir).opts("-DHAT_TARGET=" + target));
-        }
-        cmake($ -> $.cwd(backendsDir).__build(cmakeBldDebugDir));
-  } 
+         var appFrameworks = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks";
+         var MAC_APP_FRAMEWORKS = Path.of(appFrameworks);
+         var MAC_LIB_FRAMEWORKS = Path.of("/System/Library/Frameworks");
+         jextract($ -> $
+              .home(Path.of("/Users/grfrost/jextract-22/"))
+              .cwd(hattrickDir)
+              .target_package("opencl")
+              .output(path(hattrickDir, "src/main/extracted-java/"))
+              .library(path(MAC_LIB_FRAMEWORKS, "OpenCL.framework/OpenCL"))
+              .compile_flag("-F" + MAC_APP_FRAMEWORKS)
+              .header(path(MAC_APP_FRAMEWORKS, "OpenCL.framework/Headers/opencl.h"))
+         );
+
+         jextract($ -> $
+              .home(Path.of("/Users/grfrost/jextract-22/"))
+              .cwd(hattrickDir)
+              .target_package("opengl")
+              .output(path(hattrickDir, "src/main/extracted-java/"))
+              .library(path(MAC_LIB_FRAMEWORKS, "GLUT.framework/GLUT"), path(MAC_LIB_FRAMEWORKS, "OpenGL.framework/OpenGL"))
+              .compile_flag("-F" + MAC_APP_FRAMEWORKS)
+              .header(path(MAC_APP_FRAMEWORKS, "GLUT.framework/Headers/glut.h"))
+         );
+         javacjar($ -> $
+               .opts(hatJavacOpts)
+               .jar(path(target, "hat-example-" + hattrickDir.getFileName() + "-1.0.jar"))
+               .source_path(path(hattrickDir, "src/main/java"), path(hattrickDir,"src/main/extracted-java"))
+               .class_path(hatJarResult.jar)
+               .resource_path(path(hattrickDir, "src/main/resources"))
+               );
+      }
+   }
+
+   var cmakeBldDebugDir = backendsDir.resolve("bld-debug");
+   if (!existingDir(cmakeBldDebugDir)) {
+      mkdir(cmakeBldDebugDir);
+      cmake($ -> $.cwd(backendsDir)._B(cmakeBldDebugDir).opts("-DHAT_TARGET=" + target));
+   }
+   cmake($ -> $.cwd(backendsDir).__build(cmakeBldDebugDir));
+}

--- a/hat/hatrun.bash
+++ b/hat/hatrun.bash
@@ -49,15 +49,33 @@ function example(){
    echo checking backend_jar = ${backend_jar}
    if test -f ${backend_jar} -o -d ${backend_jar} ;then
       example_jar=${build_dir}/hat-example-${example}-1.0.jar
+      case ${example} in
+        nbody)
+           extraVmOpts=-XstartOnFirstThread;;
+      esac
+      case ${backend} in
+        spirv)
+           extraJars=:${build_dir}/levelzero.jar:${build_dir}/beehive-spirv-lib-0.0.4.jar;;
+      esac
+
       echo checking example_jar = ${example_jar}
       if test -f ${example_jar} ; then
-         ${JAVA_HOME}/bin/java \
+         echo ${JAVA_HOME}/bin/java \
             --enable-preview --enable-native-access=ALL-UNNAMED \
-            --class-path ${build_dir}/hat-1.0.jar:${example_jar}:${backend_jar}:${build_dir}/levelzero.jar:${build_dir}/beehive-spirv-lib-0.0.4.jar \
+            ${extraVmOpts} \
+            --class-path ${build_dir}/hat-1.0.jar:${example_jar}:${backend_jar}${extraJars} \
             --add-exports=java.base/jdk.internal=ALL-UNNAMED \
             -Djava.library.path=${build_dir}:/usr/local/lib \
             -Dheadless=${headless} \
-            ${example}.Main
+            ${example}.Main $*
+         ${JAVA_HOME}/bin/java \
+            --enable-preview --enable-native-access=ALL-UNNAMED \
+            ${extraVmOpts} \
+            --class-path ${build_dir}/hat-1.0.jar:${example_jar}:${backend_jar}${extraJars} \
+            --add-exports=java.base/jdk.internal=ALL-UNNAMED \
+            -Djava.library.path=${build_dir}:/usr/local/lib \
+            -Dheadless=${headless} \
+            ${example}.Main $*
       else
          echo no such example example_jar = ${example_jar}
       fi

--- a/hat/mkbldr
+++ b/hat/mkbldr
@@ -25,49 +25,34 @@
  */
 
 import module java.compiler;
+import com.sun.source.util.JavacTask;
+import javax.tools.ToolProvider;
 
 void main(String[] args) throws IOException, InterruptedException {
-     var pwdDir = Path.of(System.getProperty("user.dir"));
-     var toolsDir = pwdDir.resolve("bldr");
+     var toolsDir = Path.of(System.getProperty("user.dir")).resolve("bldr");
      var classesDir = toolsDir.resolve("classes");
-     var sourcePath = toolsDir.resolve("src/main/java");
 
+     // Here we remove all classes from bldr/classes i.e rm -rf bldr/classes
      if (Files.exists(classesDir)) {
         Files.walk(classesDir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
      }
+     // Now make sure the bldr/classes dir exists i.e mkdir -p bldr/classes
      Files.createDirectories(classesDir);
 
-     var src = new ArrayList<Path>();
-     Files.walk(sourcePath).forEach(s->{if (s.toString().endsWith(".java")){src.add(s);}});
+     JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
 
-     DiagnosticListener<JavaFileObject> dl = (diagnostic)-> System.out.println(diagnostic.getKind() + " " + diagnostic.getMessage(null));
-  
-     var opts = List.of(
-           "--source","24",
-           "--enable-preview",
-           "-d", classesDir.toString(),
-           "--source-path", sourcePath.toString()
-     );
-       
-     JavaCompiler javac = javax.tools.ToolProvider.getSystemJavaCompiler();
-     var javacTask = javac.getTask(
-          new PrintWriter(System.err),
-          javac.getStandardFileManager(dl, null, null),
-          dl,
-          opts,
-          null,
-          src.stream().map(path->
-               new SimpleJavaFileObject(path.toUri(),JavaFileObject.Kind.SOURCE){
-                  public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                     try {
-                       return Files.readString(Path.of(toUri()));
-                     } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
+     JavacTask javacTask = (JavacTask)javac.getTask(
+         null, null, null, 
+         List.of( "--source","24", "--enable-preview", "-d", classesDir.toString()),
+         null,
+         List.of(
+            new SimpleJavaFileObject(toolsDir.resolve("src/main/java/bldr/Bldr.java").toUri(),JavaFileObject.Kind.SOURCE){
+               public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+                 return Files.readString(Path.of(toUri()));
                }
-           }).toList()
+            }
+         )
      );
-     ((com.sun.source.util.JavacTask)javacTask).generate();
-
+     javacTask.generate();
 }
 

--- a/hat/whitespacecheck.bash
+++ b/hat/whitespacecheck.bash
@@ -35,6 +35,8 @@ find . \
    -o -name "*.h" \
    -o -name "*.md" \
    -o -name "*.cpp" \
+   -o -name "mkbld" \
+   -o -name "bld" \
    -o -name CMakeFiles.list \
    | xargs grep "  *$" \
    | cut -d: -f1 \
@@ -49,6 +51,8 @@ find . \
    -o -name "*.h" \
    -o -name "*.md" \
    -o -name "*.cpp" \
+   -o -name "mkbld" \
+   -o -name "bld" \
    -o -name CMakeFiles.list \
    | xargs grep "\t" \
    | cut -d: -f1 \


### PR DESCRIPTION
Added ability to call jextract from Bldr in bld scripts 

```java 
        var appFrameworks = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
            + "Developer/SDKs/MacOSX.sdk/System/Library/Frameworks";
         var MAC_APP_FRAMEWORKS = Path.of(appFrameworks);
         var MAC_LIB_FRAMEWORKS = Path.of("/System/Library/Frameworks");
         jextract($ -> $
              .cwd(hattrickDir)
              .target_package("opencl")
              .output(path(hattrickDir, "src/main/extracted-java/"))
              .library(path(MAC_LIB_FRAMEWORKS, "OpenCL.framework/OpenCL"))
              .compile_flag("-F" + MAC_APP_FRAMEWORKS)
              .header(path(MAC_APP_FRAMEWORKS, "OpenCL.framework/Headers/opencl.h"))
         );

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/253/head:pull/253` \
`$ git checkout pull/253`

Update a local copy of the PR: \
`$ git checkout pull/253` \
`$ git pull https://git.openjdk.org/babylon.git pull/253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 253`

View PR using the GUI difftool: \
`$ git pr show -t 253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/253.diff">https://git.openjdk.org/babylon/pull/253.diff</a>

</details>
