### PR TITLE
Fixed env.bash issue found on Linux (Mac ok?)

### DIFF
--- a/hat/env.bash
+++ b/hat/env.bash
@@ -83,7 +83,7 @@ else
       export JAVA_HOME=${BABYLON_JDK_HOME}/build/${ostype}-${archtype}-server-release/jdk
       #echo "exporting JAVA_HOME=${JAVA_HOME}"
       if echo ${PATH} | grep ${JAVA_HOME} >/dev/null ;then
-         #echo "PATH already contains \${JAVA_HOME}/bin"
+         echo "PATH already contains \${JAVA_HOME}/bin"
       else
          export SAFE_PATH=${PATH}
          echo "Adding \${JAVA_HOME}/bin prefix to PATH, SAFE_PATH contains previous value"


### PR DESCRIPTION
`env.bash` issue found on Ubuntu/Jetson

Apparently bash does not like empty `then` in `if cmd;then...else....fi`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/267/head:pull/267` \
`$ git checkout pull/267`

Update a local copy of the PR: \
`$ git checkout pull/267` \
`$ git pull https://git.openjdk.org/babylon.git pull/267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 267`

View PR using the GUI difftool: \
`$ git pr show -t 267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/267.diff">https://git.openjdk.org/babylon/pull/267.diff</a>

</details>
