### PR TITLE
using auto generated poms also a fix for CustomOpTest

### DIFF
--- a/hat/backends/opencl/pom.xml
+++ b/hat/backends/opencl/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,43 +21,34 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-backends</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-backend-opencl</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.backends</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
-               <groupId>org.codehaus.mojo</groupId>
-               <artifactId>exec-maven-plugin</artifactId>
-               <configuration>
-                  <skip>true</skip>
-                  <!-- we want to inherit properties from parent but not the
-                       plugin that calls cmake -->
-               </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <!--We want to inherit properties from parent but not plugin that calls cmake-->
+                </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -66,19 +56,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-backend-opencl-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-opencl-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,85 +21,80 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-   <modelVersion>4.0.0</modelVersion>
-   <groupId>oracle.code</groupId>
-   <version>1.0</version>
-   <artifactId>hat.backends</artifactId>
-   <packaging>pom</packaging>
-    <!-- this required to inherit parent properties -->
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    <groupId>oracle.code</groupId>
+    <artifactId>hat-backends</artifactId>
+    <version>1.0</version>
     <parent>
         <groupId>oracle.code</groupId>
+        <artifactId>hat-root</artifactId>
         <version>1.0</version>
-        <artifactId>hat.root</artifactId>
     </parent>
-
-   <modules>
-     <module>opencl</module>
-     <module>cuda</module>
-     <module>mock</module>
-     <module>ptx</module>
-     <!--<module>spirv</module>-->
-   </modules>
-   <build>
-     <plugins>
-        <plugin>
-           <groupId>org.codehaus.mojo</groupId>
-           <artifactId>exec-maven-plugin</artifactId>
-           <version>3.1.0</version>
-            <executions>
-              <execution>
-                <id>cmake_compile</id>
-                <phase>compile</phase>
-                <goals>
-                   <goal>exec</goal>
-                </goals>
-                <configuration>
-                   <executable>cmake</executable>
-                   <arguments>
-                      <argument>-DHAT_TARGET=${hat.target}</argument>
-                      <argument>-B</argument>
-                      <argument>${hat.target}/cmake-build-debug</argument>
-                   </arguments>
-                </configuration>
-             </execution>
-              <execution>
-                <id>cmake_install_build</id>
-                <phase>install</phase>
-                <goals>
-                   <goal>exec</goal>
-                </goals>
-                <configuration>
-                   <executable>cmake</executable>
-                   <arguments>
-                      <argument>--build</argument>
-                      <argument>${hat.target}/cmake-build-debug</argument>
-                   </arguments>
-                </configuration>
-             </execution>
-
-             <execution>
-                <id>cmake_clean</id>
-                <phase>clean</phase>
-                <goals>
-                   <goal>exec</goal>
-                </goals>
-                <configuration>
-                   <executable>rm </executable>
-                   <arguments>
-                      <argument>-rf</argument>
-                      <argument>cmake-build-debug</argument>
-                   </arguments>
-                </configuration>
-             </execution>
-
-           </executions>
-        </plugin>
-     </plugins>
-   </build>
-
+    <dependencies>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat</artifactId>
+            <version>1.0</version>
+        </dependency>
+    </dependencies>
+    <modules>
+        <module>ptx</module>
+        <module>opencl</module>
+    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>cmake-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>cmake</executable>
+                            <arguments>
+                                <argument>-DHAT_TARGET=${hat.target}</argument>
+                                <argument>-B</argument>
+                                <argument>${hat.target}/cmake-build-debug</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cmake_install_build</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>cmake</executable>
+                            <arguments>
+                                <argument>--build</argument>
+                                <argument>${hat.target}/cmake-build-debug</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cmake_clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>rm</executable>
+                            <arguments>
+                                <argument>-rf</argument>
+                                <argument>cmake-build-debug</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/hat/backends/ptx/pom.xml
+++ b/hat/backends/ptx/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,42 +21,34 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-backends</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-backend-ptx</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.backends</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
-               <groupId>org.codehaus.mojo</groupId>
-               <artifactId>exec-maven-plugin</artifactId>
-               <configuration>
-                  <skip>true</skip>
-                  <!-- we want to inherit properties from parent but not the
-                       plugin that calls cmake -->
-               </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <!--We want to inherit properties from parent but not plugin that calls cmake-->
+                </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -65,18 +56,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-backend-ptx-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-ptx-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/bldr/clean
+++ b/hat/bldr/clean
@@ -1,0 +1,1 @@
+--enable-preview --source 24 clean

--- a/hat/clean
+++ b/hat/clean
@@ -1,0 +1,36 @@
+/* vim: set ft=java: 
+ *
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static bldr.Bldr.*;
+
+void main(String[] args) {
+ var hatDir = Dir.current();
+ var buildDir = hatDir.buildDir("build").remove();
+ hatDir.findDirs(path->path.getFileName().endsWith("target"))
+       .map(path->BuildDir.of(path))
+       .peek(dir->println("removing " +dir.path()))
+       .forEach(dir->dir.remove());
+}

--- a/hat/examples/blackscholes/pom.xml
+++ b/hat/examples/blackscholes/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,30 +21,24 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-examples</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-example-blackscholes</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.examples</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -55,18 +48,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-example-blackscholes-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-blackscholes-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/examples/heal/pom.xml
+++ b/hat/examples/heal/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,31 +21,24 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-examples</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-example-heal</artifactId>
     <version>1.0</version>
-
- <!-- this required to inherit parent properties -->
-   <parent>
-     <groupId>oracle.code</groupId>
-     <version>1.0</version>
-     <artifactId>hat.examples</artifactId>
-   </parent>
-
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -56,18 +48,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-example-heal-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-heal-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/examples/life/pom.xml
+++ b/hat/examples/life/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,29 +21,22 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-examples</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-example-life</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-
- <!-- this required to inherit parent properties -->
-   <parent>
-     <groupId>oracle.code</groupId>
-     <version>1.0</version>
-     <artifactId>hat.examples</artifactId>
-   </parent>
-
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -56,19 +48,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-example-life-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-life-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/hat/examples/mandel/pom.xml
+++ b/hat/examples/mandel/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,27 +21,22 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-examples</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-example-mandel</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.examples</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -54,18 +48,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-example-mandel-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-mandel-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/examples/pom.xml
+++ b/hat/examples/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,31 +21,30 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-   <modelVersion>4.0.0</modelVersion>
-   <groupId>oracle.code</groupId>
-   <version>1.0</version>
-   <artifactId>hat.examples</artifactId>
-   <packaging>pom</packaging>
-
-   <!-- this required to inherit parent properties -->
-   <parent>
-     <groupId>oracle.code</groupId>
-     <version>1.0</version>
-     <artifactId>hat.root</artifactId>
-   </parent>
-
-   <modules>
-     <module>mandel</module>
-     <!--<module>experiments</module>-->
-     <module>squares</module>
-     <module>violajones</module>
-     <module>heal</module>
-     <module>life</module>
-     <module>blackscholes</module>
-   </modules>
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    <groupId>oracle.code</groupId>
+    <artifactId>hat-examples</artifactId>
+    <version>1.0</version>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-root</artifactId>
+        <version>1.0</version>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat</artifactId>
+            <version>1.0</version>
+        </dependency>
+    </dependencies>
+    <modules>
+        <module>life</module>
+        <module>blackscholes</module>
+        <module>mandel</module>
+        <module>heal</module>
+        <module>violajones</module>
+        <module>squares</module>
+    </modules>
 </project>

--- a/hat/examples/squares/pom.xml
+++ b/hat/examples/squares/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,27 +21,22 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-examples</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-example-squares</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.examples</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -54,19 +48,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-example-squares-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-squares-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/hat/examples/violajones/pom.xml
+++ b/hat/examples/violajones/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,28 +21,22 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-examples</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-example-violajones</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.examples</artifactId>
-    </parent>
-
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -55,19 +48,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-example-violajones-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-example-violajones-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/hat/hat/pom.xml
+++ b/hat/hat/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,24 +21,17 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
-
+    <packaging>jar</packaging>
     <groupId>oracle.code</groupId>
     <artifactId>hat</artifactId>
     <version>1.0</version>
-    <!-- this required to inherit parent properties -->
     <parent>
         <groupId>oracle.code</groupId>
+        <artifactId>hat-root</artifactId>
         <version>1.0</version>
-        <artifactId>hat.root</artifactId>
     </parent>
-
-
-
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -69,18 +61,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/${project.artifactId}-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/${project.artifactId}-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/hat/src/main/test/hat/CustomOpTest.java
+++ b/hat/hat/src/main/test/hat/CustomOpTest.java
@@ -31,6 +31,7 @@ import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.Op;
+
 import java.lang.reflect.Method;
 import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.CodeReflection;
@@ -79,7 +80,7 @@ public class CustomOpTest {
     @Test
     public void testDNAOp() throws NoSuchMethodException {
         Method method = CustomOpTest.class.getDeclaredMethod("addMul", int.class, int.class);
-        var funcOp = Op.of(method);//.getCodeModel().get();
+        CoreOp.FuncOp funcOp = Op.ofMethod(method).get();
         var transformed = funcOp.transform((builder, op) -> {
             CopyContext cc = builder.context();
             if (op instanceof CoreOp.InvokeOp invokeOp) {

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -1,68 +1,71 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-   <modelVersion>4.0.0</modelVersion>
-   <groupId>oracle.code</groupId>
-   <version>1.0</version>
-   <artifactId>hat.root</artifactId>
-   <packaging>pom</packaging>
-   <properties>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    <groupId>oracle.code</groupId>
+    <artifactId>hat-root</artifactId>
+    <version>1.0</version>
+    <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>
         <hat.target>${env.PWD}/build</hat.target>
-   </properties>
-
-   <profiles>
-
-       <profile>
-          <id>default</id>
-          <activation>
-             <activeByDefault>true</activeByDefault>
-          </activation>
-          <modules>
-             <module>hat</module>
-             <module>backends</module>
-             <module>examples</module>
-          </modules>
-       </profile>
-
-       <profile>
-          <id>hattricks</id>
-          <activation>
-             <file>
-                <exists>hattricks</exists>
-             </file>
-          </activation>
-          <modules>
-             <module>hat</module>
-             <module>backends</module>
-             <module>examples</module>
-             <module>hattricks</module>
-          </modules>
-       </profile>
-   </profiles>
-   <build>
-      <plugins>
-          <plugin>
-             <groupId>org.apache.maven.plugins</groupId>
-             <artifactId>maven-compiler-plugin</artifactId>
-             <version>3.11.0</version>
-             <configuration>
-                <compilerArgs>
-                    <arg>--add-modules=jdk.incubator.code</arg>
-                    <arg>--enable-preview</arg>
-                    <arg>--add-exports=java.base/jdk.internal=ALL-UNNAMED</arg>
-                    <arg>--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</arg>
-                </compilerArgs>
-                <source>${maven.compiler.source}</source>
-                <target>${maven.compiler.target}</target>
-                <showDeprecation>true</showDeprecation>
-                <failOnError>true</failOnError>
-                <showWarnings>true</showWarnings>
-                <showDeprecation>true</showDeprecation>
-            </configuration>
-         </plugin>
-     </plugins>
-   </build>
-
+    </properties>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>backends</module>
+                <module>examples</module>
+                <module>hat</module>
+            </modules>
+        </profile>
+    </profiles>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>--add-modules=jdk.incubator.code</arg>
+                        <arg>--enable-preview</arg>
+                        <arg>--add-exports=java.base/jdk.internal=ALL-UNNAMED</arg>
+                        <arg>--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <showDeprecation>true</showDeprecation>
+                    <failOnError>true</failOnError>
+                    <showWarnings>true</showWarnings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
As many pom.xml files are similar.  We now autogenerate them (I will check in the code for generating them next), this greatly simplifies maintenance. 

I also found that the CustomOpTest was failing after the transition to jdk.incubator.code so we have that fix

Added bldr/clean and clean, so now we can 

```
java @bldr/clean 
java @bldr/bld
java @bldr/hatrun opencl heal 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.org/babylon.git pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/281.diff">https://git.openjdk.org/babylon/pull/281.diff</a>

</details>
