### PR TITLE
Simplify Interpreter invocation

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/PrePostInc.java
+++ b/hat/examples/experiments/src/main/java/experiments/PrePostInc.java
@@ -26,6 +26,7 @@
 package experiments;
 
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.CopyContext;
 import java.lang.reflect.code.Op;
@@ -59,9 +60,9 @@ public class PrePostInc {
             CoreOp.FuncOp preFunc = pre.getCodeModel().get();
             CoreOp.FuncOp postFunc = post.getCodeModel().get();
 
-            Object preResult = Interpreter.invoke(preFunc,5);
+            Object preResult = Interpreter.invoke(MethodHandles.lookup(),preFunc,5);
             System.out.println("Pre "+ preResult);
-            Object postResult = Interpreter.invoke(postFunc,5);
+            Object postResult = Interpreter.invoke(MethodHandles.lookup(),postFunc,5);
             System.out.println("Pre "+ postResult);
           //  javaFunc.writeTo(System.out);
 

--- a/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
+++ b/src/java.base/share/classes/java/lang/reflect/code/Quoted.java
@@ -25,10 +25,7 @@
 
 package java.lang.reflect.code;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * The quoted form of an operation.
@@ -39,7 +36,9 @@ import java.util.Map;
  */
 public final class Quoted {
     private final Op op;
-    private final Map<Value, Object> capturedValues;
+    private final SequencedMap<Value, Object> capturedValues;
+
+    static final SequencedMap<Value, Object> EMPTY_SEQUENCED_MAP = new LinkedHashMap<>();
 
     /**
      * Constructs the quoted form of a given operation.
@@ -47,7 +46,7 @@ public final class Quoted {
      * @param op the invokable operation.
      */
     public Quoted(Op op) {
-        this(op, Map.of());
+        this(op, EMPTY_SEQUENCED_MAP);
     }
 
     /**
@@ -63,12 +62,12 @@ public final class Quoted {
      * @param capturedValues the captured values referred to by the operation
      * @see Op#capturedValues()
      */
-    public Quoted(Op op, Map<Value, Object> capturedValues) {
+    public Quoted(Op op, SequencedMap<Value, Object> capturedValues) {
         // @@@ This check is potentially expensive, remove or keep as assert?
         // @@@ Or make Quoted an interface, with a module private implementation?
         assert op.capturedValues().equals(new ArrayList<>(capturedValues.keySet()));
         this.op = op;
-        this.capturedValues = Collections.unmodifiableMap(new LinkedHashMap<>(capturedValues));
+        this.capturedValues = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(capturedValues));
     }
 
     /**
@@ -91,7 +90,7 @@ public final class Quoted {
      *
      * @return the captured values, as an unmodifiable map.
      */
-    public Map<Value, Object> capturedValues() {
+    public SequencedMap<Value, Object> capturedValues() {
         return capturedValues;
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -254,6 +254,7 @@ public class Symtab {
     public final Type opInterpreterType;
     public final Type opParserType;
     public final Type opType;
+    public final MethodSymbol methodHandlesLookup;
     public final MethodSymbol opInterpreterInvoke;
     public final MethodSymbol opParserFromString;
 
@@ -650,9 +651,14 @@ public class Symtab {
         lambdaOpType = enterClass("java.lang.reflect.code.op.CoreOp$LambdaOp");
         opInterpreterType = enterClass("java.lang.reflect.code.interpreter.Interpreter");
         opType = enterClass("java.lang.reflect.code.Op");
+        methodHandlesLookup = new MethodSymbol(PUBLIC | STATIC,
+                names.fromString("lookup"),
+                new MethodType(List.nil(), methodHandleLookupType,
+                        List.nil(), methodClass),
+                methodHandlesType.tsym);
         opInterpreterInvoke = new MethodSymbol(PUBLIC | STATIC | VARARGS,
                 names.fromString("invoke"),
-                new MethodType(List.of(opType, new ArrayType(objectType, arrayClass)), objectType,
+                new MethodType(List.of(methodHandleLookupType, opType, new ArrayType(objectType, arrayClass)), objectType,
                         List.nil(), methodClass),
                 opInterpreterType.tsym);
         opParserType = enterClass("java.lang.reflect.code.parser.OpParser");

--- a/test/jdk/java/lang/reflect/code/TestArrayCreation.java
+++ b/test/jdk/java/lang/reflect/code/TestArrayCreation.java
@@ -24,6 +24,7 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
@@ -48,7 +49,7 @@ public class TestArrayCreation {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f), f());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f());
     }
 
     @CodeReflection
@@ -62,7 +63,7 @@ public class TestArrayCreation {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f), f2());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f2());
     }
 
     @CodeReflection
@@ -76,7 +77,7 @@ public class TestArrayCreation {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f), f3());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f3());
     }
 
     static CoreOp.FuncOp getFuncOp(String name) {

--- a/test/jdk/java/lang/reflect/code/TestArrayTypes.java
+++ b/test/jdk/java/lang/reflect/code/TestArrayTypes.java
@@ -24,6 +24,7 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
@@ -48,7 +49,7 @@ public class TestArrayTypes {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f), f());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f());
     }
 
     @CodeReflection
@@ -62,7 +63,7 @@ public class TestArrayTypes {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f), f2());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f2());
     }
 
     @CodeReflection
@@ -76,7 +77,7 @@ public class TestArrayTypes {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f), f3());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f3());
     }
 
     static CoreOp.FuncOp getFuncOp(String name) {

--- a/test/jdk/java/lang/reflect/code/TestBinops.java
+++ b/test/jdk/java/lang/reflect/code/TestBinops.java
@@ -29,6 +29,7 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
@@ -49,8 +50,8 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, true), not(true));
-        Assert.assertEquals(Interpreter.invoke(f, false), not(false));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, true), not(true));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, false), not(false));
     }
 
     @CodeReflection
@@ -64,7 +65,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 42), neg(42));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 42), neg(42));
     }
 
     @CodeReflection
@@ -78,7 +79,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 42), compl(42));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 42), compl(42));
     }
 
     @CodeReflection
@@ -92,7 +93,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 10, 3), mod(10, 3));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), mod(10, 3));
     }
 
     @CodeReflection
@@ -106,7 +107,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 10, 3), bitand(10, 3));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), bitand(10, 3));
     }
 
     @CodeReflection
@@ -120,7 +121,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 10, 3), bitor(10, 3));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), bitor(10, 3));
     }
 
     @CodeReflection
@@ -134,7 +135,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 10, 3), bitxor(10, 3));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), bitxor(10, 3));
     }
 
     @CodeReflection
@@ -148,7 +149,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, true, false), booland(true, false));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, true, false), booland(true, false));
     }
 
     @CodeReflection
@@ -162,7 +163,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, false, true), boolor(false, true));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, false, true), boolor(false, true));
     }
 
     @CodeReflection
@@ -176,7 +177,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, true, true), boolxor(true, true));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, true, true), boolxor(true, true));
     }
 
     @CodeReflection
@@ -190,7 +191,7 @@ public class TestBinops {
 
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 15.6, 2.1), doublemod(15.6, 2.1));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 15.6, 2.1), doublemod(15.6, 2.1));
     }
 
     static CoreOp.FuncOp getFuncOp(String name) {

--- a/test/jdk/java/lang/reflect/code/TestBlockOp.java
+++ b/test/jdk/java/lang/reflect/code/TestBlockOp.java
@@ -24,9 +24,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -74,6 +74,6 @@ public class TestBlockOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), f());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f());
     }
 }

--- a/test/jdk/java/lang/reflect/code/TestBreakContinue.java
+++ b/test/jdk/java/lang/reflect/code/TestBreakContinue.java
@@ -29,9 +29,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -73,7 +73,7 @@ public class TestBreakContinue {
             if (i <= 5) return 0;
             return 1;
         };
-        Assert.assertEquals(Interpreter.invoke(lf, o), forLoopBreakContinue(o));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, o), forLoopBreakContinue(o));
     }
 
     @CodeReflection
@@ -115,7 +115,7 @@ public class TestBreakContinue {
         for (int r = -1; r < 4; r++) {
             int fr = r;
             IntUnaryOperator o = i -> fr;
-            Assert.assertEquals(Interpreter.invoke(lf, o), nestedForLoopBreakContinue(o));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, o), nestedForLoopBreakContinue(o));
         }
     }
 
@@ -163,7 +163,7 @@ public class TestBreakContinue {
         for (int r = -1; r < 6; r++) {
             int fr = r;
             IntUnaryOperator o = i -> fr;
-            Assert.assertEquals(Interpreter.invoke(lf, o), forLoopLabeledBreakContinue(o));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, o), forLoopLabeledBreakContinue(o));
         }
     }
 
@@ -213,7 +213,7 @@ public class TestBreakContinue {
         for (int i = 0; i < 7; i++) {
             int fi = i;
             IntUnaryOperator o = v -> v == fi ? 1 : 0;
-            Assert.assertEquals(Interpreter.invoke(lf, o), blockBreak(o));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, o), blockBreak(o));
         }
     }
 

--- a/test/jdk/java/lang/reflect/code/TestClosureOps.java
+++ b/test/jdk/java/lang/reflect/code/TestClosureOps.java
@@ -37,6 +37,8 @@ import java.lang.reflect.code.type.MethodRef;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.type.JavaType;
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.lang.reflect.code.op.CoreOp._return;
 import static java.lang.reflect.code.op.CoreOp.add;
@@ -59,8 +61,11 @@ public class TestClosureOps {
             Assert.assertEquals(1, c.capturedValues().size());
             Assert.assertEquals(1, c.capturedValues().values().iterator().next());
 
+            List<Object> arguments = new ArrayList<>();
+            arguments.add(42);
+            arguments.addAll(c.capturedValues().values());
             int r = (int) Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) c.op(),
-                    c.capturedValues(), 42);
+                    arguments);
             return r;
         }
     }

--- a/test/jdk/java/lang/reflect/code/TestConditionalExpression.java
+++ b/test/jdk/java/lang/reflect/code/TestConditionalExpression.java
@@ -29,9 +29,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -54,8 +54,8 @@ public class TestConditionalExpression {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, true, 1, 2), simpleExpression(true, 1, 2));
-        Assert.assertEquals(Interpreter.invoke(lf, false, 1, 2), simpleExpression(false, 1, 2));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, true, 1, 2), simpleExpression(true, 1, 2));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, false, 1, 2), simpleExpression(false, 1, 2));
     }
 
 

--- a/test/jdk/java/lang/reflect/code/TestConstants.java
+++ b/test/jdk/java/lang/reflect/code/TestConstants.java
@@ -30,9 +30,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -162,7 +162,7 @@ public class TestConstants {
 
             f.writeTo(System.out);
 
-            Assert.assertEquals(Interpreter.invoke(f), m.invoke(null));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), m.invoke(null));
         }
     }
 
@@ -185,7 +185,7 @@ public class TestConstants {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, (Object) null), compareNull(null));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, (Object) null), compareNull(null));
     }
 
     static CoreOp.FuncOp getFuncOp(String name) {

--- a/test/jdk/java/lang/reflect/code/TestEnhancedForOp.java
+++ b/test/jdk/java/lang/reflect/code/TestEnhancedForOp.java
@@ -24,9 +24,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -69,7 +69,7 @@ public class TestEnhancedForOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), f());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f());
     }
 
 
@@ -93,6 +93,6 @@ public class TestEnhancedForOp {
         lf.writeTo(System.out);
 
         int[] ia = new int[] {1, 2, 3, 4};
-        Assert.assertEquals(Interpreter.invoke(lf, ia), array(ia));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, ia), array(ia));
     }
 }

--- a/test/jdk/java/lang/reflect/code/TestForOp.java
+++ b/test/jdk/java/lang/reflect/code/TestForOp.java
@@ -24,9 +24,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -59,7 +59,7 @@ public class TestForOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), f());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f());
     }
 
     @CodeReflection
@@ -82,7 +82,7 @@ public class TestForOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), f2());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f2());
     }
 
     @CodeReflection
@@ -107,7 +107,7 @@ public class TestForOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), f3());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f3());
     }
 
     static CoreOp.FuncOp getFuncOp(String name) {

--- a/test/jdk/java/lang/reflect/code/TestIfOp.java
+++ b/test/jdk/java/lang/reflect/code/TestIfOp.java
@@ -24,9 +24,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -77,7 +77,7 @@ public class TestIfOp {
         lf.writeTo(System.out);
 
         for (int i = 0; i < 6; i++) {
-            Assert.assertEquals(Interpreter.invoke(lf, i), f(i));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, i), f(i));
         }
     }
 }

--- a/test/jdk/java/lang/reflect/code/TestLambdaOps.java
+++ b/test/jdk/java/lang/reflect/code/TestLambdaOps.java
@@ -62,8 +62,11 @@ public class TestLambdaOps {
             Assert.assertEquals(1, l.capturedValues().size());
             Assert.assertEquals(1, l.capturedValues().values().iterator().next());
 
+            List<Object> arguments = new ArrayList<>();
+            arguments.add(42);
+            arguments.addAll(l.capturedValues().values());
             int r = (int) Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) l.op(),
-                    l.capturedValues(), 42);
+                    arguments);
             return r;
         }
     }
@@ -181,14 +184,12 @@ public class TestLambdaOps {
             Assert.assertEquals(q.capturedValues().size(), 1);
             Assert.assertEquals(((Var<?>)q.capturedValues().values().iterator().next()).value(), 42);
 
-            int r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(), q.capturedValues(), List.of());
+            int r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(),
+                    new ArrayList<>(q.capturedValues().sequencedValues()));
             Assert.assertEquals(r, 42);
 
-            Map<Value, Object> cvs = Map.of(
-                    q.capturedValues().keySet().iterator().next(),
-                    CoreOp.Var.of(0)
-            );
-            r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(), cvs, List.of());
+            r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(),
+                    List.of(CoreOp.Var.of(0)));
             Assert.assertEquals(r, 0);
         }
 
@@ -202,14 +203,12 @@ public class TestLambdaOps {
             Assert.assertEquals(q.capturedValues().size(), 1);
             Assert.assertEquals(((Var<?>)q.capturedValues().values().iterator().next()).value(), 42);
 
-            int r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(), q.capturedValues(), List.of());
+            int r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(),
+                    new ArrayList<>(q.capturedValues().sequencedValues()));
             Assert.assertEquals(r, 42);
 
-            Map<Value, Object> cvs = Map.of(
-                    q.capturedValues().keySet().iterator().next(),
-                    CoreOp.Var.of(0)
-            );
-            r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(), cvs, List.of());
+            r = (int) Interpreter.invoke(MethodHandles.lookup(), (LambdaOp) q.op(),
+                    List.of(CoreOp.Var.of(0)));
             Assert.assertEquals(r, 0);
         }
     }

--- a/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
@@ -161,7 +161,7 @@ public class TestPrimitiveTypePatterns {
         var mh = BytecodeGenerator.generate(MethodHandles.lookup(), lmodel);
 
         for (Object v : values) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, v), mh.invoke(v));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, v), mh.invoke(v));
         }
     }
 
@@ -178,7 +178,7 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Short.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Short.MAX_VALUE), true);
     }
 
     @CodeReflection
@@ -194,8 +194,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Byte.MAX_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Byte.MIN_VALUE), false);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Byte.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Byte.MIN_VALUE), false);
     }
 
     @CodeReflection
@@ -211,8 +211,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
     }
 
     @CodeReflection
@@ -228,8 +228,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
     }
 
     @CodeReflection
@@ -245,8 +245,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, 1), true);
-        Assert.assertEquals(Interpreter.invoke(lf, (short) 1), false);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, 1), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, (short) 1), false);
     }
 
     @CodeReflection
@@ -262,8 +262,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
     }
 
     @CodeReflection
@@ -279,8 +279,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
     }
 
     @CodeReflection
@@ -296,8 +296,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, (Object) null), false);
-        Assert.assertEquals(Interpreter.invoke(lf, "str"), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, (Object) null), false);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, "str"), true);
     }
 
     @CodeReflection
@@ -313,10 +313,10 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Float.MAX_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Float.MIN_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Float.POSITIVE_INFINITY), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Float.NEGATIVE_INFINITY), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.MIN_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.POSITIVE_INFINITY), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.NEGATIVE_INFINITY), true);
     }
 
     @CodeReflection
@@ -332,10 +332,10 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Float.MAX_VALUE), false);
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), false);
-        Assert.assertEquals(Interpreter.invoke(lf, Double.POSITIVE_INFINITY), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Double.NEGATIVE_INFINITY), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.MAX_VALUE), false);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), false);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Double.POSITIVE_INFINITY), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Double.NEGATIVE_INFINITY), true);
     }
 
     @CodeReflection
@@ -351,8 +351,8 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MAX_VALUE), true);
-        Assert.assertEquals(Interpreter.invoke(lf, Integer.MIN_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
     }
 
      private CoreOp.FuncOp getFuncOp(String name) {

--- a/test/jdk/java/lang/reflect/code/TestRemoveFinalVars.java
+++ b/test/jdk/java/lang/reflect/code/TestRemoveFinalVars.java
@@ -1,6 +1,7 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.*;
 import java.lang.reflect.code.analysis.SSA;
@@ -43,7 +44,7 @@ public class TestRemoveFinalVars {
         FuncOp lf2 = lower(f2);
         lf2.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), Interpreter.invoke(lf2));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), Interpreter.invoke(MethodHandles.lookup(), lf2));
 
         SSA.transform(lower(f)).writeTo(System.out);
     }

--- a/test/jdk/java/lang/reflect/code/TestSSA.java
+++ b/test/jdk/java/lang/reflect/code/TestSSA.java
@@ -24,9 +24,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
@@ -59,8 +59,8 @@ public class TestSSA {
 
         CoreOp.FuncOp lf = generate(f);
 
-        Assert.assertEquals((int) Interpreter.invoke(lf, 0, 0, 1), ifelse(0, 0, 1));
-        Assert.assertEquals((int) Interpreter.invoke(lf, 0, 0, 11), ifelse(0, 0, 11));
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 0, 0, 1), ifelse(0, 0, 1));
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 0, 0, 11), ifelse(0, 0, 11));
     }
 
     @CodeReflection
@@ -90,7 +90,7 @@ public class TestSSA {
         CoreOp.FuncOp lf = generate(f);
 
         for (int i : new int[]{1, 11, 20, 21}) {
-            Assert.assertEquals((int) Interpreter.invoke(lf, 0, 0, 0, 0, i), ifelseNested(0, 0, 0, 0, i));
+            Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 0, 0, 0, 0, i), ifelseNested(0, 0, 0, 0, i));
         }
     }
 
@@ -109,7 +109,7 @@ public class TestSSA {
 
         CoreOp.FuncOp lf = generate(f);
 
-        Assert.assertEquals((int) Interpreter.invoke(lf, 10), loop(10));
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 10), loop(10));
     }
 
     @CodeReflection
@@ -129,7 +129,7 @@ public class TestSSA {
 
         CoreOp.FuncOp lf = generate(f);
 
-        Assert.assertEquals((int) Interpreter.invoke(lf, 10), nestedLoop(10));
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 10), nestedLoop(10));
     }
 
     @CodeReflection
@@ -148,7 +148,7 @@ public class TestSSA {
 
         CoreOp.FuncOp lf = generate(f);
 
-        Assert.assertEquals((int) Interpreter.invoke(lf, 10), nestedLambdaCapture(10));
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 10), nestedLambdaCapture(10));
     }
 
     static CoreOp.FuncOp generate(CoreOp.FuncOp f) {

--- a/test/jdk/java/lang/reflect/code/TestStringConcatTransform.java
+++ b/test/jdk/java/lang/reflect/code/TestStringConcatTransform.java
@@ -32,6 +32,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.NoInjection;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.analysis.StringConcatTransformer;
@@ -101,8 +102,8 @@ public class TestStringConcatTransform {
         model.writeTo(System.out);
         f_transformed.writeTo(System.out);
 
-        var interpreted = Interpreter.invoke(model, args);
-        var transformed_interpreted = Interpreter.invoke(f_transformed, args);
+        var interpreted = Interpreter.invoke(MethodHandles.lookup(), model, args);
+        var transformed_interpreted = Interpreter.invoke(MethodHandles.lookup(), f_transformed, args);
 
         Assert.assertEquals(interpreted, transformed_interpreted);
 
@@ -136,10 +137,10 @@ public class TestStringConcatTransform {
         CoreOp.FuncOp ssa_model = generateSSA(model);
         CoreOp.FuncOp ssa_transformed_model = ssa_model.transform(new StringConcatTransformer());
 
-        var model_interpreted = Interpreter.invoke(model, args);
-        var transformed_model_interpreted = Interpreter.invoke(transformed_model, args);
-        var ssa_interpreted = Interpreter.invoke(ssa_model, args);
-        var ssa_transformed_interpreted = Interpreter.invoke(ssa_transformed_model, args);
+        var model_interpreted = Interpreter.invoke(MethodHandles.lookup(), model, args);
+        var transformed_model_interpreted = Interpreter.invoke(MethodHandles.lookup(), transformed_model, args);
+        var ssa_interpreted = Interpreter.invoke(MethodHandles.lookup(), ssa_model, args);
+        var ssa_transformed_interpreted = Interpreter.invoke(MethodHandles.lookup(), ssa_transformed_model, args);
         Object jvm_interpreted;
         try {
             jvm_interpreted = method.invoke(null, args);

--- a/test/jdk/java/lang/reflect/code/TestSwitchExpressionOp.java
+++ b/test/jdk/java/lang/reflect/code/TestSwitchExpressionOp.java
@@ -60,7 +60,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("caseTypePattern");
         Object[] args = {"str", new ArrayList<>(), new int[]{}, new Stack[][]{}, new Collection[][][]{}, 8, 'x'};
         for (Object arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseTypePattern(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseTypePattern(arg));
         }
     }
     @CodeReflection
@@ -81,7 +81,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("casePatternWithCaseConstant");
         int[] args = {42, 43, -44, 0};
         for (int arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), casePatternWithCaseConstant(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), casePatternWithCaseConstant(arg));
         }
     }
 
@@ -101,7 +101,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("casePatternMultiLabel");
         Object[] args = {(byte) 1, (short) 2, 'A', 3, 4L, 5f, 6d, true, "str"};
         for (Object arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), casePatternMultiLabel(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), casePatternMultiLabel(arg));
         }
     }
     // @CodeReflection
@@ -120,12 +120,12 @@ public class TestSwitchExpressionOp {
 
         Object[] args = {Byte.MAX_VALUE, Short.MIN_VALUE, 0, 1L, 11f, 22d};
         for (Object arg : args) {
-            Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(lmodel, arg));
+            Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(MethodHandles.lookup(), lmodel, arg));
         }
 
         Object[] args2 = {"abc", List.of()};
         for (Object arg : args2) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), casePatternThrow(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), casePatternThrow(arg));
         }
     }
 
@@ -147,8 +147,8 @@ public class TestSwitchExpressionOp {
         Object[] args = {1, "2", 3L};
 
         for (Object arg : args) {
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(ruleBlock, arg));
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(statement, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), ruleBlock, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), statement, arg));
         }
     }
 
@@ -245,7 +245,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("caseConstantFallThrough");
         char[] args = {'A', 'B', 'C'};
         for (char arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantFallThrough(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantFallThrough(arg));
         }
     }
 
@@ -275,7 +275,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("caseConstantNullLabel");
         String[] args = {null, "non null"};
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantNullLabel(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantNullLabel(arg));
         }
     }
 
@@ -290,10 +290,10 @@ public class TestSwitchExpressionOp {
     @Test
     void testCaseConstantThrow() {
         CoreOp.FuncOp lmodel = lower("caseConstantThrow");
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(lmodel, 8));
+        Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(MethodHandles.lookup(), lmodel, 8));
         int[] args = {9, 10};
         for (int arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantThrow(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantThrow(arg));
         }
     }
 
@@ -311,7 +311,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("caseConstantMultiLabels");
         char[] args = {'a', 'e', 'i', 'o', 'u', 'j', 'p', 'g'};
         for (char arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantMultiLabels(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantMultiLabels(arg));
         }
     }
 
@@ -332,8 +332,8 @@ public class TestSwitchExpressionOp {
         String[] args = {"FOO", "BAR", "BAZ", "OTHER"};
 
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(ruleBlock, arg));
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(statement, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), ruleBlock, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), statement, arg));
         }
     }
 
@@ -380,7 +380,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("caseConstantConv");
         short[] args = {1, 2, 3, 4};
         for (short arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantConv(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantConv(arg));
         }
     }
 
@@ -401,7 +401,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("caseConstantConv2");
         Byte[] args = {1, 2, 3};
         for (Byte arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantConv2(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantConv2(arg));
         }
     }
 
@@ -420,7 +420,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("unconditionalPattern");
         String[] args = {"A", "X"};
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), unconditionalPattern(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), unconditionalPattern(arg));
         }
     }
 
@@ -438,7 +438,7 @@ public class TestSwitchExpressionOp {
         CoreOp.FuncOp lmodel = lower("defaultCaseNotTheLast");
         String[] args = {"something", "M", "A"};
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), defaultCaseNotTheLast(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), defaultCaseNotTheLast(arg));
         }
     }
 

--- a/test/jdk/java/lang/reflect/code/TestSwitchStatementOp.java
+++ b/test/jdk/java/lang/reflect/code/TestSwitchStatementOp.java
@@ -29,8 +29,8 @@ public class TestSwitchStatementOp {
         String[] args = {"FOO", "BAR", "BAZ", "OTHER"};
 
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(ruleBlock, arg));
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(statement, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), ruleBlock, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), statement, arg));
         }
     }
 
@@ -90,7 +90,7 @@ public class TestSwitchStatementOp {
         CoreOp.FuncOp lmodel = lower("caseConstantMultiLabels");
         char[] args = {'a', 'e', 'i', 'o', 'u', 'j', 'p', 'g'};
         for (char arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantMultiLabels(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantMultiLabels(arg));
         }
     }
 
@@ -111,11 +111,11 @@ public class TestSwitchStatementOp {
     void testCaseConstantThrow() {
         CoreOp.FuncOp lmodel = lower("caseConstantThrow");
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(lmodel, 8));
+        Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(MethodHandles.lookup(), lmodel, 8));
 
         int[] args = {9, 10};
         for (int arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantThrow(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantThrow(arg));
         }
     }
 
@@ -135,7 +135,7 @@ public class TestSwitchStatementOp {
         CoreOp.FuncOp lmodel = lower("caseConstantNullLabel");
         String[] args = {null, "non null"};
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantNullLabel(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantNullLabel(arg));
         }
     }
 
@@ -154,7 +154,7 @@ public class TestSwitchStatementOp {
         CoreOp.FuncOp lmodel = lower("caseConstantFallThrough");
         char[] args = {'A', 'B', 'C'};
         for (char arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseConstantFallThrough(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseConstantFallThrough(arg));
         }
     }
 
@@ -276,7 +276,7 @@ public class TestSwitchStatementOp {
     void testNonEnhancedSwStatNoDefault() {
         CoreOp.FuncOp lmodel = lower("nonEnhancedSwStatNoDefault");
         for (int i = 1; i < 4; i++) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, i), nonEnhancedSwStatNoDefault(i));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, i), nonEnhancedSwStatNoDefault(i));
         }
     }
 
@@ -298,7 +298,7 @@ public class TestSwitchStatementOp {
         CoreOp.FuncOp lmodel = lower("enhancedSwStatUnconditionalPattern");
         String[] args = {"A", "B"};
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), enhancedSwStatUnconditionalPattern(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), enhancedSwStatUnconditionalPattern(arg));
         }
     }
 
@@ -321,8 +321,8 @@ public class TestSwitchStatementOp {
         Object[] args = {1, "2", 3L};
 
         for (Object arg : args) {
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(ruleBlock, arg));
-            Assert.assertEquals(Interpreter.invoke(ruleExpression, arg), Interpreter.invoke(statement, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), ruleBlock, arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), ruleExpression, arg), Interpreter.invoke(MethodHandles.lookup(), statement, arg));
         }
     }
 
@@ -376,12 +376,12 @@ public class TestSwitchStatementOp {
 
         Object[] args = {Byte.MAX_VALUE, Short.MIN_VALUE, 0, 1L, 11f, 22d};
         for (Object arg : args) {
-            Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(lmodel, arg));
+            Assert.assertThrows(IllegalArgumentException.class, () -> Interpreter.invoke(MethodHandles.lookup(), lmodel, arg));
         }
 
         Object[] args2 = {"abc", List.of()};
         for (Object arg : args2) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), casePatternThrow(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), casePatternThrow(arg));
         }
     }
 
@@ -403,7 +403,7 @@ public class TestSwitchStatementOp {
         CoreOp.FuncOp lmodel = lower("casePatternWithCaseConstant");
         int[] args = {42, 43, -44, 0};
         for (int arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), casePatternWithCaseConstant(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), casePatternWithCaseConstant(arg));
         }
     }
 
@@ -425,7 +425,7 @@ public class TestSwitchStatementOp {
         CoreOp.FuncOp lmodel = lower("caseTypePattern");
         Object[] args = {"str", new ArrayList<>(), new int[]{}, new Stack[][]{}, new Collection[][][]{}, 8, 'x'};
         for (Object arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), caseTypePattern(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), caseTypePattern(arg));
         }
     }
 
@@ -491,7 +491,7 @@ public class TestSwitchStatementOp {
         CoreOp.FuncOp lmodel = lower("defaultCaseNotTheLast");
         String[] args = {"something", "M", "A"};
         for (String arg : args) {
-            Assert.assertEquals(Interpreter.invoke(lmodel, arg), defaultCaseNotTheLast(arg));
+            Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lmodel, arg), defaultCaseNotTheLast(arg));
         }
     }
 

--- a/test/jdk/java/lang/reflect/code/TestTransitiveInvokeModule.java
+++ b/test/jdk/java/lang/reflect/code/TestTransitiveInvokeModule.java
@@ -31,7 +31,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.analysis.SSA;
@@ -77,7 +76,7 @@ public class TestTransitiveInvokeModule {
         });
 
         List<Integer> r = new ArrayList<>();
-        Interpreter.invoke(module.functionTable().firstEntry().getValue(), 10, r);
+        Interpreter.invoke(MethodHandles.lookup(), module.functionTable().firstEntry().getValue(), 10, r);
         Assert.assertEquals(r, List.of(9, 7, 5, 3, 1, -1));
     }
 

--- a/test/jdk/java/lang/reflect/code/TestUninitializedVariable.java
+++ b/test/jdk/java/lang/reflect/code/TestUninitializedVariable.java
@@ -30,6 +30,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.analysis.SSA;
@@ -73,7 +74,7 @@ public class TestUninitializedVariable {
         CoreOp.FuncOp f = removeFirstStore(getFuncOp(method).transform(OpTransformer.LOWERING_TRANSFORMER));
         f.writeTo(System.out);
 
-        Assert.assertThrows(Interpreter.InterpreterException.class, () -> Interpreter.invoke(f, 1));
+        Assert.assertThrows(Interpreter.InterpreterException.class, () -> Interpreter.invoke(MethodHandles.lookup(), f, 1));
     }
 
     @Test(dataProvider = "methods")

--- a/test/jdk/java/lang/reflect/code/TestWhileOp.java
+++ b/test/jdk/java/lang/reflect/code/TestWhileOp.java
@@ -24,9 +24,9 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.reflect.Method;
 import java.lang.runtime.CodeReflection;
@@ -59,7 +59,7 @@ public class TestWhileOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), whileLoop());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), whileLoop());
     }
 
     @CodeReflection
@@ -81,7 +81,7 @@ public class TestWhileOp {
 
         lf.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(lf), doWhileLoop());
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), doWhileLoop());
     }
 
     static CoreOp.FuncOp getFuncOp(String name) {

--- a/test/jdk/java/lang/reflect/code/ad/TestForwardAutoDiff.java
+++ b/test/jdk/java/lang/reflect/code/ad/TestForwardAutoDiff.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 import java.lang.reflect.code.Block;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
-import java.lang.reflect.code.Op;
 import java.lang.reflect.code.analysis.SSA;
 import java.lang.reflect.code.bytecode.BytecodeGenerator;
 import java.lang.reflect.code.interpreter.Interpreter;
@@ -56,8 +55,8 @@ public class TestForwardAutoDiff {
         f = SSA.transform(f);
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 0.0, 1.0), f(0.0, 1.0));
-        Assert.assertEquals(Interpreter.invoke(f, PI_4, PI_4), f(PI_4, PI_4));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 0.0, 1.0), f(0.0, 1.0));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, PI_4, PI_4), f(PI_4, PI_4));
 
         Block.Parameter x = f.body().entryBlock().parameters().get(0);
         Block.Parameter y = f.body().entryBlock().parameters().get(1);
@@ -99,9 +98,9 @@ public class TestForwardAutoDiff {
         f = SSA.transform(f);
         f.writeTo(System.out);
 
-        Assert.assertEquals(Interpreter.invoke(f, 2.0, 6), fcf(2.0, 6));
-        Assert.assertEquals(Interpreter.invoke(f, 2.0, 5), fcf(2.0, 5));
-        Assert.assertEquals(Interpreter.invoke(f, 2.0, 4), fcf(2.0, 4));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 2.0, 6), fcf(2.0, 6));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 2.0, 5), fcf(2.0, 5));
+        Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 2.0, 4), fcf(2.0, 4));
 
         Block.Parameter x = f.body().entryBlock().parameters().get(0);
 

--- a/test/jdk/java/lang/reflect/code/bytecode/TestLiftCustomBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestLiftCustomBytecode.java
@@ -36,7 +36,6 @@ import java.lang.invoke.StringConcatFactory;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.bytecode.BytecodeLift;
 import java.lang.reflect.code.interpreter.Interpreter;
-import java.lang.runtime.CodeReflection;
 
 /*
  * @test
@@ -67,7 +66,7 @@ public class TestLiftCustomBytecode {
                        .goto_(l4);
                 })), "backJumps");
 
-        Assert.assertEquals((int) Interpreter.invoke(f, 42), 42);
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), f, 42), 42);
     }
 
     @Test
@@ -82,7 +81,7 @@ public class TestLiftCustomBytecode {
                        .lreturn();
                 })), "deepStackJump");
 
-        Assert.assertEquals((long) Interpreter.invoke(f), 4);
+        Assert.assertEquals((long) Interpreter.invoke(MethodHandles.lookup(), f), 4);
     }
 
     public record TestRecord(int i, String s) {

--- a/test/jdk/java/lang/reflect/code/expression/TestExpressionElimination.java
+++ b/test/jdk/java/lang/reflect/code/expression/TestExpressionElimination.java
@@ -24,6 +24,7 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.CopyContext;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
@@ -43,14 +44,14 @@ public class TestExpressionElimination {
     public void testAddZero() {
         CoreOp.ClosureOp lf = generate((double a) -> a + 0.0);
 
-        Assert.assertEquals((double) Interpreter.invoke(lf, 1.0d), 1.0d);
+        Assert.assertEquals((double) Interpreter.invoke(MethodHandles.lookup(), lf, 1.0d), 1.0d);
     }
 
     @Test
     public void testF() {
         CoreOp.ClosureOp lf = generate((double a, double b) -> -a + b);
 
-        Assert.assertEquals((double) Interpreter.invoke(lf, 1.0d, 1.0d), 0.0d);
+        Assert.assertEquals((double) Interpreter.invoke(MethodHandles.lookup(), lf, 1.0d, 1.0d), 0.0d);
     }
 
     static CoreOp.ClosureOp generate(Quoted q) {

--- a/test/jdk/java/lang/reflect/code/stream/TestStream.java
+++ b/test/jdk/java/lang/reflect/code/stream/TestStream.java
@@ -29,6 +29,7 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.op.CoreOp;
 import java.lang.reflect.code.Op;
@@ -56,7 +57,8 @@ public class TestStream {
 
         lf.writeTo(System.out);
 
-        Interpreter.invoke(lf, List.of(List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 100_000, 20)));
+        Interpreter.invoke(MethodHandles.lookup(), lf,
+                List.of(List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 100_000, 20)));
     }
 
     @Test
@@ -86,7 +88,8 @@ public class TestStream {
                 .toList();
 
         @SuppressWarnings("unchecked")
-        List<String> actual = (List<String>) Interpreter.invoke(lf, List.of(source));
+        List<String> actual = (List<String>) Interpreter.invoke(MethodHandles.lookup(), lf,
+                List.of(source));
 
         Assert.assertEquals(expected, actual);
     }

--- a/test/jdk/java/lang/reflect/code/stream/TestStreamUsingQuotable.java
+++ b/test/jdk/java/lang/reflect/code/stream/TestStreamUsingQuotable.java
@@ -29,6 +29,7 @@
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.code.Op;
 import java.lang.reflect.code.OpTransformer;
 import java.lang.reflect.code.interpreter.Interpreter;
@@ -55,7 +56,8 @@ public class TestStreamUsingQuotable {
 
         lf.writeTo(System.out);
 
-        Interpreter.invoke(lf, List.of(List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 100_000, 20)));
+        Interpreter.invoke(MethodHandles.lookup(), lf,
+                List.of(List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 100_000, 20)));
     }
 
     @Test
@@ -85,7 +87,8 @@ public class TestStreamUsingQuotable {
                 .toList();
 
         @SuppressWarnings("unchecked")
-        List<String> actual = (List<String>) Interpreter.invoke(lf, List.of(source));
+        List<String> actual = (List<String>) Interpreter.invoke(MethodHandles.lookup(), lf,
+                List.of(source));
 
         Assert.assertEquals(expected, actual);
     }

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -37,6 +37,7 @@ import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.IntSupplier;
 import java.util.function.IntUnaryOperator;
 import java.util.function.ToIntFunction;
@@ -52,8 +53,11 @@ public class TestCaptureQuotable {
         Quoted quoted = quotable.quoted();
         assertEquals(quoted.capturedValues().size(), 1);
         assertEquals(((Var)quoted.capturedValues().values().iterator().next()).value(), x);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
-                quoted.capturedValues(), 1);
+                arguments);
         assertEquals(res, x + 1);
     }
 
@@ -68,8 +72,11 @@ public class TestCaptureQuotable {
         assertEquals(it.next(), this);
         assertEquals(((Var)it.next()).value(), hello);
         assertEquals(((Var)it.next()).value(), x);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
-                quoted.capturedValues(), 1);
+                arguments);
         assertEquals(res, x + 1 + hashCode() + hello.length());
     }
 
@@ -115,8 +122,11 @@ public class TestCaptureQuotable {
         Quoted quoted = quotable.quoted();
         assertEquals(quoted.capturedValues().size(), 1);
         assertEquals(quoted.capturedValues().values().iterator().next(), context);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
-                quoted.capturedValues(), 1);
+                arguments);
         assertEquals(res, x + 1);
     }
 
@@ -135,8 +145,11 @@ public class TestCaptureQuotable {
         assertEquals(Box.count, prevCount + 1); // no duplicate receiver computation!
         assertEquals(quoted.capturedValues().size(), 1);
         assertEquals(((Box)((Var)quoted.capturedValues().values().iterator().next()).value()).i, i);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
-                quoted.capturedValues(), 1);
+                arguments);
         assertEquals(res, i + 1);
     }
 

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
@@ -33,7 +33,9 @@ import java.lang.reflect.code.Op;
 import java.lang.reflect.code.Quoted;
 import java.lang.reflect.code.interpreter.Interpreter;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
 
@@ -47,8 +49,11 @@ public class TestCaptureQuoted {
         Quoted quoted = (int y) -> x + y;
         assertEquals(quoted.capturedValues().size(), 1);
         assertEquals(((Var)quoted.capturedValues().values().iterator().next()).value(), x);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
-                quoted.capturedValues(), 1);
+                arguments);
         assertEquals(res, x + 1);
     }
 
@@ -69,8 +74,11 @@ public class TestCaptureQuoted {
         Quoted quoted = context.quoted();
         assertEquals(quoted.capturedValues().size(), 1);
         assertEquals(quoted.capturedValues().values().iterator().next(), context);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
-                quoted.capturedValues(), 1);
+                arguments);
         assertEquals(res, x + 1);
     }
 
@@ -84,8 +92,11 @@ public class TestCaptureQuoted {
         assertEquals(it.next(), this);
         assertEquals(((Var)it.next()).value(), hello);
         assertEquals(((Var)it.next()).value(), x);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
         int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
-                quoted.capturedValues(), 1);
+                arguments);
         assertEquals(res, x + 1 + hashCode() + hello.length());
     }
 


### PR DESCRIPTION
The overloaded `Interpreter.invoke` methods are reduced to just two methods. If the invokeable operation captures values then corresponding captured arguments must be appended, in order, to the list of arguments for invocation (those correspond to the invokeable operation's parameter, in order).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.org/babylon.git pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/271.diff">https://git.openjdk.org/babylon/pull/271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/271#issuecomment-2451039347)
</details>
