### PR TITLE
restoring older versions of CoreOp and Interpreter

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/interpreter/Interpreter.java
@@ -133,12 +133,14 @@ public final class Interpreter {
             erStack.push(erb);
         }
 
-        void popExceptionRegion(CoreOp.ExceptionRegionEnter ers) {
-            if (erStack.peek().ers != ers) {
-                // @@@ Use internal exception type
-                throw interpreterException(new IllegalStateException("Mismatched exception regions"));
-            }
-            erStack.pop();
+        void popExceptionRegion(CoreOp.ExceptionRegionExit ere) {
+            ere.catchBlocks().forEach(catchBlock -> {
+                if (erStack.peek().catchBlock != catchBlock.targetBlock()) {
+                    // @@@ Use internal exception type
+                    throw interpreterException(new IllegalStateException("Mismatched exception regions"));
+                }
+                erStack.pop();
+            });
         }
 
         Block exception(MethodHandles.Lookup l, Throwable e) {
@@ -156,6 +158,9 @@ public final class Interpreter {
 
             // Pop the block context to the block defining the start of the exception region
             popTo(er.mark);
+            while (erStack.size() > er.erStackDepth()) {
+                erStack.pop();
+            }
             return cb;
         }
     }
@@ -171,6 +176,8 @@ public final class Interpreter {
         VarBox(Object value) {
             this.value = value;
         }
+
+        static final Object UINITIALIZED = new Object();
     }
 
     record ClosureRecord(CoreOp.ClosureOp op,
@@ -189,22 +196,18 @@ public final class Interpreter {
         }
     }
 
-    record ExceptionRegionRecord(BlockContext mark, CoreOp.ExceptionRegionEnter ers)
-            implements CoreOp.ExceptionRegion {
+    record ExceptionRegionRecord(BlockContext mark, int erStackDepth, Block catchBlock) {
         Block match(MethodHandles.Lookup l, Throwable e) {
-            for (Block.Reference catchBlock : ers.catchBlocks()) {
-                Block target = catchBlock.targetBlock();
-                List<Block.Parameter> args = target.parameters();
-                if (args.size() != 1) {
-                    throw interpreterException(new IllegalStateException("Catch block must have one argument"));
-                }
-                TypeElement et = args.get(0).type();
-                if (et instanceof VarType vt) {
-                    et = vt.valueType();
-                }
-                if (resolveToClass(l, et).isInstance(e)) {
-                    return target;
-                }
+            List<Block.Parameter> args = catchBlock.parameters();
+            if (args.size() != 1) {
+                throw interpreterException(new IllegalStateException("Catch block must have one argument"));
+            }
+            TypeElement et = args.get(0).type();
+            if (et instanceof VarType vt) {
+                et = vt.valueType();
+            }
+            if (resolveToClass(l, et).isInstance(e)) {
+                return catchBlock;
             }
             return null;
         }
@@ -329,14 +332,15 @@ public final class Interpreter {
                 Value yv = yop.yieldValue();
                 return yv == null ? null : oc.getValue(yv);
             } else if (to instanceof CoreOp.ExceptionRegionEnter ers) {
-                var er = new ExceptionRegionRecord(oc.stack.peek(), ers);
-                oc.setValue(ers.result(), er);
-
-                oc.pushExceptionRegion(er);
+                int erStackDepth = oc.erStack.size();
+                ers.catchBlocks().forEach(catchBlock -> {
+                    var er = new ExceptionRegionRecord(oc.stack.peek(), erStackDepth, catchBlock.targetBlock());
+                    oc.pushExceptionRegion(er);
+                });
 
                 oc.successor(ers.start());
             } else if (to instanceof CoreOp.ExceptionRegionExit ere) {
-                oc.popExceptionRegion(ere.regionStart());
+                oc.popExceptionRegion(ere);
 
                 oc.successor(ere.end());
             } else {
@@ -413,13 +417,13 @@ public final class Interpreter {
                                 "Function " + name + " cannot be resolved: top level op is not a module"));
             }
         } else if (o instanceof CoreOp.InvokeOp co) {
-            MethodHandle mh;
-            if (co.hasReceiver()) {
-                mh = methodHandle(l, co.invokeDescriptor());
-            } else {
-                mh = methodStaticHandle(l, co.invokeDescriptor());
-            }
             MethodType target = resolveToMethodType(l, o.opType());
+            MethodHandles.Lookup il = switch (co.invokeKind()) {
+                case STATIC, INSTANCE -> l;
+                case SUPER -> l.in(target.parameterType(0));
+            };
+            MethodHandle mh = resolveToMethodHandle(il, co.invokeDescriptor(), co.invokeKind());
+
             mh = mh.asType(target).asFixedArity();
             Object[] values = o.operands().stream().map(oc::getValue).toArray();
             return invoke(mh, values);
@@ -477,12 +481,19 @@ public final class Interpreter {
 
             return Interpreter.invoke(l, cr.op(), cr.capturedValues, values.subList(1, values.size()));
         } else if (o instanceof CoreOp.VarOp vo) {
-            return new VarBox(oc.getValue(o.operands().get(0)));
+            Object v = vo.isUninitialized()
+                    ? VarBox.UINITIALIZED
+                    : oc.getValue(o.operands().get(0));
+            return new VarBox(v);
         } else if (o instanceof CoreOp.VarAccessOp.VarLoadOp vlo) {
             // Cast to CoreOp.Var, since the instance may have originated as an external instance
             // via a captured value map
             CoreOp.Var<?> vb = (CoreOp.Var<?>) oc.getValue(o.operands().get(0));
-            return vb.value();
+            Object value = vb.value();
+            if (value == VarBox.UINITIALIZED) {
+                throw interpreterException(new IllegalStateException("Loading from uninitialized variable"));
+            }
+            return value;
         } else if (o instanceof CoreOp.VarAccessOp.VarStoreOp vso) {
             VarBox vb = (VarBox) oc.getValue(o.operands().get(0));
             vb.value = oc.getValue(o.operands().get(1));
@@ -613,14 +624,6 @@ public final class Interpreter {
         }
     }
 
-    static MethodHandle methodStaticHandle(MethodHandles.Lookup l, MethodRef d) {
-        return resolveToMethodHandle(l, d);
-    }
-
-    static MethodHandle methodHandle(MethodHandles.Lookup l, MethodRef d) {
-        return resolveToMethodHandle(l, d);
-    }
-
     static MethodHandle constructorHandle(MethodHandles.Lookup l, FunctionType ft) {
         MethodType mt = resolveToMethodType(l, ft);
 
@@ -656,9 +659,9 @@ public final class Interpreter {
         return c.cast(v);
     }
 
-    static MethodHandle resolveToMethodHandle(MethodHandles.Lookup l, MethodRef d) {
+    static MethodHandle resolveToMethodHandle(MethodHandles.Lookup l, MethodRef d, CoreOp.InvokeOp.InvokeKind kind) {
         try {
-            return d.resolveToHandle(l);
+            return d.resolveToHandle(l, kind);
         } catch (ReflectiveOperationException e) {
             throw interpreterException(e);
         }

--- a/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/op/CoreOp.java
@@ -1399,26 +1399,83 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     @OpFactory.OpDeclaration(InvokeOp.NAME)
     public static final class InvokeOp extends CoreOp
             implements ReflectiveOp, JavaExpression, JavaStatement {
+
+        /**
+         * The kind of invocation.
+         */
+        public enum InvokeKind {
+            /**
+             * An invocation on a class (static) method.
+             */
+            STATIC,
+            /**
+             * An invocation on an instance method.
+             */
+            INSTANCE,
+            /**
+             * A super invocation on an instance method.
+             */
+            SUPER
+        }
+
         public static final String NAME = "invoke";
         public static final String ATTRIBUTE_INVOKE_DESCRIPTOR = NAME + ".descriptor";
+        public static final String ATTRIBUTE_INVOKE_KIND = NAME + ".kind";
+        public static final String ATTRIBUTE_INVOKE_VARARGS = NAME + ".varargs";
 
+        final InvokeKind invokeKind;
+        final boolean isVarArgs;
         final MethodRef invokeDescriptor;
         final TypeElement resultType;
 
         public static InvokeOp create(ExternalizedOp def) {
+            // Required attribute
             MethodRef invokeDescriptor = def.extractAttributeValue(ATTRIBUTE_INVOKE_DESCRIPTOR,
                     true, v -> switch (v) {
                         case String s -> MethodRef.ofString(s);
                         case MethodRef md -> md;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported invoke descriptor value:" + v);
+                        case null, default ->
+                                throw new UnsupportedOperationException("Unsupported invoke descriptor value:" + v);
                     });
 
-            return new InvokeOp(def, invokeDescriptor);
+            // If not present defaults to false
+            boolean isVarArgs = def.extractAttributeValue(ATTRIBUTE_INVOKE_VARARGS,
+                    false, v -> switch (v) {
+                        case String s -> Boolean.valueOf(s);
+                        case Boolean b -> b;
+                        case null, default -> false;
+                    });
+
+            // If not present and is not varargs defaults to class or instance invocation
+            // based on number of operands and parameters
+            InvokeKind ik = def.extractAttributeValue(ATTRIBUTE_INVOKE_KIND,
+                    false, v -> switch (v) {
+                        case String s -> InvokeKind.valueOf(s);
+                        case InvokeKind k -> k;
+                        case null, default -> {
+                            if (isVarArgs) {
+                                // If varargs then we cannot infer invoke kind
+                                throw new UnsupportedOperationException("Unsupported invoke kind value:" + v);
+                            }
+                            int paramCount = invokeDescriptor.type().parameterTypes().size();
+                            int argCount = def.operands().size();
+                            yield (argCount == paramCount + 1)
+                                    ? InvokeKind.INSTANCE
+                                    : InvokeKind.STATIC;
+                        }
+                    });
+
+
+            return new InvokeOp(def, ik, isVarArgs, invokeDescriptor);
         }
 
-        InvokeOp(ExternalizedOp def, MethodRef invokeDescriptor) {
+        InvokeOp(ExternalizedOp def, InvokeKind invokeKind, boolean isVarArgs, MethodRef invokeDescriptor) {
             super(def);
 
+            validateArgCount(invokeKind, isVarArgs, invokeDescriptor, def.operands());
+
+            this.invokeKind = invokeKind;
+            this.isVarArgs = isVarArgs;
             this.invokeDescriptor = invokeDescriptor;
             this.resultType = def.resultType();
         }
@@ -1426,6 +1483,8 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         InvokeOp(InvokeOp that, CopyContext cc) {
             super(that, cc);
 
+            this.invokeKind = that.invokeKind;
+            this.isVarArgs = that.isVarArgs;
             this.invokeDescriptor = that.invokeDescriptor;
             this.resultType = that.resultType;
         }
@@ -1435,30 +1494,70 @@ public sealed abstract class CoreOp extends ExternalizableOp {
             return new InvokeOp(this, cc);
         }
 
-        InvokeOp(MethodRef invokeDescriptor, List<Value> args) {
-            this(invokeDescriptor.type().returnType(), invokeDescriptor, args);
-        }
-
-        InvokeOp(TypeElement resultType, MethodRef invokeDescriptor, List<Value> args) {
+        InvokeOp(InvokeKind invokeKind, boolean isVarArgs, TypeElement resultType, MethodRef invokeDescriptor, List<Value> args) {
             super(NAME, args);
 
+            validateArgCount(invokeKind, isVarArgs, invokeDescriptor, args);
+
+            this.invokeKind = invokeKind;
+            this.isVarArgs = isVarArgs;
             this.invokeDescriptor = invokeDescriptor;
             this.resultType = resultType;
+        }
+
+        static void validateArgCount(InvokeKind invokeKind, boolean isVarArgs, MethodRef invokeDescriptor, List<Value> operands) {
+            int paramCount = invokeDescriptor.type().parameterTypes().size();
+            int argCount = operands.size() - (invokeKind == InvokeKind.STATIC ? 0 : 1);
+            if ((!isVarArgs && argCount != paramCount)
+                    || argCount < paramCount - 1) {
+                throw new IllegalArgumentException(invokeKind + " " + isVarArgs + " " + invokeDescriptor);
+            }
         }
 
         @Override
         public Map<String, Object> attributes() {
             HashMap<String, Object> m = new HashMap<>(super.attributes());
             m.put("", invokeDescriptor);
+            if (isVarArgs) {
+                // If varargs then we need to declare the invoke.kind attribute
+                // Given a method `A::m(A... more)` and an invocation with one
+                // operand, we don't know if that operand corresponds to the
+                // receiver or a method argument
+                m.put(ATTRIBUTE_INVOKE_KIND, invokeKind);
+                m.put(ATTRIBUTE_INVOKE_VARARGS, isVarArgs);
+            } else if (invokeKind == InvokeKind.SUPER) {
+                m.put(ATTRIBUTE_INVOKE_KIND, invokeKind);
+            }
             return Collections.unmodifiableMap(m);
+        }
+
+        public InvokeKind invokeKind() {
+            return invokeKind;
+        }
+
+        public boolean isVarArgs() {
+            return isVarArgs;
         }
 
         public MethodRef invokeDescriptor() {
             return invokeDescriptor;
         }
 
+        // @@@ remove?
         public boolean hasReceiver() {
-            return operands().size() != invokeDescriptor().type().parameterTypes().size();
+            return invokeKind != InvokeKind.STATIC;
+        }
+
+        public List<Value> varArgOperands() {
+            if (!isVarArgs) {
+                return null;
+            }
+
+            int operandCount = operands().size();
+            int argCount = operandCount - (invokeKind == InvokeKind.STATIC ? 0 : 1);
+            int paramCount = invokeDescriptor.type().parameterTypes().size();
+            int varArgCount = argCount - (paramCount - 1);
+            return operands().subList(operandCount - varArgCount, operandCount);
         }
 
         @Override
@@ -2034,7 +2133,6 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         }
     }
 
-
     /**
      * A runtime representation of a variable.
      *
@@ -2074,14 +2172,14 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         final VarType resultType;
 
         public static VarOp create(ExternalizedOp def) {
-            if (def.operands().size() != 1) {
-                throw new IllegalStateException("Operation must have one operand");
+            if (def.operands().size() > 1) {
+                throw new IllegalStateException("Operation must have zero or one operand");
             }
 
             String name = def.extractAttributeValue(ATTRIBUTE_NAME, true,
                     v -> switch (v) {
                         case String s -> s;
-                        case null -> null;
+                        case null -> "";
                         default -> throw new UnsupportedOperationException("Unsupported var name value:" + v);
                     });
             return new VarOp(def, name);
@@ -2103,7 +2201,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         }
 
         boolean isResultTypeOverridable() {
-            return resultType().valueType().equals(initOperand().type());
+            return !isUninitialized() && resultType().valueType().equals(initOperand().type());
         }
 
         @Override
@@ -2118,13 +2216,22 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         VarOp(String varName, TypeElement type, Value init) {
             super(NAME, List.of(init));
 
-            this.varName = varName;
+            this.varName =  varName == null ? "" : varName;
+            this.resultType = VarType.varType(type);
+        }
+
+        // @@@ This and the above constructor can be merged when
+        // statements before super can be used in the jdk.compiler module
+        VarOp(String varName, TypeElement type) {
+            super(NAME, List.of());
+
+            this.varName =  varName == null ? "" : varName;
             this.resultType = VarType.varType(type);
         }
 
         @Override
         public Map<String, Object> attributes() {
-            if (varName == null) {
+            if (isUnnamedVariable()) {
                 return super.attributes();
             }
 
@@ -2134,6 +2241,9 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         }
 
         public Value initOperand() {
+            if (operands().isEmpty()) {
+                throw new IllegalStateException("Uninitialized variable");
+            }
             return operands().getFirst();
         }
 
@@ -2148,6 +2258,14 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         @Override
         public VarType resultType() {
             return resultType;
+        }
+
+        public boolean isUnnamedVariable() {
+            return varName.isEmpty();
+        }
+
+        public boolean isUninitialized() {
+            return operands().isEmpty();
         }
     }
 
@@ -2462,19 +2580,6 @@ public sealed abstract class CoreOp extends ExternalizableOp {
         }
     }
 
-    // @@@ Sealed
-    // Synthetic/hidden type that is the result type of an ExceptionRegionStart operation
-    // and is an operand of an ExceptionRegionEnd operation
-
-    /**
-     * A synthetic exception region type, that is the operation result-type of an exception region
-     * start operation.
-     */
-    // @@@: Create as new type element
-    public interface ExceptionRegion {
-        TypeElement EXCEPTION_REGION_TYPE = JavaType.type(ExceptionRegion.class);
-    }
-
     /**
      * The exception region start operation.
      */
@@ -2535,7 +2640,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
 
         @Override
         public TypeElement resultType() {
-            return ExceptionRegion.EXCEPTION_REGION_TYPE;
+            return JavaType.VOID;
         }
     }
 
@@ -2547,26 +2652,24 @@ public sealed abstract class CoreOp extends ExternalizableOp {
             implements Op.BlockTerminating {
         public static final String NAME = "exception.region.exit";
 
-        final Block.Reference end;
+        // First successor is the non-exceptional successor whose target indicates
+        // the first block following the exception region.
+        final List<Block.Reference> s;
 
         public ExceptionRegionExit(ExternalizedOp def) {
             super(def);
 
-            if (def.operands().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one operand" + def.name());
+            if (def.successors().size() < 2) {
+                throw new IllegalArgumentException("Operation must have two or more successors" + def.name());
             }
 
-            if (def.successors().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one successor" + def.name());
-            }
-
-            this.end = def.successors().get(0);
+            this.s = List.copyOf(def.successors());
         }
 
         ExceptionRegionExit(ExceptionRegionExit that, CopyContext cc) {
             super(that, cc);
 
-            this.end = cc.getSuccessorOrCreate(that.end);
+            this.s = that.s.stream().map(cc::getSuccessorOrCreate).toList();
         }
 
         @Override
@@ -2574,36 +2677,27 @@ public sealed abstract class CoreOp extends ExternalizableOp {
             return new ExceptionRegionExit(this, cc);
         }
 
-        ExceptionRegionExit(Value exceptionRegion, Block.Reference end) {
-            super(NAME, checkValue(exceptionRegion));
+        ExceptionRegionExit(List<Block.Reference> s) {
+            super(NAME, List.of());
 
-            this.end = end;
-        }
-
-        static List<Value> checkValue(Value er) {
-            if (!(er instanceof Result or && or.op() instanceof ExceptionRegionEnter)) {
-                throw new IllegalArgumentException(
-                        "Operand not the result of an exception.region.start operation: " + er);
+            if (s.size() < 2) {
+                throw new IllegalArgumentException("Operation must have two or more successors" + opName());
             }
 
-            return List.of(er);
+            this.s = List.copyOf(s);
         }
 
         @Override
         public List<Block.Reference> successors() {
-            return List.of(end);
+            return s;
         }
 
         public Block.Reference end() {
-            return end;
+            return s.get(0);
         }
 
-        public ExceptionRegionEnter regionStart() {
-            if (operands().get(0) instanceof Result or &&
-                    or.op() instanceof ExceptionRegionEnter ers) {
-                return ers;
-            }
-            throw new InternalError("Should not reach here");
+        public List<Block.Reference> catchBlocks() {
+            return s.subList(1, s.size());
         }
 
         @Override
@@ -3497,12 +3591,26 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     /**
      * Creates an exception region exit operation
      *
-     * @param exceptionRegion the exception region to be exited
      * @param end             the block to which control is transferred after the exception region is exited
+     * @param catchers the blocks handling exceptions thrown by the region block
      * @return the exception region exit operation
      */
-    public static ExceptionRegionExit exceptionRegionExit(Value exceptionRegion, Block.Reference end) {
-        return new ExceptionRegionExit(exceptionRegion, end);
+    public static ExceptionRegionExit exceptionRegionExit(Block.Reference end, Block.Reference... catchers) {
+        return exceptionRegionExit(end, List.of(catchers));
+    }
+
+    /**
+     * Creates an exception region exit operation
+     *
+     * @param end             the block to which control is transferred after the exception region is exited
+     * @param catchers the blocks handling exceptions thrown by the region block
+     * @return the exception region exit operation
+     */
+    public static ExceptionRegionExit exceptionRegionExit(Block.Reference end, List<Block.Reference> catchers) {
+        List<Block.Reference> s = new ArrayList<>();
+        s.add(end);
+        s.addAll(catchers);
+        return new ExceptionRegionExit(s);
     }
 
     /**
@@ -3615,49 +3723,107 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
-     * Creates an invoke operation.
+     * Creates an invoke operation modeling an invocation to an
+     * instance or static (class) method with no variable arguments.
+     * <p>
+     * The invoke kind of the invoke operation is determined by
+     * comparing the argument count with the invoke descriptor's
+     * parameter count. If they are equal then the invoke kind is
+     * {@link InvokeOp.InvokeKind#STATIC static}. If the parameter count
+     * plus one is equal to the argument count then the invoke kind
+     * is {@link InvokeOp.InvokeKind#STATIC instance}.
+     * <p>
+     * The invoke return type is the invoke descriptors return type.
      *
-     * @param invokeDescriptor the invocation descriptor
+     * @param invokeDescriptor the invoke descriptor
      * @param args             the invoke parameters
      * @return the invoke operation
      */
     public static InvokeOp invoke(MethodRef invokeDescriptor, Value... args) {
-        return new InvokeOp(invokeDescriptor, List.of(args));
+        return invoke(invokeDescriptor, List.of(args));
     }
 
     /**
-     * Creates an invoke operation.
+     * Creates an invoke operation modeling an invocation to an
+     * instance or static (class) method with no variable arguments.
+     * <p>
+     * The invoke kind of the invoke operation is determined by
+     * comparing the argument count with the invoke descriptor's
+     * parameter count. If they are equal then the invoke kind is
+     * {@link InvokeOp.InvokeKind#STATIC static}. If the parameter count
+     * plus one is equal to the argument count then the invoke kind
+     * is {@link InvokeOp.InvokeKind#STATIC instance}.
+     * <p>
+     * The invoke return type is the invoke descriptors return type.
      *
-     * @param invokeDescriptor the invocation descriptor
-     * @param args             the invoke parameters
+     * @param invokeDescriptor the invoke descriptor
+     * @param args             the invoke arguments
      * @return the invoke operation
      */
     public static InvokeOp invoke(MethodRef invokeDescriptor, List<Value> args) {
-        return new InvokeOp(invokeDescriptor, args);
+        return invoke(invokeDescriptor.type().returnType(), invokeDescriptor, args);
     }
 
     /**
-     * Creates an invoke operation.
+     * Creates an invoke operation modeling an invocation to an
+     * instance or static (class) method with no variable arguments.
+     * <p>
+     * The invoke kind of the invoke operation is determined by
+     * comparing the argument count with the invoke descriptor's
+     * parameter count. If they are equal then the invoke kind is
+     * {@link InvokeOp.InvokeKind#STATIC static}. If the parameter count
+     * plus one is equal to the argument count then the invoke kind
+     * is {@link InvokeOp.InvokeKind#STATIC instance}.
      *
-     * @param returnType       the invocation return type
-     * @param invokeDescriptor the invocation descriptor
-     * @param args             the invoke parameters
+     * @param returnType       the invoke return type
+     * @param invokeDescriptor the invoke descriptor
+     * @param args             the invoke arguments
      * @return the invoke operation
      */
     public static InvokeOp invoke(TypeElement returnType, MethodRef invokeDescriptor, Value... args) {
-        return new InvokeOp(returnType, invokeDescriptor, List.of(args));
+        return invoke(returnType, invokeDescriptor, List.of(args));
     }
 
     /**
-     * Creates an invoke operation.
+     * Creates an invoke operation modeling an invocation to an
+     * instance or static (class) method with no variable arguments.
+     * <p>
+     * The invoke kind of the invoke operation is determined by
+     * comparing the argument count with the invoke descriptor's
+     * parameter count. If they are equal then the invoke kind is
+     * {@link InvokeOp.InvokeKind#STATIC static}. If the parameter count
+     * plus one is equal to the argument count then the invoke kind
+     * is {@link InvokeOp.InvokeKind#STATIC instance}.
      *
-     * @param returnType       the invocation return type
-     * @param invokeDescriptor the invocation descriptor
-     * @param args             the invoke parameters
-     * @return the invoke operation
+     * @param returnType       the invoke return type
+     * @param invokeDescriptor the invoke descriptor
+     * @param args             the invoke arguments
+     * @return the invoke super operation
      */
     public static InvokeOp invoke(TypeElement returnType, MethodRef invokeDescriptor, List<Value> args) {
-        return new InvokeOp(returnType, invokeDescriptor, args);
+        int paramCount = invokeDescriptor.type().parameterTypes().size();
+        int argCount = args.size();
+        InvokeOp.InvokeKind ik = (argCount == paramCount + 1)
+                ? InvokeOp.InvokeKind.INSTANCE
+                : InvokeOp.InvokeKind.STATIC;
+        return new InvokeOp(ik, false, returnType, invokeDescriptor, args);
+    }
+
+    /**
+     * Creates an invoke operation modelling an invocation to a method.
+     *
+     * @param invokeKind       the invoke kind
+     * @param isVarArgs        true if an invocation to a variable argument method
+     * @param returnType       the return type
+     * @param invokeDescriptor the invoke descriptor
+     * @param args             the invoke arguments
+     * @return the invoke operation
+     * @throws IllegalArgumentException if there is a mismatch between the argument count
+     *                                  and the invoke descriptors parameter count.
+     */
+    public static InvokeOp invoke(InvokeOp.InvokeKind invokeKind, boolean isVarArgs,
+                                  TypeElement returnType, MethodRef invokeDescriptor, List<Value> args) {
+        return new InvokeOp(invokeKind, isVarArgs, returnType, invokeDescriptor, args);
     }
 
     /**
@@ -3867,7 +4033,29 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
-     * Creates a var operation.
+     * Creates a var operation modeling an unnamed and uninitialized variable,
+     * either an unnamed local variable or an unnamed parameter.
+     *
+     * @param type the type of the var's value
+     * @return the var operation
+     */
+    public static VarOp var(TypeElement type) {
+        return var(null, type, null);
+    }
+
+    /**
+     * Creates a var operation modeling an uninitialized variable, either a local variable or a parameter.
+     *
+     * @param name the name of the var
+     * @param type the type of the var's value
+     * @return the var operation
+     */
+    public static VarOp var(String name, TypeElement type) {
+        return new VarOp(name, type);
+    }
+
+    /**
+     * Creates a var operation modeling an unnamed variable, either an unnamed local variable or an unnamed parameter.
      *
      * @param init the initial value of the var
      * @return the var operation
@@ -3877,7 +4065,9 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
-     * Creates a var operation.
+     * Creates a var operation modeling a variable, either a local variable or a parameter.
+     * <p>
+     * If the given name is {@code null} or an empty string then the variable is an unnamed variable.
      *
      * @param name the name of the var
      * @param init the initial value of the var
@@ -3888,7 +4078,9 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     }
 
     /**
-     * Creates a var operation.
+     * Creates a var operation modeling a variable, either a local variable or a parameter.
+     * <p>
+     * If the given name is {@code null} or an empty string then the variable is an unnamed variable.
      *
      * @param name the name of the var
      * @param type the type of the var's value


### PR DESCRIPTION
<!--
Restoring CoreOp and Interpreter.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/269/head:pull/269` \
`$ git checkout pull/269`

Update a local copy of the PR: \
`$ git checkout pull/269` \
`$ git pull https://git.openjdk.org/babylon.git pull/269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 269`

View PR using the GUI difftool: \
`$ git pr show -t 269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/269.diff">https://git.openjdk.org/babylon/pull/269.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/269#issuecomment-2445440672)