### PR TITLE
Support conversions of primitives in testing context

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3153,8 +3153,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 TypeElement targetType = tpOp.targetType();
 
                 // Check if instance of target type
-                Op p = null; // op that perform type check
-                Op c = null; // op that perform conversion
+                Op p; // op that perform type check
+                Op c; // op that perform conversion
                 TypeElement s = target.type();
                 TypeElement t = targetType;
                 if (t instanceof PrimitiveType pt) {
@@ -3169,6 +3169,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                             // e.g. Float -> float, unboxing
                             // e.g. Integer -> long, unboxing + widening
                             box = cs;
+                            p = null;
                         }
                         c = invoke(MethodRef.method(box, t + "Value", t), target);
                     } else {
@@ -3181,6 +3182,8 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                             // e.g. byte -> char, widening and narrowing
                             MethodRef mref = convMethodRef(s, t);
                             p = invoke(mref, target);
+                        } else {
+                            p = null;
                         }
                         c = CoreOp.conv(targetType, target);
                     }
@@ -3188,6 +3191,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     // boxing conversions
                     // e.g. int -> Number, boxing + widening
                     // e.g. byte -> Byte, boxing
+                    p = null;
                     ClassType box = ps.box().orElseThrow();
                     c = invoke(MethodRef.method(box, "valueOf", box, ps), target);
                 } else if (!s.equals(t)) {
@@ -3196,6 +3200,11 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     // e.g. Short -> Object, widening
                     p = CoreOp.instanceOf(targetType, target);
                     c = CoreOp.cast(targetType, target);
+                } else {
+                    // identity reference
+                    // e.g. Character -> Character
+                    p = null;
+                    c = null;
                 }
 
                 if (c != null) {

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3233,21 +3233,6 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 return MethodRef.method(exactConversionSupport, mn, BOOLEAN, s);
             }
 
-            private static boolean isWideningPrimitiveConv(TypeElement s, TypeElement t) {
-                if (!(s instanceof PrimitiveType sp) || !(t instanceof PrimitiveType tp)) {
-                    return false;
-                }
-                List<PrimitiveType> l = List.of(BYTE, SHORT, CHAR, INT, LONG, FLOAT, DOUBLE);
-                if (BYTE.equals(s) && CHAR.equals(t)) {
-                    return false;
-                } else if (SHORT.equals(s) && CHAR.equals(t)) {
-                    return false;
-                }
-                int si = l.indexOf(s);
-                int ti = l.indexOf(t);
-                return si < ti;
-            }
-
             private static boolean isNarrowingPrimitiveConv(TypeElement s, TypeElement t) { // s -> t
                 if (!(s instanceof PrimitiveType sp) || !(t instanceof PrimitiveType tp)) {
                     return false;
@@ -3256,14 +3241,6 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 int si = l.indexOf(s);
                 int ti = l.indexOf(t);
                 return ti < si || (SHORT.equals(s) && CHAR.equals(t));
-            }
-
-            private static boolean isNarrower(PrimitiveType s, PrimitiveType t) {
-                // byte and char ?
-                List<PrimitiveType> l = List.of(BOOLEAN, BYTE, SHORT, CHAR, INT, LONG, FLOAT, DOUBLE);
-                int si = l.indexOf(s);
-                int ti = l.indexOf(t);
-                return si != -1 && ti != -1 && si < ti;
             }
 
             private static String capitalize(String s) {

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3170,10 +3170,9 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                         c = invoke(MethodRef.method(box, t + "Value", t), target);
                     } else {
                         // primitive to primitive conversion
-                        if (isNarrowingPrimitiveConv(s, t) || isWideningPrimitiveConvThatNeedCheck(s, t)
-                                || (BYTE.equals(s) && CHAR.equals(t))) {
                         PrimitiveType ps = ((PrimitiveType) s);
-                        if (isNarrowingPrimitiveConv(ps, pt) || isWideningPrimitiveConvThatNeedCheck(s, t)
+                        if (isNarrowingPrimitiveConv(ps, pt) || isWideningPrimitiveConvThatNeedCheck(ps, pt)
+                                || isWideningAndNarrowingPrimitiveConv(ps, pt)) {
                             MethodRef mref = convMethodRef(s, t);
                             p = invoke(mref, target);
                         }
@@ -3197,7 +3196,11 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 return currentBlock;
             }
 
-            private static boolean isWideningPrimitiveConvThatNeedCheck(TypeElement s, TypeElement t) {
+            private static boolean isWideningAndNarrowingPrimitiveConv(PrimitiveType s, PrimitiveType t) {
+                return BYTE.equals(s) && CHAR.equals(t);
+            }
+
+            private static boolean isWideningPrimitiveConvThatNeedCheck(PrimitiveType s, PrimitiveType t) {
                 return (INT.equals(s) && FLOAT.equals(t))
                         || (LONG.equals(s) && FLOAT.equals(t))
                         || (LONG.equals(s) && DOUBLE.equals(t));

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3162,11 +3162,12 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                         // unboxing conversions
                         ClassType box;
                         if (cs.unbox().isEmpty()) { // s not a boxed type
-                            // e.g. Number -> int
+                            // e.g. Number -> int, narrowing + unboxing
                             box = pt.box().orElseThrow();
                             p = CoreOp.instanceOf(box, target);
                         } else {
-                            // e.g. Float -> float
+                            // e.g. Float -> float, unboxing
+                            // e.g. Integer -> long, unboxing + widening
                             box = cs;
                         }
                         c = invoke(MethodRef.method(box, t + "Value", t), target);
@@ -3196,7 +3197,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     }
                     c = invoke(MethodRef.method(box, "valueOf", box, ps), target);
                 } else {
-                    // e.g. byte -> Byte, Number -> Double, ...
+                    // e.g. Number -> Double, ...
                     p = CoreOp.instanceOf(targetType, target);
                     c = CoreOp.cast(targetType, target);
                 }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3154,7 +3154,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
 
                 // Check if instance of target type
                 Op p = null; // op that perform type check
-                Op c; // op that perform conversion
+                Op c = null; // op that perform conversion
                 TypeElement s = target.type();
                 TypeElement t = targetType;
                 if (t instanceof PrimitiveType pt) {
@@ -3196,8 +3196,10 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                         box = ct;
                     }
                     c = invoke(MethodRef.method(box, "valueOf", box, ps), target);
-                } else {
-                    // e.g. Number -> Double, ...
+                } else if (!Objects.equals(s, t)) {
+                    // reference to reference, but not identity
+                    // e.g. Number -> Double, narrowing
+                    // e.g. Short -> Object, widening
                     p = CoreOp.instanceOf(targetType, target);
                     c = CoreOp.cast(targetType, target);
                 }
@@ -3209,7 +3211,9 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     currentBlock = nextBlock;
                 }
 
-                target = currentBlock.op(c);
+                if (c != null) {
+                    target = currentBlock.op(c);
+                }
 
                 bindings.add(target);
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3183,6 +3183,18 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                         }
                         c = CoreOp.conv(targetType, target);
                     }
+                } else if (s instanceof PrimitiveType ps) {
+                    // boxing conversions
+                    ClassType ct = (ClassType) t;
+                    ClassType box;
+                    if (ct.unbox().isEmpty()) {
+                        // e.g. int -> Number, boxing + widening
+                        box = ps.box().orElseThrow();
+                    } else {
+                        // e.g. byte -> Byte, boxing
+                        box = ct;
+                    }
+                    c = invoke(MethodRef.method(box, "valueOf", box, ps), target);
                 } else {
                     // e.g. byte -> Byte, Number -> Double, ...
                     p = CoreOp.instanceOf(targetType, target);

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3198,14 +3198,13 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     c = CoreOp.cast(targetType, target);
                 }
 
-                if (p != null) {
-                    // p != null, we need to perform type check at runtime
-                    Block.Builder nextBlock = currentBlock.block();
-                    currentBlock.op(conditionalBranch(currentBlock.op(p), nextBlock.successor(), endNoMatchBlock.successor()));
-                    currentBlock = nextBlock;
-                }
-
                 if (c != null) {
+                    if (p != null) {
+                        // p != null, we need to perform type check at runtime
+                        Block.Builder nextBlock = currentBlock.block();
+                        currentBlock.op(conditionalBranch(currentBlock.op(p), nextBlock.successor(), endNoMatchBlock.successor()));
+                        currentBlock = nextBlock;
+                    }
                     target = currentBlock.op(c);
                 }
 

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3173,10 +3173,10 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     } else {
                         // primitive to primitive conversion
                         PrimitiveType ps = ((PrimitiveType) s);
-                        if (isNarrowingPrimitiveConv(ps, pt) || isWideningPrimitiveConvThatNeedCheck(ps, pt)
+                        if (isNarrowingPrimitiveConv(ps, pt) || isWideningPrimitiveConvWithCheck(ps, pt)
                                 || isWideningAndNarrowingPrimitiveConv(ps, pt)) {
                             // e.g. int -> byte, narrowing
-                            // e,g. int -> float, widening that need check
+                            // e,g. int -> float, widening with check
                             // e.g. byte -> char, widening and narrowing
                             MethodRef mref = convMethodRef(s, t);
                             p = invoke(mref, target);
@@ -3207,7 +3207,7 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                 return BYTE.equals(s) && CHAR.equals(t);
             }
 
-            private static boolean isWideningPrimitiveConvThatNeedCheck(PrimitiveType s, PrimitiveType t) {
+            private static boolean isWideningPrimitiveConvWithCheck(PrimitiveType s, PrimitiveType t) {
                 return (INT.equals(s) && FLOAT.equals(t))
                         || (LONG.equals(s) && FLOAT.equals(t))
                         || (LONG.equals(s) && DOUBLE.equals(t));

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3186,17 +3186,11 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                     }
                 } else if (s instanceof PrimitiveType ps) {
                     // boxing conversions
-                    ClassType ct = (ClassType) t;
-                    ClassType box;
-                    if (ct.unbox().isEmpty()) {
-                        // e.g. int -> Number, boxing + widening
-                        box = ps.box().orElseThrow();
-                    } else {
-                        // e.g. byte -> Byte, boxing
-                        box = ct;
-                    }
+                    // e.g. int -> Number, boxing + widening
+                    // e.g. byte -> Byte, boxing
+                    ClassType box = ps.box().orElseThrow();
                     c = invoke(MethodRef.method(box, "valueOf", box, ps), target);
-                } else if (!Objects.equals(s, t)) {
+                } else if (!s.equals(t)) {
                     // reference to reference, but not identity
                     // e.g. Number -> Double, narrowing
                     // e.g. Short -> Object, widening

--- a/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/ExtendedOp.java
@@ -3162,9 +3162,11 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                         // unboxing conversions
                         ClassType box;
                         if (cs.unbox().isEmpty()) { // s not a boxed type
+                            // e.g. Number -> int
                             box = pt.box().orElseThrow();
                             p = CoreOp.instanceOf(box, target);
                         } else {
+                            // e.g. Float -> float
                             box = cs;
                         }
                         c = invoke(MethodRef.method(box, t + "Value", t), target);
@@ -3173,17 +3175,22 @@ public sealed abstract class ExtendedOp extends ExternalizableOp {
                         PrimitiveType ps = ((PrimitiveType) s);
                         if (isNarrowingPrimitiveConv(ps, pt) || isWideningPrimitiveConvThatNeedCheck(ps, pt)
                                 || isWideningAndNarrowingPrimitiveConv(ps, pt)) {
+                            // e.g. int -> byte, narrowing
+                            // e,g. int -> float, widening that need check
+                            // e.g. byte -> char, widening and narrowing
                             MethodRef mref = convMethodRef(s, t);
                             p = invoke(mref, target);
                         }
                         c = CoreOp.conv(targetType, target);
                     }
                 } else {
+                    // e.g. byte -> Byte, Number -> Double, ...
                     p = CoreOp.instanceOf(targetType, target);
                     c = CoreOp.cast(targetType, target);
                 }
 
                 if (p != null) {
+                    // p != null, we need to perform type check at runtime
                     Block.Builder nextBlock = currentBlock.block();
                     currentBlock.op(conditionalBranch(currentBlock.op(p), nextBlock.successor(), endNoMatchBlock.successor()));
                     currentBlock = nextBlock;

--- a/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
@@ -338,6 +338,23 @@ public class TestPrimitiveTypePatterns {
         Assert.assertEquals(Interpreter.invoke(lf, Double.NEGATIVE_INFINITY), true);
     }
 
+    @CodeReflection
+    static boolean wp(int i) {
+        return i instanceof long _;
+    }
+
+    @Test
+    void test_wp() {
+        FuncOp f = getFuncOp("wp");
+        f.writeTo(System.out);
+
+        FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+    }
+
      private CoreOp.FuncOp getFuncOp(String name) {
         Optional<Method> om = Stream.of(this.getClass().getDeclaredMethods())
                 .filter(m -> m.getName().equals(name))

--- a/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
@@ -232,6 +232,112 @@ public class TestPrimitiveTypePatterns {
         Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
     }
 
+    @CodeReflection
+    static boolean nr_unboxing(Number n) {
+        return n instanceof int _;
+    }
+
+    @Test
+    void test_nr_unboxing() {
+        FuncOp f = getFuncOp("nr_unboxing");
+        f.writeTo(System.out);
+
+        FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, 1), true);
+        Assert.assertEquals(Interpreter.invoke(lf, (short) 1), false);
+    }
+
+    @CodeReflection
+    static boolean unboxing(Integer n) {
+        return n instanceof int _;
+    }
+
+    @Test
+    void test_unboxing() {
+        FuncOp f = getFuncOp("unboxing");
+        f.writeTo(System.out);
+
+        FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+    }
+
+    @CodeReflection
+    static boolean unboxing_wp(Integer n) {
+        return n instanceof long _;
+    }
+
+    @Test
+    void test_unboxing_wp() {
+        FuncOp f = getFuncOp("unboxing_wp");
+        f.writeTo(System.out);
+
+        FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+    }
+
+    @CodeReflection
+    static boolean wr(String s) {
+        return s instanceof Object _;
+    }
+
+    @Test
+    void test_wr() {
+        FuncOp f = getFuncOp("wr");
+        f.writeTo(System.out);
+
+        FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, (Object) null), false);
+        Assert.assertEquals(Interpreter.invoke(lf, "str"), true);
+    }
+
+    @CodeReflection
+    static boolean ir(Float f) {
+        return f instanceof Float _;
+    }
+
+    @Test
+    void test_ir() {
+        FuncOp f = getFuncOp("ir");
+        f.writeTo(System.out);
+
+        FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, Float.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(lf, Float.MIN_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(lf, Float.POSITIVE_INFINITY), true);
+        Assert.assertEquals(Interpreter.invoke(lf, Float.NEGATIVE_INFINITY), true);
+    }
+
+    @CodeReflection
+    static boolean nr(Number n) {
+        return n instanceof Double _;
+    }
+
+    @Test
+    void test_nr() {
+        FuncOp f = getFuncOp("nr");
+        f.writeTo(System.out);
+
+        FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
+        lf.writeTo(System.out);
+
+        Assert.assertEquals(Interpreter.invoke(lf, Float.MAX_VALUE), false);
+        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), false);
+        Assert.assertEquals(Interpreter.invoke(lf, Double.POSITIVE_INFINITY), true);
+        Assert.assertEquals(Interpreter.invoke(lf, Double.NEGATIVE_INFINITY), true);
+    }
+
      private CoreOp.FuncOp getFuncOp(String name) {
         Optional<Method> om = Stream.of(this.getClass().getDeclaredMethods())
                 .filter(m -> m.getName().equals(name))
@@ -244,7 +350,7 @@ public class TestPrimitiveTypePatterns {
     static FuncOp buildTypePatternModel(JavaType sourceType, JavaType targetType) {
         // builds the model of:
         // static boolean f(sourceType a) { return a instanceof targetType _; }
-        return func("f", functionType(JavaType.BOOLEAN, sourceType)).body(fblock -> {
+        return func(sourceType + "_" + targetType, functionType(JavaType.BOOLEAN, sourceType)).body(fblock -> {
 
             var paramVal = fblock.parameters().get(0);
 

--- a/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
@@ -46,7 +46,7 @@ public class TestPrimitiveTypePatterns {
     }
 
     @DataProvider
-    public static Object[][] dp() {
+    public static Object[][] narrowingPrimitiveAndWideningPrimitiveThatNeedCheck() {
         return new Object[][]{
                 {JavaType.INT, JavaType.BYTE, new Object[] {
                         Byte.MIN_VALUE - 1, Byte.MIN_VALUE, Byte.MAX_VALUE, Byte.MAX_VALUE + 1
@@ -138,8 +138,8 @@ public class TestPrimitiveTypePatterns {
         };
     }
 
-    @Test(dataProvider = "dp")
-    void test(JavaType sourceType, JavaType targetType, Object[] values) throws Throwable {
+    @Test(dataProvider = "narrowingPrimitiveAndWideningPrimitiveThatNeedCheck")
+    void testNarrowingPrimitiveAndWideningPrimitiveThatNeedCheck(JavaType sourceType, JavaType targetType, Object[] values) throws Throwable {
 
         var model = buildTypePatternModel(sourceType, targetType);
         model.writeTo(System.out);
@@ -166,13 +166,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean ip(short s) {
+    static boolean identityPrimitive(short s) {
         return s instanceof short _;
     }
 
     @Test
-    void test_ip() {
-        FuncOp f = getFuncOp("ip");
+    void testIdentityPrimitive() {
+        FuncOp f = getFuncOp("identityPrimitive");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -182,13 +182,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean wnp(byte s) {
+    static boolean wideningNarrowingPrimitive(byte s) {
         return s instanceof char _;
     }
 
     @Test
-    void test_wnp() {
-        FuncOp f = getFuncOp("wnp");
+    void testWideningNarrowingPrimitive() {
+        FuncOp f = getFuncOp("wideningNarrowingPrimitive");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -199,13 +199,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean b(int s) {
+    static boolean boxing(int s) {
         return s instanceof Integer _;
     }
 
     @Test
-    void test_b() {
-        FuncOp f = getFuncOp("b");
+    void testBoxing() {
+        FuncOp f = getFuncOp("boxing");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -216,13 +216,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean bw(int s) {
+    static boolean boxingWideningReference(int s) {
         return s instanceof Number _;
     }
 
     @Test
-    void test_bw() {
-        FuncOp f = getFuncOp("bw");
+    void testBoxingWideningReference() {
+        FuncOp f = getFuncOp("boxingWideningReference");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -233,13 +233,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean nr_unboxing(Number n) {
+    static boolean narrowingReferenceUnboxing(Number n) {
         return n instanceof int _;
     }
 
     @Test
-    void test_nr_unboxing() {
-        FuncOp f = getFuncOp("nr_unboxing");
+    void testNarrowingReferenceUnboxing() {
+        FuncOp f = getFuncOp("narrowingReferenceUnboxing");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -255,7 +255,7 @@ public class TestPrimitiveTypePatterns {
     }
 
     @Test
-    void test_unboxing() {
+    void testUnboxing() {
         FuncOp f = getFuncOp("unboxing");
         f.writeTo(System.out);
 
@@ -267,13 +267,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean unboxing_wp(Integer n) {
+    static boolean unboxingWideningPrimitive(Integer n) {
         return n instanceof long _;
     }
 
     @Test
-    void test_unboxing_wp() {
-        FuncOp f = getFuncOp("unboxing_wp");
+    void testUnboxingWideningPrimitive() {
+        FuncOp f = getFuncOp("unboxingWideningPrimitive");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -284,13 +284,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean wr(String s) {
+    static boolean wideningReference(String s) {
         return s instanceof Object _;
     }
 
     @Test
-    void test_wr() {
-        FuncOp f = getFuncOp("wr");
+    void testWideningReference() {
+        FuncOp f = getFuncOp("wideningReference");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -301,13 +301,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean ir(Float f) {
+    static boolean identityReference(Float f) {
         return f instanceof Float _;
     }
 
     @Test
-    void test_ir() {
-        FuncOp f = getFuncOp("ir");
+    void testIdentityReference() {
+        FuncOp f = getFuncOp("identityReference");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -320,13 +320,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean nr(Number n) {
+    static boolean narrowingReference(Number n) {
         return n instanceof Double _;
     }
 
     @Test
-    void test_nr() {
-        FuncOp f = getFuncOp("nr");
+    void testNarrowingReference() {
+        FuncOp f = getFuncOp("narrowingReference");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
@@ -339,13 +339,13 @@ public class TestPrimitiveTypePatterns {
     }
 
     @CodeReflection
-    static boolean wp(int i) {
+    static boolean wideningPrimitive(int i) {
         return i instanceof long _;
     }
 
     @Test
-    void test_wp() {
-        FuncOp f = getFuncOp("wp");
+    void testWideningPrimitive() {
+        FuncOp f = getFuncOp("wideningPrimitive");
         f.writeTo(System.out);
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);


### PR DESCRIPTION
Support conversions of primitives in testing context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.org/babylon.git pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/265.diff">https://git.openjdk.org/babylon/pull/265.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/265#issuecomment-2436705756)
</details>
