### PR TITLE
Exception regions patch

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/NormalizeBlocksTransformer.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/NormalizeBlocksTransformer.java
@@ -78,6 +78,9 @@ public final class NormalizeBlocksTransformer implements OpTransformer {
         } else if (op instanceof CoreOp.ExceptionRegionEnter ere) {
             // Cannot remove block parameters from exception handlers
             removeUnusedBlockParameters(b, ere.start());
+        } else if (op instanceof CoreOp.ExceptionRegionExit ere) {
+            // Cannot remove block parameters from exception handlers
+            removeUnusedBlockParameters(b, ere.end());
         } else if (op instanceof Op.BlockTerminating) {
             for (Block.Reference successor : op.successors()) {
                 removeUnusedBlockParameters(b, successor);

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -532,7 +532,7 @@ public final class BytecodeGenerator {
                     setExceptionRegionStack(cop.trueBranch(), activeRegionStack);
                 }
                 case ExceptionRegionEnter er -> {
-                    for (Block.Reference catchBlock : er.catchBlocks().reversed()) {
+                    for (Block.Reference catchBlock : er.catchBlocks()) {
                         catchingBlocks.set(catchBlock.targetBlock().index());
                         setExceptionRegionStack(catchBlock, activeRegionStack);
                     }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/BytecodeGenerator.java
@@ -561,7 +561,7 @@ public final class BytecodeGenerator {
                 if (!(blocks.get(start).firstOp() instanceof ExceptionRegionExit erEx) || erEx.end().targetBlock().index() != end) {
                     Label startLabel = getLabel(start);
                     Label endLabel = getLabel(end);
-                    for (Block.Reference cbr : erNode.ere.catchBlocks()) {
+                    for (Block.Reference cbr : erNode.ere.catchBlocks().reversed()) {
                         List<Block.Parameter> params = cbr.targetBlock().parameters();
                         if (!params.isEmpty()) {
                             JavaType jt = (JavaType) params.get(0).type();

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -485,8 +485,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             // Exception region for the body
             Block.Builder syncRegionEnter = b.block();
             Block.Builder catcherFinally = b.block();
-            Result syncExceptionRegion = b.op(exceptionRegionEnter(
-                    syncRegionEnter.successor(), List.of(catcherFinally.successor())));
+            b.op(exceptionRegionEnter(
+                    syncRegionEnter.successor(), catcherFinally.successor()));
 
             OpTransformer syncExitTransformer = opT.compose((block, op) -> {
                 if (op instanceof CoreOp.ReturnOp ||
@@ -495,7 +495,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     block.op(CoreOp.monitorExit(monitorTarget));
                     // Exit the exception region
                     Block.Builder exitRegion = block.block();
-                    block.op(exceptionRegionExit(syncExceptionRegion, exitRegion.successor()));
+                    block.op(exceptionRegionExit(exitRegion.successor(), catcherFinally.successor()));
                     return exitRegion;
                 } else {
                     return block;
@@ -507,7 +507,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     // Monitor exit
                     block.op(CoreOp.monitorExit(monitorTarget));
                     // Exit the exception region
-                    block.op(exceptionRegionExit(syncExceptionRegion, exit.successor()));
+                    block.op(exceptionRegionExit(exit.successor(), catcherFinally.successor()));
                 } else {
                     // @@@ Composition of lowerable ops
                     if (op instanceof Lowerable lop) {
@@ -521,15 +521,15 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
 
             // The catcher, with an exception region back branching to itself
             Block.Builder catcherFinallyRegionEnter = b.block();
-            Result catcherExceptionRegion = catcherFinally.op(exceptionRegionEnter(
-                    catcherFinallyRegionEnter.successor(), List.of(catcherFinally.successor())));
+            catcherFinally.op(exceptionRegionEnter(
+                    catcherFinallyRegionEnter.successor(), catcherFinally.successor()));
 
             // Monitor exit
             catcherFinallyRegionEnter.op(CoreOp.monitorExit(monitorTarget));
             Block.Builder catcherFinallyRegionExit = b.block();
             // Exit the exception region
             catcherFinallyRegionEnter.op(exceptionRegionExit(
-                    catcherExceptionRegion, catcherFinallyRegionExit.successor()));
+                    catcherFinallyRegionExit.successor(), catcherFinally.successor()));
             // Rethrow outside of region
             Block.Parameter t = catcherFinally.parameter(type(Throwable.class));
             catcherFinallyRegionExit.op(_throw(t));
@@ -2544,16 +2544,17 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             }
 
             // Enter the try exception region
-            Result tryExceptionRegion = b.op(exceptionRegionEnter(tryRegionEnter.successor(), catchers.stream()
+            List<Block.Reference> exitHandlers = catchers.stream()
                     .map(Block.Builder::successor)
-                    .toList()));
+                    .toList();
+            b.op(exceptionRegionEnter(tryRegionEnter.successor(), exitHandlers.reversed()));
 
             OpTransformer tryExitTransformer;
             if (finalizer != null) {
                 tryExitTransformer = opT.compose((block, op) -> {
                     if (op instanceof CoreOp.ReturnOp ||
                             (op instanceof ExtendedOp.JavaLabelOp lop && ifExitFromTry(lop))) {
-                        return inlineFinalizer(block, tryExceptionRegion, opT);
+                        return inlineFinalizer(block, exitHandlers, opT);
                     } else {
                         return block;
                     }
@@ -2563,7 +2564,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     if (op instanceof CoreOp.ReturnOp ||
                             (op instanceof ExtendedOp.JavaLabelOp lop && ifExitFromTry(lop))) {
                         Block.Builder tryRegionReturnExit = block.block();
-                        block.op(exceptionRegionExit(tryExceptionRegion, tryRegionReturnExit.successor()));
+                        block.op(exceptionRegionExit(tryRegionReturnExit.successor(), exitHandlers));
                         return tryRegionReturnExit;
                     } else {
                         return block;
@@ -2592,11 +2593,11 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 finallyEnter = b.block();
                 if (hasTryRegionExit.get()) {
                     // Exit the try exception region
-                    tryRegionExit.op(exceptionRegionExit(tryExceptionRegion, finallyEnter.successor()));
+                    tryRegionExit.op(exceptionRegionExit(finallyEnter.successor(), exitHandlers));
                 }
             } else if (hasTryRegionExit.get()) {
                 // Exit the try exception region
-                tryRegionExit.op(exceptionRegionExit(tryExceptionRegion, exit.successor()));
+                tryRegionExit.op(exceptionRegionExit(exit.successor(), exitHandlers));
             }
 
             // Inline the catch bodies
@@ -2616,9 +2617,9 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
 
                     OpTransformer catchExitTransformer = opT.compose((block, op) -> {
                         if (op instanceof CoreOp.ReturnOp) {
-                            return inlineFinalizer(block, catchExceptionRegion, opT);
+                            return inlineFinalizer(block, exitHandlers, opT);
                         } else if (op instanceof ExtendedOp.JavaLabelOp lop && ifExitFromTry(lop)) {
-                            return inlineFinalizer(block, catchExceptionRegion, opT);
+                            return inlineFinalizer(block, exitHandlers, opT);
                         } else {
                             return block;
                         }
@@ -2643,7 +2644,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     // Exit the catch exception region
                     if (hasCatchRegionExit.get()) {
                         hasTryRegionExit.set(true);
-                        catchRegionExit.op(exceptionRegionExit(catchExceptionRegion, finallyEnter.successor()));
+                        catchRegionExit.op(exceptionRegionExit(finallyEnter.successor(), exitHandlers));
                     }
                 } else {
                     // Inline the catch body
@@ -2717,11 +2718,11 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
             return false;
         }
 
-        Block.Builder inlineFinalizer(Block.Builder block1, Value exceptionRegion, OpTransformer opT) {
+        Block.Builder inlineFinalizer(Block.Builder block1, List<Block.Reference> tryHandlers, OpTransformer opT) {
             Block.Builder finallyEnter = block1.block();
             Block.Builder finallyExit = block1.block();
 
-            block1.op(exceptionRegionExit(exceptionRegion, finallyEnter.successor()));
+            block1.op(exceptionRegionExit(finallyEnter.successor(), tryHandlers));
 
             // Inline the finally body
             finallyEnter.transformBody(finalizer, List.of(), opT.andThen((block2, op2) -> {

--- a/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
+++ b/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
@@ -81,7 +81,7 @@ public class TestExceptionRegionOps {
                     var c = fblock.parameters().get(0);
                     fblock.op(exceptionRegionEnter(
                             enterER1.successor(),
-                            catchER1ISE.successor(), catchER1IAE.successor()));
+                            catchER1IAE.successor(), catchER1ISE.successor()));
 
                     // Start of exception region
                     enterER1.ops(b -> {
@@ -89,7 +89,7 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of exception region
                         b.op(exceptionRegionExit(end.successor(),
-                            catchER1IAE.successor(), catchER1ISE.successor()));
+                            catchER1ISE.successor(), catchER1IAE.successor()));
                     });
 
                     // First catch block for exception region
@@ -173,7 +173,7 @@ public class TestExceptionRegionOps {
                     var c = fblock.parameters().get(0);
                     fblock.op(exceptionRegionEnter(
                             enterER1.successor(),
-                            catchER1ISE.successor(), catchER1T.successor()));
+                            catchER1T.successor(), catchER1ISE.successor()));
 
                     // Start of exception region
                     enterER1.ops(b -> {
@@ -181,7 +181,7 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of exception region
                         b.op(exceptionRegionExit(end.successor(),
-                            catchER1T.successor(), catchER1ISE.successor()));
+                            catchER1ISE.successor(), catchER1T.successor()));
 
                     });
 
@@ -395,7 +395,7 @@ public class TestExceptionRegionOps {
                     var c = fblock.parameters().get(0);
                     fblock.op(exceptionRegionEnter(
                             enterER1.successor(),
-                            catchRE.successor(), catchAll.successor()));
+                            catchAll.successor(), catchRE.successor()));
 
                     // Start of exception region
                     enterER1.ops(b -> {
@@ -403,7 +403,7 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of exception region
                         b.op(exceptionRegionExit(exitER1.successor(),
-                            catchAll.successor(), catchRE.successor()));
+                            catchRE.successor(), catchAll.successor()));
                     });
                     // Inline finally
                     exitER1.ops(b -> {

--- a/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
+++ b/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
@@ -79,7 +79,7 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    var er1 = fblock.op(exceptionRegionEnter(
+                    fblock.op(exceptionRegionEnter(
                             enterER1.successor(),
                             catchER1ISE.successor(), catchER1IAE.successor()));
 
@@ -88,7 +88,8 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, 0))));
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of exception region
-                        b.op(exceptionRegionExit(er1, end.successor()));
+                        b.op(exceptionRegionExit(end.successor(),
+                            catchER1IAE.successor(), catchER1ISE.successor()));
                     });
 
                     // First catch block for exception region
@@ -170,7 +171,7 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    var er1 = fblock.op(exceptionRegionEnter(
+                    fblock.op(exceptionRegionEnter(
                             enterER1.successor(),
                             catchER1ISE.successor(), catchER1T.successor()));
 
@@ -179,7 +180,9 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, 0))));
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of exception region
-                        b.op(exceptionRegionExit(er1, end.successor()));
+                        b.op(exceptionRegionExit(end.successor(),
+                            catchER1T.successor(), catchER1ISE.successor()));
+
                     });
 
                     // First catch block for exception region
@@ -266,7 +269,7 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    var er1 = fblock.op(exceptionRegionEnter(
+                    fblock.op(exceptionRegionEnter(
                             enterER1.successor(),
                             catchER1.successor()));
 
@@ -275,7 +278,7 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, 0))));
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                     });
-                    var er2 = enterER1.op(exceptionRegionEnter(
+                    enterER1.op(exceptionRegionEnter(
                             enterER2.successor(),
                             catchER2.successor()));
 
@@ -284,7 +287,8 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, 1))));
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of second exception region
-                        b.op(exceptionRegionExit(er2, b3.successor()));
+                        b.op(exceptionRegionExit(b3.successor(),
+                            catchER2.successor()));
                     });
 
                     // Catch block for second exception region
@@ -298,7 +302,8 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, 3))));
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of first exception region
-                        b.op(exceptionRegionExit(er1, end.successor()));
+                        b.op(exceptionRegionExit(end.successor(),
+                            catchER1.successor()));
                     });
 
                     // Catch block for first exception region
@@ -388,7 +393,7 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    var er1 = fblock.op(exceptionRegionEnter(
+                    fblock.op(exceptionRegionEnter(
                             enterER1.successor(),
                             catchRE.successor(), catchAll.successor()));
 
@@ -397,7 +402,8 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, 0))));
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of exception region
-                        b.op(exceptionRegionExit(er1, exitER1.successor()));
+                        b.op(exceptionRegionExit(exitER1.successor(),
+                            catchAll.successor(), catchRE.successor()));
                     });
                     // Inline finally
                     exitER1.ops(b -> {
@@ -407,7 +413,7 @@ public class TestExceptionRegionOps {
                     });
 
                     // Catch block for RuntimeException
-                    var er2 = catchRE.op(exceptionRegionEnter(
+                    catchRE.op(exceptionRegionEnter(
                             enterER2.successor(),
                             catchAll.successor()));
                     // Start of exception region
@@ -415,7 +421,8 @@ public class TestExceptionRegionOps {
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, 1))));
                         b.op(CoreOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b.op(constant(INT, -1))));
                         // End of exception region
-                        b.op(exceptionRegionExit(er2, exitER2.successor()));
+                        b.op(exceptionRegionExit(exitER2.successor(),
+                            catchAll.successor()));
                     });
                     // Inline finally
                     exitER2.ops(b -> {

--- a/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
+++ b/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
@@ -71,24 +71,24 @@ public class TestNormalizeBlocksTransformer {
     static final String TEST2_INPUT = """
             func @"f" (%0 : java.lang.Object)void -> {
                 %1 : Var<java.lang.Object> = var %0 @"o";
-                %2 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_1 ^block_3 ^block_8;
+                exception.region.enter ^block_1 ^block_8 ^block_3;
 
               ^block_1:
                 %3 : int = invoke @"A::try_()int";
                 branch ^block_2;
 
               ^block_2:
-                exception.region.exit %2 ^block_6;
+                exception.region.exit ^block_6 ^block_3 ^block_8;
 
               ^block_3(%4 : java.lang.RuntimeException):
-                %5 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_4 ^block_8;
+                exception.region.enter ^block_4 ^block_8;
 
               ^block_4:
                 %6 : Var<java.lang.RuntimeException> = var %4 @"e";
                 branch ^block_5;
 
               ^block_5:
-                exception.region.exit %5 ^block_6;
+                exception.region.exit ^block_6 ^block_8;
 
               ^block_6:
                 %7 : int = invoke @"A::finally_()int";
@@ -105,18 +105,18 @@ public class TestNormalizeBlocksTransformer {
     static final String TEST2_EXPECTED = """
             func @"f" (%0 : java.lang.Object)void -> {
                 %1 : Var<java.lang.Object> = var %0 @"o";
-                %2 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_1 ^block_2 ^block_5;
+                exception.region.enter ^block_1 ^block_5 ^block_2;
 
               ^block_1:
                 %3 : int = invoke @"A::try_()int";
-                exception.region.exit %2 ^block_4;
+                exception.region.exit ^block_4 ^block_2 ^block_5;
 
               ^block_2(%4 : java.lang.RuntimeException):
-                %5 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_3 ^block_5;
+                exception.region.enter ^block_3 ^block_5;
 
               ^block_3:
                 %6 : Var<java.lang.RuntimeException> = var %4 @"e";
-                exception.region.exit %5 ^block_4;
+                exception.region.exit ^block_4 ^block_5;
 
               ^block_4:
                 %7 : int = invoke @"A::finally_()int";
@@ -213,14 +213,14 @@ public class TestNormalizeBlocksTransformer {
 
     static final String TEST5_INPUT = """
             func @"f" ()void -> {
-                %0 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_1 ^block_4;
+                exception.region.enter ^block_1 ^block_4;
 
               ^block_1:
                 invoke @"A::m()void";
                 branch ^block_2;
 
               ^block_2:
-                exception.region.exit %0 ^block_3;
+                exception.region.exit ^block_3 ^block_4;
 
               ^block_3:
                 branch ^block_5;
@@ -234,11 +234,11 @@ public class TestNormalizeBlocksTransformer {
             """;
     static final String TEST5_EXPECTED = """
             func @"f" ()void -> {
-                %0 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_1 ^block_3;
+                exception.region.enter ^block_1 ^block_3;
 
               ^block_1:
                 invoke @"A::m()void";
-                exception.region.exit %0 ^block_2;
+                exception.region.exit ^block_2 ^block_3;
 
               ^block_2:
                 branch ^block_4;

--- a/test/jdk/java/lang/reflect/code/lower/TestSynchronized.java
+++ b/test/jdk/java/lang/reflect/code/lower/TestSynchronized.java
@@ -43,7 +43,7 @@ public class TestSynchronized {
 
               ^block_1(%5 : java.lang.Object):
                 monitor.enter %5;
-                %6 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_2 ^block_4;
+                exception.region.enter ^block_2 ^block_4;
 
               ^block_2:
                 %7 : int = var.load %3;
@@ -51,18 +51,18 @@ public class TestSynchronized {
                 %9 : int = add %7 %8;
                 var.store %3 %9;
                 monitor.exit %5;
-                exception.region.exit %6 ^block_3;
+                exception.region.exit ^block_3 ^block_4;
 
               ^block_3:
                 %10 : int = var.load %3;
                 return %10;
 
               ^block_4(%11 : java.lang.Throwable):
-                %12 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_5 ^block_4;
+                exception.region.enter ^block_5 ^block_4;
 
               ^block_5:
                 monitor.exit %5;
-                exception.region.exit %12 ^block_6;
+                exception.region.exit ^block_6 ^block_4;
 
               ^block_6:
                 throw %11;
@@ -86,7 +86,7 @@ public class TestSynchronized {
 
               ^block_1(%5 : java.lang.Object):
                 monitor.enter %5;
-                %6 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_2 ^block_8;
+                exception.region.enter ^block_2 ^block_8;
 
               ^block_2:
                 %7 : int = var.load %3;
@@ -97,7 +97,7 @@ public class TestSynchronized {
               ^block_3:
                 %10 : int = constant @"-1";
                 monitor.exit %5;
-                exception.region.exit %6 ^block_4;
+                exception.region.exit ^block_4 ^block_8;
 
               ^block_4:
                 return %10;
@@ -111,18 +111,18 @@ public class TestSynchronized {
                 %13 : int = add %11 %12;
                 var.store %3 %13;
                 monitor.exit %5;
-                exception.region.exit %6 ^block_7;
+                exception.region.exit ^block_7 ^block_8;
 
               ^block_7:
                 %14 : int = var.load %3;
                 return %14;
 
               ^block_8(%15 : java.lang.Throwable):
-                %16 : java.lang.reflect.code.op.CoreOp$ExceptionRegion = exception.region.enter ^block_9 ^block_8;
+                exception.region.enter ^block_9 ^block_8;
 
               ^block_9:
                 monitor.exit %5;
-                exception.region.exit %16 ^block_10;
+                exception.region.exit ^block_10 ^block_8;
 
               ^block_10:
                 throw %15;


### PR DESCRIPTION
Proposed partial change of the `exception.region.enter` and `exception.region.exit`, as discussed at https://mail.openjdk.org/pipermail/babylon-dev/2024-October/001674.html

Summary of the change:
- `exception.region.enter` catch handler blocks appear in reverse order of the try/catch declaration to reflect natural nesting "outer first"
- return typeof `exception.region.enter` is void
- `exception.region.exit` does not refer to `exception.region.enter`, its first successor is end block and following successors are catch handler blocks in order as they appear in try/catch declaration (reverse to `exception.region.enter` order)
- `Interpreter`, `BytecodeGenerator`, `BytecodeLift`, `ExtendedOp`, `NormalizeBlockTransformer` and tests are fixed
- no change in the documentation is a part of this PR

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/256/head:pull/256` \
`$ git checkout pull/256`

Update a local copy of the PR: \
`$ git checkout pull/256` \
`$ git pull https://git.openjdk.org/babylon.git pull/256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 256`

View PR using the GUI difftool: \
`$ git pr show -t 256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/256.diff">https://git.openjdk.org/babylon/pull/256.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/256#issuecomment-2419707985)