### PR TITLE
Integrate HIP backend to bldr infrastructure.

### DIFF
--- a/hat/backends/hip/src/main/java/hat/backend/HIPHatKernelBuilder.java
+++ b/hat/backends/hip/src/main/java/hat/backend/HIPHatKernelBuilder.java
@@ -4,8 +4,8 @@ import hat.backend.c99codebuilders.C99HatBuildContext;
 import hat.backend.c99codebuilders.C99HatKernelBuilder;
 import hat.optools.OpWrapper;
 
-import java.lang.reflect.code.Op;
-import java.lang.reflect.code.type.JavaType;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.type.JavaType;
 
 public class HIPHatKernelBuilder extends C99HatKernelBuilder<HIPHatKernelBuilder> {
 

--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -45,6 +45,7 @@ You should have received a copy of the GNU General Public License version
         <module>cuda</module>
         <module>mock</module>
         <module>opencl</module>
+        <module>hip</module>
     </modules>
     <build>
         <plugins>

--- a/hat/bld
+++ b/hat/bld
@@ -87,7 +87,9 @@ void main(String[] args) {
     var hip = Capabilities.HIP.of();
     var capabilities= Capabilities.of(opencl, opengl, cuda, hip);
     var cmakeProbe = new CMakeProbe(buildDir, capabilities);
-    if (opencl.available()) {
+
+    if (opencl.available() && !hip.available()) {
+        System.out.println("OPENCL FOUND");
         if (extractedOpenCLJar.exists()) {
             println("We've already extracted and jarred" + extractedOpenCLJar.path());
         } else {
@@ -116,7 +118,7 @@ void main(String[] args) {
         println("According to cmake probe this platform does not have OpenCL");
     }
 
-    if (opengl.available()) {
+    if (opengl.available() && !hip.available()) {
         if (extractedOpenGLJar.exists()) {
             println("We've already extracted and jarred" + extractedOpenGLJar.path());
         } else {
@@ -150,6 +152,11 @@ void main(String[] args) {
         println("According to cmake probe this platform does not have CUDA");
     }
 
+    if (hip.available()) {
+    } else {
+        println("According to cmake probe this platform does not have HIP");
+    }
+
     var hatOpts = JavaOpts.of()
             .enable_preview()
             .add_modules("jdk.incubator.code")
@@ -163,7 +170,7 @@ void main(String[] args) {
 
     // Here we create all backend jars.
     backendsDir
-            .subDirs(backendDir -> !backendDir.matches("^.*(spirv|hip|shared|target|.idea)$"))
+            .subDirs(backendDir -> !backendDir.matches("^.*(spirv|shared|target|.idea)$"))
             .peek(backendDir->println("Building backend " + backendDir.fileName()))
             .forEach(backendDir->
                  buildDir.jarFile("hat-backend-" + backendDir.fileName() + "-1.0.jar",$->$.verbose(verbose)

--- a/hat/bldr/Capabilities.java
+++ b/hat/bldr/Capabilities.java
@@ -88,6 +88,8 @@ public class Capabilities {
     }
 
     public static class HIP extends CMakeCapability {
+        public static String hipDirKey = "CMAKE_HIP_DIR";
+        public static String hipDirNotFoundValue = "CMAKE_HIP_DIR-NOTFOUND";
         public HIP() {
             super("HIP");
         }
@@ -96,7 +98,7 @@ public class Capabilities {
         }
         @Override
         public boolean available() {
-            return false;
+            return cmakeProbe.hasKey(hipDirKey) && !cmakeProbe.value(hipDirKey).equals(hipDirNotFoundValue);
         }
     }
     public static class CUDA extends CMakeCapability {

--- a/hat/docs/hat-01-03-building-hat.md
+++ b/hat/docs/hat-01-03-building-hat.md
@@ -123,7 +123,7 @@ ${JAVA_HOME}/bin/java \
 ```
 
 The `hatrun` script can also be used which simply needs the backend
-name `opencl|java|cuda|ptx|mock` and the package name `mandel`
+name `opencl|java|cuda|ptx|hip|mock` and the package name `mandel`
 
 ```bash
 java @bldr/args hatrun opencl mandel

--- a/hat/hatrun
+++ b/hat/hatrun
@@ -32,7 +32,7 @@ void main(String[] args) {
     usage:
       java @bldr/args hatrun [headless] backend package args ...
          [headless] : Optional passes -Dheadless=true to app
-          backend   : opencl|cuda|spirv|ptx|mock
+          backend   : opencl|cuda|spirv|ptx|hip|mock
           package   : the examples package (and dirname under hat/examples)
 
       class name is assumed to be package.Main  (i.e. mandel.main) 


### PR DESCRIPTION
jextract fails in the presence of HIP on OpenCL/OpenGL - disable those for now if HIP is present.

While there, catch up to the reflection include change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/296/head:pull/296` \
`$ git checkout pull/296`

Update a local copy of the PR: \
`$ git checkout pull/296` \
`$ git pull https://git.openjdk.org/babylon.git pull/296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 296`

View PR using the GUI difftool: \
`$ git pr show -t 296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/296.diff">https://git.openjdk.org/babylon/pull/296.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/296#issuecomment-2539721727)
</details>
