### PR TITLE
Simplify pom.xml and maven build doc

### DIFF
--- a/hat/docs/hat-01-03-building-hat-with-maven.md
+++ b/hat/docs/hat-01-03-building-hat-with-maven.md
@@ -53,30 +53,14 @@ properties should look like this, and should not need changing
 <project>
     <!-- yada -->
     <properties>
-        <babylon.repo.name>babylon</babylon.repo.name>  <!--replace with your fork name -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>
-        <github.dir>${env.HOME}/github</github.dir>
-        <beehive.spirv.toolkit.dir>${github.dir}/beehive-spirv-toolkit/</beehive.spirv.toolkit.dir>
-        <babylon.dir>${github.dir}/${babylon.repo.name}</babylon.dir>
-        <hat.dir>${babylon.dir}/hat</hat.dir>
-        <hat.target>${hat.dir}/build</hat.target>
+        <hat.target>${env.PWD}/maven-build</hat.target>
     </properties>
     <!-- yada -->
 </project>
 ```
-If say your github dir (the one containing babylon) is somewhere other than `${HOME}/github` then make sure that `github.dir` is
-set accordingly.
-
-```xml
-    <properties>
-        <!-- ... -->
-        <github.dir>/full/path/to/github</github.dir>
-        <!-- ... -->
-    </properties>
-```
-
 ## Sanity checking your env and root pom.xml
 
 After sourcing `env.bash` or making changes to `pom.xml` we can

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -6,15 +6,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
    <artifactId>hat.root</artifactId>
    <packaging>pom</packaging>
    <properties>
-        <babylon.repo.name>babylon</babylon.repo.name>  <!--replace with your fork name -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>
-        <github.dir>${env.HOME}/github</github.dir>
-        <beehive.spirv.toolkit.dir>${github.dir}/beehive-spirv-toolkit/</beehive.spirv.toolkit.dir>
-        <babylon.dir>${github.dir}/${babylon.repo.name}</babylon.dir>
-        <hat.dir>${babylon.dir}/hat</hat.dir>
-        <hat.target>${hat.dir}/maven-build</hat.target>
+        <hat.target>${env.PWD}/build</hat.target>
    </properties>
 
    <profiles>
@@ -54,7 +49,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
              <version>3.11.0</version>
              <configuration>
                 <compilerArgs>
-                    <arg>--add-modules</arg><arg>jdk.incubator.code</arg>
+                    <arg>--add-modules=jdk.incubator.code</arg>
                     <arg>--enable-preview</arg>
                     <arg>--add-exports=java.base/jdk.internal=ALL-UNNAMED</arg>
                     <arg>--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</arg>


### PR DESCRIPTION
Simplified root pom.xml (no github vars needed) + maven build docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/280/head:pull/280` \
`$ git checkout pull/280`

Update a local copy of the PR: \
`$ git checkout pull/280` \
`$ git pull https://git.openjdk.org/babylon.git pull/280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 280`

View PR using the GUI difftool: \
`$ git pr show -t 280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/280.diff">https://git.openjdk.org/babylon/pull/280.diff</a>

</details>
