### PR TITLE
Support for Generalized Buffer Type in Hat SPIR-V Backend

### DIFF
--- a/hat/backends/spirv/src/main/java/intel/code/spirv/LevelZero.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/LevelZero.java
@@ -166,7 +166,7 @@ public class LevelZero {
         CoreOp.FuncOp funcOp = kernelEntrypoint.funcOpWrapper().op();
         String kernelName = funcOp.funcName();
         // System.out.println(funcOp.toText());
-        MemorySegment spirvBinary = SpirvModuleGenerator.generateModule(kernelName, kernelCallGraph);
+        MemorySegment spirvBinary = SpirvModuleGenerator.generateModule(kernelName, kernelCallGraph, args);
         String path = "/tmp/" + kernelName + ".spv";
         SpirvModuleGenerator.writeModuleToFile(spirvBinary, path);
         // System.out.println("generated module \n" + SpirvModuleGenerator.disassembleModule(spirvBinary));

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvModuleGenerator.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvModuleGenerator.java
@@ -289,7 +289,7 @@ public class SpirvModuleGenerator {
                         } else if (field instanceof Schema.FieldNode.AbstractIfaceField ifaceField) {
                             if (ifaceField instanceof Schema.FieldNode.IfaceArray array) {
                                 int arrayLen;
-                                if (array instanceof Schema.FieldNode.IfaceFieldControlledArray fieldControlledArray) {          
+                                if (array instanceof Schema.FieldNode.IfaceFieldControlledArray fieldControlledArray) {
                                     int[] len = new int[]{0};
                                     if (isLast && t.parent == null) {
                                         len[0] = 1;
@@ -803,7 +803,7 @@ public class SpirvModuleGenerator {
                                     accessReturnType = spirvVariableType(spirvType(returnTypeName));
                                 } else {
                                     accessReturnType = spirvType(returnTypeName);
-                                }    
+                                }
                                 String typeName = call.operands().get(0).type().toString().replaceAll("\\$", ".");
                                 SPIRVId returnType = spirvType(fnType.returnType().toString());
                                 SPIRVId accessResult = nextId();
@@ -838,7 +838,7 @@ public class SpirvModuleGenerator {
                                     // only support atomic increment for now
                                     spirvBlock.add(new SPIRVOpAtomicIIncrement(returnType, result, accessResult, getConst("int", 0), getConst("int", 0x8)));
                                     addResult(call.result(), new SpirvResult(returnType, null, result));
-                                } else if (isPrimitiveType(fnType.returnType().toString())) {    
+                                } else if (isPrimitiveType(fnType.returnType().toString())) {
                                     spirvBlock.add(new SPIRVOpLoad(returnType, result, accessResult, align(returnType.getName())));
                                     addResult(call.result(), new SpirvResult(returnType, null, result));
                                 } else if (setter) {

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvOp.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/SpirvOp.java
@@ -282,6 +282,23 @@ public abstract class SpirvOp extends ExternalizableOp {
         }
     }
 
+    public static final class CastOp extends SpirvOp {
+        public static final String OPNAME = NAME_PREFIX + "cast";
+
+        public CastOp(TypeElement resultType, List<Value> operands) {
+                super(OPNAME, resultType, operands);
+        }
+
+        public CastOp(CastOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public CastOp transform(CopyContext cc, OpTransformer ot) {
+            return new CastOp(this, cc);
+        }
+    }
+
     public static final class BitwiseAndOp extends SpirvOp {
         public static final String NAME = NAME_PREFIX + "and";
 
@@ -624,6 +641,23 @@ public abstract class SpirvOp extends ExternalizableOp {
         }
     }
 
+    public static final class AshrOp extends SpirvOp {
+        public static final String NAME = NAME_PREFIX + "ashr";
+
+        public AshrOp(TypeElement resultType, List<Value> operands) {
+                super(NAME, resultType, operands);
+        }
+
+        public AshrOp(AshrOp that, CopyContext cc) {
+            super(that, cc);
+        }
+
+        @Override
+        public AshrOp transform(CopyContext cc, OpTransformer ot) {
+            return new AshrOp(this, cc);
+        }
+    }
+    // TODO: add more
     public static final class BranchOp extends SpirvOp implements Op.BlockTerminating {
         public static final String NAME = NAME_PREFIX + "br";
         private final Block.Reference successor;

--- a/hat/backends/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
+++ b/hat/backends/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
@@ -165,6 +165,8 @@ public class TranslateToSpirvModel  {
             for (Op op : block.ops()) {
                 switch (op) {
                     case CoreOp.VarOp vop -> {
+                        if (vop.operands().size() == 0)
+                            continue;
                         Value dest = valueMap.get(vop.result());
                         Value value = valueMap.get(vop.operands().get(0));
                         // init variable here; declaration has been moved to top of function
@@ -221,7 +223,7 @@ public class TranslateToSpirvModel  {
                         SpirvOp saop = new SpirvOp.BitwiseAndOp(type, operands);
                         spirvBlock.op(saop);
                         valueMap.put(andop.result(), saop.result());
-                     }
+                    }
                     case CoreOp.AddOp aop -> {
                         TypeElement type = aop.operands().get(0).type();
                         List<Value> operands = mapOperands(aop);
@@ -231,7 +233,7 @@ public class TranslateToSpirvModel  {
                         else throw unsupported("type", type);
                         spirvBlock.op(addOp);
                         valueMap.put(aop.result(), addOp.result());
-                     }
+                    }
                     case CoreOp.SubOp sop -> {
                         TypeElement  type = sop.operands().get(0).type();
                         List<Value> operands = mapOperands(sop);
@@ -241,7 +243,7 @@ public class TranslateToSpirvModel  {
                         else throw unsupported("type", type);
                         spirvBlock.op(subOp);
                         valueMap.put(sop.result(), subOp.result());
-                     }
+                    }
                     case CoreOp.MulOp mop -> {
                         TypeElement type = mop.operands().get(0).type();
                         List<Value> operands = mapOperands(mop);
@@ -310,7 +312,7 @@ public class TranslateToSpirvModel  {
                     case CoreOp.GtOp gtop -> {
                         TypeElement type = gtop.operands().get(0).type();
                         List<Value> operands = mapOperands(gtop);
-                        SpirvOp sgtop = new SpirvOp.LtOp(type, operands);
+                        SpirvOp sgtop = new SpirvOp.GtOp(type, operands);
                         spirvBlock.op(sgtop);
                         valueMap.put(gtop.result(), sgtop.result());
                     }
@@ -320,6 +322,13 @@ public class TranslateToSpirvModel  {
                         SpirvOp sgeop = new SpirvOp.GeOp(type, operands);
                         spirvBlock.op(sgeop);
                         valueMap.put(geop.result(), sgeop.result());
+                    }
+                    case CoreOp.AshrOp asop -> {
+                        TypeElement type = asop.operands().get(0).type();
+                        List<Value> operands = mapOperands(asop);
+                        SpirvOp sasop = new SpirvOp.AshrOp(type, operands);
+                        spirvBlock.op(sasop);
+                        valueMap.put(asop.result(), sasop.result());
                     }
                     case CoreOp.InvokeOp inv -> {
                         List<Value> operands = mapOperands(inv);
@@ -335,6 +344,12 @@ public class TranslateToSpirvModel  {
                     case CoreOp.ConvOp cop -> {
                         List<Value> operands = mapOperands(cop);
                         SpirvOp scop = new SpirvOp.ConvertOp(cop.resultType(), operands);
+                        spirvBlock.op(scop);
+                        valueMap.put(cop.result(), scop.result());
+                    }
+                    case CoreOp.CastOp cop -> {
+                        List<Value> operands = mapOperands(cop);
+                        SpirvOp scop = new SpirvOp.CastOp(cop.resultType(), operands);
                         spirvBlock.op(scop);
                         valueMap.put(cop.result(), scop.result());
                     }

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
@@ -184,6 +184,7 @@ public class ViolaJonesCoreCompute {
             int x,
             int y,
             float vnorm,
+            float threshold,
             F32Array2D integral,
             Cascade.Stage stage,
             Cascade cascade
@@ -227,7 +228,7 @@ public class ViolaJonesCoreCompute {
                 }
             }
         }
-        return sumOfThisStage > stage.threshold(); // true if this looks like a face
+        return sumOfThisStage > threshold; // true if this looks like a face
     }
 
     @CodeReflection
@@ -286,7 +287,7 @@ public class ViolaJonesCoreCompute {
                 Cascade.Stage stage = cascade.stage(stagec);
               //  Class stageClass = stage.getClass();
                // long stageOffset = stage.offset();
-                stillLooksLikeAFace = isAFaceStage(kc.x, scale.scaleValue(), scale.invArea(), x, y, vnorm, integral, stage, cascade);
+                stillLooksLikeAFace = isAFaceStage(kc.x, scale.scaleValue(), scale.invArea(), x, y, vnorm, stage.threshold(), integral, stage, cascade);
             }
 
             if (stillLooksLikeAFace) {


### PR DESCRIPTION
This PR introduces support for generalized buffer by creating SPIRV type structure and arrays in the generated module. Most of the implementation references the OpenCL Hat builder. The SPIR-V module assumes the same memory layout as the java buffer object, provided there is not additional customized padding between fields. Also, generated dependent functions from callgraph instead of using code model to resolve the issue where private functions can't be accessed.

The blackscholes, mandel, and violajones examples now run successfully. However, the violajones example still gets wrong value when accessing `threshold` from `stage` inside `isAFaceStage` function, so I currently update the condition to `sumOfThisStage > threshold`.

For machines that don't have `float64` capability, enable `FP64` emulation by setting the environment variable: `OverrideDefaultFP64Settings=1` and `IGC_EnableDPEmulation=1` before running. For more details: https://github.com/intel/compute-runtime/blob/master/opencl/doc/FAQ.md#feature-double-precision-emulation-fp64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/298/head:pull/298` \
`$ git checkout pull/298`

Update a local copy of the PR: \
`$ git checkout pull/298` \
`$ git pull https://git.openjdk.org/babylon.git pull/298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 298`

View PR using the GUI difftool: \
`$ git pr show -t 298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/298.diff">https://git.openjdk.org/babylon/pull/298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/298#issuecomment-2546978570)
</details>
