### PR TITLE
Hat mark buffers 1

### DIFF
--- a/hat/backends/ffi/mock/cpp/mock_backend.cpp
+++ b/hat/backends/ffi/mock/cpp/mock_backend.cpp
@@ -30,6 +30,12 @@ public:
     public :
     };
 
+      class MockQueue : public Backend::Queue {
+        public :
+         MockQueue():Backend::Queue(){}
+         virtual ~MockQueue(){}
+        };
+
     class MockProgram : public Backend::Program {
         class MockKernel : public Backend::Program::Kernel {
         public:
@@ -65,8 +71,8 @@ public:
 
 public:
 
-    MockBackend(MockConfig *mockConfig, int mockConfigSchemeLen, char *mockBackendSchema)
-            : Backend(mockConfig, mockConfigSchemeLen, mockBackendSchema) {
+    MockBackend(MockConfig *mockConfig, int mockConfigSchemeLen, char *mockBackendSchema, MockQueue *mockQueue)
+            : Backend(mockConfig, mockConfigSchemeLen, mockBackendSchema, mockQueue) {
         if (mockConfig == nullptr) {
             std::cout << "mockConfig == null" << std::endl;
         } else {
@@ -99,5 +105,6 @@ public:
 
 long getBackend(void *config, int configSchemaLen, char *configSchema) {
     MockBackend::MockConfig *mockConfig = (MockBackend::MockConfig *) config;
-    return (long) new MockBackend(mockConfig, configSchemaLen, configSchema);
+    MockBackend::MockQueue *mockQueue = (MockBackend::MockQueue *) new MockBackend::MockQueue();
+    return (long) new MockBackend(mockConfig, configSchemaLen, configSchema, mockQueue);
 }

--- a/hat/backends/ffi/opencl/include/opencl_backend.h
+++ b/hat/backends/ffi/opencl/include/opencl_backend.h
@@ -68,7 +68,8 @@ public:
        cl_event *events;
        size_t eventc;
        cl_command_queue command_queue;
-       OpenCLQueue():Backend::Queue(){}
+       OpenCLQueue():Backend::Queue(), eventMax(256), events(new cl_event[eventMax]), eventc(0){
+       }
        virtual ~OpenCLQueue(){}
     };
 
@@ -78,21 +79,14 @@ public:
             class OpenCLBuffer : public Backend::Program::Kernel::Buffer {
             public:
                 cl_mem clMem;
-
                 void copyToDevice();
-
                 void copyFromDevice();
-
                 OpenCLBuffer(Backend::Program::Kernel *kernel, Arg_s *arg);
-
                 virtual ~OpenCLBuffer();
             };
 
         private:
             cl_kernel kernel;
-            size_t eventMax;
-            cl_event *events;
-            size_t eventc;
         protected:
             void showEvents(int width);
         public:
@@ -119,18 +113,11 @@ public:
 public:
     cl_platform_id platform_id;
     cl_context context;
-   // cl_command_queue command_queue;
     cl_device_id device_id;
-
-
     OpenCLBackend();
-
     OpenCLBackend(OpenCLConfig *config, int configSchemaLen, char *configSchema);
-
     ~OpenCLBackend();
-
     int getMaxComputeUnits();
-
     void info();
     void dumpSled(std::ostream &out,void *argArray);
     char *dumpSchema(std::ostream &out,int depth, char *ptr, void *data);

--- a/hat/backends/ffi/opencl/include/opencl_backend.h
+++ b/hat/backends/ffi/opencl/include/opencl_backend.h
@@ -62,6 +62,15 @@ public:
     public:
         boolean gpu;
     };
+    class OpenCLQueue : public Backend::Queue {
+    public:
+       size_t eventMax;
+       cl_event *events;
+       size_t eventc;
+       cl_command_queue command_queue;
+       OpenCLQueue():Backend::Queue(){}
+       virtual ~OpenCLQueue(){}
+    };
 
     class OpenCLProgram : public Backend::Program {
         class OpenCLKernel : public Backend::Program::Kernel {
@@ -110,7 +119,7 @@ public:
 public:
     cl_platform_id platform_id;
     cl_context context;
-    cl_command_queue command_queue;
+   // cl_command_queue command_queue;
     cl_device_id device_id;
 
 

--- a/hat/backends/ffi/shared/cpp/shared.cpp
+++ b/hat/backends/ffi/shared/cpp/shared.cpp
@@ -109,7 +109,7 @@ void Sled::show(std::ostream &out, void *argArray) {
                 break;
             }
             default: {
-                std::cerr << "unexpected variant '" << (char) arg->variant << "'" << std::endl;
+                std::cerr << "unexpected variant (shared.cpp) '" << (char) arg->variant << "'" << std::endl;
                 exit(1);
             }
         }

--- a/hat/backends/ffi/shared/include/shared.h
+++ b/hat/backends/ffi/shared/include/shared.h
@@ -109,7 +109,6 @@ extern void hexdump(void *ptr, int buflen);
     long sizeInBytes;     // The size of the memory segment in bytes
     void *vendorPtr;       // The vendor side can reference vendor into
     u8_t access;          // 0=??/1=RO/2=WO/3=RW if this is a buffer
-  //  u8_t state;           // 0=UNKNOWN/1=GPUDIRTY/2=JAVADIRTY
 } ;
 
  union Value_u {

--- a/hat/backends/ffi/shared/include/shared.h
+++ b/hat/backends/ffi/shared/include/shared.h
@@ -77,16 +77,17 @@ extern void hexdump(void *ptr, int buflen);
  // hat iface buffer bits
  // hat iface bffa   bits
  // 4a7 1face bffa   b175
- #define MAGIC (0x4a71facebffab175)
- #define BIT_HOST_NEW (0x0004)
- #define BIT_GPU_NEW (0x0008)
- #define BIT_HOST_DIRTY (0x0001)
- #define BIT_GPU_DIRTY (0x0002)
- #define MODE_ALWAYS_COPY_OUT (0x0001)
- #define MODE_ALWAYS_COPY_IN  (0x0002)
- #define MODE_ALWAYS_COPY_IN_AND_OUT (MODE_ALWAYS_COPY_IN | MODE_ALWAYS_COPY_OUT)
+
 
  struct BufferState_s{
+   static const long  MAGIC =0x4a71facebffab175;
+   static const int   BIT_HOST_NEW =0x0004;
+   static const int   BIT_GPU_NEW =0x0008;
+   static const int   BIT_HOST_DIRTY =0x0001;
+   static const int   BIT_GPU_DIRTY =0x0002;
+   static const int   MODE_ALWAYS_COPY_OUT =0x0001;
+   static const int   MODE_ALWAYS_COPY_IN  =0x0002;
+   static const int   MODE_ALWAYS_COPY_IN_AND_OUT=(MODE_ALWAYS_COPY_IN | MODE_ALWAYS_COPY_OUT);
    long magic1;
    int bits;
    int mode;
@@ -104,9 +105,17 @@ extern void hexdump(void *ptr, int buflen);
    bool isGpuDirty(){
       return (bits&BIT_GPU_DIRTY)==BIT_GPU_DIRTY;
    }
+   bool isModeAlwaysCopyInAndOut(){
+      return (mode&MODE_ALWAYS_COPY_IN_AND_OUT)==MODE_ALWAYS_COPY_IN_AND_OUT;
+   }
+   bool isModeAlwaysCopyIn(){
+      return (mode&MODE_ALWAYS_COPY_IN)==MODE_ALWAYS_COPY_IN;
+   }
+   bool isModeAlwaysCopyOut(){
+      return (mode&MODE_ALWAYS_COPY_OUT)==MODE_ALWAYS_COPY_OUT;
+   }
 
    void dump(const char *msg){
-
      if (ok()){
         printf("{%s, bits:%08x, mode:%08x, vendorPtr:%016lx}\n", msg, bits, mode, (long)vendorPtr);
      }else{

--- a/hat/backends/ffi/spirv/cpp/spirv_backend.cpp
+++ b/hat/backends/ffi/spirv/cpp/spirv_backend.cpp
@@ -29,6 +29,11 @@ public:
     class SpirvConfig : public Backend::Config {
     public :
     };
+      class SpirvQueue : public Backend::Queue {
+        public :
+           SpirvQueue():Backend::Queue(){}
+                 virtual ~SpirvQueue(){}
+        };
 
     class SpirvProgram : public Backend::Program {
         class SpirvKernel : public Backend::Program::Kernel {
@@ -65,8 +70,8 @@ public:
 
 public:
 
-    SpirvBackend(SpirvConfig *spirvConfig, int spirvConfigSchemeLen, char *spirvBackendSchema)
-            : Backend(spirvConfig, spirvConfigSchemeLen, spirvBackendSchema) {
+    SpirvBackend(SpirvConfig *spirvConfig, int spirvConfigSchemeLen, char *spirvBackendSchema, SpirvQueue *spirvQueue )
+            : Backend(spirvConfig, spirvConfigSchemeLen, spirvBackendSchema, spirvQueue) {
         if (spirvConfig == nullptr) {
             std::cout << "spirvConfig == null" << std::endl;
         } else {
@@ -99,5 +104,6 @@ public:
 
 long getBackend(void *config, int configSchemaLen, char *configSchema) {
     SpirvBackend::SpirvConfig *spirvConfig = (SpirvBackend::SpirvConfig *) config;
-    return (long) new SpirvBackend(spirvConfig, configSchemaLen, configSchema);
+    SpirvBackend::SpirvQueue *spirvQueue = new SpirvBackend::SpirvQueue();
+    return (long) new SpirvBackend(spirvConfig, configSchemaLen, configSchema, spirvQueue);
 }

--- a/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
+++ b/hat/examples/violajones/src/main/java/violajones/ifaces/Cascade.java
@@ -132,15 +132,9 @@ public interface Cascade extends Buffer {
 
     int featureCount();
 
- //  void featureCount(int featureCount);
-
-
     Feature feature(long idx);
 
     int stageCount();
-
-  //  void stageCount(int stageCount);
-
 
     Stage stage(long idx);
 

--- a/hat/hat/src/main/java/hat/ComputeContext.java
+++ b/hat/hat/src/main/java/hat/ComputeContext.java
@@ -155,34 +155,16 @@ public class ComputeContext implements BufferAllocator {
         }
     }
 
-   // public void clearRuntimeInfo() {
-     //   runtimeInfo = new RuntimeInfo();
-   // }
-
-  //  public static class RuntimeInfo {
-      //  public Set<Buffer> javaDirty = new HashSet<>();
-       // Set<Buffer> gpuDirty = new HashSet<>();
-  //  }
-
-  //  public RuntimeInfo runtimeInfo = null;
-
     public void preMutate(Buffer b) {
         // System.out.println("preMutate " + b);
-       // if (runtimeInfo.gpuDirty.contains(b)) {
-          //  throw new IllegalStateException("We want to mutate a buffer on the java side but it is marked as gpu dirty.");
-       // }
     }
 
     public void postMutate(Buffer b) {
         // System.out.println("postMutate " + b);
-       // runtimeInfo.javaDirty.add(b);
     }
 
     public void preAccess(Buffer b) {
         // System.out.println("preAccess " + b);
-      //  if (runtimeInfo.gpuDirty.contains(b)) {
-        //    throw new IllegalStateException("We want to access a buffer on the java side but it is marked as gpu dirty.");
-       // }
     }
 
     public void postAccess(Buffer b) {
@@ -191,14 +173,11 @@ public class ComputeContext implements BufferAllocator {
 
     public void preEscape(Buffer b) {
         // System.out.println("preEscape " + b);
-       // if (runtimeInfo.gpuDirty.contains(b)) {
-           // throw new IllegalStateException("We called a method which escapes a buffer on the java side but it is marked as gpu dirty.");
-      //  }
+
     }
 
     public void postEscape(Buffer b) {
         // System.out.println("postEscape " + b);
-      //  runtimeInfo.javaDirty.add(b);
     }
 
     @Override

--- a/hat/hat/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/hat/src/main/java/hat/buffer/ArgArray.java
@@ -287,8 +287,6 @@ public interface ArgArray extends Buffer {
     }
 
     static void update(ArgArray argArray,  Object... args) {
-        final byte javaDirty = 1;
-        final byte javaClean = 0;
         for (int i = 0; i < args.length; i++) {
             Object argObject = args[i];
             Arg arg = argArray.arg(i);

--- a/hat/hat/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/hat/src/main/java/hat/buffer/ArgArray.java
@@ -42,11 +42,8 @@ public interface ArgArray extends Buffer {
                 void address(MemorySegment address);
                 long bytes();
                 void bytes(long bytes);
-                MemorySegment vendorPtr();
-                void vendorPtr(MemorySegment vendorPtr);
                 byte access();
                 void access(byte access);
-
             }
 
             boolean z1();
@@ -212,8 +209,8 @@ public interface ArgArray extends Buffer {
     Arg arg(long idx);
 
 
-    MemorySegment vendorPtr();
-    void vendorPtr(MemorySegment vendorPtr);
+    //MemorySegment vendorPtr();
+    //void vendorPtr(MemorySegment vendorPtr);
 
     int schemaLen();
 
@@ -227,12 +224,12 @@ public interface ArgArray extends Buffer {
                             .field("value", value->value
                                             .fields("z1","s8","u16","s16","s32","u32","f32","s64","u64","f64")
                                                     .field("buf", buf->buf
-                                                            .fields("address","bytes","vendorPtr","access")
+                                                            .fields("address","bytes",/*"vendorPtr",*/"access")
                                                             .pad((int)(16 - JAVA_BYTE.byteSize()/* - JAVA_BYTE.byteSize()*/))
                                                     )
                             )
                     )
-            .field("vendorPtr")
+         //   .field("vendorPtr")
             .arrayLen("schemaLen").array("schemaBytes")
     );
 

--- a/hat/hat/src/main/java/hat/buffer/Buffer.java
+++ b/hat/hat/src/main/java/hat/buffer/Buffer.java
@@ -30,15 +30,12 @@ import hat.ifacemapper.MappableIface;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.lang.invoke.VarHandle;
 import java.lang.reflect.InvocationTargetException;
 
 import static hat.ifacemapper.MapperUtil.SECRET_BOUND_SCHEMA_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_LAYOUT_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_OFFSET_METHOD_NAME;
 import static hat.ifacemapper.MapperUtil.SECRET_SEGMENT_METHOD_NAME;
-import static hat.ifacemapper.SegmentMapper.MAGIC;
 
 public interface Buffer extends MappableIface {
 
@@ -56,7 +53,7 @@ public interface Buffer extends MappableIface {
         }
     }
 
-    static <T extends Buffer> BoundSchema getBoundSchema(T buffer) {
+    static <T extends Buffer> BoundSchema<?> getBoundSchema(T buffer) {
         try {
             return (BoundSchema<?>) buffer.getClass().getDeclaredMethod(SECRET_BOUND_SCHEMA_METHOD_NAME).invoke(buffer);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
@@ -77,86 +74,6 @@ public interface Buffer extends MappableIface {
             return (long) buffer.getClass().getDeclaredMethod(SECRET_OFFSET_METHOD_NAME).invoke(buffer);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    /*
-     * A hack for accessing the tailbits from a memory segment.  Hopefully I can get this from
-     * ifacemapper
-     * See SegmentMapper allocate and backend_ffi_shared/include/shared.h
-
-        struct ifacebufferpayload_t{
-          int javaDirty;
-          int gpuDirty;
-          int unused[2];
-        };
-
-        struct ifacebufferbitz_t{
-           long magic1; // MAGIC
-           ifacebufferpayload_t payload;
-           long magic2; // MAGIC
-        }
-     */
-
-    record Tail(Buffer buffer, MemorySegment segment, long offset ) implements MappableIface {
-
-        public static final long tailLength = 4 * ValueLayout.JAVA_LONG.byteSize();
-        public static final long magic1Offset =0;
-        public static final long magic2Offset =3 * ValueLayout.JAVA_LONG.byteSize();
-        public static final long javaDirtyOffset =ValueLayout.JAVA_LONG.byteSize();
-        public static final long gpuDirtyOffset =ValueLayout.JAVA_LONG.byteSize()+ValueLayout.JAVA_INT.byteSize();
-
-        public static Tail of(Buffer buffer) {
-            MemorySegment segment = getMemorySegment(buffer);
-            return new Tail(buffer, segment, segment.byteSize() - tailLength);
-        }
-        public long magic1(){
-            return segment.get(ValueLayout.JAVA_LONG, offset +magic1Offset);
-        }
-        public int javaDirty(){
-            return segment.get(ValueLayout.JAVA_INT, offset +javaDirtyOffset);
-        }
-        public boolean isJavaDirty(){
-            return javaDirty()!=0;
-        }
-        public int gpuDirty(){
-            return segment.get(ValueLayout.JAVA_INT, offset +gpuDirtyOffset);
-        }
-        public boolean isGpuDirty(){
-            return gpuDirty()!=0;
-        }
-
-        public long magic2(){
-            return segment.get(ValueLayout.JAVA_LONG, offset+ magic2Offset);
-        }
-        public boolean isOK() {
-            if (magic1() != MAGIC) {
-                System.out.println("magic1=" + magic1()+ " != " + MAGIC);
-                return false;
-            }
-            if (magic2() != MAGIC) {
-                System.out.println("magic2=" + magic2() + " != " + MAGIC);
-                return false;
-            }
-            return true;
-        }
-    }
-
-
-    default boolean isJavaDirty(){
-        var seg = getMemorySegment(this);
-        if (seg != null){
-            long sizeInBytes = seg.byteSize();
-            long magic1 = seg.get(ValueLayout.JAVA_LONG, sizeInBytes-4*ValueLayout.JAVA_LONG.byteSize());
-
-            if (magic1 != MAGIC){
-                System.out.println("magic1=" + magic1+" != "+MAGIC);
-            }else{
-                System.out.println("magic1=" + magic1+" != "+MAGIC);
-            }
-            return true;
-        } else {
-            return false;
         }
     }
 }

--- a/hat/hat/src/main/java/hat/callgraph/CallGraph.java
+++ b/hat/hat/src/main/java/hat/callgraph/CallGraph.java
@@ -27,6 +27,7 @@ package hat.callgraph;
 import hat.ComputeContext;
 import hat.optools.FuncOpWrapper;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import jdk.incubator.code.type.MethodRef;
 import java.util.HashSet;
@@ -55,14 +56,13 @@ public abstract class CallGraph<E extends Entrypoint> {
     }
 
     public abstract static class MethodCall {
-
+        public CallGraph<?> callGraph;
         public final Method method;
         public final Class<?> declaringClass;
-        public CallGraph<?> callGraph;
+        private final Annotation[][] annotatedParameters;
         public final Set<MethodCall> calls = new HashSet<>();
         public final Set<MethodCall> callers = new HashSet<>();
         public final MethodRef targetMethodRef;
-
         public boolean closed = false;
         public int rank = 0;
 
@@ -71,6 +71,16 @@ public abstract class CallGraph<E extends Entrypoint> {
             this.targetMethodRef = targetMethodRef;
             this.method = method;
             this.declaringClass = method.getDeclaringClass();
+            this.annotatedParameters= method.getParameterAnnotations();
+            for (int i = 0; i < annotatedParameters.length; i++) {
+                Annotation[] annotations = annotatedParameters[i];
+                if (annotations.length != 0) {
+                    for (int a = 0; a < annotations.length; a++) {
+                        Annotation annotation = annotations[a];
+                        //System.out.println("annotation: " + annotation);
+                    }
+                }
+            }
         }
 
 

--- a/hat/hat/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/hat/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -29,18 +29,14 @@ import hat.optools.FuncOpWrapper;
 import hat.optools.OpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.op.CoreOp;
-import jdk.incubator.code.type.ClassType;
-import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.type.MethodRef;
-import jdk.incubator.code.type.PrimitiveType;
-
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
+    public final ComputeCallGraph computeCallGraph;
+
     public interface KernelReachable {
     }
 
@@ -68,8 +64,6 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
             super(callGraph, targetMethodRef, method);
         }
     }
-
-    public final ComputeCallGraph computeCallGraph;
 
     public Stream<KernelReachableResolvedMethodCall> kernelReachableResolvedStream() {
         return methodRefToMethodCallMap.values().stream()

--- a/hat/hat/src/main/java/hat/ifacemapper/SegmentMapper.java
+++ b/hat/hat/src/main/java/hat/ifacemapper/SegmentMapper.java
@@ -359,7 +359,7 @@ public interface SegmentMapper<T> {
         struct ifacebufferpayload_t{
           int javaDirty;
           int gpuDirty;
-          int unused[2];
+          long vendorPtr; void *vendorPtr
         };
 
         struct ifacebufferbitz_t{

--- a/hat/intellij/.idea/compiler.xml
+++ b/hat/intellij/.idea/compiler.xml
@@ -10,6 +10,7 @@
     <option name="ADDITIONAL_OPTIONS_STRING" value="--add-modules=jdk.incubator.code --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">
       <module name="glwrap" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
+      <module name="hat" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
       <module name="life" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
       <module name="mandel" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
     </option>


### PR DESCRIPTION
Ongoing work for moving towards buffer marking to reduce unnecessary copies. 

Here mostly infrastructural 

We moved buffer status data from the ArgSled to a trailing BufferState section at the end of each Buffer. 
The native buffers now are kept in this buffer state section along with marker bits (host dirty, gpu dirty) 
OpenCL + Mock + Spirv native backends now have event queues separated from the Kernel (in prep for the buffer to outlive the kernel dispatch)
Changes tested on OpenCL (and Mock). 
CUDA Backends very likely broken.  I will come back to those. 
HIP also.  I need to work with AMD to sync the OpenCL changes to HIP backend. 

Buffers are still copied in and out on each dispatch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/318/head:pull/318` \
`$ git checkout pull/318`

Update a local copy of the PR: \
`$ git checkout pull/318` \
`$ git pull https://git.openjdk.org/babylon.git pull/318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 318`

View PR using the GUI difftool: \
`$ git pr show -t 318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/318.diff">https://git.openjdk.org/babylon/pull/318.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/318#issuecomment-2659650707)
</details>
