### PR TITLE
Replace opField with opMethod for lambdas.

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -69,10 +69,9 @@ import static sun.invoke.util.Wrapper.isWrapperType;
     final boolean isSerializable;             // Should the returned instance be serializable
     final Class<?>[] altInterfaces;           // Additional interfaces to be implemented
     final MethodType[] altMethods;            // Signatures of additional methods to bridge
-    final MethodHandle quotableOpField;       // A getter method handle that is used to retrieve the
-                                              // string representation of the quotable lambda's associated
-                                              // intermediate representation (can be null).
-    final MethodHandleInfo quotableOpFieldInfo;  // Info about the quotable getter method handle (can be null).
+    final MethodHandle quotableOpGetter;       // A getter method handle that is used to retrieve the
+                                              // the quotable lambda's associated intermediate representation (can be null).
+    final MethodHandleInfo quotableOpGetterInfo;  // Info about the quotable getter method handle (can be null).
 
     /**
      * Meta-factory constructor.
@@ -187,7 +186,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
         this.isSerializable = isSerializable;
         this.altInterfaces = altInterfaces;
         this.altMethods = altMethods;
-        this.quotableOpField = reflectiveField;
+        this.quotableOpGetter = reflectiveField;
 
         if (interfaceMethodName.isEmpty() ||
                 interfaceMethodName.indexOf('.') >= 0 ||
@@ -217,16 +216,15 @@ import static sun.invoke.util.Wrapper.isWrapperType;
 
         if (reflectiveField != null) {
             try {
-                quotableOpFieldInfo = caller.revealDirect(reflectiveField); // may throw SecurityException
+                quotableOpGetterInfo = caller.revealDirect(reflectiveField); // may throw SecurityException
             } catch (IllegalArgumentException e) {
                 throw new LambdaConversionException(implementation + " is not direct or cannot be cracked");
             }
-            if (quotableOpFieldInfo.getReferenceKind() != REF_getField &&
-                    quotableOpFieldInfo.getReferenceKind() != REF_getStatic) {
-                throw new LambdaConversionException(String.format("Unsupported MethodHandle kind: %s", quotableOpFieldInfo));
+            if (quotableOpGetterInfo.getReferenceKind() != REF_invokeStatic) {
+                throw new LambdaConversionException(String.format("Unsupported MethodHandle kind: %s", quotableOpGetterInfo));
             }
         } else {
-            quotableOpFieldInfo = null;
+            quotableOpGetterInfo = null;
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -472,7 +472,7 @@ import sun.invoke.util.Wrapper;
             cob.aastore();
         }
 
-        // now create a Quoted from FuncOp and captured args Object[]
+        // Create a Quoted from FuncOp and captured args Object[]
 
         cob.invokevirtual(CD_MethodHandle, "invokeExact", methodDesc(CodeReflectionSupport.HANDLE_MAKE_QUOTED.type()))
            .putfield(lambdaClassEntry.asSymbol(), quotedInstanceFieldName, CodeReflectionSupport.CD_Quoted);

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -472,7 +472,7 @@ import sun.invoke.util.Wrapper;
             cob.aastore();
         }
 
-        // now create a Quoted from String and captured args Object[]
+        // now create a Quoted from FuncOp and captured args Object[]
 
         cob.invokevirtual(CD_MethodHandle, "invokeExact", methodDesc(CodeReflectionSupport.HANDLE_MAKE_QUOTED.type()))
            .putfield(lambdaClassEntry.asSymbol(), quotedInstanceFieldName, CodeReflectionSupport.CD_Quoted);

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -486,14 +486,11 @@ import sun.invoke.util.Wrapper;
         static {
             try {
                 ModuleLayer layer = codeLayer();
-                QUOTED_CLASS = layer.findLoader("jdk.incubator.code")
-                        .loadClass("jdk.incubator.code.Quoted");
-                QUOTABLE_CLASS = layer.findLoader("jdk.incubator.code")
-                        .loadClass("jdk.incubator.code.Quotable");
-                Class<?> quotedHelper = layer.findLoader("jdk.incubator.code")
-                        .loadClass("jdk.incubator.code.internal.QuotedHelper");
-                Class<?> funcOp = layer.findLoader("jdk.incubator.code")
-                        .loadClass("jdk.incubator.code.op.CoreOp$FuncOp");
+                ClassLoader cl = layer.findLoader("jdk.incubator.code");
+                QUOTED_CLASS = cl.loadClass("jdk.incubator.code.Quoted");
+                QUOTABLE_CLASS = cl.loadClass("jdk.incubator.code.Quotable");
+                Class<?> quotedHelper = cl.loadClass("jdk.incubator.code.internal.QuotedHelper");
+                Class<?> funcOp = cl.loadClass("jdk.incubator.code.op.CoreOp$FuncOp");
                 MethodHandle makeQuoted = Lookup.IMPL_LOOKUP.findStatic(quotedHelper, "makeQuoted",
                         MethodType.methodType(QUOTED_CLASS, MethodHandles.Lookup.class, funcOp, Object[].class));
                 HANDLE_MAKE_QUOTED = makeQuoted.bindTo(Lookup.IMPL_LOOKUP);

--- a/src/java.base/share/classes/java/lang/invoke/LambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaMetafactory.java
@@ -500,7 +500,8 @@ public final class LambdaMetafactory {
         int flags = extractArg(args, argIndex++, Integer.class);
         Class<?>[] altInterfaces = EMPTY_CLASS_ARRAY;
         MethodType[] altMethods = EMPTY_MT_ARRAY;
-        MethodHandle quotableField = null;
+        // Getter that returns the op of a Quotable instance
+        MethodHandle quotableOpGetter = null;
         if ((flags & FLAG_MARKERS) != 0) {
             int altInterfaceCount = extractArg(args, argIndex++, Integer.class);
             if (altInterfaceCount < 0) {
@@ -522,7 +523,7 @@ public final class LambdaMetafactory {
             }
         }
         if ((flags & FLAG_QUOTABLE) != 0) {
-            quotableField = extractArg(args, argIndex++, MethodHandle.class);
+            quotableOpGetter = extractArg(args, argIndex++, MethodHandle.class);
             altInterfaces = Arrays.copyOf(altInterfaces, altInterfaces.length + 1);
             altInterfaces[altInterfaces.length-1] = InnerClassLambdaMetafactory.CodeReflectionSupport.QUOTABLE_CLASS;
         }
@@ -551,7 +552,7 @@ public final class LambdaMetafactory {
                                                   isSerializable,
                                                   altInterfaces,
                                                   altMethods,
-                                                  quotableField);
+                                                  quotableOpGetter);
         mf.validateMetafactoryArgs();
         return mf.buildCallSite();
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -879,8 +879,8 @@ public class LambdaToMethod extends TreeTranslator {
                 }
             }
             if (isQuotable) {
-                VarSymbol reflectField = (VarSymbol)tree.codeModel;
-                staticArgs = staticArgs.append(reflectField.asMethodHandle(true));
+                MethodSymbol opMethodSym = (MethodSymbol)tree.codeModel;
+                staticArgs = staticArgs.append(opMethodSym.asHandle());
             }
             if (isSerializable) {
                 int prevPos = make.pos;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -879,7 +879,7 @@ public class LambdaToMethod extends TreeTranslator {
                 }
             }
             if (isQuotable) {
-                MethodSymbol opMethodSym = (MethodSymbol)tree.codeModel;
+                MethodSymbol opMethodSym = tree.codeModel;
                 staticArgs = staticArgs.append(opMethodSym.asHandle());
             }
             if (isSerializable) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -811,7 +811,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         /** The owner of this functional expression. */
         public Symbol owner;
         /** code reflection specific metadata. */
-        public Symbol codeModel;
+        public MethodSymbol codeModel;
 
         public Type getDescriptorType(Types types) {
             if (target == null) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -494,7 +494,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
                 case '.', ';', '[', '/': sig[i] = '$';
             }
         }
-        String opMethodName = "method$op$" + new String(sig);
+        String opMethodName = "op$" + new String(sig);
         Method opMethod;
         try {
             // @@@ Use method handle with full power mode

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -54,6 +54,7 @@ import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.op.CoreOp.*;
+import jdk.incubator.code.parser.OpParser;
 import jdk.incubator.code.type.ArrayType;
 import jdk.incubator.code.type.FieldRef;
 import jdk.incubator.code.type.FunctionType;
@@ -163,9 +164,15 @@ public final class BytecodeGenerator {
             for (int i = 0; i < lambdaSink.size(); i++) {
                 LambdaOp lop = lambdaSink.get(i);
                 if (quotable.get(i)) {
-                    clb.withField("lambda$" + i + "$op", CD_String, fb -> fb
-                            .withFlags(ClassFile.ACC_STATIC)
-                            .with(ConstantValueAttribute.of(quote(lop).toText())));
+                    // return (FuncOp) OpParser.fromOpString(opText)
+                    clb.withMethod("op$lambda$" + i, MethodTypeDesc.of(FuncOp.class.describeConstable().get()),
+                        ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC | ClassFile.ACC_SYNTHETIC, mb -> mb.withCode(cb -> cb
+                                .loadConstant(quote(lop).toText())
+                                .invoke(Opcode.INVOKESTATIC, OpParser.class.describeConstable().get(),
+                                        "fromStringOfFuncOp",
+                                        MethodTypeDesc.of(Op.class.describeConstable().get(), CD_String), false)
+                                .checkcast(FuncOp.class.describeConstable().get())
+                                .areturn()));
                 }
                 generateMethod(lookup, className, "lambda$" + i, lop, clb, lambdaSink, quotable);
             }
@@ -891,10 +898,10 @@ public final class BytecodeGenerator {
                                                                   mtd.insertParameterTypes(0, captureTypes)),
                                         mtd,
                                         LambdaMetafactory.FLAG_QUOTABLE,
-                                        MethodHandleDesc.ofField(DirectMethodHandleDesc.Kind.STATIC_GETTER,
-                                                                 className,
-                                                                 "lambda$" + lambdaIndex + "$op",
-                                                                 CD_String)));
+                                        MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC,
+                                                className,
+                                                "op$lambda$" + lambdaIndex,
+                                                MethodTypeDesc.of(FuncOp.class.describeConstable().get()))));
                                 quotable.set(lambdaSink.size());
                             } else {
                                 cob.invokedynamic(DynamicCallSiteDesc.of(

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/QuotedHelper.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/QuotedHelper.java
@@ -37,4 +37,7 @@ public class QuotedHelper {
         FuncOp op = (FuncOp)OpParser.fromStringOfFuncOp(opText);
         return (Quoted)Interpreter.invoke(lookup, op, args);
     }
+    public static Quoted makeQuoted(MethodHandles.Lookup lookup, FuncOp op, Object[] args) {
+        return (Quoted)Interpreter.invoke(lookup, op, args);
+    }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/QuotedHelper.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/QuotedHelper.java
@@ -33,10 +33,6 @@ import jdk.incubator.code.parser.OpParser;
 import java.lang.invoke.MethodHandles;
 
 public class QuotedHelper {
-    public static Quoted makeQuoted(MethodHandles.Lookup lookup, String opText, Object[] args) {
-        FuncOp op = (FuncOp)OpParser.fromStringOfFuncOp(opText);
-        return (Quoted)Interpreter.invoke(lookup, op, args);
-    }
     public static Quoted makeQuoted(MethodHandles.Lookup lookup, FuncOp op, Object[] args) {
         return (Quoted)Interpreter.invoke(lookup, op, args);
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -253,24 +253,23 @@ public class ReflectMethods extends TreeTranslator {
                     // dump the method IR if requested
                     log.note(QuotedIrDump(funcOp.toText()));
                 }
-                // create a static final field holding the op' string text.
-                // The name of the field is foo$op, where 'foo' is the name of the corresponding method.
-                JCVariableDecl opField = opFieldDecl(lambdaName(), 0, funcOp);
-                classOps.add(opField);
+                // create a static method that returns the FuncOp representing the lambda
+                JCMethodDecl opMethod = opMethodDecl(lambdaName(), funcOp);
+                classOps.add(opMethod);
 
                 switch (kind) {
                     case QUOTED_STRUCTURAL -> {
                         // @@@ Consider replacing with invokedynamic to quoted bootstrap method
                         // Thereby we avoid certain dependencies and hide specific details
-                        JCIdent opFieldId = make.Ident(opField.sym);
+                        JCIdent opMethodId = make.Ident(opMethod.sym);
                         ListBuffer<JCExpression> interpreterArgs = new ListBuffer<>();
                         // Obtain MethodHandles.lookup()
                         // @@@ Could probably use MethodHandles.publicLookup()
                         JCMethodInvocation lookup = make.App(make.Ident(crSyms.methodHandlesLookup), com.sun.tools.javac.util.List.nil());
                         interpreterArgs.append(lookup);
                         // Deserialize the func operation
-                        JCMethodInvocation parsedOp = make.App(make.Ident(crSyms.opParserFromString), com.sun.tools.javac.util.List.of(opFieldId));
-                        interpreterArgs.append(parsedOp);
+                        JCMethodInvocation op = make.App(opMethodId);
+                        interpreterArgs.append(op);
                         // Append captured vars
                         ListBuffer<JCExpression> capturedArgs = quotedCapturedArgs(tree, bodyScanner);
                         interpreterArgs.appendList(capturedArgs.toList());
@@ -283,7 +282,7 @@ public class ReflectMethods extends TreeTranslator {
                     }
                     case QUOTABLE -> {
                         // leave the lambda in place, but also leave a trail for LambdaToMethod
-                        tree.codeModel = opField.sym;
+                        tree.codeModel = opMethod.sym;
                         super.visitLambda(tree);
                     }
                 }
@@ -315,11 +314,10 @@ public class ReflectMethods extends TreeTranslator {
                     // dump the method IR if requested
                     log.note(QuotedIrDump(funcOp.toText()));
                 }
-                // create a static final field holding the op' string text.
-                // The name of the field is foo$op, where 'foo' is the name of the corresponding method.
-                JCVariableDecl opField = opFieldDecl(lambdaName(), 0, funcOp);
-                classOps.add(opField);
-                tree.codeModel = opField.sym;
+                // create a method that returns the FuncOp representing the lambda
+                JCMethodDecl opMethod = opMethodDecl(lambdaName(), funcOp);
+                classOps.add(opMethod);
+                tree.codeModel = opMethod.sym;
                 super.visitReference(tree);
                 if (recvDecl != null) {
                     result = copyReferenceWithReceiverVar(tree, recvDecl);
@@ -390,22 +388,10 @@ public class ReflectMethods extends TreeTranslator {
         return names.fromChars(sigCh, 0, sigCh.length);
     }
 
-    private JCVariableDecl opFieldDecl(Name prefix, long flags, CoreOp.FuncOp op) {
-        VarSymbol opFieldSym = new VarSymbol(flags | Flags.STATIC | Flags.FINAL | Flags.SYNTHETIC,
-                prefix.append('$', names.fromString("op")),
-                syms.stringType,
-                currentClassSym);
-
-        currentClassSym.members().enter(opFieldSym);
-        JCLiteral opText = make.Literal(op.toText());
-        JCVariableDecl opFieldTree = make.VarDef(opFieldSym, opText);
-        return opFieldTree;
-    }
-
     private JCMethodDecl opMethodDecl(Name methodName, CoreOp.FuncOp op) {
         var mt = new MethodType(com.sun.tools.javac.util.List.nil(), crSyms.funcOpType,
                 com.sun.tools.javac.util.List.nil(), syms.methodClass);
-        var mn = names.fromString("method$op$").append(methodName);
+        var mn = names.fromString("op$").append(methodName);
         var ms = new MethodSymbol(PUBLIC | STATIC | SYNTHETIC, mn, mt, currentClassSym);
         currentClassSym.members().enter(ms);
 


### PR DESCRIPTION
We replace field holding the textual representation of an identified lambda with method that returns the representation of that lambda.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [5c5f8e48](https://git.openjdk.org/babylon/pull/301/files/5c5f8e48b48230916c95995f212eb8ddb9308383)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [0378f828](https://git.openjdk.org/babylon/pull/301/files/0378f82865671be982140e61c0d6230bcdde6872)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/301/head:pull/301` \
`$ git checkout pull/301`

Update a local copy of the PR: \
`$ git checkout pull/301` \
`$ git pull https://git.openjdk.org/babylon.git pull/301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 301`

View PR using the GUI difftool: \
`$ git pr show -t 301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/301.diff">https://git.openjdk.org/babylon/pull/301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/301#issuecomment-2561824566)
</details>
