### PR TITLE
Use Op.ofQuoted

### DIFF
--- a/hat/docs/hat-05-accelerator-compute.md
+++ b/hat/docs/hat-05-accelerator-compute.md
@@ -207,7 +207,7 @@ Here is how we extract the 'target' from such a lambda
 
 ```java
  public void  compute(QuotableComputeContextConsumer qccc) {
-   Quoted quoted = qccc.quoted();
+   Quoted quoted = Op.ofQuotable(qccc).orElseThrow();
    LambdaOpWrapper lambda = OpTools.wrap((CoreOps.LambdaOp)quoted.op());
 
    Method method = lambda.getQuotableComputeContextTargetMethod();

--- a/hat/examples/experiments/src/main/java/experiments/TestQuoted.java
+++ b/hat/examples/experiments/src/main/java/experiments/TestQuoted.java
@@ -131,7 +131,7 @@ public class TestQuoted {
         }
 
         static void isMethodRef(Quotable q) {
-            Quoted quoted = q.quoted();
+            Quoted quoted = Op.ofQuotable(q).orElseThrow();;
             CoreOp.LambdaOp op = (CoreOp.LambdaOp) quoted.op();
             System.out.println(isMethodRef(op));
         }

--- a/hat/hat/src/main/java/hat/Accelerator.java
+++ b/hat/hat/src/main/java/hat/Accelerator.java
@@ -35,6 +35,8 @@ import hat.optools.OpWrapper;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
+
+import jdk.incubator.code.Op;
 import jdk.incubator.code.Quotable;
 import jdk.incubator.code.Quoted;
 import jdk.incubator.code.op.CoreOp;
@@ -147,7 +149,7 @@ public class Accelerator implements BufferAllocator {
      */
 
     public void compute(QuotableComputeContextConsumer quotableComputeContextConsumer) {
-        Quoted quoted = CoreOp.ofQuotable(quotableComputeContextConsumer).orElseThrow();
+        Quoted quoted = Op.ofQuotable(quotableComputeContextConsumer).orElseThrow();
         LambdaOpWrapper lambda = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op());
         Method method = lambda.getQuotableTargetMethod(this.lookup);
 

--- a/hat/hat/src/main/java/hat/Accelerator.java
+++ b/hat/hat/src/main/java/hat/Accelerator.java
@@ -147,7 +147,7 @@ public class Accelerator implements BufferAllocator {
      */
 
     public void compute(QuotableComputeContextConsumer quotableComputeContextConsumer) {
-        Quoted quoted = quotableComputeContextConsumer.quoted();
+        Quoted quoted = CoreOp.ofQuotable(quotableComputeContextConsumer).orElseThrow();
         LambdaOpWrapper lambda = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op());
         Method method = lambda.getQuotableTargetMethod(this.lookup);
 

--- a/hat/hat/src/main/java/hat/ComputeContext.java
+++ b/hat/hat/src/main/java/hat/ComputeContext.java
@@ -140,7 +140,7 @@ public class ComputeContext implements BufferAllocator {
      */
 
     public void dispatchKernel(int range, QuotableKernelContextConsumer quotableKernelContextConsumer) {
-        Quoted quoted = quotableKernelContextConsumer.quoted();
+        Quoted quoted = Op.ofQuotable(quotableKernelContextConsumer).orElseThrow();
         LambdaOpWrapper lambdaOpWrapper = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op());
         MethodRef methodRef = lambdaOpWrapper.getQuotableTargetMethodRef();
         KernelCallGraph kernelCallGraph = computeCallGraph.kernelCallGraphMap.get(methodRef);


### PR DESCRIPTION
The `Quotable` interface was modified to become a marker interface. To obtain the corresponding `Quoted`  instance (and the code model) we now need to call `Op.ofQuotable()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/304/head:pull/304` \
`$ git checkout pull/304`

Update a local copy of the PR: \
`$ git checkout pull/304` \
`$ git pull https://git.openjdk.org/babylon.git pull/304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 304`

View PR using the GUI difftool: \
`$ git pr show -t 304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/304.diff">https://git.openjdk.org/babylon/pull/304.diff</a>

</details>
