### PR TITLE
Some build fixups after merging hip backend

### DIFF
--- a/hat/backends/cuda/pom.xml
+++ b/hat/backends/cuda/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,43 +21,34 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-backends</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-backend-cuda</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.backends</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
-             <plugin>
-               <groupId>org.codehaus.mojo</groupId>
-               <artifactId>exec-maven-plugin</artifactId>
-               <configuration>
-                  <skip>true</skip>
-                  <!-- we want to inherit properties from parent but not the
-                       plugin that calls cmake -->
-               </configuration>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <!--We want to inherit properties from parent but not plugin that calls cmake-->
+                </configuration>
             </plugin>
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -66,18 +56,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-backend-cuda-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-cuda-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/backends/hip/pom.xml
+++ b/hat/backends/hip/pom.xml
@@ -1,40 +1,54 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-backends</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-backend-hip</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.backends</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
-             <plugin>
-               <groupId>org.codehaus.mojo</groupId>
-               <artifactId>exec-maven-plugin</artifactId>
-               <configuration>
-                  <skip>true</skip>
-                  <!-- we want to inherit properties from parent but not the
-                       plugin that calls cmake -->
-               </configuration>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <!--We want to inherit properties from parent but not plugin that calls cmake-->
+                </configuration>
             </plugin>
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -42,18 +56,17 @@
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-backend-hip-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-hip-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/backends/mock/pom.xml
+++ b/hat/backends/mock/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,42 +21,34 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-backends</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-backend-mock</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.backends</artifactId>
-    </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
-               <groupId>org.codehaus.mojo</groupId>
-               <artifactId>exec-maven-plugin</artifactId>
-               <configuration>
-                  <skip>true</skip>
-                  <!-- we want to inherit properties from parent but not the
-                       plugin that calls cmake -->
-               </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <!--We want to inherit properties from parent but not plugin that calls cmake-->
+                </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -65,18 +56,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-backend-mock-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <copy file="target/hat-backend-mock-1.0.jar" toDir="${hat.target}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -32,7 +32,6 @@ questions.
         <artifactId>hat-root</artifactId>
         <version>1.0</version>
     </parent>
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
@@ -42,8 +41,9 @@ questions.
     </dependencies>
     <modules>
         <module>ptx</module>
+        <module>cuda</module>
+        <module>mock</module>
         <module>opencl</module>
-        <module>hip</module>
     </modules>
     <build>
         <plugins>

--- a/hat/backends/spirv/pom.xml
+++ b/hat/backends/spirv/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -22,52 +21,34 @@ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 or visit www.oracle.com if you need additional information or have any
 questions.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>oracle.code</groupId>
+        <artifactId>hat-backends</artifactId>
+        <version>1.0</version>
+    </parent>
     <groupId>oracle.code</groupId>
     <artifactId>hat-backend-spirv</artifactId>
     <version>1.0</version>
-    <packaging>jar</packaging>
-    <!-- this required to inherit parent properties -->
-    <parent>
-        <groupId>oracle.code</groupId>
-        <version>1.0</version>
-        <artifactId>hat.backends</artifactId>
-    </parent>
-
-
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <version>1.0</version>
             <artifactId>hat</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>beehive-lab</groupId>
-            <version>0.0.4</version>
-            <artifactId>beehive-spirv-lib</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>oneapi</groupId>
-            <version>0.0.1</version>
-            <artifactId>levelzero</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
-               <groupId>org.codehaus.mojo</groupId>
-               <artifactId>exec-maven-plugin</artifactId>
-               <configuration>
-                  <skip>true</skip>
-                  <!-- we want to inherit properties from parent but not the
-                       plugin that calls cmake -->
-               </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <!--We want to inherit properties from parent but not plugin that calls cmake-->
+                </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -75,40 +56,17 @@ questions.
                 <executions>
                     <execution>
                         <phase>install</phase>
-                        <configuration>
-                            <target>
-                                <copy file="target/hat-backend-spirv-1.0.jar" todir="${hat.target}"/>
-                            </target>
-                        </configuration>
                         <goals>
                             <goal>run</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>add-source1</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
                         <configuration>
-                            <sources>
-                                <!-- <source>${babylon.dir}/cr-examples/spirv/src/main/java/</source> -->
-                                <!-- <source>${beehive.spirv.toolkit.dir}/lib/src/main/java/</source> -->
-                            </sources>
+                            <target>
+                                <copy file="target/hat-backend-spirv-1.0.jar" toDir="${hat.target}"/>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/hat/bld
+++ b/hat/bld
@@ -45,8 +45,10 @@ void main(String[] args) {
 
  record TypedDir(String type, Dir dir) {@Override public String toString(){return "hat-"+type()+"-" + dir().fileName() + "-1.0.jar";}}
 
+//We need to exclude hip and spirv until we have staged beehive spirv. Once we have spirv staged remove hip and spirv from the regex below
+
  var stream =  Stream.concat(
-     backends.subDirs().filter(dir-> dir.matches("^.*(opencl|ptx)$")).map(dir->new TypedDir("backend",dir)),
+     backends.subDirs().filter(dir-> !dir.matches("^.*(hip|spirv|hared|.idea)$")).map(dir->new TypedDir("backend",dir)),
      examples.subDirs().filter( dir-> !dir.matches("^.*(experiments|target)$")).map(dir->new TypedDir("example",dir))
  );
 


### PR DESCRIPTION
After merging HIP backend I had to add hip to pom.xml files and to bldr. 

Although at this point we 'skip' the build by default (sadly we need to work out how to stage SPIRV beehive) 

Comments in the `bld` file show how to include hip. For those with appropriate build infra.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/283/head:pull/283` \
`$ git checkout pull/283`

Update a local copy of the PR: \
`$ git checkout pull/283` \
`$ git pull https://git.openjdk.org/babylon.git pull/283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 283`

View PR using the GUI difftool: \
`$ git pr show -t 283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/283.diff">https://git.openjdk.org/babylon/pull/283.diff</a>

</details>
