### PR TITLE
Unreachable switch expression block

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -1605,7 +1605,6 @@ public class ReflectMethods extends TreeTranslator {
 
         @Override
         public void visitSwitchExpression(JCTree.JCSwitchExpression tree) {
-
             Value target = toValue(tree.selector);
 
             Type switchType = adaptBottom(tree.type);
@@ -1619,7 +1618,6 @@ public class ReflectMethods extends TreeTranslator {
 
         @Override
         public void visitSwitch(JCTree.JCSwitch tree) {
-
             Value target = toValue(tree.selector);
 
             FunctionType actionType = FunctionType.VOID;
@@ -1633,13 +1631,11 @@ public class ReflectMethods extends TreeTranslator {
         private List<Body.Builder> visitSwitchStatAndExpr(JCTree tree, JCExpression selector, Value target,
                                                           List<JCTree.JCCase> cases, FunctionType caseBodyType,
                                                           boolean isDefaultCaseNeeded) {
-
             List<Body.Builder> bodies = new ArrayList<>();
             Body.Builder defaultLabel = null;
             Body.Builder defaultBody = null;
 
             for (JCTree.JCCase c : cases) {
-
                 Body.Builder caseLabel = visitCaseLabel(tree, selector, target, c);
                 Body.Builder caseBody = visitCaseBody(tree, c, caseBodyType);
 
@@ -1675,7 +1671,6 @@ public class ReflectMethods extends TreeTranslator {
         }
 
         private Body.Builder visitCaseLabel(JCTree tree, JCExpression selector, Value target, JCTree.JCCase c) {
-
             Body.Builder body;
             FunctionType caseLabelType = FunctionType.functionType(JavaType.BOOLEAN, target.type());
 
@@ -1779,7 +1774,6 @@ public class ReflectMethods extends TreeTranslator {
         }
 
         private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, FunctionType caseBodyType) {
-
             Body.Builder body = null;
             Type yieldType = tree.type != null ? adaptBottom(tree.type) : null;
 
@@ -1796,11 +1790,11 @@ public class ReflectMethods extends TreeTranslator {
                         Type prevBodyTarget = bodyTarget;
                         try {
                             bodyTarget = yieldType;
-                            Value bodyVal = toValue(s);
-                            appendTerminating(CoreOp::_yield);
+                            toValue(s);
                         } finally {
                             bodyTarget = prevBodyTarget;
                         }
+                        appendTerminating(c.completesNormally ? CoreOp::_yield : CoreOp::unreachable);
                     }
                     body = stack.body;
 

--- a/test/langtools/tools/javac/reflect/UnreachableTest.java
+++ b/test/langtools/tools/javac/reflect/UnreachableTest.java
@@ -132,6 +132,47 @@ public class UnreachableTest {
         };
     }
 
+    @CodeReflection
+    @IR("""
+            func @"test5" (%0 : int)void -> {
+                %1 : Var<int> = var %0 @"n";
+                %2 : int = var.load %1;
+                %3 : java.lang.String = java.switch.expression %2
+                    (%4 : int)boolean -> {
+                        %5 : int = constant @"42";
+                        %6 : boolean = eq %4 %5;
+                        yield %6;
+                    }
+                    ()java.lang.String -> {
+                        java.while
+                            ()boolean -> {
+                                %7 : boolean = constant @"true";
+                                yield %7;
+                            }
+                            ()void -> {
+                                java.continue;
+                            };
+                        unreachable;
+                    }
+                    ()boolean -> {
+                        %8 : boolean = constant @"true";
+                        yield %8;
+                    }
+                    ()java.lang.String -> {
+                        %9 : java.lang.String = constant @"";
+                        yield %9;
+                    };
+                %10 : Var<java.lang.String> = var %3 @"s";
+                return;
+            };
+            """)
+    static void test5(int n) {
+        String s = switch (n) {
+            case 42 -> { while (true); }
+            default -> "";
+        };
+    }
+
     @IR("""
             func @"f" ()void -> {
                 %1 : java.util.function.IntUnaryOperator = lambda (%2 : int)int -> {


### PR DESCRIPTION
This fixes the generated code model for an unreachable edge case discussed in PR #257:
```
String s = switch (n) {
    case 3 -> { while (true); }
    default -> " Hello!";
};
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.org/babylon.git pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/260.diff">https://git.openjdk.org/babylon/pull/260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/260#issuecomment-2430385802)