### PR TITLE
Regression: compiler SPI does not work with exploded build

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1682,12 +1682,8 @@ public class JavaCompiler {
     }
 
     Optional<CodeReflectionTransformer> reflectMethods() {
-        if (CodeReflectionSupport.CODE_LAYER != null) {
-            return ServiceLoader.load(CodeReflectionSupport.CODE_LAYER, CodeReflectionTransformer.class)
-                            .findFirst();
-        } else {
-            return Optional.empty();
-        }
+        return ServiceLoader.load(CodeReflectionSupport.CODE_LAYER, CodeReflectionTransformer.class)
+                        .findFirst();
     }
 
     static class CodeReflectionSupport {
@@ -1709,7 +1705,7 @@ public class JavaCompiler {
                 }
             } else {
                 // if we run javac in bootstrap mode, there might be no jdk.incubator.code
-                CODE_LAYER = null;
+                CODE_LAYER = ModuleLayer.boot();
             }
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1682,16 +1682,20 @@ public class JavaCompiler {
     }
 
     Optional<CodeReflectionTransformer> reflectMethods() {
-        return ServiceLoader.load(CodeReflectionSupport.CODE_LAYER, CodeReflectionTransformer.class)
-                        .findFirst();
+        return CodeReflectionSupport.CODE_LAYER != null ?
+                ServiceLoader.load(CodeReflectionSupport.CODE_LAYER, CodeReflectionTransformer.class).findFirst() :
+                Optional.empty();
     }
 
     static class CodeReflectionSupport {
         static final ModuleLayer CODE_LAYER;
 
         static {
-            if (java.lang.module.ModuleFinder.ofSystem().find("jdk.incubator.code").isPresent() &&
-                    !ModuleLayer.boot().findModule("jdk.incubator.code").isPresent()) {
+            if (ModuleLayer.boot().findModule("jdk.incubator.code").isPresent()) {
+                // we are in an exploded build, so just use the boot layer
+                CODE_LAYER = ModuleLayer.boot();
+            } else if (java.lang.module.ModuleFinder.ofSystem().find("jdk.incubator.code").isPresent()) {
+                // the code module is installed, but not in the boot layer, create a new layer which contains it
                 ModuleLayer parent = ModuleLayer.boot();
                 Configuration cf = parent.configuration()
                         .resolve(java.lang.module.ModuleFinder.of(), java.lang.module.ModuleFinder.ofSystem(), Set.of("jdk.incubator.code"));
@@ -1704,8 +1708,8 @@ public class JavaCompiler {
                     jdkCompilerModule.addExports(packageName, codeReflectionModule);
                 }
             } else {
-                // if we run javac in bootstrap mode, there might be no jdk.incubator.code
-                CODE_LAYER = ModuleLayer.boot();
+                // if we run in bootstrap mode, there might be no jdk.incubator.code
+                CODE_LAYER = null;
             }
         }
     }


### PR DESCRIPTION
The recent refactoring from compiler plugin to simple SPI introduced a regression.
With compiler plugins, the code-reflection extension was effectively loaded in two steps:
* if the code reflection module was not available in the boot layer, then an attempt was made to load it from a fresh layer created on the fly
* otherwise, plugins were searched in the boot layer (like for any other regular plugin)

When running in exploded mode, incubating modules are part of the boot layer, so they are loaded normally (w/o the need of an extra layer).
Unfortunately, the recent refactoring from plugin to SPI removed the second kind of lookup, meaning that now javac will no longer look for an extension in the boot layer.

The solution is simple: javac should look in the fresh layer if it has created one (meaning the incubating module is not part of the boot layer); otherwise, it should just look for the extension in the boot layer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.org/babylon.git pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/278.diff">https://git.openjdk.org/babylon/pull/278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/278#issuecomment-2492425791)
</details>
