### PR TITLE
Model uninitialized variables

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
@@ -263,6 +263,7 @@ public final class SSA {
         }
         return to;
     }
+
     /**
      * Finds the join points of a body.
      * <p>

--- a/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/analysis/SSA.java
@@ -254,10 +254,10 @@ public final class SSA {
 
     static Object peekAtCurrentVariable(Map<CoreOp.VarOp, Deque<Object>> variableStack, CoreOp.VarOp vop) {
         Object to = variableStack.get(vop).peek();
-        return throwIfUnitialized(vop, to);
+        return throwIfUninitialized(vop, to);
     }
 
-    static Object throwIfUnitialized(CoreOp.VarOp vop, Object to) {
+    static Object throwIfUninitialized(CoreOp.VarOp vop, Object to) {
         if (to instanceof Value v && v.type() instanceof UnknownValueType) {
             throw new IllegalStateException("Loading from uninitialized variable: " + vop);
         }

--- a/src/java.base/share/classes/java/lang/reflect/code/bytecode/LocalsToVarMapper.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/bytecode/LocalsToVarMapper.java
@@ -240,7 +240,7 @@ final class LocalsToVarMapper {
     private final Map<Label, Frame> stackMap;
 
     /**
-     * Map of new object types (to resolve unitialized verification types in the stack map).
+     * Map of new object types (to resolve uninitialized verification types in the stack map).
      */
     private final Map<Label, ClassDesc> newMap;
 
@@ -483,7 +483,7 @@ final class LocalsToVarMapper {
 
     /**
      * {@return map of labels immediately preceding {@link NewObjectInstruction} to the object types}
-     * The map is important to resolve unitialized verification types in the stack map.
+     * The map is important to resolve uninitialized verification types in the stack map.
      * @param codeElements List of code elements to scan
      */
     private static Map<Label, ClassDesc> computeNewMap(List<CodeElement> codeElements) {

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
@@ -170,12 +170,15 @@ public final class Interpreter {
         Object value;
 
         public Object value() {
+            // @@@ throw exception if holding UINITIALIZED?
             return value;
         }
 
         VarBox(Object value) {
             this.value = value;
         }
+
+        static final Object UINITIALIZED = new Object();
     }
 
     record ClosureRecord(CoreOp.ClosureOp op,
@@ -478,12 +481,15 @@ public final class Interpreter {
             ClosureRecord cr = (ClosureRecord) values.get(0);
 
             return Interpreter.invoke(l, cr.op(), cr.capturedValues, values.subList(1, values.size()));
+        } else if (o instanceof CoreOp.UndefinedValueOp uo) {
+            return VarBox.UINITIALIZED;
         } else if (o instanceof CoreOp.VarOp vo) {
             return new VarBox(oc.getValue(o.operands().get(0)));
         } else if (o instanceof CoreOp.VarAccessOp.VarLoadOp vlo) {
             // Cast to CoreOp.Var, since the instance may have originated as an external instance
             // via a captured value map
             CoreOp.Var<?> vb = (CoreOp.Var<?>) oc.getValue(o.operands().get(0));
+            // @@@ throw exception if var holds VarBox.UINITIALIZED?
             return vb.value();
         } else if (o instanceof CoreOp.VarAccessOp.VarStoreOp vso) {
             VarBox vb = (VarBox) oc.getValue(o.operands().get(0));

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
@@ -481,7 +481,7 @@ public final class Interpreter {
             ClosureRecord cr = (ClosureRecord) values.get(0);
 
             return Interpreter.invoke(l, cr.op(), cr.capturedValues, values.subList(1, values.size()));
-        } else if (o instanceof CoreOp.UndefinedValueOp uo) {
+        } else if (o instanceof CoreOp.UnknownValueOp uo) {
             return VarBox.UINITIALIZED;
         } else if (o instanceof CoreOp.VarOp vo) {
             return new VarBox(oc.getValue(o.operands().get(0)));

--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
@@ -170,7 +170,6 @@ public final class Interpreter {
         Object value;
 
         public Object value() {
-            // @@@ throw exception if holding UINITIALIZED?
             return value;
         }
 
@@ -489,8 +488,11 @@ public final class Interpreter {
             // Cast to CoreOp.Var, since the instance may have originated as an external instance
             // via a captured value map
             CoreOp.Var<?> vb = (CoreOp.Var<?>) oc.getValue(o.operands().get(0));
-            // @@@ throw exception if var holds VarBox.UINITIALIZED?
-            return vb.value();
+            Object value = vb.value();
+            if (value == VarBox.UINITIALIZED) {
+                throw interpreterException(new IllegalStateException("Loading from uninitialized variable"));
+            }
+            return value;
         } else if (o instanceof CoreOp.VarAccessOp.VarStoreOp vso) {
             VarBox vb = (VarBox) oc.getValue(o.operands().get(0));
             vb.value = oc.getValue(o.operands().get(1));

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
@@ -2163,7 +2163,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         UnknownValueOp(TypeElement type) {
             super(NAME, List.of());
 
-            this.type = UnknownValueType.undefinedType(type);
+            this.type = UnknownValueType.unknownValueType(type);
         }
 
         @Override

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
@@ -2134,36 +2134,36 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
-     * The undefined value operation, whose result can model the value of an uninitialized variable.
+     * The unknown value operation, whose result can model the value of an uninitialized variable.
      */
-    @OpFactory.OpDeclaration(UndefinedValueOp.NAME)
-    public static final class UndefinedValueOp extends CoreOp
+    @OpFactory.OpDeclaration(UnknownValueOp.NAME)
+    public static final class UnknownValueOp extends CoreOp
             implements Op.Pure {
-        public static final String NAME = "undefined.value";
+        public static final String NAME = "unknown.value";
 
         final TypeElement type;
 
-        public UndefinedValueOp(ExternalizedOp def) {
+        public UnknownValueOp(ExternalizedOp def) {
             super(def);
 
             this.type = def.resultType();
         }
 
-        UndefinedValueOp(UndefinedValueOp that, CopyContext cc) {
+        UnknownValueOp(UnknownValueOp that, CopyContext cc) {
             super(that, cc);
 
             this.type = that.type;
         }
 
         @Override
-        public UndefinedValueOp transform(CopyContext cc, OpTransformer ot) {
-            return new UndefinedValueOp(this, cc);
+        public UnknownValueOp transform(CopyContext cc, OpTransformer ot) {
+            return new UnknownValueOp(this, cc);
         }
 
-        UndefinedValueOp(TypeElement type) {
+        UnknownValueOp(TypeElement type) {
             super(NAME, List.of());
 
-            this.type = UndefinedType.undefinedType(type);
+            this.type = UnknownValueType.undefinedType(type);
         }
 
         @Override
@@ -2292,7 +2292,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         }
 
         public boolean isUnitialized() {
-            return initOperand().type() instanceof UndefinedType;
+            return initOperand().type() instanceof UnknownValueType;
         }
     }
 
@@ -4060,13 +4060,13 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
-     * Creates an undefined value operation, whose result models the value of an uninitialized variable
+     * Creates an unknown value operation, whose result models the value of an uninitialized variable
      *
-     * @param valueType the undefined type's value type
-     * @return the undefined operation.
+     * @param valueType the unknown value type's value type
+     * @return the unknown value operation.
      */
-    public static UndefinedValueOp undefinedValue(TypeElement valueType) {
-        return new UndefinedValueOp(valueType);
+    public static UnknownValueOp unknownValue(TypeElement valueType) {
+        return new UnknownValueOp(valueType);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
@@ -2133,6 +2133,44 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         }
     }
 
+    /**
+     * The undefined value operation, whose result can model the value of an uninitialized variable.
+     */
+    @OpFactory.OpDeclaration(UndefinedValueOp.NAME)
+    public static final class UndefinedValueOp extends CoreOp
+            implements Op.Pure {
+        public static final String NAME = "undefined.value";
+
+        final TypeElement type;
+
+        public UndefinedValueOp(ExternalizedOp def) {
+            super(def);
+
+            this.type = def.resultType();
+        }
+
+        UndefinedValueOp(UndefinedValueOp that, CopyContext cc) {
+            super(that, cc);
+
+            this.type = that.type;
+        }
+
+        @Override
+        public UndefinedValueOp transform(CopyContext cc, OpTransformer ot) {
+            return new UndefinedValueOp(this, cc);
+        }
+
+        UndefinedValueOp(TypeElement type) {
+            super(NAME, List.of());
+
+            this.type = UndefinedType.undefinedType(type);
+        }
+
+        @Override
+        public TypeElement resultType() {
+            return type;
+        }
+    }
 
     /**
      * A runtime representation of a variable.
@@ -2251,6 +2289,10 @@ public sealed abstract class CoreOp extends ExternalizableOp {
 
         public boolean isUnnamedVariable() {
             return varName.isEmpty();
+        }
+
+        public boolean isUnitialized() {
+            return initOperand().type() instanceof UndefinedType;
         }
     }
 
@@ -4015,6 +4057,16 @@ public sealed abstract class CoreOp extends ExternalizableOp {
      */
     public static CastOp cast(TypeElement resultType, JavaType t, Value v) {
         return new CastOp(resultType, t, v);
+    }
+
+    /**
+     * Creates an undefined value operation, whose result models the value of an uninitialized variable
+     *
+     * @param valueType the undefined type's value type
+     * @return the undefined operation.
+     */
+    public static UndefinedValueOp undefinedValue(TypeElement valueType) {
+        return new UndefinedValueOp(valueType);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -29,6 +29,17 @@ public final class CoreTypeFactory {
             @Override
             public TypeElement constructType(TypeElement.ExternalizedTypeElement tree) {
                 return switch (tree.identifier()) {
+                    case UndefinedType.NAME -> {
+                        if (tree.arguments().size() != 1) {
+                            throw new IllegalArgumentException();
+                        }
+
+                        TypeElement v = thisThenF.constructType(tree.arguments().getFirst());
+                        if (v == null) {
+                            throw new IllegalArgumentException("Bad type: " + tree);
+                        }
+                        yield UndefinedType.undefinedType(v);
+                    }
                     case VarType.NAME -> {
                         if (tree.arguments().size() != 1) {
                             throw new IllegalArgumentException();

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -38,7 +38,7 @@ public final class CoreTypeFactory {
                         if (v == null) {
                             throw new IllegalArgumentException("Bad type: " + tree);
                         }
-                        yield UnknownValueType.undefinedType(v);
+                        yield UnknownValueType.unknownValueType(v);
                     }
                     case VarType.NAME -> {
                         if (tree.arguments().size() != 1) {

--- a/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/CoreTypeFactory.java
@@ -29,7 +29,7 @@ public final class CoreTypeFactory {
             @Override
             public TypeElement constructType(TypeElement.ExternalizedTypeElement tree) {
                 return switch (tree.identifier()) {
-                    case UndefinedType.NAME -> {
+                    case UnknownValueType.NAME -> {
                         if (tree.arguments().size() != 1) {
                             throw new IllegalArgumentException();
                         }
@@ -38,7 +38,7 @@ public final class CoreTypeFactory {
                         if (v == null) {
                             throw new IllegalArgumentException("Bad type: " + tree);
                         }
-                        yield UndefinedType.undefinedType(v);
+                        yield UnknownValueType.undefinedType(v);
                     }
                     case VarType.NAME -> {
                         if (tree.arguments().size() != 1) {

--- a/src/java.base/share/classes/java/lang/reflect/code/type/UndefinedType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/UndefinedType.java
@@ -1,0 +1,61 @@
+package java.lang.reflect.code.type;
+
+import java.lang.reflect.code.TypeElement;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An undefined type.
+ * <p>
+ * A value whose type is the undefined type holds an unknown value whose type
+ * is the undefined type's value type.
+ */
+public class UndefinedType implements TypeElement {
+    static final String NAME = "Undefined";
+
+    final TypeElement valueType;
+
+    UndefinedType(TypeElement valueType) {
+        this.valueType = valueType;
+    }
+
+    /**
+     * {@return the undefined type's value type}
+     */
+    public TypeElement valueType() {
+        return valueType;
+    }
+
+    @Override
+    public ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(NAME, List.of(valueType.externalize()));
+    }
+
+    @Override
+    public String toString() {
+        return externalize().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o instanceof UndefinedType that &&
+                valueType.equals(that.valueType);
+    }
+
+    @Override
+    public int hashCode() {
+        return valueType.hashCode();
+    }
+
+    /**
+     * Constructs an undefined type.
+     *
+     * @param valueType the undefined type's value type.
+     * @return an undefined type.
+     */
+    public static UndefinedType undefinedType(TypeElement valueType) {
+        Objects.requireNonNull(valueType);
+        return new UndefinedType(valueType);
+    }
+}

--- a/src/java.base/share/classes/java/lang/reflect/code/type/UnknownValueType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/UnknownValueType.java
@@ -52,7 +52,7 @@ public class UnknownValueType implements TypeElement {
      * @param valueType the unknown value type's value type.
      * @return an unknown value type.
      */
-    public static UnknownValueType undefinedType(TypeElement valueType) {
+    public static UnknownValueType unknownValueType(TypeElement valueType) {
         Objects.requireNonNull(valueType);
         return new UnknownValueType(valueType);
     }

--- a/src/java.base/share/classes/java/lang/reflect/code/type/UnknownValueType.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/type/UnknownValueType.java
@@ -5,22 +5,20 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * An undefined type.
- * <p>
- * A value whose type is the undefined type holds an unknown value whose type
- * is the undefined type's value type.
+ * An unknown value type. A value whose type is of the unknown value type has a value
+ * of some other type but that value is unknown.
  */
-public class UndefinedType implements TypeElement {
-    static final String NAME = "Undefined";
+public class UnknownValueType implements TypeElement {
+    static final String NAME = "UnknownValue";
 
     final TypeElement valueType;
 
-    UndefinedType(TypeElement valueType) {
+    UnknownValueType(TypeElement valueType) {
         this.valueType = valueType;
     }
 
     /**
-     * {@return the undefined type's value type}
+     * {@return the unknown value type's value type}
      */
     public TypeElement valueType() {
         return valueType;
@@ -39,7 +37,7 @@ public class UndefinedType implements TypeElement {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        return o instanceof UndefinedType that &&
+        return o instanceof UnknownValueType that &&
                 valueType.equals(that.valueType);
     }
 
@@ -49,13 +47,13 @@ public class UndefinedType implements TypeElement {
     }
 
     /**
-     * Constructs an undefined type.
+     * Constructs an unknown value type.
      *
-     * @param valueType the undefined type's value type.
-     * @return an undefined type.
+     * @param valueType the unknown value type's value type.
+     * @return an unknown value type.
      */
-    public static UndefinedType undefinedType(TypeElement valueType) {
+    public static UnknownValueType undefinedType(TypeElement valueType) {
         Objects.requireNonNull(valueType);
-        return new UndefinedType(valueType);
+        return new UnknownValueType(valueType);
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -157,7 +157,8 @@ public class ReflectMethods extends TreeTranslator {
     // Cannot compute within constructor due to circular dependencies on bootstrap compilation
     // syms.objectType == null
     private Map<JavaType, Type> primitiveAndBoxTypeMap;
-    Map<JavaType, Type> primitiveAndBoxTypeMap() {
+    Map<
+            JavaType, Type> primitiveAndBoxTypeMap() {
         Map<JavaType, Type> m = primitiveAndBoxTypeMap;
         if (m == null) {
             m = primitiveAndBoxTypeMap = Map.ofEntries(
@@ -840,7 +841,7 @@ public class ReflectMethods extends TreeTranslator {
                 initOp = toValue(tree.init, tree.type);
                 result = append(CoreOp.var(tree.name.toString(), typeToTypeElement(tree.type), initOp));
             } else {
-                // If uninitialized, then the var's operand is the result of the undefined value operation
+                // If uninitialized, then the var's operand is the result of the unknown value operation
                 JavaType javaType = typeToTypeElement(tree.type);
                 initOp = append(CoreOp.unknownValue(javaType));
                 result = append(CoreOp.var(tree.name.toString(), javaType, initOp));
@@ -1370,7 +1371,7 @@ public class ReflectMethods extends TreeTranslator {
             // Create pattern var ops for pattern variables using the
             // builder associated with the nearest statement tree
             for (JCVariableDecl jcVar : variables) {
-                // @@@ use undefined value?
+                // @@@ use unknown value?
                 Value init = variablesStack.block.op(defaultValue(jcVar.type));
                 Op.Result op = variablesStack.block.op(CoreOp.var(jcVar.name.toString(), typeToTypeElement(jcVar.type), init));
                 variablesStack.localToOp.put(jcVar.sym, op);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -157,8 +157,7 @@ public class ReflectMethods extends TreeTranslator {
     // Cannot compute within constructor due to circular dependencies on bootstrap compilation
     // syms.objectType == null
     private Map<JavaType, Type> primitiveAndBoxTypeMap;
-    Map<
-            JavaType, Type> primitiveAndBoxTypeMap() {
+    Map<JavaType, Type> primitiveAndBoxTypeMap() {
         Map<JavaType, Type> m = primitiveAndBoxTypeMap;
         if (m == null) {
             m = primitiveAndBoxTypeMap = Map.ofEntries(

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -838,10 +838,13 @@ public class ReflectMethods extends TreeTranslator {
             Value initOp;
             if (tree.init != null) {
                 initOp = toValue(tree.init, tree.type);
+                result = append(CoreOp.var(tree.name.toString(), typeToTypeElement(tree.type), initOp));
             } else {
-                initOp = append(defaultValue(tree.type));
+                // If uninitialized, then the var's operand is the result of the undefined value operation
+                JavaType javaType = typeToTypeElement(tree.type);
+                initOp = append(CoreOp.undefinedValue(javaType));
+                result = append(CoreOp.var(tree.name.toString(), javaType, initOp));
             }
-            result = append(CoreOp.var(tree.name.toString(), typeToTypeElement(tree.type), initOp));
             stack.localToOp.put(tree.sym, result);
         }
 
@@ -1367,6 +1370,7 @@ public class ReflectMethods extends TreeTranslator {
             // Create pattern var ops for pattern variables using the
             // builder associated with the nearest statement tree
             for (JCVariableDecl jcVar : variables) {
+                // @@@ use undefined value?
                 Value init = variablesStack.block.op(defaultValue(jcVar.type));
                 Op.Result op = variablesStack.block.op(CoreOp.var(jcVar.name.toString(), typeToTypeElement(jcVar.type), init));
                 variablesStack.localToOp.put(jcVar.sym, op);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ReflectMethods.java
@@ -842,7 +842,7 @@ public class ReflectMethods extends TreeTranslator {
             } else {
                 // If uninitialized, then the var's operand is the result of the undefined value operation
                 JavaType javaType = typeToTypeElement(tree.type);
-                initOp = append(CoreOp.undefinedValue(javaType));
+                initOp = append(CoreOp.unknownValue(javaType));
                 result = append(CoreOp.var(tree.name.toString(), javaType, initOp));
             }
             stack.localToOp.put(tree.sym, result);

--- a/test/jdk/java/lang/reflect/code/TestUninitializedVariable.java
+++ b/test/jdk/java/lang/reflect/code/TestUninitializedVariable.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestUninitializedVariable
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.code.OpTransformer;
+import java.lang.reflect.code.analysis.SSA;
+import java.lang.reflect.code.interpreter.Interpreter;
+import java.lang.reflect.code.op.CoreOp;
+import java.lang.runtime.CodeReflection;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+public class TestUninitializedVariable {
+
+    @CodeReflection
+    static int simple(int i) {
+        int x;
+        x = i; // drop store
+        return x;
+    }
+
+    @CodeReflection
+    static int controlFlow(int i) {
+        int x;
+        if (i > 0) {
+            x = i;  // drop store
+        } else {
+            x = -i;
+        }
+        return x;
+    }
+
+    @DataProvider
+    Object[][] methods() {
+        return new Object[][] {
+                { "simple" },
+                { "controlFlow" }
+        };
+    }
+
+    @Test(dataProvider = "methods")
+    public void testInterpret(String method) {
+        CoreOp.FuncOp f = removeFirstStore(getFuncOp(method).transform(OpTransformer.LOWERING_TRANSFORMER));
+        f.writeTo(System.out);
+
+        Assert.assertThrows(Interpreter.InterpreterException.class, () -> Interpreter.invoke(f, 1));
+    }
+
+    @Test(dataProvider = "methods")
+    public void testSSA(String method) {
+        CoreOp.FuncOp f = removeFirstStore(getFuncOp(method).transform(OpTransformer.LOWERING_TRANSFORMER));
+        f.writeTo(System.out);
+
+        Assert.assertThrows(IllegalStateException.class, () -> SSA.transform(f));
+    }
+
+    static CoreOp.FuncOp removeFirstStore(CoreOp.FuncOp f) {
+        AtomicBoolean b = new AtomicBoolean();
+        return f.transform((block, op) -> {
+            if (op instanceof CoreOp.VarAccessOp.VarStoreOp vop && !b.getAndSet(true)) {
+                // Drop first encountered var store
+            } else {
+                block.op(op);
+            }
+            return block;
+        });
+    }
+
+    static CoreOp.FuncOp getFuncOp(String name) {
+        Optional<Method> om = Stream.of(TestUninitializedVariable.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+
+        Method m = om.get();
+        return m.getCodeModel().get();
+    }
+}

--- a/test/langtools/tools/javac/reflect/IfTest.java
+++ b/test/langtools/tools/javac/reflect/IfTest.java
@@ -325,7 +325,7 @@ public class IfTest {
     @IR("""
             func @"test9" (%0 : java.lang.Boolean)void -> {
                 %1 : Var<java.lang.Boolean> = var %0 @"b";
-                %2 : Undefined<int> = undefined.value;
+                %2 : UnknownValue<int> = unknown.value;
                 %3 : Var<int> = var %2 @"i";
                 java.if
                     ()boolean -> {

--- a/test/langtools/tools/javac/reflect/IfTest.java
+++ b/test/langtools/tools/javac/reflect/IfTest.java
@@ -325,7 +325,7 @@ public class IfTest {
     @IR("""
             func @"test9" (%0 : java.lang.Boolean)void -> {
                 %1 : Var<java.lang.Boolean> = var %0 @"b";
-                %2 : int = constant @"0";
+                %2 : Undefined<int> = undefined.value;
                 %3 : Var<int> = var %2 @"i";
                 java.if
                     ()boolean -> {

--- a/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
+++ b/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
@@ -51,7 +51,7 @@ public class ImplicitConversionTest {
     @CodeReflection
     @IR("""
             func @"test2" (%0: ImplicitConversionTest)void -> {
-                %1 : Undefined<long> = undefined.value;
+                %1 : UnknownValue<long> = unknown.value;
                 %2 : Var<long> = var %1 @"x";
                 %3 : int = constant @"1";
                 %4 : long = conv %3;
@@ -86,7 +86,7 @@ public class ImplicitConversionTest {
     @IR("""
             func @"test4" (%0: ImplicitConversionTest, %1 : boolean)void -> {
                 %2 : Var<boolean> = var %1 @"cond";
-                %3 : Undefined<long> = undefined.value;
+                %3 : UnknownValue<long> = unknown.value;
                 %4 : Var<long> = var %3 @"x";
                 %5 : long = java.cexpression
                     ^cond()boolean -> {
@@ -115,7 +115,7 @@ public class ImplicitConversionTest {
     @IR("""
            func @"test5" (%0: ImplicitConversionTest, %1 : boolean)void -> {
                %2 : Var<boolean> = var %1 @"cond";
-               %3 : Undefined<long> = undefined.value;
+               %3 : UnknownValue<long> = unknown.value;
                %4 : Var<long> = var %3 @"x";
                %5 : long = java.cexpression
                    ^cond()boolean -> {
@@ -144,7 +144,7 @@ public class ImplicitConversionTest {
     @IR("""
            func @"test6" (%0: ImplicitConversionTest, %1 : boolean)void -> {
                %2 : Var<boolean> = var %1 @"cond";
-               %3 : Undefined<long> = undefined.value;
+               %3 : UnknownValue<long> = unknown.value;
                %4 : Var<long> = var %3 @"x";
                %5 : int = java.cexpression
                    ^cond()boolean -> {

--- a/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
+++ b/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
@@ -51,7 +51,7 @@ public class ImplicitConversionTest {
     @CodeReflection
     @IR("""
             func @"test2" (%0: ImplicitConversionTest)void -> {
-                %1 : long = constant @"0";
+                %1 : Undefined<long> = undefined.value;
                 %2 : Var<long> = var %1 @"x";
                 %3 : int = constant @"1";
                 %4 : long = conv %3;
@@ -86,7 +86,7 @@ public class ImplicitConversionTest {
     @IR("""
             func @"test4" (%0: ImplicitConversionTest, %1 : boolean)void -> {
                 %2 : Var<boolean> = var %1 @"cond";
-                %3 : long = constant @"0";
+                %3 : Undefined<long> = undefined.value;
                 %4 : Var<long> = var %3 @"x";
                 %5 : long = java.cexpression
                     ^cond()boolean -> {
@@ -115,7 +115,7 @@ public class ImplicitConversionTest {
     @IR("""
            func @"test5" (%0: ImplicitConversionTest, %1 : boolean)void -> {
                %2 : Var<boolean> = var %1 @"cond";
-               %3 : long = constant @"0";
+               %3 : Undefined<long> = undefined.value;
                %4 : Var<long> = var %3 @"x";
                %5 : long = java.cexpression
                    ^cond()boolean -> {
@@ -144,7 +144,7 @@ public class ImplicitConversionTest {
     @IR("""
            func @"test6" (%0: ImplicitConversionTest, %1 : boolean)void -> {
                %2 : Var<boolean> = var %1 @"cond";
-               %3 : long = constant @"0";
+               %3 : Undefined<long> = undefined.value;
                %4 : Var<long> = var %3 @"x";
                %5 : int = java.cexpression
                    ^cond()boolean -> {

--- a/test/langtools/tools/javac/reflect/LocalVarTest.java
+++ b/test/langtools/tools/javac/reflect/LocalVarTest.java
@@ -70,9 +70,9 @@ public class LocalVarTest {
     @CodeReflection
     @IR("""
             func @"test3" (%0 : LocalVarTest)int -> {
-                %1 : Undefined<int> = undefined.value;
+                %1 : UnknownValue<int> = unknown.value;
                 %2 : Var<int> = var %1 @"x";
-                %3 : Undefined<int> = undefined.value;
+                %3 : UnknownValue<int> = unknown.value;
                 %4 : Var<int> = var %3 @"y";
                 %5 : int = constant @"1";
                 var.store %2 %5;

--- a/test/langtools/tools/javac/reflect/LocalVarTest.java
+++ b/test/langtools/tools/javac/reflect/LocalVarTest.java
@@ -70,9 +70,9 @@ public class LocalVarTest {
     @CodeReflection
     @IR("""
             func @"test3" (%0 : LocalVarTest)int -> {
-                %1 : int = constant @"0";
+                %1 : Undefined<int> = undefined.value;
                 %2 : Var<int> = var %1 @"x";
-                %3 : int = constant @"0";
+                %3 : Undefined<int> = undefined.value;
                 %4 : Var<int> = var %3 @"y";
                 %5 : int = constant @"1";
                 var.store %2 %5;

--- a/test/langtools/tools/javac/reflect/WhileLoopTest.java
+++ b/test/langtools/tools/javac/reflect/WhileLoopTest.java
@@ -168,7 +168,7 @@ public class WhileLoopTest {
     @IR("""
             func @"test5" (%0 : int)void -> {
                 %1 : Var<int> = var %0 @"i";
-                %2 : java.lang.Boolean = constant @null;
+                %2 : Undefined<java.lang.Boolean> = undefined.value;
                 %3 : Var<java.lang.Boolean> = var %2 @"b";
                 java.do.while
                     ()void -> {

--- a/test/langtools/tools/javac/reflect/WhileLoopTest.java
+++ b/test/langtools/tools/javac/reflect/WhileLoopTest.java
@@ -168,7 +168,7 @@ public class WhileLoopTest {
     @IR("""
             func @"test5" (%0 : int)void -> {
                 %1 : Var<int> = var %0 @"i";
-                %2 : Undefined<java.lang.Boolean> = undefined.value;
+                %2 : UnknownValue<java.lang.Boolean> = unknown.value;
                 %3 : Var<java.lang.Boolean> = var %2 @"b";
                 java.do.while
                     ()void -> {


### PR DESCRIPTION
Uninitialized variables are currently modeled as if they are variables initialized with a default value.

To directly model uninitialized variables we introduce the undefined value operation. This operation has a result that is an undefined value whose type is the undefined type. Such a value can be used as the init operand of a var operation. Thereby we can distinguish between the modeling of uninitialized variables and variables initialized with a default value.

The approach of using a special value means there are very little changes to code operating on models, and undefined values can be tracked. For example, there were no changes required to the SSA transformation. Although, we should update that transformation to check if a value being used is an unitialized value, and if so throw an exception that the variable is not definitely assigned.

A value of the undefined type holds another value of the undefined type's value type, but we don't know what the actual value is and nor can we obtain it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/263/head:pull/263` \
`$ git checkout pull/263`

Update a local copy of the PR: \
`$ git checkout pull/263` \
`$ git pull https://git.openjdk.org/babylon.git pull/263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 263`

View PR using the GUI difftool: \
`$ git pr show -t 263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/263.diff">https://git.openjdk.org/babylon/pull/263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/263#issuecomment-2433672890)