### PR TITLE
More jextract prep

### DIFF
--- a/hat/bld
+++ b/hat/bld
@@ -1,4 +1,4 @@
-/* vim: set ft=java: 
+/* vim: set ft=java:
  *
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,54 +28,160 @@ import static bldr.Bldr.*;
 
 void main(String[] args) {
  var hatDir = Dir.current();
- var buildDir = BuildDir.of(hatDir.path("build")).create();
- var hatCoreDir = hatDir.existingDir("hat");
- var backends = hatDir.existingDir("backends");
- var examples = hatDir.existingDir("examples");
+
+
+
+    /*
+     *  ./
+     *    +--build/                     All jars, native libs and executables
+     *    |    +--cmake-build-debug/    All intermediate cmake artifacts
+     *    |
+     *    +--stage/
+     *    |    +--repo/                 All downloaded maven assets
+     *    |    |
+     *    |    +--jextract/             All jextracted files
+     *    |    |    +--opencl
+     *    |    |    +--opengl
+     *    |    |    +--cuda
+     *    |
+     *    +--hat                        * Note maven style layout
+     *    |    +--src/main/java
+     *    |    |    +--hat/
+     *    |    |
+     *    |    +--src/main/test
+     *    |         +--hat/
+     *    |
+     *    +--backends
+     *    |    +--opencl                (*)
+     *    |    +--ptx                   (*)
+     *    |    +--mock                  (*)
+     *    |    +--spirv                 (*)
+     *    |    +--cuda                  (*)
+     *    |    +--hip                   (*)
+     *    |
+     *    +--examples
+     *    |    +--mandel                (*)
+     *    |    +--squares               (*)
+     *    |    +--heal                  (*)
+     *    |    +--life                  (*)
+     *    |    +--violajones            (*)
+     *
+     */
+
+    var hatCoreDir = hatDir.existingDir("hat");
+    var backendsDir = hatDir.existingDir("backends");
+    var examplesDir = hatDir.existingDir("examples");
+    var stageDir = hatDir.buildDir("stage").create();
+    var repoDir = stageDir.repoDir("repo").create();
+    var jextractDir = stageDir.buildDir("jextract").create();
+
+    var buildDir = BuildDir.of(hatDir.path("build")).create();
+    var cmakeBuildDir = buildDir.cMakeBuildDir("cmake-build-debug");
+
+    var extractOpenCL= false;
+    var extractOpenGL= false;
+    if (extractOpenCL || extractOpenGL){
+       var optionalJextract =fromPATH("jextract");
+       if (optionalJextract.isPresent()){
+          var jextract = Jextract.of(optionalJextract.get());
+          if (extractOpenCL){
+             var extractedOpenCLJar = buildDir.jarFile("jextracted-opencl.jar");
+             if (extractedOpenCLJar.exists()) {
+                println("We have " + extractedOpenCLJar.path());
+             } else {
+                var openclSource = jextractDir.sourceDir("opencl");
+                if (openclSource.exists()) {
+                   println("We have already extracted " + openclSource.path() + " to the staging area");
+                }else{
+                   jextract.extract($ -> {
+                      $.output(jextractDir).target_package(openclSource.fileName());
+                      switch (os) {
+                        case OS.Mac mac -> $
+                           .compile_flag("-F" + mac.appLibFrameworks())
+                           .library(mac.frameworkLibrary("OpenCL"))
+                           .header(mac.frameworkHeader("OpenCL", "opencl.h"));
+                        case OS.Linux linux -> {}
+                           default -> throw new RuntimeException("Unsupported OS: " + os);
+                      }
+                   });
+                } 
+                extractedOpenCLJar.create($ -> $.javac($$ -> $$.source(24).source_path(openclSource)));
+             }
+          }
+          if (extractOpenGL){
+             var extractedOpenGLJar = buildDir.jarFile("jextracted-opengl.jar");
+             if (extractedOpenGLJar.exists()) {
+                println("We have " + extractedOpenGLJar.path());
+             } else {
+               var openglSource = jextractDir.sourceDir("opengl");
+               if (openglSource.exists()) {
+                   println("We have already extracted " + openglSource.path() + " to the staging area");
+               }else{
+                  jextract.extract($ -> {
+                     $.output(jextractDir).target_package(openglSource.fileName());
+                     switch (os) {
+                        case OS.Mac mac -> $
+                           .compile_flag("-F" + mac.appLibFrameworks())
+                           .library(mac.frameworkLibrary("GLUT"), mac.frameworkLibrary("OpenGL")) .header(mac.frameworkHeader("GLUT", "glut.h"));
+                        case OS.Linux linux -> {}
+                        default -> throw new RuntimeException("Unsupported OS: " + os);
+                     }
+                  });
+               }
+               extractedOpenGLJar.create($ -> $.javac($$ -> $$.source(24).source_path(openglSource)));
+             }
+         }
+      }else{
+         println("Failed to locate jextract in the path.  Some examples and some backends will be skipped!");
+      }
+   }
+
+
+ var hatOpts = JavaOpts.of()
+   .enable_preview().add_modules("jdk.incubator.code")
+   .add_exports("java.base", List.of("jdk.internal", "jdk.internal.vm.annotation"), "ALL-UNNAMED");
 
  var hatJar = buildDir.jarFile("hat-1.0.jar", $->$
-   .javac($$->$$
-     .add_modules("jdk.incubator.code")
-     .source(24)
-     .enable_preview()
-     .add_exports("java.base", List.of("jdk.internal", "jdk.internal.vm.annotation"), "ALL-UNNAMED")
-     .source_path(hatCoreDir.sourceDir("src/main/java"))
+   .javac($$->$$.opts(hatOpts)
+      .source(24)
+      .source_path(hatCoreDir.sourceDir("src/main/java"))
    )
  );
 
- record TypedDir(String type, Dir dir) {@Override public String toString(){return "hat-"+type()+"-" + dir().fileName() + "-1.0.jar";}}
+// This allows us to essentially concat the backends and examples into a single stream
+record TypedDir(String type, Dir dir) {
+  public String jarName(){
+    return "hat-"+type()+"-" + dir().fileName() + "-1.0.jar";
+  }
+}
 
-//We need to exclude hip and spirv until we have staged beehive spirv. Once we have spirv staged remove hip and spirv from the regex below
-
- var stream =  Stream.concat(
-     backends.subDirs().filter(dir-> !dir.matches("^.*(hip|spirv|hared|.idea)$")).map(dir->new TypedDir("backend",dir)),
-     examples.subDirs().filter( dir-> !dir.matches("^.*(experiments|target)$")).map(dir->new TypedDir("example",dir))
- );
-
- if (hatDir.dir("hattricks") instanceof Dir hattricks && hattricks.exists()) {
-    stream = Stream.concat(stream,hattricks.subDirs().filter(dir -> dir.matches("^.*chess$")).map(dir -> new TypedDir("example", dir)));
- }
-
- stream.parallel().peek(IO::println).forEach(typeDir->
-    buildDir.jarFile(
-       typeDir.toString(), $->$
-        .javac($$->$$
-           .add_modules("jdk.incubator.code")
-           .source(24)
-           .enable_preview()
-           .add_exports("java.base", List.of("jdk.internal", "jdk.internal.vm.annotation"), "ALL-UNNAMED")
-           .class_path(hatJar)
-           .source_path(typeDir.dir().sourceDir("src/main/java"))
-        )
-        .whenExists(typeDir.dir().dir("src/main/resources"), (dir, $$$)->$$$.dir_list(dir))
-    )
- );
+//We exclude hip and spirv until we have staged beehive spirv. Once we have spirv staged remove hip and spirv from the regex below
+Predicate<Dir>  examplePredicate = example -> !example.matches("^.*(experiments|target|.idea)$");
+Predicate<Dir>  backendPredicate = backend -> !backend.matches("^.*(hip|spirv|shared|target|.idea)$");
 
 
- var cmakeBuildDir = buildDir.cMakeBuildDir("cmake-build-debug");
+Stream.concat(
+  backendsDir.subDirs().filter(backendPredicate).map(backend->new TypedDir("backend",backend)),
+  examplesDir.subDirs().filter(examplePredicate).map(example->new TypedDir("example",example))
+  ) .parallel()
+    .peek(typeDir->println(typeDir.jarName()))
+    .forEach(typeDir->
+       buildDir.jarFile(typeDir.jarName(), $->$
+          .javac($$->$$.opts(hatOpts)
+              .source(24)
+              .class_path(hatJar)
+              .source_path(typeDir.dir().sourceDir("src/main/java"))
+          )
+          .whenExists(typeDir.dir().dir("src/main/resources"), (resources,_)->$
+              .dir_list(resources)
+          )
+       )
+    );
+
+
  if (!cmakeBuildDir.exists()) {
    cmake($->$
-     .source_dir(backends)
+     .source_dir(backendsDir)
      .build_dir(cmakeBuildDir)
      .copy_to(buildDir)
    );

--- a/hat/bldr/MavenStyleRepository.java
+++ b/hat/bldr/MavenStyleRepository.java
@@ -1,9 +1,7 @@
 package bldr;
 
-import static bldr.Bldr.assertExists;
-import static bldr.Bldr.curl;
-import static java.io.IO.print;
-import static java.io.IO.println;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -22,593 +20,585 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
+
+import static bldr.Bldr.curl;
+import static java.io.IO.print;
+import static java.io.IO.println;
 
 public class MavenStyleRepository {
-  private final String repoBase = "https://repo1.maven.org/maven2/";
-  private final String searchBase = "https://search.maven.org/solrsearch/";
-  public Bldr.BuildDir dir;
+    private final String repoBase = "https://repo1.maven.org/maven2/";
+    private final String searchBase = "https://search.maven.org/solrsearch/";
+    public Bldr.RepoDir dir;
 
-  Bldr.JarFile jarFile(Id id) {
-    return dir.jarFile(id.artifactAndVersion() + ".jar");
-  }
-
-  Bldr.XMLFile pomFile(Id id) {
-    return dir.xmlFile(id.artifactAndVersion() + ".pom");
-  }
-
-  public enum Scope {
-    TEST,
-    COMPILE,
-    PROVIDED,
-    RUNTIME,
-    SYSTEM;
-
-    static Scope of(String name) {
-      return switch (name.toLowerCase()) {
-        case "test" -> TEST;
-        case "compile" -> COMPILE;
-        case "provided" -> PROVIDED;
-        case "runtime" -> RUNTIME;
-        case "system" -> SYSTEM;
-        default -> COMPILE;
-      };
-    }
-  }
-
-  public record GroupAndArtifactId(GroupId groupId, ArtifactId artifactId) {
-
-    public static GroupAndArtifactId of(String groupAndArtifactId) {
-      int idx = groupAndArtifactId.indexOf('/');
-      return of(groupAndArtifactId.substring(0, idx), groupAndArtifactId.substring(idx + 1));
+    Bldr.JarFile jarFile(Id id) {
+        return dir.jarFile(id.artifactAndVersion() + ".jar");
     }
 
-    public static GroupAndArtifactId of(GroupId groupId, ArtifactId artifactId) {
-      return new GroupAndArtifactId(groupId, artifactId);
+    Bldr.XMLFile pomFile(Id id) {
+        return dir.xmlFile(id.artifactAndVersion() + ".pom");
     }
 
-    public static GroupAndArtifactId of(String groupId, String artifactId) {
-      return of(GroupId.of(groupId), ArtifactId.of(artifactId));
-    }
+    public enum Scope {
+        TEST,
+        COMPILE,
+        PROVIDED,
+        RUNTIME,
+        SYSTEM;
 
-    String location() {
-      return groupId().string().replace('.', '/') + "/" + artifactId().string();
-    }
-
-    @Override
-    public String toString() {
-      return groupId() + "/" + artifactId();
-    }
-  }
-
-  public sealed interface Id permits DependencyId, MetaDataId {
-    MavenStyleRepository mavenStyleRepository();
-
-    GroupAndArtifactId groupAndArtifactId();
-
-    VersionId versionId();
-
-    default String artifactAndVersion() {
-      return groupAndArtifactId().artifactId().string() + '-' + versionId();
-    }
-
-    default String location() {
-      return mavenStyleRepository().repoBase + groupAndArtifactId().location() + "/" + versionId();
-    }
-
-    default URL url(String suffix) {
-      try {
-        return new URI(location() + "/" + artifactAndVersion() + "." + suffix).toURL();
-      } catch (MalformedURLException | URISyntaxException e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
-
-  public record DependencyId(
-      MavenStyleRepository mavenStyleRepository,
-      GroupAndArtifactId groupAndArtifactId,
-      VersionId versionId,
-      Scope scope,
-      boolean required)
-      implements Id {
-    @Override
-    public String toString() {
-      return groupAndArtifactId().toString()
-          + "/"
-          + versionId()
-          + ":"
-          + scope.toString()
-          + ":"
-          + (required ? "Required" : "Optiona");
-    }
-  }
-
-  public record Pom(MetaDataId metaDataId, XMLNode xmlNode) {
-    Bldr.JarFile getJar() {
-      var jarFile = metaDataId.mavenStyleRepository().jarFile(metaDataId); // ;
-      metaDataId.mavenStyleRepository.queryAndCache(metaDataId.jarURL(), jarFile);
-      return jarFile;
-    }
-
-    String description() {
-      return xmlNode().xpathQueryString("/project/description/text()");
-    }
-
-    Stream<DependencyId> dependencies() {
-      return xmlNode()
-          .nodes(xmlNode.xpath("/project/dependencies/dependency"))
-          .map(node -> new XMLNode((Element) node))
-          .map(
-              dependency ->
-                  new DependencyId(
-                      metaDataId().mavenStyleRepository(),
-                      GroupAndArtifactId.of(
-                          GroupId.of(dependency.xpathQueryString("groupId/text()")),
-                          ArtifactId.of(dependency.xpathQueryString("artifactId/text()"))),
-                      VersionId.of(dependency.xpathQueryString("version/text()")),
-                      Scope.of(dependency.xpathQueryString("scope/text()")),
-                      !Boolean.parseBoolean(dependency.xpathQueryString("optional/text()"))));
-    }
-
-    Stream<DependencyId> requiredDependencies() {
-      return dependencies().filter(DependencyId::required);
-    }
-  }
-
-  public Optional<Pom> pom(Id id) {
-    return switch (id) {
-      case MetaDataId metaDataId -> {
-        if (metaDataId.versionId() == VersionId.UNSPECIFIED) {
-          // println("what to do when the version is unspecified");
-          yield Optional.empty();
+        static Scope of(String name) {
+            return switch (name.toLowerCase()) {
+                case "test" -> TEST;
+                case "compile" -> COMPILE;
+                case "provided" -> PROVIDED;
+                case "runtime" -> RUNTIME;
+                case "system" -> SYSTEM;
+                default -> COMPILE;
+            };
         }
-        try {
-          yield Optional.of(
-              new Pom(
-                  metaDataId,
-                  queryAndCache(
-                      metaDataId.pomURL(), metaDataId.mavenStyleRepository.pomFile(metaDataId))));
-        } catch (Throwable e) {
-          throw new RuntimeException(e);
+    }
+
+    public record GroupAndArtifactId(GroupId groupId, ArtifactId artifactId) {
+
+        public static GroupAndArtifactId of(String groupAndArtifactId) {
+            int idx = groupAndArtifactId.indexOf('/');
+            return of(groupAndArtifactId.substring(0, idx), groupAndArtifactId.substring(idx + 1));
         }
-      }
-      case DependencyId dependencyId -> {
-        if (metaData(
-                    id.groupAndArtifactId().groupId().string(),
-                    id.groupAndArtifactId().artifactId().string())
-                instanceof Optional<MetaData> optionalMetaData
-            && optionalMetaData.isPresent()) {
-          if (optionalMetaData
-                      .get()
-                      .metaDataIds()
-                      .filter(metaDataId -> metaDataId.versionId().equals(id.versionId()))
-                      .findFirst()
-                  instanceof Optional<MetaDataId> metaId
-              && metaId.isPresent()) {
-            yield pom(metaId.get());
-          } else {
-            yield Optional.empty();
-          }
-        } else {
-          yield Optional.empty();
+
+        public static GroupAndArtifactId of(GroupId groupId, ArtifactId artifactId) {
+            return new GroupAndArtifactId(groupId, artifactId);
         }
-      }
-      default -> throw new IllegalStateException("Unexpected value: " + id);
-    };
-  }
 
-  public Optional<Pom> pom(GroupAndArtifactId groupAndArtifactId) {
-    var metaData = metaData(groupAndArtifactId).orElseThrow();
-    var metaDataId = metaData.latestMetaDataId().orElseThrow();
-    return pom(metaDataId);
-  }
-
-  record IdVersions(GroupAndArtifactId groupAndArtifactId, Set<Id> versions) {
-    static IdVersions of(GroupAndArtifactId groupAndArtifactId) {
-      return new IdVersions(groupAndArtifactId, new HashSet<>());
-    }
-  }
-
-
-
-  public static class Dag implements Bldr.ClassPathEntryProvider {
-    private final MavenStyleRepository repo;
-    private final List<GroupAndArtifactId> rootGroupAndArtifactIds;
-    Map<GroupAndArtifactId, IdVersions> nodes = new HashMap<>();
-    Map<IdVersions, List<IdVersions>> edges = new HashMap<>();
-
-    Dag add(Id from, Id to) {
-      var fromNode =
-              nodes.computeIfAbsent(
-                      from.groupAndArtifactId(), _ -> IdVersions.of(from.groupAndArtifactId()));
-      fromNode.versions().add(from);
-      var toNode =
-              nodes.computeIfAbsent(
-                      to.groupAndArtifactId(), _ -> IdVersions.of(to.groupAndArtifactId()));
-      toNode.versions().add(to);
-      edges.computeIfAbsent(fromNode, k -> new ArrayList<>()).add(toNode);
-      return this;
-    }
-
-    void removeUNSPECIFIED() {
-      nodes
-              .values()
-              .forEach(
-                      idversions -> {
-                        if (idversions.versions().size() > 1) {
-                          List<Id> versions = new ArrayList<>(idversions.versions());
-                          idversions.versions().clear();
-                          idversions
-                                  .versions()
-                                  .addAll(
-                                          versions.stream()
-                                                  .filter(v -> !v.versionId().equals(VersionId.UNSPECIFIED))
-                                                  .toList());
-                          println(idversions);
-                        }
-                        if (idversions.versions().size() > 1) {
-                          throw new IllegalStateException("more than one version");
-                        }
-                      });
-    }
-
-    Dag(MavenStyleRepository repo, List<GroupAndArtifactId> rootGroupAndArtifactIds) {
-      this.repo = repo;
-      this.rootGroupAndArtifactIds = rootGroupAndArtifactIds;
-
-      Set<Id> unresolved = new HashSet<>();
-      rootGroupAndArtifactIds.forEach(
-              rootGroupAndArtifactId -> {
-                var metaData = repo.metaData(rootGroupAndArtifactId).orElseThrow();
-                var metaDataId = metaData.latestMetaDataId().orElseThrow();
-                var optionalPom = repo.pom(rootGroupAndArtifactId);
-
-                if (optionalPom.isPresent() && optionalPom.get() instanceof Pom pom) {
-                  pom.requiredDependencies()
-                          .filter(dependencyId -> !dependencyId.scope.equals(Scope.TEST))
-                          .forEach(
-                                  dependencyId -> {
-                                    add(metaDataId, dependencyId);
-                                    unresolved.add(dependencyId);
-                                  });
-                }
-              });
-
-      while (!unresolved.isEmpty()) {
-        var resolveSet = new HashSet<>(unresolved);
-        unresolved.clear();
-        resolveSet.forEach(
-                id -> {
-                  if (repo.pom(id) instanceof Optional<Pom> p && p.isPresent()) {
-                    p.get()
-                            .requiredDependencies()
-                            .filter(dependencyId -> !dependencyId.scope.equals(Scope.TEST))
-                            .forEach(
-                                    dependencyId -> {
-                                      unresolved.add(dependencyId);
-                                      add(id, dependencyId);
-                                    });
-                    // }else{
-                    // throw new IllegalArgumentException("unresolved pom " + id);
-                  }
-                });
-      }
-      removeUNSPECIFIED();
-    }
-
-    @Override public List<Bldr.ClassPathEntry> classPathEntries(){
-      return classPath().classPathEntries();
-    }
-
-    Bldr.ClassPath classPath() {
-
-      Bldr.ClassPath jars = Bldr.ClassPath.of();
-      nodes
-              .keySet()
-              .forEach(
-                      id -> {
-                        // println("looking for pom for "+id);
-                        Optional<Pom> optionalPom = repo.pom(id);
-                        if (optionalPom.isPresent() && optionalPom.get() instanceof Pom pom) {
-                          jars.add(pom.getJar());
-                        } else {
-                          throw new RuntimeException("No pom for " + id + " needed by " + id);
-                        }
-                      });
-      return jars;
-    }
-  }
-
-  public Dag dag(String... rootGroupAndArtifactIds) {
-    return dag(Stream.of(rootGroupAndArtifactIds).map(GroupAndArtifactId::of).toList());
-  }
-
-  public Dag dag(GroupAndArtifactId... rootGroupAndArtifactIds) {
-    return dag(List.of(rootGroupAndArtifactIds));
-  }
-
-  public Dag dag(List<GroupAndArtifactId> rootGroupAndArtifactIds) {
-    var dag = new Dag(this, rootGroupAndArtifactIds);
-    return dag;
-  }
-
-
-  public record VersionId(Integer maj, Integer min, Integer point, String classifier)
-      implements Comparable<VersionId> {
-    static Integer integerOrNull(String s) {
-      return (s == null || s.isEmpty()) ? null : Integer.parseInt(s);
-    }
-
-    public static Pattern pattern = Pattern.compile("^(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(.*))?)?$");
-    static VersionId UNSPECIFIED = new VersionId(null, null, null, null);
-
-    static VersionId of(String version) {
-      Matcher matcher = pattern.matcher(version);
-      if (matcher.matches()) {
-        return new VersionId(
-            integerOrNull(matcher.group(1)),
-            integerOrNull(matcher.group(2)),
-            integerOrNull(matcher.group(3)),
-            matcher.group(4));
-      } else {
-        return UNSPECIFIED;
-      }
-    }
-
-    int cmp(Integer v1, Integer v2) {
-      if (v1 == null && v2 == null) {
-        return 0;
-      }
-      if (v1 == null) {
-        return -v2;
-      } else if (v2 == null) {
-        return v1;
-      } else {
-        return v1 - v2;
-      }
-    }
-
-    @Override
-    public int compareTo(VersionId o) {
-      if (cmp(maj(), o.maj()) == 0) {
-        if (cmp(min(), o.min()) == 0) {
-          if (cmp(point(), o.point()) == 0) {
-            return classifier().compareTo(o.classifier());
-          } else {
-            return cmp(point(), o.point());
-          }
-        } else {
-          return cmp(min(), o.min());
+        public static GroupAndArtifactId of(String groupId, String artifactId) {
+            return of(GroupId.of(groupId), ArtifactId.of(artifactId));
         }
-      } else {
-        return cmp(maj(), o.maj());
-      }
+
+        String location() {
+            return groupId().string().replace('.', '/') + "/" + artifactId().string();
+        }
+
+        @Override
+        public String toString() {
+            return groupId() + "/" + artifactId();
+        }
     }
 
-    @Override
-    public String toString() {
-      StringBuilder sb = new StringBuilder();
-      if (maj() != null) {
-        sb.append(maj());
-        if (min() != null) {
-          sb.append(".").append(min());
-          if (point() != null) {
-            sb.append(".").append(point());
-            if (classifier() != null) {
-              sb.append(classifier());
+    public sealed interface Id permits DependencyId, MetaDataId {
+        MavenStyleRepository mavenStyleRepository();
+
+        GroupAndArtifactId groupAndArtifactId();
+
+        VersionId versionId();
+
+        default String artifactAndVersion() {
+            return groupAndArtifactId().artifactId().string() + '-' + versionId();
+        }
+
+        default String location() {
+            return mavenStyleRepository().repoBase + groupAndArtifactId().location() + "/" + versionId();
+        }
+
+        default URL url(String suffix) {
+            try {
+                return new URI(location() + "/" + artifactAndVersion() + "." + suffix).toURL();
+            } catch (MalformedURLException | URISyntaxException e) {
+                throw new RuntimeException(e);
             }
-          }
         }
-      } else {
-        sb.append("UNSPECIFIED");
-      }
-      return sb.toString();
-    }
-  }
-
-  public record GroupId(String string) {
-    public static GroupId of(String s) {
-      return new GroupId(s);
     }
 
-    @Override
-    public String toString() {
-      return string;
-    }
-  }
-
-  public record ArtifactId(String string) {
-    static ArtifactId of(String string) {
-      return new ArtifactId(string);
-    }
-
-    @Override
-    public String toString() {
-      return string;
-    }
-  }
-
-  public record MetaDataId(
-      MavenStyleRepository mavenStyleRepository,
-      GroupAndArtifactId groupAndArtifactId,
-      VersionId versionId,
-      Set<String> downloadables,
-      Set<String> tags)
-      implements Id {
-
-    public URL pomURL() {
-      return url("pom");
-    }
-
-    public URL jarURL() {
-      return url("jar");
-    }
-
-    public XMLNode getPom() {
-      if (downloadables.contains(".pom")) {
-        return mavenStyleRepository.queryAndCache(
-            url("pom"), mavenStyleRepository.dir.xmlFile(artifactAndVersion() + ".pom"));
-      } else {
-        throw new IllegalStateException("no pom");
-      }
-    }
-
-    @Override
-    public String toString() {
-      return groupAndArtifactId().toString() + "." + versionId();
-    }
-  }
-
-  public MavenStyleRepository(Bldr.BuildDir dir) {
-    this.dir = dir.create();
-  }
-
-  Bldr.JarFile queryAndCache(URL query, Bldr.JarFile jarFile) {
-    try {
-      if (!jarFile.exists()) {
-        print("Querying and caching " + jarFile.fileName());
-        println(" downloading " + query);
-        curl(query, jarFile.path());
-      } else {
-        // println("Using cached " + jarFile.fileName());
-
-      }
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
-    }
-    return jarFile;
-  }
-
-  XMLNode queryAndCache(URL query, Bldr.XMLFile xmlFile) {
-    XMLNode xmlNode = null;
-    try {
-      if (!xmlFile.exists()) {
-        print("Querying and caching " + xmlFile.fileName());
-        println(" downloading " + query);
-        xmlNode = new XMLNode(query);
-        xmlNode.write(xmlFile.path().toFile());
-      } else {
-        // println("Using cached " + xmlFile.fileName());
-        xmlNode = new XMLNode(xmlFile.path());
-      }
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
-    }
-    return xmlNode;
-  }
-
-  public record MetaData(
-      MavenStyleRepository mavenStyleRepository,
-      GroupAndArtifactId groupAndArtifactId,
-      XMLNode xmlNode) {
-
-    public Stream<MetaDataId> metaDataIds() {
-      return xmlNode
-          .xmlNodes(xmlNode.xpath("/response/result/doc"))
-          .map(
-              xmln ->
-                  new MetaDataId(
-                      this.mavenStyleRepository,
-                      GroupAndArtifactId.of(
-                          GroupId.of(xmln.xpathQueryString("str[@name='g']/text()")),
-                          ArtifactId.of(xmln.xpathQueryString("str[@name='a']/text()"))),
-                      VersionId.of(xmln.xpathQueryString("str[@name='v']/text()")),
-                      new HashSet<>(
-                          xmln.nodes(xmln.xpath("arr[@name='ec']/str/text()"))
-                              .map(Node::getNodeValue)
-                              .toList()),
-                      new HashSet<>(
-                          xmln.nodes(xmln.xpath("arr[@name='tags']/str/text()"))
-                              .map(Node::getNodeValue)
-                              .toList())));
-    }
-
-    public Stream<MetaDataId> sortedMetaDataIds() {
-      return metaDataIds().sorted(Comparator.comparing(MetaDataId::versionId));
-    }
-
-    public Optional<MetaDataId> latestMetaDataId() {
-      return metaDataIds().max(Comparator.comparing(MetaDataId::versionId));
-    }
-
-    public Optional<MetaDataId> getMetaDataId(VersionId versionId) {
-      return metaDataIds().filter(id -> versionId.compareTo(id.versionId()) == 0).findFirst();
-    }
-  }
-
-  public Optional<MetaData> metaData(String groupId, String artifactId) {
-    return metaData(GroupAndArtifactId.of(groupId, artifactId));
-  }
-
-  public Optional<MetaData> metaData(GroupAndArtifactId groupAndArtifactId) {
-    try {
-      var query = "g:" + groupAndArtifactId.groupId() + " AND a:" + groupAndArtifactId.artifactId();
-      URL rowQueryUrl =
-          new URI(
-                  searchBase
-                      + "select?q="
-                      + URLEncoder.encode(query, StandardCharsets.UTF_8)
-                      + "&core=gav&wt=xml&rows=0")
-              .toURL();
-      var rowQueryResponse = new XMLNode(rowQueryUrl);
-      var numFound = rowQueryResponse.xpathQueryString("/response/result/@numFound");
-
-      URL url =
-          new URI(
-                  searchBase
-                      + "select?q="
-                      + URLEncoder.encode(query, StandardCharsets.UTF_8)
-                      + "&core=gav&wt=xml&rows="
-                      + numFound)
-              .toURL();
-      try {
-        // println(url);
-        var xmlNode =
-            queryAndCache(url, dir.xmlFile(groupAndArtifactId.artifactId() + ".meta.xml"));
-        // var numFound2 = xmlNode.xpathQueryString("/response/result/@numFound");
-        // var start = xmlNode.xpathQueryString("/response/result/@start");
-        // var rows =
-        // xmlNode.xpathQueryString("/response/lst[@name='responseHeader']/lst[@name='params']/str[@name='rows']/text()");
-        // println("numFound = "+numFound+" rows ="+rows+ " start ="+start);
-        if (numFound.isEmpty() || numFound.equals("0")) {
-          return Optional.empty();
-        } else {
-          return Optional.of(new MetaData(this, groupAndArtifactId, xmlNode));
+    public record DependencyId(
+            MavenStyleRepository mavenStyleRepository,
+            GroupAndArtifactId groupAndArtifactId,
+            VersionId versionId,
+            Scope scope,
+            boolean required)
+            implements Id {
+        @Override
+        public String toString() {
+            return groupAndArtifactId().toString()
+                    + "/"
+                    + versionId()
+                    + ":"
+                    + scope.toString()
+                    + ":"
+                    + (required ? "Required" : "Optiona");
         }
-      } catch (Throwable e) {
-        throw new RuntimeException(e);
+    }
+
+    public record Pom(MetaDataId metaDataId, XMLNode xmlNode) {
+        Bldr.JarFile getJar() {
+            var jarFile = metaDataId.mavenStyleRepository().jarFile(metaDataId); // ;
+            metaDataId.mavenStyleRepository.queryAndCache(metaDataId.jarURL(), jarFile);
+            return jarFile;
+        }
+
+        String description() {
+            return xmlNode().xpathQueryString("/project/description/text()");
+        }
+
+        Stream<DependencyId> dependencies() {
+            return xmlNode()
+                    .nodes(xmlNode.xpath("/project/dependencies/dependency"))
+                    .map(node -> new XMLNode((Element) node))
+                    .map(
+                            dependency ->
+                                    new DependencyId(
+                                            metaDataId().mavenStyleRepository(),
+                                            GroupAndArtifactId.of(
+                                                    GroupId.of(dependency.xpathQueryString("groupId/text()")),
+                                                    ArtifactId.of(dependency.xpathQueryString("artifactId/text()"))),
+                                            VersionId.of(dependency.xpathQueryString("version/text()")),
+                                            Scope.of(dependency.xpathQueryString("scope/text()")),
+                                            !Boolean.parseBoolean(dependency.xpathQueryString("optional/text()"))));
+        }
+
+        Stream<DependencyId> requiredDependencies() {
+            return dependencies().filter(DependencyId::required);
+        }
+    }
+
+    public Optional<Pom> pom(Id id) {
+        return switch (id) {
+            case MetaDataId metaDataId -> {
+                if (metaDataId.versionId() == VersionId.UNSPECIFIED) {
+                    // println("what to do when the version is unspecified");
+                    yield Optional.empty();
+                }
+                try {
+                    yield Optional.of(
+                            new Pom(
+                                    metaDataId,
+                                    queryAndCache(
+                                            metaDataId.pomURL(), metaDataId.mavenStyleRepository.pomFile(metaDataId))));
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            case DependencyId dependencyId -> {
+                if (metaData(
+                        id.groupAndArtifactId().groupId().string(),
+                        id.groupAndArtifactId().artifactId().string())
+                        instanceof Optional<MetaData> optionalMetaData
+                        && optionalMetaData.isPresent()) {
+                    if (optionalMetaData
+                            .get()
+                            .metaDataIds()
+                            .filter(metaDataId -> metaDataId.versionId().equals(id.versionId()))
+                            .findFirst()
+                            instanceof Optional<MetaDataId> metaId
+                            && metaId.isPresent()) {
+                        yield pom(metaId.get());
+                    } else {
+                        yield Optional.empty();
+                    }
+                } else {
+                    yield Optional.empty();
+                }
+            }
+            default -> throw new IllegalStateException("Unexpected value: " + id);
+        };
+    }
+
+    public Optional<Pom> pom(GroupAndArtifactId groupAndArtifactId) {
+        var metaData = metaData(groupAndArtifactId).orElseThrow();
+        var metaDataId = metaData.latestMetaDataId().orElseThrow();
+        return pom(metaDataId);
+    }
+
+    record IdVersions(GroupAndArtifactId groupAndArtifactId, Set<Id> versions) {
+        static IdVersions of(GroupAndArtifactId groupAndArtifactId) {
+            return new IdVersions(groupAndArtifactId, new HashSet<>());
+        }
+    }
+
+    public static class Dag implements Bldr.ClassPathEntryProvider {
+        private final MavenStyleRepository repo;
+        private final List<GroupAndArtifactId> rootGroupAndArtifactIds;
+        Map<GroupAndArtifactId, IdVersions> nodes = new HashMap<>();
+        Map<IdVersions, List<IdVersions>> edges = new HashMap<>();
+
+        Dag add(Id from, Id to) {
+            var fromNode =
+                    nodes.computeIfAbsent(
+                            from.groupAndArtifactId(), _ -> IdVersions.of(from.groupAndArtifactId()));
+            fromNode.versions().add(from);
+            var toNode =
+                    nodes.computeIfAbsent(
+                            to.groupAndArtifactId(), _ -> IdVersions.of(to.groupAndArtifactId()));
+            toNode.versions().add(to);
+            edges.computeIfAbsent(fromNode, k -> new ArrayList<>()).add(toNode);
+            return this;
+        }
+
+        void removeUNSPECIFIED() {
+            nodes
+                    .values()
+                    .forEach(
+                            idversions -> {
+                                if (idversions.versions().size() > 1) {
+                                    List<Id> versions = new ArrayList<>(idversions.versions());
+                                    idversions.versions().clear();
+                                    idversions
+                                            .versions()
+                                            .addAll(
+                                                    versions.stream()
+                                                            .filter(v -> !v.versionId().equals(VersionId.UNSPECIFIED))
+                                                            .toList());
+                                    println(idversions);
+                                }
+                                if (idversions.versions().size() > 1) {
+                                    throw new IllegalStateException("more than one version");
+                                }
+                            });
+        }
+
+        Dag(MavenStyleRepository repo, List<GroupAndArtifactId> rootGroupAndArtifactIds) {
+            this.repo = repo;
+            this.rootGroupAndArtifactIds = rootGroupAndArtifactIds;
+
+            Set<Id> unresolved = new HashSet<>();
+            rootGroupAndArtifactIds.forEach(
+                    rootGroupAndArtifactId -> {
+                        var metaData = repo.metaData(rootGroupAndArtifactId).orElseThrow();
+                        var metaDataId = metaData.latestMetaDataId().orElseThrow();
+                        var optionalPom = repo.pom(rootGroupAndArtifactId);
+
+                        if (optionalPom.isPresent() && optionalPom.get() instanceof Pom pom) {
+                            pom.requiredDependencies()
+                                    .filter(dependencyId -> !dependencyId.scope.equals(Scope.TEST))
+                                    .forEach(
+                                            dependencyId -> {
+                                                add(metaDataId, dependencyId);
+                                                unresolved.add(dependencyId);
+                                            });
+                        }
+                    });
+
+            while (!unresolved.isEmpty()) {
+                var resolveSet = new HashSet<>(unresolved);
+                unresolved.clear();
+                resolveSet.forEach(id -> {
+                            if (repo.pom(id) instanceof Optional<Pom> p && p.isPresent()) {
+                                p.get()
+                                        .requiredDependencies()
+                                        .filter(dependencyId -> !dependencyId.scope.equals(Scope.TEST))
+                                        .forEach(
+                                                dependencyId -> {
+                                                    unresolved.add(dependencyId);
+                                                    add(id, dependencyId);
+                                                });
+                            }
+                        });
+            }
+            removeUNSPECIFIED();
+        }
+
+        @Override
+        public List<Bldr.ClassPathEntry> classPathEntries() {
+            return classPath().classPathEntries();
+        }
+
+        Bldr.ClassPath classPath() {
+
+            Bldr.ClassPath jars = Bldr.ClassPath.of();
+            nodes
+                    .keySet()
+                    .forEach(
+                            id -> {
+                                Optional<Pom> optionalPom = repo.pom(id);
+                                if (optionalPom.isPresent() && optionalPom.get() instanceof Pom pom) {
+                                    jars.add(pom.getJar());
+                                } else {
+                                    throw new RuntimeException("No pom for " + id + " needed by " + id);
+                                }
+                            });
+            return jars;
+        }
+    }
+
+    public Bldr.ClassPathEntryProvider classPathEntries(String... rootGroupAndArtifactIds) {
+        return classPathEntries(Stream.of(rootGroupAndArtifactIds).map(GroupAndArtifactId::of).toList());
+    }
+
+    public Bldr.ClassPathEntryProvider classPathEntries(GroupAndArtifactId... rootGroupAndArtifactIds) {
+        return classPathEntries(List.of(rootGroupAndArtifactIds));
+    }
+
+    public Bldr.ClassPathEntryProvider classPathEntries(List<GroupAndArtifactId> rootGroupAndArtifactIds) {
+      StringBuilder sb = new StringBuilder();
+      rootGroupAndArtifactIds.forEach(groupAndArtifactId->sb.append(sb.isEmpty() ?"":"-").append(groupAndArtifactId.groupId+"-"+groupAndArtifactId.artifactId));
+      System.out.println(sb);
+      Bldr.ClassPathEntryProvider classPathEntries=null;
+      var pathFileName = sb+"-path.xml";
+      var pathFile = dir.xmlFile(pathFileName);
+      if (pathFile.exists()){
+          System.out.println(pathFileName + " exists " + pathFile.path().toString());
+          XMLNode path = new XMLNode(pathFile.path());
+          Bldr.ClassPath classPath = Bldr.ClassPath.of();
+          path.nodes(path.xpath("/path/jar/text()")).forEach(e->
+                  classPath.add(dir.jarFile(e.getNodeValue()))
+          );
+          classPathEntries = classPath;
+      }else {
+         var finalClassPathEntries =  new Dag(this, rootGroupAndArtifactIds);
+              XMLNode.create("path", xml-> {
+                  finalClassPathEntries.classPathEntries().forEach(cpe ->
+                          xml.element("jar",jar->jar.text(dir.path().relativize(cpe.path()).toString()))
+                  );
+              }).write(pathFile);
+         System.out.println("created "+pathFile.path());
+         classPathEntries = finalClassPathEntries;
       }
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
+        return classPathEntries;
     }
-  }
 
-  public static void main(String[] args) {
+    public record VersionId(Integer maj, Integer min, Integer point, String classifier)
+            implements Comparable<VersionId> {
+        static Integer integerOrNull(String s) {
+            return (s == null || s.isEmpty()) ? null : Integer.parseInt(s);
+        }
 
-    var hatDir = assertExists(Bldr.Dir.of("/Users/grfrost/github/babylon-grfrost-fork/hat"));
+        public static Pattern pattern = Pattern.compile("^(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(.*))?)?$");
+        static VersionId UNSPECIFIED = new VersionId(null, null, null, null);
 
-    var repo = new MavenStyleRepository(hatDir.buildDir("repo"));
-    var testngMeta = repo.metaData("org.testng", "testng");
-    if (testngMeta.isPresent()) {
-      testngMeta
-          .get()
-          .sortedMetaDataIds()
-          .forEach(
-              metaDataId -> {
-                var pom = metaDataId.getPom();
-                //   println(pom.toString());
-              });
+        static VersionId of(String version) {
+            Matcher matcher = pattern.matcher(version);
+            if (matcher.matches()) {
+                return new VersionId(
+                        integerOrNull(matcher.group(1)),
+                        integerOrNull(matcher.group(2)),
+                        integerOrNull(matcher.group(3)),
+                        matcher.group(4));
+            } else {
+                return UNSPECIFIED;
+            }
+        }
+
+        int cmp(Integer v1, Integer v2) {
+            if (v1 == null && v2 == null) {
+                return 0;
+            }
+            if (v1 == null) {
+                return -v2;
+            } else if (v2 == null) {
+                return v1;
+            } else {
+                return v1 - v2;
+            }
+        }
+
+        @Override
+        public int compareTo(VersionId o) {
+            if (cmp(maj(), o.maj()) == 0) {
+                if (cmp(min(), o.min()) == 0) {
+                    if (cmp(point(), o.point()) == 0) {
+                        return classifier().compareTo(o.classifier());
+                    } else {
+                        return cmp(point(), o.point());
+                    }
+                } else {
+                    return cmp(min(), o.min());
+                }
+            } else {
+                return cmp(maj(), o.maj());
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            if (maj() != null) {
+                sb.append(maj());
+                if (min() != null) {
+                    sb.append(".").append(min());
+                    if (point() != null) {
+                        sb.append(".").append(point());
+                        if (classifier() != null) {
+                            sb.append(classifier());
+                        }
+                    }
+                }
+            } else {
+                sb.append("UNSPECIFIED");
+            }
+            return sb.toString();
+        }
     }
-    var junitMeta = repo.metaData("org.junit.platform", "junit-platform-console-standalone");
-    if (junitMeta.isPresent()) {
-      var latest = junitMeta.get().latestMetaDataId();
-      if (latest.isPresent()) {
-        var id = latest.get();
-        var pom = id.getPom();
-        // println(pom.toString());
-      }
+
+    public record GroupId(String string) {
+        public static GroupId of(String s) {
+            return new GroupId(s);
+        }
+
+        @Override
+        public String toString() {
+            return string;
+        }
     }
-  }
+
+    public record ArtifactId(String string) {
+        static ArtifactId of(String string) {
+            return new ArtifactId(string);
+        }
+
+        @Override
+        public String toString() {
+            return string;
+        }
+    }
+
+    public record MetaDataId(
+            MavenStyleRepository mavenStyleRepository,
+            GroupAndArtifactId groupAndArtifactId,
+            VersionId versionId,
+            Set<String> downloadables,
+            Set<String> tags)
+            implements Id {
+
+        public URL pomURL() {
+            return url("pom");
+        }
+
+        public URL jarURL() {
+            return url("jar");
+        }
+
+        public XMLNode getPom() {
+            if (downloadables.contains(".pom")) {
+                return mavenStyleRepository.queryAndCache(
+                        url("pom"), mavenStyleRepository.dir.xmlFile(artifactAndVersion() + ".pom"));
+            } else {
+                throw new IllegalStateException("no pom");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return groupAndArtifactId().toString() + "." + versionId();
+        }
+    }
+
+    public MavenStyleRepository(Bldr.RepoDir dir) {
+        this.dir = dir.create();
+    }
+
+    Bldr.JarFile queryAndCache(URL query, Bldr.JarFile jarFile) {
+        try {
+            if (!jarFile.exists()) {
+                print("Querying and caching " + jarFile.fileName());
+                println(" downloading " + query);
+                curl(query, jarFile.path());
+            } else {
+                // println("Using cached " + jarFile.fileName());
+
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+        return jarFile;
+    }
+
+    XMLNode queryAndCache(URL query, Bldr.XMLFile xmlFile) {
+        XMLNode xmlNode = null;
+        try {
+            if (!xmlFile.exists()) {
+                print("Querying and caching " + xmlFile.fileName());
+                println(" downloading " + query);
+                xmlNode = new XMLNode(query);
+                xmlNode.write(xmlFile.path().toFile());
+            } else {
+                // println("Using cached " + xmlFile.fileName());
+                xmlNode = new XMLNode(xmlFile.path());
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+        return xmlNode;
+    }
+
+    public record MetaData(
+            MavenStyleRepository mavenStyleRepository,
+            GroupAndArtifactId groupAndArtifactId,
+            XMLNode xmlNode) {
+
+        public Stream<MetaDataId> metaDataIds() {
+            return xmlNode
+                    .xmlNodes(xmlNode.xpath("/response/result/doc"))
+                    .map(
+                            xmln ->
+                                    new MetaDataId(
+                                            this.mavenStyleRepository,
+                                            GroupAndArtifactId.of(
+                                                    GroupId.of(xmln.xpathQueryString("str[@name='g']/text()")),
+                                                    ArtifactId.of(xmln.xpathQueryString("str[@name='a']/text()"))),
+                                            VersionId.of(xmln.xpathQueryString("str[@name='v']/text()")),
+                                            new HashSet<>(
+                                                    xmln.nodes(xmln.xpath("arr[@name='ec']/str/text()"))
+                                                            .map(Node::getNodeValue)
+                                                            .toList()),
+                                            new HashSet<>(
+                                                    xmln.nodes(xmln.xpath("arr[@name='tags']/str/text()"))
+                                                            .map(Node::getNodeValue)
+                                                            .toList())));
+        }
+
+        public Stream<MetaDataId> sortedMetaDataIds() {
+            return metaDataIds().sorted(Comparator.comparing(MetaDataId::versionId));
+        }
+
+        public Optional<MetaDataId> latestMetaDataId() {
+            return metaDataIds().max(Comparator.comparing(MetaDataId::versionId));
+        }
+
+        public Optional<MetaDataId> getMetaDataId(VersionId versionId) {
+            return metaDataIds().filter(id -> versionId.compareTo(id.versionId()) == 0).findFirst();
+        }
+    }
+
+    public Optional<MetaData> metaData(String groupId, String artifactId) {
+        return metaData(GroupAndArtifactId.of(groupId, artifactId));
+    }
+
+    public Optional<MetaData> metaData(GroupAndArtifactId groupAndArtifactId) {
+        try {
+            var query = "g:" + groupAndArtifactId.groupId() + " AND a:" + groupAndArtifactId.artifactId();
+            URL rowQueryUrl =
+                    new URI(
+                            searchBase
+                                    + "select?q="
+                                    + URLEncoder.encode(query, StandardCharsets.UTF_8)
+                                    + "&core=gav&wt=xml&rows=0")
+                            .toURL();
+            var rowQueryResponse = new XMLNode(rowQueryUrl);
+            var numFound = rowQueryResponse.xpathQueryString("/response/result/@numFound");
+
+            URL url =
+                    new URI(
+                            searchBase
+                                    + "select?q="
+                                    + URLEncoder.encode(query, StandardCharsets.UTF_8)
+                                    + "&core=gav&wt=xml&rows="
+                                    + numFound)
+                            .toURL();
+            try {
+                // println(url);
+                var xmlNode =
+                        queryAndCache(url, dir.xmlFile(groupAndArtifactId.artifactId() + ".meta.xml"));
+                // var numFound2 = xmlNode.xpathQueryString("/response/result/@numFound");
+                // var start = xmlNode.xpathQueryString("/response/result/@start");
+                // var rows =
+                // xmlNode.xpathQueryString("/response/lst[@name='responseHeader']/lst[@name='params']/str[@name='rows']/text()");
+                // println("numFound = "+numFound+" rows ="+rows+ " start ="+start);
+                if (numFound.isEmpty() || numFound.equals("0")) {
+                    return Optional.empty();
+                } else {
+                    return Optional.of(new MetaData(this, groupAndArtifactId, xmlNode));
+                }
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/hat/bldr/XMLNode.java
+++ b/hat/bldr/XMLNode.java
@@ -1,5 +1,21 @@
 package bldr;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,835 +33,892 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 public class XMLNode {
-  org.w3c.dom.Element element;
-  List<XMLNode> children = new ArrayList<>();
-  Map<String, String> attrMap = new HashMap<>();
-
-  public static class AbstractXMLBuilder<T extends AbstractXMLBuilder<T>>{
-    public org.w3c.dom.Element element;
-    @SuppressWarnings("unchecked")
-    public T self(){
-      return (T)this;
+    org.w3c.dom.Element element;
+    List<XMLNode> children = new ArrayList<>();
+    Map<String, String> attrMap = new HashMap<>();
+
+    public static class AbstractXMLBuilder<T extends AbstractXMLBuilder<T>> {
+        public org.w3c.dom.Element element;
+
+        @SuppressWarnings("unchecked")
+        public T self() {
+            return (T) this;
+        }
+
+        public T attr(String name, String value) {
+            // var att = element.getOwnerDocument().createAttribute(name);
+            // att.setValue(value);
+            element.setAttribute(name, value);
+            // element.appendChild(att);
+            return self();
+        }
+
+        public T attr(URI uri, String name, String value) {
+            // var att = element.getOwnerDocument().createAttribute(name);
+            // att.setValue(value);
+            element.setAttributeNS(uri.toString(), name, value);
+            // element.appendChild(att);
+            return self();
+        }
+
+        public T element(String name, Function<Element, T> factory, Consumer<T> xmlBuilderConsumer) {
+            var node = element.getOwnerDocument().createElement(name);
+            element.appendChild(node);
+            var builder = factory.apply(node);
+            xmlBuilderConsumer.accept(builder);
+            return self();
+        }
+
+        public T element(
+                URI uri, String name, Function<Element, T> factory, Consumer<T> xmlBuilderConsumer) {
+            var node = element.getOwnerDocument().createElementNS(uri.toString(), name);
+            element.appendChild(node);
+            var builder = factory.apply(node);
+            xmlBuilderConsumer.accept(builder);
+            return self();
+        }
+
+        AbstractXMLBuilder(org.w3c.dom.Element element) {
+            this.element = element;
+        }
+
+        public T text(String thisText) {
+            var node = element.getOwnerDocument().createTextNode(thisText);
+            element.appendChild(node);
+            return self();
+        }
+
+        public T comment(String thisComment) {
+            var node = element.getOwnerDocument().createComment(thisComment);
+            element.appendChild(node);
+            return self();
+        }
+
+        <L> T forEach(List<L> list, BiConsumer<T, L> biConsumer) {
+            list.forEach(l -> biConsumer.accept(self(), l));
+            return self();
+        }
+
+        <L> T forEach(Stream<L> stream, BiConsumer<T, L> biConsumer) {
+            stream.forEach(l -> biConsumer.accept(self(), l));
+            return self();
+        }
+
+        <L> T forEach(Stream<L> stream, Consumer<L> consumer) {
+            stream.forEach(consumer);
+            return self();
+        }
+
+        protected T then(Consumer<T> xmlBuilderConsumer) {
+            xmlBuilderConsumer.accept(self());
+            return self();
+        }
+    }
+
+    public static class PomXmlBuilder extends AbstractXMLBuilder<PomXmlBuilder> {
+        PomXmlBuilder(Element element) {
+            super(element);
+        }
+
+        public PomXmlBuilder element(String name, Consumer<PomXmlBuilder> xmlBuilderConsumer) {
+            return element(name, PomXmlBuilder::new, xmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder element(URI uri, String name, Consumer<PomXmlBuilder> xmlBuilderConsumer) {
+            return element(uri, name, PomXmlBuilder::new, xmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder modelVersion(String s) {
+            return element("modelVersion", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder pom(String groupId, String artifactId, String version) {
+            return modelVersion("4.0.0").packaging("pom").ref(groupId, artifactId, version);
+        }
+
+        public PomXmlBuilder jar(String groupId, String artifactId, String version) {
+            return modelVersion("4.0.0").packaging("jar").ref(groupId, artifactId, version);
+        }
+
+        public PomXmlBuilder groupId(String s) {
+            return element("groupId", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder artifactId(String s) {
+            return element("artifactId", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder packaging(String s) {
+            return element("packaging", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder version(String s) {
+            return element("version", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder build(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("build", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder plugins(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("plugins", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder plugin(
+                String groupId,
+                String artifactId,
+                String version,
+                Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element(
+                    "plugin", $ -> $.ref(groupId, artifactId, version).then(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder antPluginExecutions(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return plugin(
+                    "org.apache.maven.plugins",
+                    "maven-antrun-plugin",
+                    "1.8",
+                    plugin -> plugin.executions(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder compilerPluginConfiguration(
+                Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return plugin(
+                    "org.apache.maven.plugins",
+                    "maven-compiler-plugin",
+                    "3.11.0",
+                    plugin -> plugin.configuration(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder execPlugin(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return plugin("org.codehaus.mojo", "exec-maven-plugin", "3.1.0", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder execPluginExecutions(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return execPlugin(plugin -> plugin.executions(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder plugin(
+                String groupId, String artifactId, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element(
+                    "plugin", $ -> $.groupIdArtifactId(groupId, artifactId).then(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder plugin(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("plugin", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder parent(String groupId, String artifactId, String version) {
+            return parent(parent -> parent.ref(groupId, artifactId, version));
+        }
+
+        public PomXmlBuilder parent(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("parent", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder pluginManagement(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("pluginManagement", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder file(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("file", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder activation(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("activation", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder profiles(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("profiles", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder profile(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("profile", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder arguments(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("arguments", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder executions(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("executions", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder execution(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("execution", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder execIdPhaseConf(
+                String id, String phase, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return execution(
+                    ex ->
+                            ex.id(id)
+                                    .phase(phase)
+                                    .goals(gs -> gs.goal("exec"))
+                                    .configuration(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder exec(
+                String phase, String executable, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return execIdPhaseConf(
+                    executable + "-" + phase,
+                    phase,
+                    conf -> conf.executable(executable).arguments(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder cmake(
+                String id, String phase, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return execIdPhaseConf(
+                    id, phase, conf -> conf.executable("cmake").arguments(pomXmlBuilderConsumer));
+        }
+
+        public PomXmlBuilder cmake(String id, String phase, String... args) {
+            return execIdPhaseConf(
+                    id,
+                    phase,
+                    conf ->
+                            conf.executable("cmake")
+                                    .arguments(arguments -> arguments.forEach(Stream.of(args), arguments::argument)));
+        }
+
+        public PomXmlBuilder jextract(String id, String phase, String... args) {
+            return execIdPhaseConf(
+                    id,
+                    phase,
+                    conf ->
+                            conf.executable("jextract")
+                                    .arguments(arguments -> arguments.forEach(Stream.of(args), arguments::argument)));
+        }
+
+        public PomXmlBuilder ant(
+                String id, String phase, String goal, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return execution(
+                    execution ->
+                            execution
+                                    .id(id)
+                                    .phase(phase)
+                                    .goals(gs -> gs.goal(goal))
+                                    .configuration(configuration -> configuration.target(pomXmlBuilderConsumer)));
+        }
+
+        public PomXmlBuilder goals(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("goals", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder target(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("target", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder configuration(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("configuration", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder compilerArgs(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("compilerArgs", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder compilerArgs(String... args) {
+            return element("compilerArgs", $ -> $.forEach(Stream.of(args), $::arg));
+        }
+
+        public PomXmlBuilder properties(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("properties", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder dependencies(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("dependencies", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder dependsOn(String groupId, String artifactId, String version) {
+            return element("dependencies", $ -> $.dependency(groupId, artifactId, version));
+        }
+
+        public PomXmlBuilder dependency(String groupId, String artifactId, String version) {
+            return dependency($ -> $.ref(groupId, artifactId, version));
+        }
+
+        public PomXmlBuilder dependency(
+                String groupId, String artifactId, String version, String scope) {
+            return dependency($ -> $.ref(groupId, artifactId, version).scope(scope));
+        }
+
+        public PomXmlBuilder dependency(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("dependency", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder modules(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+            return element("modules", pomXmlBuilderConsumer);
+        }
+
+        public PomXmlBuilder modules(String... modules) {
+            return element("modules", $ -> $.forEach(Stream.of(modules), $::module));
+        }
+
+        public PomXmlBuilder module(String name) {
+            return element("module", $ -> $.text(name));
+        }
+
+        public PomXmlBuilder property(String name, String value) {
+            return element(name, $ -> $.text(value));
+        }
+
+        public PomXmlBuilder scope(String s) {
+            return element("scope", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder phase(String s) {
+            return element("phase", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder argument(String s) {
+            return element("argument", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder goal(String s) {
+            return element("goal", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder copy(String file, String toDir) {
+            return element("copy", $ -> $.attr("file", file).attr("toDir", toDir));
+        }
+
+        public PomXmlBuilder echo(String message) {
+            return element("echo", $ -> $.attr("message", message));
+        }
+
+        public PomXmlBuilder echo(String filename, String message) {
+            return element("echo", $ -> $.attr("message", message).attr("file", filename));
+        }
+
+        public PomXmlBuilder groupIdArtifactId(String groupId, String artifactId) {
+            return groupId(groupId).artifactId(artifactId);
+        }
+
+        public PomXmlBuilder ref(String groupId, String artifactId, String version) {
+            return groupIdArtifactId(groupId, artifactId).version(version);
+        }
+
+        public PomXmlBuilder skip(String string) {
+            return element("skip", $ -> $.text(string));
+        }
+
+        public PomXmlBuilder id(String s) {
+            return element("id", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder arg(String s) {
+            return element("arg", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder argLine(String s) {
+            return element("argLine", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder source(String s) {
+            return element("source", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder target(String s) {
+            return element("target", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder showWarnings(String s) {
+            return element("showWarnings", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder showDeprecation(String s) {
+            return element("showDeprecation", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder failOnError(String s) {
+            return element("failOnError", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder exists(String s) {
+            return element("exists", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder activeByDefault(String s) {
+            return element("activeByDefault", $ -> $.text(s));
+        }
+
+        public PomXmlBuilder executable(String s) {
+            return element("executable", $ -> $.text(s));
+        }
+    }
+
+    public static class ImlBuilder extends AbstractXMLBuilder<ImlBuilder> {
+        ImlBuilder(Element element) {
+            super(element);
+        }
+
+        public ImlBuilder element(String name, Consumer<ImlBuilder> xmlBuilderConsumer) {
+            return element(name, ImlBuilder::new, xmlBuilderConsumer);
+        }
+
+        public ImlBuilder element(URI uri, String name, Consumer<ImlBuilder> xmlBuilderConsumer) {
+            return element(uri, name, ImlBuilder::new, xmlBuilderConsumer);
+        }
+
+        public ImlBuilder modelVersion(String s) {
+            return element("modelVersion", $ -> $.text(s));
+        }
+
+        public ImlBuilder groupId(String s) {
+            return element("groupId", $ -> $.text(s));
+        }
+
+        public ImlBuilder artifactId(String s) {
+            return element("artifactId", $ -> $.text(s));
+        }
+
+        public ImlBuilder packaging(String s) {
+            return element("packaging", $ -> $.text(s));
+        }
+
+        public ImlBuilder version(String s) {
+            return element("version", $ -> $.text(s));
+        }
+
+        public ImlBuilder build(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("build", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder plugins(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("plugins", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder plugin(
+                String groupId,
+                String artifactId,
+                String version,
+                Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element(
+                    "plugin",
+                    $ ->
+                            $.groupIdArtifactIdVersion(groupId, artifactId, version).then(pomXmlBuilderConsumer));
+        }
+
+        public ImlBuilder plugin(
+                String groupId, String artifactId, Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element(
+                    "plugin", $ -> $.groupIdArtifactId(groupId, artifactId).then(pomXmlBuilderConsumer));
+        }
+
+        public ImlBuilder plugin(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("plugin", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder parent(String groupId, String artifactId, String version) {
+            return parent(parent -> parent.groupIdArtifactIdVersion(groupId, artifactId, version));
+        }
+
+        public ImlBuilder parent(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("parent", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder pluginManagement(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("pluginManagement", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder file(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("file", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder activation(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("activation", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder profiles(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("profiles", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder profile(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("profile", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder arguments(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("arguments", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder executions(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("executions", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder execution(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("execution", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder goals(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("goals", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder target(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("target", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder configuration(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("configuration", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder compilerArgs(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("compilerArgs", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder properties(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("properties", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder dependencies(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("dependencies", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder dependency(String groupId, String artifactId, String version) {
+            return dependency($ -> $.groupIdArtifactIdVersion(groupId, artifactId, version));
+        }
+
+        public ImlBuilder dependency(String groupId, String artifactId, String version, String scope) {
+            return dependency($ -> $.groupIdArtifactIdVersion(groupId, artifactId, version).scope(scope));
+        }
+
+        public ImlBuilder dependency(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("dependency", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder modules(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
+            return element("modules", pomXmlBuilderConsumer);
+        }
+
+        public ImlBuilder module(String name) {
+            return element("module", $ -> $.text(name));
+        }
+
+        public ImlBuilder property(String name, String value) {
+            return element(name, $ -> $.text(value));
+        }
+
+        public ImlBuilder scope(String s) {
+            return element("scope", $ -> $.text(s));
+        }
+
+        public ImlBuilder phase(String s) {
+            return element("phase", $ -> $.text(s));
+        }
+
+        public ImlBuilder argument(String s) {
+            return element("argument", $ -> $.text(s));
+        }
+
+        public ImlBuilder goal(String s) {
+            return element("goal", $ -> $.text(s));
+        }
+
+        public ImlBuilder copy(String file, String toDir) {
+            return element("copy", $ -> $.attr("file", file).attr("toDir", toDir));
+        }
+
+        public ImlBuilder groupIdArtifactId(String groupId, String artifactId) {
+            return groupId(groupId).artifactId(artifactId);
+        }
+
+        public ImlBuilder groupIdArtifactIdVersion(String groupId, String artifactId, String version) {
+            return groupIdArtifactId(groupId, artifactId).version(version);
+        }
+
+        public ImlBuilder skip(String string) {
+            return element("skip", $ -> $.text(string));
+        }
+
+        public ImlBuilder id(String s) {
+            return element("id", $ -> $.text(s));
+        }
+
+        public ImlBuilder arg(String s) {
+            return element("arg", $ -> $.text(s));
+        }
+
+        public ImlBuilder argLine(String s) {
+            return element("argLine", $ -> $.text(s));
+        }
+
+        public ImlBuilder source(String s) {
+            return element("source", $ -> $.text(s));
+        }
+
+        public ImlBuilder target(String s) {
+            return element("target", $ -> $.text(s));
+        }
+
+        public ImlBuilder showWarnings(String s) {
+            return element("showWarnings", $ -> $.text(s));
+        }
+
+        public ImlBuilder showDeprecation(String s) {
+            return element("showDeprecation", $ -> $.text(s));
+        }
+
+        public ImlBuilder failOnError(String s) {
+            return element("failOnError", $ -> $.text(s));
+        }
+
+        public ImlBuilder exists(String s) {
+            return element("exists", $ -> $.text(s));
+        }
+
+        public ImlBuilder activeByDefault(String s) {
+            return element("activeByDefault", $ -> $.text(s));
+        }
+
+        public ImlBuilder executable(String s) {
+            return element("executable", $ -> $.text(s));
+        }
+    }
+
+    public static class XMLBuilder extends AbstractXMLBuilder<XMLBuilder> {
+        XMLBuilder(Element element) {
+            super(element);
+        }
+
+        public XMLBuilder element(String name, Consumer<XMLBuilder> xmlBuilderConsumer) {
+            return element(name, XMLBuilder::new, xmlBuilderConsumer);
+        }
+
+        public XMLBuilder element(URI uri, String name, Consumer<XMLBuilder> xmlBuilderConsumer) {
+            return element(uri, name, XMLBuilder::new, xmlBuilderConsumer);
+        }
+    }
+
+    static XMLNode create(String nodeName, Consumer<XMLBuilder> xmlBuilderConsumer) {
+
+        try {
+            var doc =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            var element = doc.createElement(nodeName);
+            doc.appendChild(element);
+            XMLBuilder xmlBuilder = new XMLBuilder(element);
+            xmlBuilderConsumer.accept(xmlBuilder);
+            return new XMLNode(element);
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static XMLNode createIml(String commentText, Consumer<ImlBuilder> imlBuilderConsumer) {
+        try {
+            var doc =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            var uri1 = URI.create("http://maven.apache.org/POM/4.0.0");
+            var uri2 = URI.create("http://www.w3.org/2001/XMLSchema-instance");
+            var uri3 = URI.create("http://maven.apache.org/xsd/maven-4.0.0.xsd");
+            var comment = doc.createComment(commentText);
+            doc.appendChild(comment);
+            var element = doc.createElementNS(uri1.toString(), "project");
+            doc.appendChild(element);
+            element.setAttributeNS(uri2.toString(), "xsi:schemaLocation", uri1 + " " + uri3);
+            ImlBuilder imlBuilder = new ImlBuilder(element);
+            imlBuilderConsumer.accept(imlBuilder);
+            return new XMLNode(element);
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static XMLNode createPom(
+            String commentText, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
+        try {
+            var doc =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+
+            var uri1 = URI.create("http://maven.apache.org/POM/4.0.0");
+            var uri2 = URI.create("http://www.w3.org/2001/XMLSchema-instance");
+            var uri3 = URI.create("http://maven.apache.org/xsd/maven-4.0.0.xsd");
+            var comment = doc.createComment(commentText);
+            doc.appendChild(comment);
+            var element = doc.createElementNS(uri1.toString(), "project");
+            doc.appendChild(element);
+            element.setAttributeNS(uri2.toString(), "xsi:schemaLocation", uri1 + " " + uri3);
+            PomXmlBuilder pomXmlBuilder = new PomXmlBuilder(element);
+            pomXmlBuilderConsumer.accept(pomXmlBuilder);
+            return new XMLNode(element);
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static XMLNode create(URI uri, String nodeName, Consumer<XMLBuilder> xmlBuilderConsumer) {
+        try {
+            var doc =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            var element = doc.createElementNS(uri.toString(), nodeName);
+            doc.appendChild(element);
+            XMLBuilder xmlBuilder = new XMLBuilder(element);
+            xmlBuilderConsumer.accept(xmlBuilder);
+            return new XMLNode(element);
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    XMLNode(org.w3c.dom.Element element) {
+        this.element = element;
+        this.element.normalize();
+        NodeList nodeList = element.getChildNodes();
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            if (nodeList.item(i) instanceof org.w3c.dom.Element e) {
+                this.children.add(new XMLNode(e));
+            }
+        }
+        for (int i = 0; i < element.getAttributes().getLength(); i++) {
+            if (element.getAttributes().item(i) instanceof org.w3c.dom.Attr attr) {
+                this.attrMap.put(attr.getName(), attr.getValue());
+            }
+        }
+    }
+
+    public boolean hasAttr(String name) {
+        return attrMap.containsKey(name);
+    }
+
+    public String attr(String name) {
+        return attrMap.get(name);
+    }
+
+    static Document parse(InputStream is) {
+        try {
+            return javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Document parse(Path path) {
+        try {
+            return parse(Files.newInputStream(path));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    XMLNode(Path path) {
+        this(parse(path).getDocumentElement());
+    }
+
+    XMLNode(File file) {
+        this(parse(file.toPath()).getDocumentElement());
+    }
+
+    XMLNode(URL url) throws Throwable {
+        this(parse(url.openStream()).getDocumentElement());
+    }
+
+    void write(StreamResult streamResult) throws Throwable {
+        var transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+        transformer.transform(new DOMSource(element.getOwnerDocument()), streamResult);
+    }
+
+    void write(File file) {
+        try {
+            write(new StreamResult(file));
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    public void write(Bldr.XMLFile xmlFile) {
+        try {
+            write(new StreamResult(xmlFile.path().toFile()));
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    @Override
+    public String toString() {
+        var stringWriter = new StringWriter();
+        try {
+            var transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+            transformer.transform(new DOMSource(element), new StreamResult(stringWriter));
+            return stringWriter.toString();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    XPathExpression xpath(String expression) {
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        try {
+            return xpath.compile(expression);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    Node node(XPathExpression xPathExpression) {
+        try {
+            return (Node) xPathExpression.evaluate(this.element, XPathConstants.NODE);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    Optional<Node> optionalNode(XPathExpression xPathExpression) {
+        var nodes = nodes(xPathExpression).toList();
+        return switch (nodes.size()) {
+            case 0 -> Optional.empty();
+            case 1 -> Optional.of(nodes.getFirst());
+            default -> throw new IllegalStateException("Expected 0 or 1 but got more");
+        };
+    }
+
+    String str(XPathExpression xPathExpression) {
+        try {
+            return (String) xPathExpression.evaluate(this.element, XPathConstants.STRING);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    String xpathQueryString(String xpathString) {
+        try {
+            return (String) xpath(xpathString).evaluate(this.element, XPathConstants.STRING);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    NodeList nodeList(XPathExpression xPathExpression) {
+        try {
+            return (NodeList) xPathExpression.evaluate(this.element, XPathConstants.NODESET);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    Stream<Node> nodes(XPathExpression xPathExpression) {
+        var nodeList = nodeList(xPathExpression);
+        List<Node> nodes = new ArrayList<>();
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            nodes.add(nodeList.item(i));
+        }
+        return nodes.stream();
+    }
+
+    Stream<org.w3c.dom.Element> elements(XPathExpression xPathExpression) {
+        return nodes(xPathExpression)
+                .filter(n -> n instanceof org.w3c.dom.Element)
+                .map(n -> (Element) n);
+    }
+
+    Stream<XMLNode> xmlNodes(XPathExpression xPathExpression) {
+        return elements(xPathExpression).map(e -> new XMLNode(e));
     }
-    public T attr(String name, String value) {
-       // var att = element.getOwnerDocument().createAttribute(name);
-        //att.setValue(value);
-        element.setAttribute(name, value);
-       // element.appendChild(att);
-      return self();
-    }
-    public T attr(URI uri,String name, String value) {
-      // var att = element.getOwnerDocument().createAttribute(name);
-      //att.setValue(value);
-      element.setAttributeNS(uri.toString(),name, value);
-      // element.appendChild(att);
-      return self();
-    }
-    public T element(String name, Function<Element,T> factory, Consumer<T> xmlBuilderConsumer) {
-      var node = element.getOwnerDocument().createElement(name);
-      element.appendChild(node);
-      var builder = factory.apply(node);
-      xmlBuilderConsumer.accept(builder);
-      return self();
-    }
-    public T element(URI uri, String name,  Function<Element,T> factory,Consumer<T> xmlBuilderConsumer) {
-      var node = element.getOwnerDocument().createElementNS(uri.toString(), name);
-      element.appendChild(node);
-      var builder = factory.apply(node);
-      xmlBuilderConsumer.accept(builder);
-      return self();
-    }
-
-    AbstractXMLBuilder(org.w3c.dom.Element element) {this.element=element;}
-
-    public T text(String thisText) {
-      var node = element.getOwnerDocument().createTextNode(thisText);
-      element.appendChild(node);
-      return self();
-    }
-
-    public T comment(String thisComment) {
-      var node = element.getOwnerDocument().createComment(thisComment);
-      element.appendChild(node);
-      return self();
-    }
-    /*
-    public T oracleComment () {
-      return comment("""
-                        Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
-                        DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
-
-                        This code is free software; you can redistribute it and/or modify it
-                        under the terms of the GNU General Public License version 2 only, as
-                        published by the Free Software Foundation.  Oracle designates this
-                        particular file as subject to the "Classpath" exception as provided
-                        by Oracle in the LICENSE file that accompanied this code.
-
-                        This code is distributed in the hope that it will be useful, but WITHOUT
-                        ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-                        FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-                        version 2 for more details (a copy is included in the LICENSE file that
-                        accompanied this code).
-
-                        You should have received a copy of the GNU General Public License version
-                        2 along with this work; if not, write to the Free Software Foundation,
-                        Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
-
-                        Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
-                        or visit www.oracle.com if you need additional information or have any
-                        questions.
-                        """);
-    } */
-    <L> T forEach(List<L> list, BiConsumer<T,L> biConsumer){
-      list.forEach(l->biConsumer.accept(self(),l));
-      return self();
-    }
-
-    <L> T forEach(Stream<L> stream, BiConsumer<T,L> biConsumer){
-      stream.forEach(l->biConsumer.accept(self(),l));
-      return self();
-    }
-
-    <L> T forEach(Stream<L> stream, Consumer<L> consumer){
-      stream.forEach(consumer);
-      return self();
-    }
-
-    protected T then(Consumer<T> xmlBuilderConsumer) {
-      xmlBuilderConsumer.accept(self());
-      return self();
-    }
-  }
-  public static class PomXmlBuilder extends AbstractXMLBuilder<PomXmlBuilder>{
-    PomXmlBuilder(Element element) {
-      super(element);
-    }
-    public PomXmlBuilder element(String name, Consumer<PomXmlBuilder> xmlBuilderConsumer) {
-      return element(name, PomXmlBuilder::new, xmlBuilderConsumer);
-    }
-    public PomXmlBuilder element(URI uri, String name, Consumer<PomXmlBuilder> xmlBuilderConsumer) {
-      return element(uri, name, PomXmlBuilder::new, xmlBuilderConsumer);
-    }
-
-    public PomXmlBuilder modelVersion(String s) {
-      return element("modelVersion", $->$.text(s));
-    }
-
-    public PomXmlBuilder pom(String groupId, String artifactId, String version) {
-      return modelVersion("4.0.0").packaging("pom").ref(groupId, artifactId, version);
-    }
-    public PomXmlBuilder jar(String groupId, String artifactId, String version) {
-      return modelVersion("4.0.0").packaging("jar").ref(groupId, artifactId, version);
-    }
-    public PomXmlBuilder groupId(String s) {
-      return element("groupId", $->$.text(s));
-    }
-    public PomXmlBuilder artifactId(String s) {
-      return element("artifactId", $->$.text(s));
-    }
-    public PomXmlBuilder packaging(String s) {
-      return element("packaging", $->$.text(s));
-    }
-    public PomXmlBuilder version(String s) {
-      return element("version", $->$.text(s));
-    }
-    public PomXmlBuilder build(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("build", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder plugins(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("plugins", pomXmlBuilderConsumer);
-    }
-
-    public PomXmlBuilder plugin(String groupId, String artifactId, String version, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("plugin", $->$
-              .ref(groupId, artifactId, version)
-              .then(pomXmlBuilderConsumer)
-      );
-    }
-    public PomXmlBuilder antPluginExecutions(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return plugin("org.apache.maven.plugins", "maven-antrun-plugin", "1.8", plugin -> plugin
-              .executions(pomXmlBuilderConsumer)
-      );
-    }
-    public PomXmlBuilder compilerPluginConfiguration(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return plugin("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0", plugin -> plugin
-                                        .configuration(pomXmlBuilderConsumer)
-      );
-    }
-
-    public PomXmlBuilder execPlugin(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return plugin("org.codehaus.mojo", "exec-maven-plugin", "3.1.0",pomXmlBuilderConsumer);
-    }
-
-    public PomXmlBuilder execPluginExecutions(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return execPlugin(plugin->plugin.executions(pomXmlBuilderConsumer));
-    }
-
-    public PomXmlBuilder plugin(String groupId, String artifactId,  Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("plugin", $->$
-              .groupIdArtifactId(groupId, artifactId).then(pomXmlBuilderConsumer)
-      );
-    }
-    public PomXmlBuilder plugin(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("plugin", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder parent(String groupId, String artifactId, String version){
-      return parent(parent -> parent.ref(groupId, artifactId, version));
-    }
-    public PomXmlBuilder parent(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("parent", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder pluginManagement(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("pluginManagement", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder file(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("file", pomXmlBuilderConsumer);
-    }
-
-    public PomXmlBuilder activation(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("activation", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder profiles(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("profiles", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder profile(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("profile", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder arguments(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("arguments", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder executions(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("executions", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder execution(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("execution", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder execIdPhaseConf(String id, String phase, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return execution(ex -> ex
-              .id(id)
-              .phase(phase)
-              .goals(gs -> gs
-                      .goal("exec")
-              )
-              .configuration(pomXmlBuilderConsumer)
-      );
-    }
-    public PomXmlBuilder exec(String phase, String executable, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return execIdPhaseConf(executable+"-"+phase,phase,conf->conf
-              .executable(executable)
-              .arguments(pomXmlBuilderConsumer)
-      );
-    }
-    public PomXmlBuilder cmake(String id, String phase,  Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return execIdPhaseConf(id,phase,conf->conf
-              .executable("cmake")
-              .arguments(pomXmlBuilderConsumer)
-      );
-    }
-    public PomXmlBuilder cmake(String id, String phase,  String ...args) {
-      return execIdPhaseConf(id,phase,conf->conf
-              .executable("cmake")
-              .arguments(arguments->arguments
-                  .forEach(Stream.of(args), arguments::argument)
-              )
-      );
-    }
-    public PomXmlBuilder jextract(String id, String phase,  String ...args) {
-      return execIdPhaseConf(id,phase,conf->conf
-              .executable("jextract")
-              .arguments(arguments->arguments
-                      .forEach(Stream.of(args), arguments::argument)
-              )
-      );
-    }
-
-    public PomXmlBuilder ant(String id, String phase, String goal, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return execution(execution -> execution
-              .id(id)
-              .phase(phase)
-              .goals(gs -> gs.goal(goal))
-              .configuration(configuration -> configuration
-                      .target(pomXmlBuilderConsumer)
-              )
-      );
-
-
-    }
-    public PomXmlBuilder goals(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("goals", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder target(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("target", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder configuration(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("configuration", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder compilerArgs(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("compilerArgs", pomXmlBuilderConsumer);
-    }
-
-    public PomXmlBuilder compilerArgs(String ...args) {
-      return element("compilerArgs", $->$.forEach(Stream.of(args), $::arg));
-    }
-    public PomXmlBuilder properties(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("properties", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder dependencies(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("dependencies", pomXmlBuilderConsumer);
-    }
-    public PomXmlBuilder dependsOn(String groupId, String artifactId, String version) {
-      return element("dependencies", $->$.dependency(groupId, artifactId, version));
-    }
-    public    PomXmlBuilder dependency(String groupId, String artifactId, String version) {
-      return dependency($->$.ref(groupId, artifactId, version));
-    }
-    public    PomXmlBuilder dependency(String groupId, String artifactId, String version, String scope) {
-      return dependency($->$.ref(groupId, artifactId, version).scope(scope));
-    }
-    public PomXmlBuilder dependency(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("dependency", pomXmlBuilderConsumer);
-    }
-
-    public PomXmlBuilder modules(Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-      return element("modules", pomXmlBuilderConsumer);
-    }
-
-    public PomXmlBuilder modules(String ...modules) {
-       return element("modules", $->$.forEach(Stream.of(modules), $::module));
-    }
-    public PomXmlBuilder module(String name) {
-      return element("module", $->$.text(name));
-    }
-
-    public PomXmlBuilder property(String name, String value) {
-      return element(name,$->$.text(value));
-    }
-
-    public PomXmlBuilder scope(String s) {
-      return element("scope", $->$.text(s));
-    }
-    public PomXmlBuilder phase(String s) {
-      return element("phase", $->$.text(s));
-    }
-    public PomXmlBuilder argument(String s) {
-      return element("argument", $->$.text(s));
-    }
-
-    public PomXmlBuilder goal(String s) {
-      return element("goal", $->$.text(s));
-    }
-
-    public PomXmlBuilder copy(String file, String toDir) {
-      return element("copy", $->$.attr("file", file).attr("toDir", toDir));
-    }
-    public PomXmlBuilder echo(String message) {
-      return element("echo", $->$.attr("message", message));
-    }
-    public PomXmlBuilder echo(String filename, String message) {
-      return element("echo", $->$.attr("message", message).attr("file", filename));
-    }
-
-    public PomXmlBuilder groupIdArtifactId(String groupId, String artifactId) {
-      return groupId(groupId).artifactId(artifactId);
-    }
-    public PomXmlBuilder ref(String groupId, String artifactId, String version) {
-      return groupIdArtifactId(groupId,artifactId).version(version);
-    }
-
-    public PomXmlBuilder skip(String string) {
-      return element("skip", $->$.text(string));
-    }
-
-    public PomXmlBuilder id(String s) {
-      return element("id", $->$.text(s));
-    }
-
-    public PomXmlBuilder arg(String s) {
-      return element("arg", $->$.text(s));
-    }
-    public PomXmlBuilder argLine(String s) {
-      return element("argLine", $->$.text(s));
-    }
-    public PomXmlBuilder source(String s) {
-      return element("source", $->$.text(s));
-    }
-    public PomXmlBuilder target(String s) {
-      return element("target", $->$.text(s));
-    }
-    public PomXmlBuilder showWarnings(String s) {
-      return element("showWarnings", $->$.text(s));
-    }
-    public PomXmlBuilder showDeprecation(String s) {
-      return element("showDeprecation", $->$.text(s));
-    }
-    public PomXmlBuilder failOnError(String s) {
-      return element("failOnError", $->$.text(s));
-    }
-    public PomXmlBuilder exists(String s) {
-      return element("exists", $->$.text(s));
-    }
-    public PomXmlBuilder activeByDefault(String s) {
-      return element("activeByDefault", $->$.text(s));
-    }
-
-    public PomXmlBuilder executable(String s) {
-      return element("executable", $->$.text(s));
-    }
-  }
-  public static class ImlBuilder extends AbstractXMLBuilder<ImlBuilder>{
-    ImlBuilder(Element element) {
-      super(element);
-    }
-    public ImlBuilder element(String name, Consumer<ImlBuilder> xmlBuilderConsumer) {
-      return element(name, ImlBuilder::new, xmlBuilderConsumer);
-    }
-    public ImlBuilder element(URI uri, String name, Consumer<ImlBuilder> xmlBuilderConsumer) {
-      return element(uri, name, ImlBuilder::new, xmlBuilderConsumer);
-    }
-
-    public ImlBuilder modelVersion(String s) {
-      return element("modelVersion", $->$.text(s));
-    }
-    public ImlBuilder groupId(String s) {
-      return element("groupId", $->$.text(s));
-    }
-    public ImlBuilder artifactId(String s) {
-      return element("artifactId", $->$.text(s));
-    }
-    public ImlBuilder packaging(String s) {
-      return element("packaging", $->$.text(s));
-    }
-    public ImlBuilder version(String s) {
-      return element("version", $->$.text(s));
-    }
-    public ImlBuilder build(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("build", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder plugins(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("plugins", pomXmlBuilderConsumer);
-    }
-
-    public ImlBuilder plugin(String groupId, String artifactId, String version, Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("plugin", $->$
-              .groupIdArtifactIdVersion(groupId, artifactId, version).then(pomXmlBuilderConsumer)
-      );
-    }
-    public ImlBuilder plugin(String groupId, String artifactId,  Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("plugin", $->$
-              .groupIdArtifactId(groupId, artifactId).then(pomXmlBuilderConsumer)
-      );
-    }
-    public ImlBuilder plugin(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("plugin", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder parent(String groupId, String artifactId, String version){
-      return parent(parent -> parent.groupIdArtifactIdVersion(groupId, artifactId, version));
-    }
-    public ImlBuilder parent(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("parent", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder pluginManagement(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("pluginManagement", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder file(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("file", pomXmlBuilderConsumer);
-    }
-
-    public ImlBuilder activation(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("activation", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder profiles(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-       return element("profiles", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder profile(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("profile", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder arguments(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("arguments", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder executions(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("executions", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder execution(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("execution", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder goals(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("goals", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder target(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("target", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder configuration(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("configuration", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder compilerArgs(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("compilerArgs", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder properties(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("properties", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder dependencies(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("dependencies", pomXmlBuilderConsumer);
-    }
-    public    ImlBuilder dependency(String groupId, String artifactId, String version) {
-      return dependency($->$.groupIdArtifactIdVersion(groupId, artifactId, version));
-    }
-    public    ImlBuilder dependency(String groupId, String artifactId, String version, String scope) {
-      return dependency($->$.groupIdArtifactIdVersion(groupId, artifactId, version).scope(scope));
-    }
-    public ImlBuilder dependency(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("dependency", pomXmlBuilderConsumer);
-    }
-
-    public ImlBuilder modules(Consumer<ImlBuilder> pomXmlBuilderConsumer) {
-      return element("modules", pomXmlBuilderConsumer);
-    }
-    public ImlBuilder module(String name) {
-      return element("module", $->$.text(name));
-    }
-
-    public ImlBuilder property(String name, String value) {
-      return element(name,$->$.text(value));
-    }
-
-    public ImlBuilder scope(String s) {
-      return element("scope", $->$.text(s));
-    }
-    public ImlBuilder phase(String s) {
-      return element("phase", $->$.text(s));
-    }
-    public ImlBuilder argument(String s) {
-      return element("argument", $->$.text(s));
-    }
-
-    public ImlBuilder goal(String s) {
-      return element("goal", $->$.text(s));
-    }
-
-    public ImlBuilder copy(String file, String toDir) {
-      return element("copy", $->$.attr("file", file).attr("toDir", toDir));
-    }
-
-    public ImlBuilder groupIdArtifactId(String groupId, String artifactId) {
-        return groupId(groupId).artifactId(artifactId);
-    }
-    public ImlBuilder groupIdArtifactIdVersion(String groupId, String artifactId, String version) {
-      return groupIdArtifactId(groupId,artifactId).version(version);
-    }
-
-    public ImlBuilder skip(String string) {
-      return element("skip", $->$.text(string));
-    }
-
-    public ImlBuilder id(String s) {
-      return element("id", $->$.text(s));
-    }
-
-    public ImlBuilder arg(String s) {
-      return element("arg", $->$.text(s));
-    }
-    public ImlBuilder argLine(String s) {
-      return element("argLine", $->$.text(s));
-    }
-    public ImlBuilder source(String s) {
-      return element("source", $->$.text(s));
-    }
-    public ImlBuilder target(String s) {
-      return element("target", $->$.text(s));
-    }
-    public ImlBuilder showWarnings(String s) {
-      return element("showWarnings", $->$.text(s));
-    }
-    public ImlBuilder showDeprecation(String s) {
-      return element("showDeprecation", $->$.text(s));
-    }
-    public ImlBuilder failOnError(String s) {
-      return element("failOnError", $->$.text(s));
-    }
-    public ImlBuilder exists(String s) {
-      return element("exists", $->$.text(s));
-    }
-    public ImlBuilder activeByDefault(String s) {
-      return element("activeByDefault", $->$.text(s));
-    }
-
-    public ImlBuilder executable(String s) {
-      return element("executable", $->$.text(s));
-    }
-  }
-  public static class XMLBuilder extends AbstractXMLBuilder<XMLBuilder>{
-
-    XMLBuilder(Element element) {
-      super(element);
-    }
-    public XMLBuilder element(String name, Consumer<XMLBuilder> xmlBuilderConsumer) {
-      return element(name, XMLBuilder::new, xmlBuilderConsumer);
-    }
-    public XMLBuilder element(URI uri, String name, Consumer<XMLBuilder> xmlBuilderConsumer) {
-      return element(uri, name, XMLBuilder::new, xmlBuilderConsumer);
-    }
-  }
-  static XMLNode create( String nodeName, Consumer<XMLBuilder> xmlBuilderConsumer) {
-
-      try {
-          var doc  = javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-          //var nl = doc.createTextNode("\n");
-          //doc.appendChild(nl);
-          var element = doc.createElement(nodeName);
-          doc.appendChild(element);
-        XMLBuilder xmlBuilder = new XMLBuilder(element);
-        xmlBuilderConsumer.accept(xmlBuilder);
-        return new XMLNode(element);
-      } catch (ParserConfigurationException e) {
-          throw new RuntimeException(e);
-      }
-
-
-
-    }
-  static XMLNode createIml(String commentText, Consumer<ImlBuilder> imlBuilderConsumer) {
-    try {
-      var doc  = javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-
-      var uri1 = URI.create("http://maven.apache.org/POM/4.0.0");
-      var uri2 = URI.create("http://www.w3.org/2001/XMLSchema-instance");
-      var uri3 = URI.create("http://maven.apache.org/xsd/maven-4.0.0.xsd");
-      var comment = doc.createComment(commentText);
-      doc.appendChild(comment);
-      //   var nl = doc.createTextNode("\n");
-      //   doc.appendChild(nl);
-      var element = doc.createElementNS(uri1.toString(),"project");
-      doc.appendChild(element);
-      element.setAttributeNS(uri2.toString(), "xsi:schemaLocation",uri1+" "+ uri3);
-      ImlBuilder imlBuilder = new ImlBuilder(element);
-      imlBuilderConsumer.accept(imlBuilder);
-      return new XMLNode(element);
-    } catch (ParserConfigurationException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static XMLNode createPom(String commentText, Consumer<PomXmlBuilder> pomXmlBuilderConsumer) {
-    try {
-      var doc  = javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-
-      var uri1 = URI.create("http://maven.apache.org/POM/4.0.0");
-      var uri2 = URI.create("http://www.w3.org/2001/XMLSchema-instance");
-      var uri3 = URI.create("http://maven.apache.org/xsd/maven-4.0.0.xsd");
-      var comment = doc.createComment(commentText);
-      doc.appendChild(comment);
-   //   var nl = doc.createTextNode("\n");
-   //   doc.appendChild(nl);
-      var element = doc.createElementNS(uri1.toString(),"project");
-      doc.appendChild(element);
-      element.setAttributeNS(uri2.toString(), "xsi:schemaLocation",uri1+" "+ uri3);
-      PomXmlBuilder pomXmlBuilder = new PomXmlBuilder(element);
-      pomXmlBuilderConsumer.accept(pomXmlBuilder);
-      return new XMLNode(element);
-    } catch (ParserConfigurationException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  static XMLNode create(URI uri, String nodeName, Consumer<XMLBuilder> xmlBuilderConsumer) {
-
-    try {
-      var doc  = javax.xml.parsers.DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-      //var nl = doc.createTextNode("\n");
-      //doc.appendChild(nl);
-      var element = doc.createElementNS(uri.toString(),nodeName);
-      doc.appendChild(element);
-      XMLBuilder xmlBuilder = new XMLBuilder(element);
-      xmlBuilderConsumer.accept(xmlBuilder);
-      return new XMLNode(element);
-    } catch (ParserConfigurationException e) {
-      throw new RuntimeException(e);
-    }
-
-
-
-  }
-
-
-  XMLNode(org.w3c.dom.Element element) {
-    this.element = element;
-    this.element.normalize();
-    NodeList nodeList = element.getChildNodes();
-    for (int i = 0; i < nodeList.getLength(); i++) {
-      if (nodeList.item(i) instanceof org.w3c.dom.Element e) {
-        this.children.add(new XMLNode(e));
-      }
-    }
-    for (int i = 0; i < element.getAttributes().getLength(); i++) {
-      if (element.getAttributes().item(i) instanceof org.w3c.dom.Attr attr) {
-        this.attrMap.put(attr.getName(), attr.getValue());
-      }
-    }
-  }
-
-  public boolean hasAttr(String name) {
-    return attrMap.containsKey(name);
-  }
-
-  public String attr(String name) {
-    return attrMap.get(name);
-  }
-
-  static Document parse(InputStream is) {
-    try {
-      return javax.xml.parsers.DocumentBuilderFactory.newInstance()
-              .newDocumentBuilder()
-              .parse(is);
-    }catch (ParserConfigurationException | SAXException | IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  static Document parse(Path path) {
-      try {
-          return parse(Files.newInputStream(path));
-      } catch (IOException e) {
-          throw new RuntimeException(e);
-      }
-  }
-
-
-  XMLNode(Path path) {
-    this(parse(path).getDocumentElement());
-  }
-
-  XMLNode(File file)  {
-    this(parse(file.toPath()).getDocumentElement());
-  }
-
-  XMLNode(URL url) throws Throwable {
-    this(parse(url.openStream()).getDocumentElement());
-  }
-
-  void write(StreamResult streamResult) throws Throwable {
-    var transformer = TransformerFactory.newInstance().newTransformer();
-    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-    transformer.setOutputProperty(OutputKeys.METHOD, "xml");
-    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
-    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
-  //  transformer.setOutputProperty("http://www.oracle.com/xml/is-standalone", "yes");
-    transformer.transform(new DOMSource(element.getOwnerDocument()), streamResult);
-  }
-
-  void write(File file) {
-    try {
-      write(new StreamResult(file));
-    }catch (Throwable t){
-      throw new RuntimeException(t);
-    }
-  }
-  public void write(Bldr.XMLFile xmlFile) {
-    try {
-      write(new StreamResult(xmlFile.path().toFile()));
-    }catch (Throwable t){
-      throw new RuntimeException(t);
-    }
-  }
-
-  @Override
-  public String toString() {
-    var stringWriter = new StringWriter();
-    try {
-      var transformer = TransformerFactory.newInstance().newTransformer();
-      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-      transformer.setOutputProperty(OutputKeys.METHOD, "xml");
-      transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
-      transformer.transform(new DOMSource(element), new StreamResult(stringWriter));
-      return stringWriter.toString();
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  XPathExpression xpath(String expression) {
-    XPath xpath = XPathFactory.newInstance().newXPath();
-    try {
-      return xpath.compile(expression);
-    } catch (XPathExpressionException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  Node node(XPathExpression xPathExpression) {
-    try {
-      return (Node) xPathExpression.evaluate(this.element, XPathConstants.NODE);
-    } catch (XPathExpressionException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  Optional<Node> optionalNode(XPathExpression xPathExpression) {
-    var nodes = nodes(xPathExpression).toList();
-    return switch (nodes.size()) {
-      case 0 -> Optional.empty();
-      case 1 -> Optional.of(nodes.getFirst());
-      default -> throw new IllegalStateException("Expected 0 or 1 but got more");
-    };
-  }
-
-  String str(XPathExpression xPathExpression) {
-    try {
-      return (String) xPathExpression.evaluate(this.element, XPathConstants.STRING);
-    } catch (XPathExpressionException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  String xpathQueryString(String xpathString) {
-    try {
-      return (String) xpath(xpathString).evaluate(this.element, XPathConstants.STRING);
-    } catch (XPathExpressionException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  NodeList nodeList(XPathExpression xPathExpression) {
-    try {
-      return (NodeList) xPathExpression.evaluate(this.element, XPathConstants.NODESET);
-    } catch (XPathExpressionException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  Stream<Node> nodes(XPathExpression xPathExpression) {
-    var nodeList = nodeList(xPathExpression);
-    List<Node> nodes = new ArrayList<>();
-    for (int i = 0; i < nodeList.getLength(); i++) {
-      nodes.add(nodeList.item(i));
-    }
-    return nodes.stream();
-  }
-
-  Stream<org.w3c.dom.Element> elements(XPathExpression xPathExpression) {
-    return nodes(xPathExpression)
-        .filter(n -> n instanceof org.w3c.dom.Element)
-        .map(n -> (Element) n);
-  }
-
-  Stream<XMLNode> xmlNodes(XPathExpression xPathExpression) {
-    return elements(xPathExpression).map(e -> new XMLNode(e));
-  }
 }

--- a/hat/clean
+++ b/hat/clean
@@ -28,9 +28,6 @@ import static bldr.Bldr.*;
 
 void main(String[] args) {
  var hatDir = Dir.current();
- var buildDir = hatDir.buildDir("build").remove();
- hatDir.findDirs(path->path.getFileName().endsWith("target"))
-       .map(path->BuildDir.of(path))
-       .peek(dir->println("removing " +dir.path()))
-       .forEach(dir->dir.remove());
+ hatDir.buildDir("build").remove();
+ hatDir.buildDir("stage").remove();
 }


### PR DESCRIPTION
As we move towards creating a jextracted opencl and cuda backends we need bld changes to support using jextract.

This is step one in that process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/287/head:pull/287` \
`$ git checkout pull/287`

Update a local copy of the PR: \
`$ git checkout pull/287` \
`$ git pull https://git.openjdk.org/babylon.git pull/287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 287`

View PR using the GUI difftool: \
`$ git pr show -t 287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/287.diff">https://git.openjdk.org/babylon/pull/287.diff</a>

</details>
