### PR TITLE
bld/hatrun fixes after PR 278

### DIFF
--- a/hat/bld
+++ b/hat/bld
@@ -35,6 +35,7 @@ void main(String[] args) {
 
  var hatJar = buildDir.jarFile("hat-1.0.jar", $->$
    .javac($$->$$
+     .add_modules("jdk.incubator.code")
      .source(24)
      .enable_preview()
      .add_exports("java.base", List.of("jdk.internal", "jdk.internal.vm.annotation"), "ALL-UNNAMED")
@@ -57,6 +58,7 @@ void main(String[] args) {
     buildDir.jarFile(
        typeDir.toString(), $->$
         .javac($$->$$
+           .add_modules("jdk.incubator.code")
            .source(24)
            .enable_preview()
            .add_exports("java.base", List.of("jdk.internal", "jdk.internal.vm.annotation"), "ALL-UNNAMED")

--- a/hat/bldr/Bldr.java
+++ b/hat/bldr/Bldr.java
@@ -786,6 +786,10 @@ public class Bldr {
         public T add_exports(String fromModule, String pack, String toModule) {
             return opts("--add-exports=" + fromModule + "/" + pack + "=" + toModule);
         }
+        public T add_modules(String ... modules) {
+            List.of(modules).forEach(module->  opts("--add-modules=" + module));
+            return self();
+        }
 
         public T add_exports(String fromModule, List<String> packages, String toModule) {
             packages.forEach(p -> add_exports(fromModule, p, toModule));

--- a/hat/examples/pom.xml
+++ b/hat/examples/pom.xml
@@ -42,7 +42,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
    <modules>
      <module>mandel</module>
-     <module>experiments</module>
+     <!--<module>experiments</module>-->
      <module>squares</module>
      <module>violajones</module>
      <module>heal</module>

--- a/hat/hat/src/main/test/hat/CustomOpTest.java
+++ b/hat/hat/src/main/test/hat/CustomOpTest.java
@@ -33,7 +33,7 @@ import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.Op;
 import java.lang.reflect.Method;
 import jdk.incubator.code.type.JavaType;
-import java.lang.runtime.CodeReflection;
+import jdk.incubator.code.CodeReflection;
 import java.util.List;
 
 
@@ -79,7 +79,7 @@ public class CustomOpTest {
     @Test
     public void testDNAOp() throws NoSuchMethodException {
         Method method = CustomOpTest.class.getDeclaredMethod("addMul", int.class, int.class);
-        var funcOp = method.getCodeModel().get();
+        var funcOp = Op.of(method);//.getCodeModel().get();
         var transformed = funcOp.transform((builder, op) -> {
             CopyContext cc = builder.context();
             if (op instanceof CoreOp.InvokeOp invokeOp) {

--- a/hat/hat/src/main/test/hat/SquaresTest.java
+++ b/hat/hat/src/main/test/hat/SquaresTest.java
@@ -37,7 +37,7 @@ import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.JavaType;
-import java.lang.runtime.CodeReflection;
+import jdk.incubator.code.CodeReflection;
 import java.util.List;
 
 

--- a/hat/hatrun
+++ b/hat/hatrun
@@ -49,6 +49,7 @@ void main(String[] args) {
 
   var javaBuilder = javaBuilder()
     .enable_preview()
+    .add_modules("jdk.incubator.code")
     .add_exports("java.base", "jdk.internal", "ALL-UNNAMED")
     .enable_native_access("ALL-UNNAMED")
     .library_path(buildDir)

--- a/hat/hatrun.bash
+++ b/hat/hatrun.bash
@@ -40,6 +40,7 @@ elif [[ -d build ]] ; then
    export VMOPTS=""
    export JARS="" 
 
+   export VMOPTS="${VMOPTS} --add-modules jdk.incubator.code"
    export VMOPTS="${VMOPTS} --enable-preview"
    export VMOPTS="${VMOPTS} --enable-native-access=ALL-UNNAMED"
    export VMOPTS="${VMOPTS} --add-exports=java.base/jdk.internal=ALL-UNNAMED"

--- a/hat/intellij/.idea/compiler.xml
+++ b/hat/intellij/.idea/compiler.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CompilerConfiguration">
+    <option name="USE_RELEASE_OPTION" value="false" />
+  </component>
   <component name="JavacSettings">
-    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
-      <module name="hat" options="--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal=ALL-UNNAMED" />
-    </option>
+    <option name="ADDITIONAL_OPTIONS_STRING" value="--add-modules=jdk.incubator.code --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
   </component>
 </project>

--- a/hat/intellij/.idea/vcs.xml
+++ b/hat/intellij/.idea/vcs.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../hattricks" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/../../../beehive-spirv-toolkit" vcs="Git" />
   </component>
 </project>

--- a/hat/maven-build.bash
+++ b/hat/maven-build.bash
@@ -25,4 +25,4 @@ cat >/dev/null<<LICENSE
  */
 LICENSE
 
-mvn clean compile jar:jar install
+mvn -e clean compile jar:jar install

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -6,7 +6,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
    <artifactId>hat.root</artifactId>
    <packaging>pom</packaging>
    <properties>
-        <babylon.repo.name>babylon</babylon.repo.name>  <!--replace with your fork name -->
+        <babylon.repo.name>babylon-grfrost-fork</babylon.repo.name>  <!--replace with your fork name -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -6,7 +6,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
    <artifactId>hat.root</artifactId>
    <packaging>pom</packaging>
    <properties>
-        <babylon.repo.name>babylon-grfrost-fork</babylon.repo.name>  <!--replace with your fork name -->
+        <babylon.repo.name>babylon</babylon.repo.name>  <!--replace with your fork name -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>


### PR DESCRIPTION
I messed up the bld/hatrun launcher scripts on my previous push 

Here I added back in the --add-modules jdk.incubator.code needed for compiling and running

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/279/head:pull/279` \
`$ git checkout pull/279`

Update a local copy of the PR: \
`$ git checkout pull/279` \
`$ git pull https://git.openjdk.org/babylon.git pull/279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 279`

View PR using the GUI difftool: \
`$ git pr show -t 279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/279.diff">https://git.openjdk.org/babylon/pull/279.diff</a>

</details>
