### PR TITLE
Remove redundant type variables

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxOperators.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxOperators.java
@@ -52,12 +52,12 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2, T3> List<Tensor<T3>> Adagrad(Tensor<T1> R, Tensor<Long> T, List<Tensor<T3>> inputs, Optional<Float> epsilon, Optional<Float> decay_factor, Optional<Float> norm_coefficient) {
+    public static <T1, T3> List<Tensor<T3>> Adagrad(Tensor<T1> R, Tensor<Long> T, List<Tensor<T3>> inputs, Optional<Float> epsilon, Optional<Float> decay_factor, Optional<Float> norm_coefficient) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Adagrad.class, List.of(R, T, inputs), List.of(epsilon, decay_factor, norm_coefficient));
         return (List<Tensor<T3>>) result;
     }
 
-    public static <T1, T2, T3> List<Tensor<T3>> Adam(Tensor<T1> R, Tensor<Long> T, List<Tensor<T3>> inputs, Optional<Float> epsilon, Optional<Float> norm_coefficient_post, Optional<Float> norm_coefficient, Optional<Float> alpha, Optional<Float> beta) {
+    public static <T1, T3> List<Tensor<T3>> Adam(Tensor<T1> R, Tensor<Long> T, List<Tensor<T3>> inputs, Optional<Float> epsilon, Optional<Float> norm_coefficient_post, Optional<Float> norm_coefficient, Optional<Float> alpha, Optional<Float> beta) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Adam.class, List.of(R, T, inputs), List.of(epsilon, norm_coefficient_post, norm_coefficient, alpha, beta));
         return (List<Tensor<T3>>) result;
     }
@@ -67,12 +67,12 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2> Tensor<T1> AffineGrid(Tensor<T1> theta, Tensor<Long> size, Optional<Long> align_corners) {
+    public static <T1> Tensor<T1> AffineGrid(Tensor<T1> theta, Tensor<Long> size, Optional<Long> align_corners) {
         Object result = OnnxInterpreter.interpret(OnnxOps.AffineGrid.class, List.of(theta, size), List.of(align_corners));
         return (Tensor<T1>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> And(Tensor<Boolean> A, Tensor<Boolean> B) {
+    public static Tensor<Boolean> And(Tensor<Boolean> A, Tensor<Boolean> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.And.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }
@@ -117,8 +117,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public record BatchNormalizationResult<T, T1, T2>(Tensor<T> Y, Tensor<T2> running_mean, Tensor<T2> running_var) { }
-    public static <T, T1, T2> BatchNormalizationResult<T, T1, T2> BatchNormalization(Tensor<T> X, Tensor<T1> scale, Tensor<T1> B, Tensor<T2> input_mean, Tensor<T2> input_var, Optional<Float> epsilon, Optional<Long> training_mode, Optional<Float> momentum) {
+    public record BatchNormalizationResult<T, T2>(Tensor<T> Y, Tensor<T2> running_mean, Tensor<T2> running_var) { }
+    public static <T, T1, T2> BatchNormalizationResult<T, T2> BatchNormalization(Tensor<T> X, Tensor<T1> scale, Tensor<T1> B, Tensor<T2> input_mean, Tensor<T2> input_var, Optional<Float> epsilon, Optional<Long> training_mode, Optional<Float> momentum) {
         Object result = OnnxInterpreter.interpret(OnnxOps.BatchNormalization.class, List.of(X, scale, B, input_mean, input_var), List.of(epsilon, training_mode, momentum));
         Object[] resultArray = (Object[]) result;
         return new BatchNormalizationResult<>((Tensor<T>)resultArray[0], (Tensor<T2>)resultArray[1], (Tensor<T2>)resultArray[2]);
@@ -189,7 +189,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T> Tensor<Float> Celu(Tensor<Float> X, Optional<Float> alpha) {
+    public static Tensor<Float> Celu(Tensor<Float> X, Optional<Float> alpha) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Celu.class, List.of(X), List.of(alpha));
         return (Tensor<Float>) result;
     }
@@ -209,7 +209,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T, T1> Tensor<T> Compress(Tensor<T> input, Tensor<Boolean> condition, Optional<Long> axis) {
+    public static <T> Tensor<T> Compress(Tensor<T> input, Tensor<Boolean> condition, Optional<Long> axis) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Compress.class, List.of(input, condition), List.of(axis));
         return (Tensor<T>) result;
     }
@@ -229,7 +229,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2> Tensor<T2> ConstantOfShape(Tensor<Long> input, Optional<byte[]> value) {
+    public static <T2> Tensor<T2> ConstantOfShape(Tensor<Long> input, Optional<byte[]> value) {
         Object result = OnnxInterpreter.interpret(OnnxOps.ConstantOfShape.class, List.of(input), List.of(value));
         return (Tensor<T2>) result;
     }
@@ -239,7 +239,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2, T3> Tensor<Integer> ConvInteger(Tensor<T1> x, Tensor<T2> w, Optional<Tensor<T1>> x_zero_point, Optional<Tensor<T2>> w_zero_point, Optional<long[]> pads, Optional<long[]> dilations, Optional<String> auto_pad, Optional<long[]> strides, Optional<Long> group, Optional<long[]> kernel_shape) {
+    public static <T1, T2> Tensor<Integer> ConvInteger(Tensor<T1> x, Tensor<T2> w, Optional<Tensor<T1>> x_zero_point, Optional<Tensor<T2>> w_zero_point, Optional<long[]> pads, Optional<long[]> dilations, Optional<String> auto_pad, Optional<long[]> strides, Optional<Long> group, Optional<long[]> kernel_shape) {
         Object result = OnnxInterpreter.interpret(OnnxOps.ConvInteger.class, List.of(x, w, x_zero_point, w_zero_point), List.of(pads, dilations, auto_pad, strides, group, kernel_shape));
         return (Tensor<Integer>) result;
     }
@@ -289,7 +289,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2> Tensor<T2> DictVectorizer(Map<?, ?> X, Optional<String[]> string_vocabulary, Optional<long[]> int64_vocabulary) {
+    public static <T2> Tensor<T2> DictVectorizer(Map<?, ?> X, Optional<String[]> string_vocabulary, Optional<long[]> int64_vocabulary) {
         Object result = OnnxInterpreter.interpret(OnnxOps.DictVectorizer.class, List.of(X), List.of(string_vocabulary, int64_vocabulary));
         return (Tensor<T2>) result;
     }
@@ -299,18 +299,18 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public record DropoutResult<T, T1, T2>(Tensor<T> output, Tensor<Boolean> mask) { }
-    public static <T, T1, T2> DropoutResult<T, T1, T2> Dropout(Tensor<T> data, Optional<Tensor<T1>> ratio, Optional<Tensor<Boolean>> training_mode, Optional<Long> seed) {
+    public record DropoutResult<T>(Tensor<T> output, Tensor<Boolean> mask) { }
+    public static <T, T1> DropoutResult<T> Dropout(Tensor<T> data, Optional<Tensor<T1>> ratio, Optional<Tensor<Boolean>> training_mode, Optional<Long> seed) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Dropout.class, List.of(data, ratio, training_mode), List.of(seed));
         Object[] resultArray = (Object[]) result;
         return new DropoutResult<>((Tensor<T>)resultArray[0], (Tensor<Boolean>)resultArray[1]);
     }
 
-    public record DynamicQuantizeLinearResult<T1, T2>(Tensor<Byte> y, Tensor<Float> y_scale, Tensor<Byte> y_zero_point) { }
-    public static <T1, T2> DynamicQuantizeLinearResult<T1, T2> DynamicQuantizeLinear(Tensor<Float> x) {
+    public record DynamicQuantizeLinearResult(Tensor<Byte> y, Tensor<Float> y_scale, Tensor<Byte> y_zero_point) { }
+    public static DynamicQuantizeLinearResult DynamicQuantizeLinear(Tensor<Float> x) {
         Object result = OnnxInterpreter.interpret(OnnxOps.DynamicQuantizeLinear.class, List.of(x), List.of());
         Object[] resultArray = (Object[]) result;
-        return new DynamicQuantizeLinearResult<>((Tensor<Byte>)resultArray[0], (Tensor<Float>)resultArray[1], (Tensor<Byte>)resultArray[2]);
+        return new DynamicQuantizeLinearResult((Tensor<Byte>)resultArray[0], (Tensor<Float>)resultArray[1], (Tensor<Byte>)resultArray[2]);
     }
 
     public static <T> Tensor<T> Einsum(List<Tensor<T>> Inputs, String equation) {
@@ -323,7 +323,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> Equal(Tensor<T> A, Tensor<T> B) {
+    public static <T> Tensor<Boolean> Equal(Tensor<T> A, Tensor<T> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Equal.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }
@@ -363,8 +363,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public record GRUResult<T, T1>(Tensor<T> Y, Tensor<T> Y_h) { }
-    public static <T, T1> GRUResult<T, T1> GRU(Tensor<T> X, Tensor<T> W, Tensor<T> R, Optional<Tensor<T>> B, Optional<Tensor<Integer>> sequence_lens, Optional<Tensor<T>> initial_h, Optional<Long> layout, Optional<float[]> activation_alpha, Optional<Long> hidden_size, Optional<float[]> activation_beta, Optional<String[]> activations, Optional<Long> linear_before_reset, Optional<Float> clip, Optional<String> direction) {
+    public record GRUResult<T>(Tensor<T> Y, Tensor<T> Y_h) { }
+    public static <T> GRUResult<T> GRU(Tensor<T> X, Tensor<T> W, Tensor<T> R, Optional<Tensor<T>> B, Optional<Tensor<Integer>> sequence_lens, Optional<Tensor<T>> initial_h, Optional<Long> layout, Optional<float[]> activation_alpha, Optional<Long> hidden_size, Optional<float[]> activation_beta, Optional<String[]> activations, Optional<Long> linear_before_reset, Optional<Float> clip, Optional<String> direction) {
         Object result = OnnxInterpreter.interpret(OnnxOps.GRU.class, List.of(X, W, R, B, sequence_lens, initial_h), List.of(layout, activation_alpha, hidden_size, activation_beta, activations, linear_before_reset, clip, direction));
         Object[] resultArray = (Object[]) result;
         return new GRUResult<>((Tensor<T>)resultArray[0], (Tensor<T>)resultArray[1]);
@@ -415,12 +415,12 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (List<Tensor<T2>>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> Greater(Tensor<T> A, Tensor<T> B) {
+    public static <T> Tensor<Boolean> Greater(Tensor<T> A, Tensor<T> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Greater.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> GreaterOrEqual(Tensor<T> A, Tensor<T> B) {
+    public static <T> Tensor<Boolean> GreaterOrEqual(Tensor<T> A, Tensor<T> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.GreaterOrEqual.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }
@@ -465,7 +465,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (V) result;
     }
 
-    public static <T1, T2> Tensor<Byte> ImageDecoder(Tensor<Byte> encoded_stream, Optional<String> pixel_format) {
+    public static Tensor<Byte> ImageDecoder(Tensor<Byte> encoded_stream, Optional<String> pixel_format) {
         Object result = OnnxInterpreter.interpret(OnnxOps.ImageDecoder.class, List.of(encoded_stream), List.of(pixel_format));
         return (Tensor<Byte>) result;
     }
@@ -480,12 +480,12 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2> Tensor<Boolean> IsInf(Tensor<T1> X, Optional<Long> detect_negative, Optional<Long> detect_positive) {
+    public static <T1> Tensor<Boolean> IsInf(Tensor<T1> X, Optional<Long> detect_negative, Optional<Long> detect_positive) {
         Object result = OnnxInterpreter.interpret(OnnxOps.IsInf.class, List.of(X), List.of(detect_negative, detect_positive));
         return (Tensor<Boolean>) result;
     }
 
-    public static <T1, T2> Tensor<Boolean> IsNaN(Tensor<T1> X) {
+    public static <T1> Tensor<Boolean> IsNaN(Tensor<T1> X) {
         Object result = OnnxInterpreter.interpret(OnnxOps.IsNaN.class, List.of(X), List.of());
         return (Tensor<Boolean>) result;
     }
@@ -495,8 +495,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public record LSTMResult<T, T1>(Tensor<T> Y, Tensor<T> Y_h, Tensor<T> Y_c) { }
-    public static <T, T1> LSTMResult<T, T1> LSTM(Tensor<T> X, Tensor<T> W, Tensor<T> R, Optional<Tensor<T>> B, Optional<Tensor<Integer>> sequence_lens, Optional<Tensor<T>> initial_h, Optional<Tensor<T>> initial_c, Optional<Tensor<T>> P, Optional<Long> layout, Optional<Long> input_forget, Optional<float[]> activation_alpha, Optional<Long> hidden_size, Optional<float[]> activation_beta, Optional<String[]> activations, Optional<Float> clip, Optional<String> direction) {
+    public record LSTMResult<T>(Tensor<T> Y, Tensor<T> Y_h, Tensor<T> Y_c) { }
+    public static <T> LSTMResult<T> LSTM(Tensor<T> X, Tensor<T> W, Tensor<T> R, Optional<Tensor<T>> B, Optional<Tensor<Integer>> sequence_lens, Optional<Tensor<T>> initial_h, Optional<Tensor<T>> initial_c, Optional<Tensor<T>> P, Optional<Long> layout, Optional<Long> input_forget, Optional<float[]> activation_alpha, Optional<Long> hidden_size, Optional<float[]> activation_beta, Optional<String[]> activations, Optional<Float> clip, Optional<String> direction) {
         Object result = OnnxInterpreter.interpret(OnnxOps.LSTM.class, List.of(X, W, R, B, sequence_lens, initial_h, initial_c, P), List.of(layout, input_forget, activation_alpha, hidden_size, activation_beta, activations, clip, direction));
         Object[] resultArray = (Object[]) result;
         return new LSTMResult<>((Tensor<T>)resultArray[0], (Tensor<T>)resultArray[1], (Tensor<T>)resultArray[2]);
@@ -519,18 +519,18 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> Less(Tensor<T> A, Tensor<T> B) {
+    public static <T> Tensor<Boolean> Less(Tensor<T> A, Tensor<T> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Less.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> LessOrEqual(Tensor<T> A, Tensor<T> B) {
+    public static <T> Tensor<Boolean> LessOrEqual(Tensor<T> A, Tensor<T> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.LessOrEqual.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }
 
-    public record LinearClassifierResult<T1, T2>(Tensor<T2> Y, Tensor<Float> Z) { }
-    public static <T1, T2> LinearClassifierResult<T1, T2> LinearClassifier(Tensor<T1> X, Optional<long[]> classlabels_ints, Optional<String> post_transform, float[] coefficients, Optional<Long> multi_class, Optional<float[]> intercepts, Optional<String[]> classlabels_strings) {
+    public record LinearClassifierResult<T2>(Tensor<T2> Y, Tensor<Float> Z) { }
+    public static <T1, T2> LinearClassifierResult<T2> LinearClassifier(Tensor<T1> X, Optional<long[]> classlabels_ints, Optional<String> post_transform, float[] coefficients, Optional<Long> multi_class, Optional<float[]> intercepts, Optional<String[]> classlabels_strings) {
         Object result = OnnxInterpreter.interpret(OnnxOps.LinearClassifier.class, List.of(X), List.of(classlabels_ints, post_transform, coefficients, multi_class, intercepts, classlabels_strings));
         Object[] resultArray = (Object[]) result;
         return new LinearClassifierResult<>((Tensor<T2>)resultArray[0], (Tensor<Float>)resultArray[1]);
@@ -566,7 +566,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2, T3> Tensor<Integer> MatMulInteger(Tensor<T1> A, Tensor<T2> B, Optional<Tensor<T1>> a_zero_point, Optional<Tensor<T2>> b_zero_point) {
+    public static <T1, T2> Tensor<Integer> MatMulInteger(Tensor<T1> A, Tensor<T2> B, Optional<Tensor<T1>> a_zero_point, Optional<Tensor<T2>> b_zero_point) {
         Object result = OnnxInterpreter.interpret(OnnxOps.MatMulInteger.class, List.of(A, B, a_zero_point, b_zero_point), List.of());
         return (Tensor<Integer>) result;
     }
@@ -576,8 +576,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public record MaxPoolResult<T, I>(Tensor<T> Y, Tensor<Long> Indices) { }
-    public static <T, I> MaxPoolResult<T, I> MaxPool(Tensor<T> X, Optional<long[]> pads, Optional<long[]> dilations, Optional<String> auto_pad, Optional<Long> ceil_mode, Optional<Long> storage_order, Optional<long[]> strides, long[] kernel_shape) {
+    public record MaxPoolResult<T>(Tensor<T> Y, Tensor<Long> Indices) { }
+    public static <T> MaxPoolResult<T> MaxPool(Tensor<T> X, Optional<long[]> pads, Optional<long[]> dilations, Optional<String> auto_pad, Optional<Long> ceil_mode, Optional<Long> storage_order, Optional<long[]> strides, long[] kernel_shape) {
         Object result = OnnxInterpreter.interpret(OnnxOps.MaxPool.class, List.of(X), List.of(pads, dilations, auto_pad, ceil_mode, storage_order, strides, kernel_shape));
         Object[] resultArray = (Object[]) result;
         return new MaxPoolResult<>((Tensor<T>)resultArray[0], (Tensor<Long>)resultArray[1]);
@@ -588,7 +588,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2> Tensor<T1> MaxUnpool(Tensor<T1> X, Tensor<Long> I, Optional<Tensor<Long>> output_shape, Optional<long[]> pads, Optional<long[]> strides, long[] kernel_shape) {
+    public static <T1> Tensor<T1> MaxUnpool(Tensor<T1> X, Tensor<Long> I, Optional<Tensor<Long>> output_shape, Optional<long[]> pads, Optional<long[]> strides, long[] kernel_shape) {
         Object result = OnnxInterpreter.interpret(OnnxOps.MaxUnpool.class, List.of(X, I, output_shape), List.of(pads, strides, kernel_shape));
         return (Tensor<T1>) result;
     }
@@ -623,7 +623,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2, T3> List<Tensor<T3>> Momentum(Tensor<T1> R, Tensor<Long> T, List<Tensor<T3>> inputs, String mode, float norm_coefficient, float alpha, float beta) {
+    public static <T1, T3> List<Tensor<T3>> Momentum(Tensor<T1> R, Tensor<Long> T, List<Tensor<T3>> inputs, String mode, float norm_coefficient, float alpha, float beta) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Momentum.class, List.of(R, T, inputs), List.of(mode, norm_coefficient, alpha, beta));
         return (List<Tensor<T3>>) result;
     }
@@ -663,7 +663,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<Float>) result;
     }
 
-    public static <T> Tensor<Boolean> Not(Tensor<Boolean> X) {
+    public static Tensor<Boolean> Not(Tensor<Boolean> X) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Not.class, List.of(X), List.of());
         return (Tensor<Boolean>) result;
     }
@@ -688,12 +688,12 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (V) result;
     }
 
-    public static <O, B> Tensor<Boolean> OptionalHasElement(Optional<O> input) {
+    public static <O> Tensor<Boolean> OptionalHasElement(Optional<O> input) {
         Object result = OnnxInterpreter.interpret(OnnxOps.OptionalHasElement.class, List.of(input), List.of());
         return (Tensor<Boolean>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> Or(Tensor<Boolean> A, Tensor<Boolean> B) {
+    public static Tensor<Boolean> Or(Tensor<Boolean> A, Tensor<Boolean> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Or.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }
@@ -713,7 +713,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2, T3, T4> Tensor<T3> QLinearConv(Tensor<T1> x, Tensor<Float> x_scale, Tensor<T1> x_zero_point, Tensor<T2> w, Tensor<Float> w_scale, Tensor<T2> w_zero_point, Tensor<Float> y_scale, Tensor<T3> y_zero_point, Optional<Tensor<Integer>> B, Optional<long[]> pads, Optional<long[]> dilations, Optional<String> auto_pad, Optional<long[]> strides, Optional<Long> group, Optional<long[]> kernel_shape) {
+    public static <T1, T2, T3> Tensor<T3> QLinearConv(Tensor<T1> x, Tensor<Float> x_scale, Tensor<T1> x_zero_point, Tensor<T2> w, Tensor<Float> w_scale, Tensor<T2> w_zero_point, Tensor<Float> y_scale, Tensor<T3> y_zero_point, Optional<Tensor<Integer>> B, Optional<long[]> pads, Optional<long[]> dilations, Optional<String> auto_pad, Optional<long[]> strides, Optional<Long> group, Optional<long[]> kernel_shape) {
         Object result = OnnxInterpreter.interpret(OnnxOps.QLinearConv.class, List.of(x, x_scale, x_zero_point, w, w_scale, w_zero_point, y_scale, y_zero_point, B), List.of(pads, dilations, auto_pad, strides, group, kernel_shape));
         return (Tensor<T3>) result;
     }
@@ -728,8 +728,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T2>) result;
     }
 
-    public record RNNResult<T, T1>(Tensor<T> Y, Tensor<T> Y_h) { }
-    public static <T, T1> RNNResult<T, T1> RNN(Tensor<T> X, Tensor<T> W, Tensor<T> R, Optional<Tensor<T>> B, Optional<Tensor<Integer>> sequence_lens, Optional<Tensor<T>> initial_h, Optional<Long> layout, Optional<float[]> activation_alpha, Optional<Long> hidden_size, Optional<float[]> activation_beta, Optional<String[]> activations, Optional<Float> clip, Optional<String> direction) {
+    public record RNNResult<T>(Tensor<T> Y, Tensor<T> Y_h) { }
+    public static <T> RNNResult<T> RNN(Tensor<T> X, Tensor<T> W, Tensor<T> R, Optional<Tensor<T>> B, Optional<Tensor<Integer>> sequence_lens, Optional<Tensor<T>> initial_h, Optional<Long> layout, Optional<float[]> activation_alpha, Optional<Long> hidden_size, Optional<float[]> activation_beta, Optional<String[]> activations, Optional<Float> clip, Optional<String> direction) {
         Object result = OnnxInterpreter.interpret(OnnxOps.RNN.class, List.of(X, W, R, B, sequence_lens, initial_h), List.of(layout, activation_alpha, hidden_size, activation_beta, activations, clip, direction));
         Object[] resultArray = (Object[]) result;
         return new RNNResult<>((Tensor<T>)resultArray[0], (Tensor<T>)resultArray[1]);
@@ -815,7 +815,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2> Tensor<Boolean> RegexFullMatch(Tensor<String> X, Optional<String> pattern) {
+    public static Tensor<Boolean> RegexFullMatch(Tensor<String> X, Optional<String> pattern) {
         Object result = OnnxInterpreter.interpret(OnnxOps.RegexFullMatch.class, List.of(X), List.of(pattern));
         return (Tensor<Boolean>) result;
     }
@@ -840,7 +840,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T1, T2> Tensor<T1> RoiAlign(Tensor<T1> X, Tensor<T1> rois, Tensor<Long> batch_indices, Optional<String> mode, Optional<Long> output_width, Optional<Float> spatial_scale, Optional<String> coordinate_transformation_mode, Optional<Long> sampling_ratio, Optional<Long> output_height) {
+    public static <T1> Tensor<T1> RoiAlign(Tensor<T1> X, Tensor<T1> rois, Tensor<Long> batch_indices, Optional<String> mode, Optional<Long> output_width, Optional<Float> spatial_scale, Optional<String> coordinate_transformation_mode, Optional<Long> sampling_ratio, Optional<Long> output_height) {
         Object result = OnnxInterpreter.interpret(OnnxOps.RoiAlign.class, List.of(X, rois, batch_indices), List.of(mode, output_width, spatial_scale, coordinate_transformation_mode, sampling_ratio, output_height));
         return (Tensor<T1>) result;
     }
@@ -855,8 +855,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T1>) result;
     }
 
-    public record SVMClassifierResult<T1, T2>(Tensor<T2> Y, Tensor<Float> Z) { }
-    public static <T1, T2> SVMClassifierResult<T1, T2> SVMClassifier(Tensor<T1> X, Optional<float[]> prob_b, Optional<float[]> kernel_params, Optional<String> kernel_type, Optional<long[]> classlabels_ints, Optional<String> post_transform, Optional<float[]> rho, Optional<float[]> coefficients, Optional<float[]> support_vectors, Optional<long[]> vectors_per_class, Optional<float[]> prob_a, Optional<String[]> classlabels_strings) {
+    public record SVMClassifierResult<T2>(Tensor<T2> Y, Tensor<Float> Z) { }
+    public static <T1, T2> SVMClassifierResult<T2> SVMClassifier(Tensor<T1> X, Optional<float[]> prob_b, Optional<float[]> kernel_params, Optional<String> kernel_type, Optional<long[]> classlabels_ints, Optional<String> post_transform, Optional<float[]> rho, Optional<float[]> coefficients, Optional<float[]> support_vectors, Optional<long[]> vectors_per_class, Optional<float[]> prob_a, Optional<String[]> classlabels_strings) {
         Object result = OnnxInterpreter.interpret(OnnxOps.SVMClassifier.class, List.of(X), List.of(prob_b, kernel_params, kernel_type, classlabels_ints, post_transform, rho, coefficients, support_vectors, vectors_per_class, prob_a, classlabels_strings));
         Object[] resultArray = (Object[]) result;
         return new SVMClassifierResult<>((Tensor<T2>)resultArray[0], (Tensor<Float>)resultArray[1]);
@@ -917,12 +917,12 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (List<Tensor<S>>) result;
     }
 
-    public static <S, I> Tensor<Long> SequenceLength(List<Tensor<S>> input_sequence) {
+    public static <S> Tensor<Long> SequenceLength(List<Tensor<S>> input_sequence) {
         Object result = OnnxInterpreter.interpret(OnnxOps.SequenceLength.class, List.of(input_sequence), List.of());
         return (Tensor<Long>) result;
     }
 
-    public static <T, T1> Tensor<Long> Shape(Tensor<T> data, Optional<Long> start, Optional<Long> end) {
+    public static <T> Tensor<Long> Shape(Tensor<T> data, Optional<Long> start, Optional<Long> end) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Shape.class, List.of(data), List.of(start, end));
         return (Tensor<Long>) result;
     }
@@ -952,7 +952,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T, T1> Tensor<Long> Size(Tensor<T> data) {
+    public static <T> Tensor<Long> Size(Tensor<T> data) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Size.class, List.of(data), List.of());
         return (Tensor<Long>) result;
     }
@@ -967,8 +967,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public record SoftmaxCrossEntropyLossResult<T, Tind>(Tensor<T> output, Tensor<T> log_prob) { }
-    public static <T, Tind> SoftmaxCrossEntropyLossResult<T, Tind> SoftmaxCrossEntropyLoss(Tensor<T> scores, Tensor<Tind> labels, Optional<Tensor<T>> weights, Optional<Long> ignore_index, Optional<String> reduction) {
+    public record SoftmaxCrossEntropyLossResult<T>(Tensor<T> output, Tensor<T> log_prob) { }
+    public static <T, Tind> SoftmaxCrossEntropyLossResult<T> SoftmaxCrossEntropyLoss(Tensor<T> scores, Tensor<Tind> labels, Optional<Tensor<T>> weights, Optional<Long> ignore_index, Optional<String> reduction) {
         Object result = OnnxInterpreter.interpret(OnnxOps.SoftmaxCrossEntropyLoss.class, List.of(scores, labels, weights), List.of(ignore_index, reduction));
         Object[] resultArray = (Object[]) result;
         return new SoftmaxCrossEntropyLossResult<>((Tensor<T>)resultArray[0], (Tensor<T>)resultArray[1]);
@@ -1009,7 +1009,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T> Tensor<String> StringConcat(Tensor<String> X, Tensor<String> Y) {
+    public static Tensor<String> StringConcat(Tensor<String> X, Tensor<String> Y) {
         Object result = OnnxInterpreter.interpret(OnnxOps.StringConcat.class, List.of(X, Y), List.of());
         return (Tensor<String>) result;
     }
@@ -1019,11 +1019,11 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<String>) result;
     }
 
-    public record StringSplitResult<T1, T2, T3>(Tensor<String> Y, Tensor<Long> Z) { }
-    public static <T1, T2, T3> StringSplitResult<T1, T2, T3> StringSplit(Tensor<String> X, Optional<String> delimiter, Optional<Long> maxsplit) {
+    public record StringSplitResult(Tensor<String> Y, Tensor<Long> Z) { }
+    public static StringSplitResult StringSplit(Tensor<String> X, Optional<String> delimiter, Optional<Long> maxsplit) {
         Object result = OnnxInterpreter.interpret(OnnxOps.StringSplit.class, List.of(X), List.of(delimiter, maxsplit));
         Object[] resultArray = (Object[]) result;
-        return new StringSplitResult<>((Tensor<String>)resultArray[0], (Tensor<Long>)resultArray[1]);
+        return new StringSplitResult((Tensor<String>)resultArray[0], (Tensor<Long>)resultArray[1]);
     }
 
     public static <T> Tensor<T> Sub(Tensor<T> A, Tensor<T> B) {
@@ -1046,7 +1046,7 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T, T1> Tensor<Float> TfIdfVectorizer(Tensor<T> X, long[] ngram_counts, long min_gram_length, Optional<String[]> pool_strings, String mode, long max_gram_length, long max_skip_count, Optional<long[]> pool_int64s, Optional<float[]> weights, long[] ngram_indexes) {
+    public static <T> Tensor<Float> TfIdfVectorizer(Tensor<T> X, long[] ngram_counts, long min_gram_length, Optional<String[]> pool_strings, String mode, long max_gram_length, long max_skip_count, Optional<long[]> pool_int64s, Optional<float[]> weights, long[] ngram_indexes) {
         Object result = OnnxInterpreter.interpret(OnnxOps.TfIdfVectorizer.class, List.of(X), List.of(ngram_counts, min_gram_length, pool_strings, mode, max_gram_length, max_skip_count, pool_int64s, weights, ngram_indexes));
         return (Tensor<Float>) result;
     }
@@ -1056,13 +1056,13 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <T, T1> Tensor<T> Tile(Tensor<T> input, Tensor<Long> repeats) {
+    public static <T> Tensor<T> Tile(Tensor<T> input, Tensor<Long> repeats) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Tile.class, List.of(input, repeats), List.of());
         return (Tensor<T>) result;
     }
 
-    public record TopKResult<T, I>(Tensor<T> Values, Tensor<Long> Indices) { }
-    public static <T, I> TopKResult<T, I> TopK(Tensor<T> X, Tensor<Long> K, Optional<Long> largest, Optional<Long> sorted, Optional<Long> axis) {
+    public record TopKResult<T>(Tensor<T> Values, Tensor<Long> Indices) { }
+    public static <T> TopKResult<T> TopK(Tensor<T> X, Tensor<Long> K, Optional<Long> largest, Optional<Long> sorted, Optional<Long> axis) {
         Object result = OnnxInterpreter.interpret(OnnxOps.TopK.class, List.of(X, K), List.of(largest, sorted, axis));
         Object[] resultArray = (Object[]) result;
         return new TopKResult<>((Tensor<T>)resultArray[0], (Tensor<Long>)resultArray[1]);
@@ -1078,8 +1078,8 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public record TreeEnsembleClassifierResult<T1, T2>(Tensor<T2> Y, Tensor<Float> Z) { }
-    public static <T1, T2> TreeEnsembleClassifierResult<T1, T2> TreeEnsembleClassifier(Tensor<T1> X, Optional<long[]> classlabels_int64s, Optional<long[]> class_ids, Optional<float[]> nodes_hitrates, Optional<long[]> nodes_featureids, Optional<long[]> nodes_treeids, Optional<byte[]> class_weights_as_tensor, Optional<String> post_transform, Optional<String[]> nodes_modes, Optional<long[]> nodes_falsenodeids, Optional<String[]> classlabels_strings, Optional<long[]> nodes_truenodeids, Optional<long[]> nodes_nodeids, Optional<byte[]> nodes_hitrates_as_tensor, Optional<float[]> class_weights, Optional<byte[]> base_values_as_tensor, Optional<long[]> nodes_missing_value_tracks_true, Optional<long[]> class_nodeids, Optional<long[]> class_treeids, Optional<float[]> base_values, Optional<float[]> nodes_values, Optional<byte[]> nodes_values_as_tensor) {
+    public record TreeEnsembleClassifierResult<T2>(Tensor<T2> Y, Tensor<Float> Z) { }
+    public static <T1, T2> TreeEnsembleClassifierResult<T2> TreeEnsembleClassifier(Tensor<T1> X, Optional<long[]> classlabels_int64s, Optional<long[]> class_ids, Optional<float[]> nodes_hitrates, Optional<long[]> nodes_featureids, Optional<long[]> nodes_treeids, Optional<byte[]> class_weights_as_tensor, Optional<String> post_transform, Optional<String[]> nodes_modes, Optional<long[]> nodes_falsenodeids, Optional<String[]> classlabels_strings, Optional<long[]> nodes_truenodeids, Optional<long[]> nodes_nodeids, Optional<byte[]> nodes_hitrates_as_tensor, Optional<float[]> class_weights, Optional<byte[]> base_values_as_tensor, Optional<long[]> nodes_missing_value_tracks_true, Optional<long[]> class_nodeids, Optional<long[]> class_treeids, Optional<float[]> base_values, Optional<float[]> nodes_values, Optional<byte[]> nodes_values_as_tensor) {
         Object result = OnnxInterpreter.interpret(OnnxOps.TreeEnsembleClassifier.class, List.of(X), List.of(classlabels_int64s, class_ids, nodes_hitrates, nodes_featureids, nodes_treeids, class_weights_as_tensor, post_transform, nodes_modes, nodes_falsenodeids, classlabels_strings, nodes_truenodeids, nodes_nodeids, nodes_hitrates_as_tensor, class_weights, base_values_as_tensor, nodes_missing_value_tracks_true, class_nodeids, class_treeids, base_values, nodes_values, nodes_values_as_tensor));
         Object[] resultArray = (Object[]) result;
         return new TreeEnsembleClassifierResult<>((Tensor<T2>)resultArray[0], (Tensor<Float>)resultArray[1]);
@@ -1112,12 +1112,12 @@ public final class OnnxOperators extends ExplicitOnnxOperators {
         return (Tensor<T>) result;
     }
 
-    public static <B, T> Tensor<T> Where(Tensor<Boolean> condition, Tensor<T> X, Tensor<T> Y) {
+    public static <T> Tensor<T> Where(Tensor<Boolean> condition, Tensor<T> X, Tensor<T> Y) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Where.class, List.of(condition, X, Y), List.of());
         return (Tensor<T>) result;
     }
 
-    public static <T, T1> Tensor<Boolean> Xor(Tensor<Boolean> A, Tensor<Boolean> B) {
+    public static Tensor<Boolean> Xor(Tensor<Boolean> A, Tensor<Boolean> B) {
         Object result = OnnxInterpreter.interpret(OnnxOps.Xor.class, List.of(A, B), List.of());
         return (Tensor<Boolean>) result;
     }


### PR DESCRIPTION
Remove redundant type variables from the ONNX operator API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/315/head:pull/315` \
`$ git checkout pull/315`

Update a local copy of the PR: \
`$ git checkout pull/315` \
`$ git pull https://git.openjdk.org/babylon.git pull/315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 315`

View PR using the GUI difftool: \
`$ git pr show -t 315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/315.diff">https://git.openjdk.org/babylon/pull/315.diff</a>

</details>
