### PR TITLE
Cleanup of HAT env.bash, bld and hatrun scripts

### DIFF
--- a/hat/env.bash
+++ b/hat/env.bash
@@ -29,16 +29,21 @@ END_OF_LICENSE
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then 
    # We just bail if it was not sourced.. We want to set AND export PATH and JAVA_HOME...
+   # So we must be sourced.  Otherwise we just fork a new shell, set the vars in the temp shell and exit
    echo "You must source this file ..."
    echo "Using either "
    echo "    . ${0}"
    echo "or"
    echo "    source ${0}"
-   exit 1;  # this is ok because we were not sourced 
+   exit 1;  # exiting here is ONLY ok because we were not sourced.
 else
 
-  # We were indeed sourced so don't exit below here or we will trash the users shell ;)
-  #    possibly loging them out 
+  # We were sourced so must not exit below or we will trash the users shell ;) possibly logging them out 
+  # We first need to determine the arch an os types so we can construct/test against something like
+  #    macosx-aarch64-server-release
+  #       ^     ^
+  #       |     + ${archtype}
+  #       + ${ostype}
 
   OS=$(uname -s )
   if [[ "$OS" == Linux ]]; then
@@ -91,13 +96,15 @@ else
       fi
 
       if [[ ${1} = "clean" ]]; then 
-         rm -rf build maven-build thirdparty repoDir
+         rm -rf build 
       fi 
-      if [[ ! -e bldr/Bldr.java ]]; then 
-         ln -s src/main/java/bldr/Bldr.java bldr/Bldr.java
-         echo "Created a symlink bldr/Bldr.java "
-      fi 
-      echo "SUCCESS!"
+
+      if command -v jextract; then 
+         echo 'SUCCESS.. Found a valid JDK and found jextract in your PATH'
+      else
+         echo 'CAUTION.. Found a valid JDK, but you will need to add jextract to your PATH to be able to build'
+      fi
+
     else
       echo "We expected either:-"
       echo "    \${PWD} to be in a hat subdir of a compiled babylon jdk build" 

--- a/hat/hatrun
+++ b/hat/hatrun
@@ -23,8 +23,7 @@
  * questions.
  */
 
-import static bldr.Bldr.*;           // all the helpers are here 
-//import static java.nio.file.Files.*; // so we can use isDirectory(path);
+import static bldr.Bldr.*;  
  
 
 void main(String[] argv) {
@@ -38,8 +37,11 @@ void main(String[] argv) {
       class name is assumed to be package.Main  (i.e. mandel.main) 
 
       examples:
-         java @bldr/args opencl mandel
-         java @bldr/args headless opencl mandel
+         java @bldr/args ffi-opencl mandel
+         java @bldr/args java-opencl mandel
+         java @bldr/args headless ffi-opencl mandel
+         java @bldr/args ffi-opencl life
+         java @bldr/args java-opencl life
   """;
 
   var hatDir =  DirEntry.current();

--- a/hat/intellij/.idea/compiler.xml
+++ b/hat/intellij/.idea/compiler.xml
@@ -7,6 +7,7 @@
     <option name="ADDITIONAL_OPTIONS_STRING" value="--add-modules=jdk.incubator.code --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">
       <module name="life" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
+      <module name="mandel" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
     </option>
   </component>
 </project>


### PR DESCRIPTION
Added a jextract check in env.bash 

hatrun's usage now shows way to specify backend (i.e. ffi-opencl vs just opencl) in preparation for jextracted backends

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/309/head:pull/309` \
`$ git checkout pull/309`

Update a local copy of the PR: \
`$ git checkout pull/309` \
`$ git pull https://git.openjdk.org/babylon.git pull/309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 309`

View PR using the GUI difftool: \
`$ git pr show -t 309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/309.diff">https://git.openjdk.org/babylon/pull/309.diff</a>

</details>
