### PR TITLE
Dont use hashbang for launcher scripts

### DIFF
--- a/hat/bld
+++ b/hat/bld
@@ -1,4 +1,3 @@
-//usr/bin/env java --enable-preview --source 24 --class-path bldr/bldr.jar "$0" "$@"; exit $?
 /*
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -123,7 +122,7 @@ void main(String[] args) throws IOException, InterruptedException, URISyntaxExce
                    )
                 );
 
-                java($ -> $
+                /*java($ -> $
                    .vmopts(
                        "--enable-preview",
                        "--enable-native-access=ALL-UNNAMED",
@@ -132,7 +131,7 @@ void main(String[] args) throws IOException, InterruptedException, URISyntaxExce
                     )
                     .class_path(nbodyJar.jar)
                     .main_class("nbody.Main")
-                );
+                ); */
              });
           });
       });

--- a/hat/bldr/.gitignore
+++ b/hat/bldr/.gitignore
@@ -1,2 +1,0 @@
-classes
-bldr.jar

--- a/hat/bldr/Bldr.java
+++ b/hat/bldr/Bldr.java
@@ -1,1 +1,0 @@
-src/main/java/bldr/Bldr.java

--- a/hat/bldr/Bldr.java
+++ b/hat/bldr/Bldr.java
@@ -1,0 +1,1 @@
+src/main/java/bldr/Bldr.java

--- a/hat/bldr/args
+++ b/hat/bldr/args
@@ -1,0 +1,1 @@
+--enable-preview --source 24

--- a/hat/bldr/src/main/java/bldr/Bldr.java
+++ b/hat/bldr/src/main/java/bldr/Bldr.java
@@ -595,7 +595,7 @@ public class Bldr {
     }
 
     public static class Builder<T extends Builder<T>> {
-        T self() {
+        @SuppressWarnings("unchecked") T self() {
             return (T) this;
         }
 
@@ -1868,7 +1868,7 @@ public class Bldr {
     }
 
     //  https://stackoverflow.com/questions/23272861/how-to-call-testng-xml-from-java-main-method
-    public static void main(String[] args) throws Throwable {
+    public static void lomain(String[] args) throws Throwable {
         var hatDir = new Root(Path.of("/Users/grfrost/github/babylon-grfrost-fork/hat"));
 
         // varMap.entrySet().forEach(value->println("+"+value) );

--- a/hat/docs/hat-01-03-building-hat.md
+++ b/hat/docs/hat-01-03-building-hat.md
@@ -33,8 +33,6 @@ to point to our babylon jdk (the one we built [here](hat-01-02-building-babylon.
 It simplifes our tasks going forward if we
 add `${JAVA_HOME}/bin` to our PATH (before any other JAVA installs).
 
-We also need to prebuild the `bldr/bldr.jar`
-
 Thankfully just sourcing the top level `env.bash` script will perform these tasks
 
 It should detect the arch type (AARCH64 or X86_46) and
@@ -47,63 +45,48 @@ echo ${JAVA_HOME}
 /Users/ME/github/babylon/hat/../build/macosx-aarch64-server-release/jdk
 echo ${PATH}
 /Users/ME/github/babylon/hat/../build/macosx-aarch64-server-release/jdk/bin:/usr/local/bin:......
-ls bldr/bldr.jar
-bldr/bldr.jar
 ```
 
 # Introducing Bldr
-`Bldr` is an evolving set of static methods and types needed (so far.. ;) )
-to build HAT as well as the HAT examples and backends.
+`Bldr` is an evolving set of static methods and types required (so far.. ;) )
+to be able to build HAT, hat backends and examples.
 
-`Bldr` itself is a java class in
+We rely on the ability to launch java source directly (without needing to javac first)
+
+* [JEP 458: Launch Multi-File Source-Code Program](https://openjdk.org/jeps/458)
+* [JEP 330: Launch Single-File Source-Code Programs](https://openjdk.org/jeps/330)
+
+The `bld` script (really java source) can be run like this
+
+```bash
+java --enable-preview --source 24 bld
+```
+
+In our case the  magic is under the `hat/bldr`subdir
+
 ```
 bldr
-  └── src
-      └── main
-          └── java
-              └── bldr
-                  └── Bldr.java
+├── Bldr.java (symlink) -> src/main/java/bldr/Bldr.java
+├── args      (text)       "--enable-preview --source 24"
+└── src
+    └── main
+        └── java
+            └── bldr
+                └── Bldr.java
 ```
 
-The first run of  `env.bash` will compile and create build `bldr/bldr.jar`
-
-Assuming we have our babylon JDK build in our path (via `. env.bash`) we should do this every time we 'pull' HAT.
-
-```shell
-mkdir bldr/classes
-javac --enable-preview -source 24 -d bldr/classes bldr/src/main/java/bldr/Bldr.java
-jar -cf bldr/bldr.jar -C bldr/classes bldr
-```
-In HAT's root dir is a `#!` (Hash Bang) java launcher style script called `bld` (and one called `sanity`)
-which uses tools exposed by the precompiled `Bldr` to compile, create jars, run jextract, download dependencies, tar/untar etc.
-
-As git does not allow us to check in scripts with execute permission, we need to `chmod +x` this `bld` file.
+We also have a handy `bldr/args` which allows us to avoid specifying commmon args `--enable-preview --source 24` which are always needed
 
 ```bash
-chmod +x bld sanity
+java @bldr/args bld
 ```
 
-Note that the first line has the `#!` magic to allow this java code to be executed as if it
-were a script.  Whilst `bld` is indeed real java code,  we do not need to compile it. Instead we just execute using
-
-```bash
-./bld
-```
-
-`bld` will build hat-1.0.jar, along with all the backend jars hat-backend-?-1.0.jar,
-all the example jars hat-example-?-1.0.jar and will try to build all native artifacts (.so/.dylib) it can.
-
-So if cmake finds OpenCL libs/headers, you will see libopencl_backend (.so or .dylib)
-
-On a CUDA machine you will see libcuda_backend(.so or .dylib)
-
-`sanity` will sanity check all  .md/.java/.cpp/.h files to make sure we don't have any tabs, lines that with whitespace
-or files without appropriate licence headers
+This `bld` script builds HAT, all the backends and examples and places buildable artifacts in `build` dir
 
 ```bash
 cd hat
 . ./env.bash
-./bld
+java @bld/args bld
 ls build
 hat-1.0.jar                     hat-example-heal-1.0.jar        libptx_backend.dylib
 hat-backend-cuda-1.0.jar        hat-example-mandel-1.0.jar      libspirv_backend.dylib
@@ -113,6 +96,18 @@ hat-backend-ptx-1.0.jar         hat-example-violajones-1.0.jar  ptx_info
 hat-backend-spirv-1.0.jar       libmock_backend.dylib           spirv_info
 hat-example-experiments-1.0.jar libopencl_backend.dylib
 ```
+
+`bld` relies on cmake to build native code for backends, so if cmake finds OpenCL libs/headers, you will see libopencl_backend (.so or .dylib) in the build dir, if cmake finds CUDA you will see libcuda_backend(.so or .dylib)
+
+We have another script called `sanity` which will check all  .md/.java/.cpp/.h for tabs, lines that end with whitespace
+or files without appropriate licence headers
+
+This is run using
+
+```
+java @bldr/args sanity
+```
+
 
 ## Running an example
 
@@ -127,11 +122,18 @@ ${JAVA_HOME}/bin/java \
    mandel.Main
 ```
 
-The provided `hatrun.bash` script simplifies this somewhat, we just need to pass the backend
-name `opencl` and the package name `mandel`
-(all examples are assumed to be in `packagename/Main.java`
+The `hatrun` script can also be used which simply needs the backend
+name `opencl|java|cuda|ptx|mock` and the package name `mandel`
 
 ```bash
-bash hatrun.bash opencl mandel
-bash hatrun.bash opencl heal
+java @bldr/args hatrun opencl mandel
 ```
+
+If you pass `headless` as the first arg
+
+```bash
+java @bldr/args hatrun headless opencl mandel
+```
+
+This sets `-Dheadless=true` and passes '--headless' to the example.  Some examples can use this to avoid launching UI.
+

--- a/hat/env.bash
+++ b/hat/env.bash
@@ -91,24 +91,8 @@ else
       fi
 
       if [[ ${1} = "clean" ]]; then 
-         rm -rf bldr/bldr.classes bldr/bldr.jar build maven-build thirdparty repoDir
+         rm -rf build maven-build thirdparty repoDir
       fi 
-
-      # Our java source launcher based build system needs bldr/bldr.jar so we create it here if needed. 
-      if [[ ${1} != "clean" && -f bldr/bldr.jar ]]; then 
-         echo "Found prebuilt bldr.jar"
-      else
-         mkdir -p bldr/classes
-         echo "Bootrapping a build of bldr.jar"
-         javac \
-           --enable-preview \
-           --source 24 \
-           -d bldr/classes \
-           --source-path bldr/src/main/java \
-           bldr/src/main/java/bldr/Bldr.java
-  
-         jar -cf bldr/bldr.jar -C bldr/classes bldr 
-      fi
       echo "SUCCESS!"
     else
       echo "We expected either:-"

--- a/hat/env.bash
+++ b/hat/env.bash
@@ -93,6 +93,10 @@ else
       if [[ ${1} = "clean" ]]; then 
          rm -rf build maven-build thirdparty repoDir
       fi 
+      if [[ ! -e bldr/Bldr.java ]]; then 
+         ln -s src/main/java/bldr/Bldr.java bldr/Bldr.java
+         echo "Created a symlink bldr/Bldr.java "
+      fi 
       echo "SUCCESS!"
     else
       echo "We expected either:-"

--- a/hat/hatrun
+++ b/hat/hatrun
@@ -1,4 +1,3 @@
-//usr/bin/env java --enable-preview --source 24 --class-path bldr/bldr.jar "$0" "$@"; exit $?
 /*
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/hat/sanity
+++ b/hat/sanity
@@ -1,5 +1,3 @@
-//usr/bin/env java --enable-preview --source 24 --class-path bldr/bldr.jar "$0" "$@"; exit $?
-
 /*
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.


### PR DESCRIPTION
Pivoted away from using shebang/hashbang for `bld`, `sanity` and `hatrun` scripts. 

This was not really portable (clearly will not work on Windows) and also forced env.bash to precompile bldr/../Bldr.java

Now we rely on these scripts being launched using 

```
java bldr/@args bld 
``` 

Which relies on JEP 458 to launch 'multi source' to  pick up Bldr.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/268/head:pull/268` \
`$ git checkout pull/268`

Update a local copy of the PR: \
`$ git checkout pull/268` \
`$ git pull https://git.openjdk.org/babylon.git pull/268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 268`

View PR using the GUI difftool: \
`$ git pr show -t 268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/268.diff">https://git.openjdk.org/babylon/pull/268.diff</a>

</details>
