### PR TITLE
MNISTDemo UI tweak

### DIFF
--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/MNISTDemo.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/MNISTDemo.java
@@ -29,6 +29,7 @@ import java.awt.image.BufferedImage;
 import java.io.*;
 import jdk.incubator.code.CodeReflection;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -47,10 +48,9 @@ import static oracle.code.onnx.OnnxOperators.*;
 import static oracle.code.onnx.Tensor.ElementType.*;
 
 public class MNISTDemo {
-
     private static float[] loadConstant(String resource) throws IOException {
-        var bb = ByteBuffer.wrap(MNISTDemo.class.getResourceAsStream(resource).readAllBytes()).order(ByteOrder.LITTLE_ENDIAN);
-        return FloatBuffer.allocate(bb.capacity() / 4).put(bb.asFloatBuffer()).array();
+        return MemorySegment.ofArray(MNISTDemo.class.getResourceAsStream(resource).readAllBytes())
+                .toArray(ValueLayout.JAVA_FLOAT_UNALIGNED);
     }
 
     @CodeReflection

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/MNISTDemo.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/MNISTDemo.java
@@ -110,6 +110,7 @@ public class MNISTDemo {
     static final int IMAGE_SIZE = 28;
     static final int DRAW_AREA_SIZE = 600;
     static final int PEN_SIZE = 20;
+    static final String[] COLORS = {"1034a6", "412f88", "722b6a", "a2264b", "d3212d", "f62d2d"};
 
     public static void main(String[] args) throws Exception {
         var frame = new JFrame("CNN MNIST Demo - Handwritten Digit Classification");
@@ -161,7 +162,9 @@ public class MNISTDemo {
                     FloatBuffer result = OnnxRuntime.getInstance().tensorBuffer(modelRuntimeSession.run(inputArguments).getFirst()).asFloatBuffer();
                     var msg = new StringBuilder("<html>");
                     for (int i = 0; i < 10; i++) {
-                        msg.append("&nbsp;<font size=\"%d\">%d</font>&nbsp;(%.1f%%)&nbsp;<br><br><br>".formatted((int)(20 * result.get(i) + 3), i, 100 * result.get(i)));
+                        var w = result.get(i);
+                        msg.append("&nbsp;<font size=\"%d\" color=\"#%s\">%d</font>&nbsp;(%.1f%%)&nbsp;<br><br><br>"
+                                .formatted((int)(20 * w) + 3, COLORS[(int)(5.99 * w)], i, 100 * w));
                     }
                     results.setText(msg.toString());
                     cleanFlag.set(true);


### PR DESCRIPTION
MNISTDemo UI adjusted.

![screenshot](https://github.com/user-attachments/assets/e0054126-45e5-4eec-bf2d-707475dfc5b1)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [6799f648](https://git.openjdk.org/babylon/pull/327/files/6799f648b927bc1ae56d10617f55b2e2fcb950e5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/327/head:pull/327` \
`$ git checkout pull/327`

Update a local copy of the PR: \
`$ git checkout pull/327` \
`$ git pull https://git.openjdk.org/babylon.git pull/327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 327`

View PR using the GUI difftool: \
`$ git pr show -t 327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/327.diff">https://git.openjdk.org/babylon/pull/327.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/327#issuecomment-2679440690)
</details>
