### PR TITLE
Use memory segment

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/Tensor.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/Tensor.java
@@ -28,7 +28,6 @@ package oracle.code.onnx;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.nio.ByteBuffer;
 
     /*
 class DataType(enum.IntEnum):
@@ -93,20 +92,20 @@ public class Tensor<T> extends OnnxNumber {
 
     public static Tensor<Byte> ofShape(long[] shape, byte... values) {
         var data = Arena.ofAuto().allocateFrom(ValueLayout.JAVA_BYTE, values);
-        return new Tensor(data, ElementType.UINT8, shape);
+        return new Tensor<>(data, ElementType.UINT8, shape);
     }
 
     public static Tensor<Long> ofShape(long[] shape, long... values) {
         var data = Arena.ofAuto().allocateFrom(ValueLayout.JAVA_LONG, values);
-        return new Tensor(data, ElementType.INT64, shape);
+        return new Tensor<>(data, ElementType.INT64, shape);
     }
 
     public static Tensor<Float> ofShape(long[] shape, float... values) {
         var data = Arena.ofAuto().allocateFrom(ValueLayout.JAVA_FLOAT, values);
-        return new Tensor(data, ElementType.FLOAT, shape);
+        return new Tensor<>(data, ElementType.FLOAT, shape);
     }
 
-    // Mandatory reference to dataAddr to avoid its garbage colletion
+    // Mandatory reference to dataAddr to avoid its garbage collection
     private final MemorySegment dataAddr;
     final MemorySegment tensorAddr;
 
@@ -123,8 +122,8 @@ public class Tensor<T> extends OnnxNumber {
         this.tensorAddr = tensorAddr;
     }
 
-    public ByteBuffer asByteBuffer() {
-        return OnnxRuntime.getInstance().tensorBuffer(tensorAddr);
+    public MemorySegment data() {
+        return OnnxRuntime.getInstance().tensorData(tensorAddr);
     }
 
     public enum ElementType {

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
@@ -38,8 +38,10 @@ import oracle.code.onnx.ir.OnnxType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
+import java.nio.ByteOrder;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -321,12 +323,12 @@ public class CNNTest {
         });
     }
 
-    static void printImage(int imageIndex, ByteBuffer bb) {
+    static void printImage(int imageIndex, MemorySegment bb) {
         System.out.println("Image #" + imageIndex + " :");
         int offset = imageIndex * 28 * 28;
         for (int y = 0; y < 28; y++) {
             for (int x = 0; x < 28; x++) {
-                System.out.print(GREY_SCALE.charAt(GREY_SCALE.length() * (0xff & bb.get(offset + y * 28 + x)) / 256));
+                System.out.print(GREY_SCALE.charAt(GREY_SCALE.length() * (0xff & bb.get(ValueLayout.JAVA_BYTE, offset + y * 28 + x)) / 256));
             }
             System.out.println();
         }
@@ -334,7 +336,8 @@ public class CNNTest {
 
     private static Tensor<Float> floatTensor(String resource, long... shape) throws IOException {
         try (var file = new RandomAccessFile(CNNTest.class.getResource(resource).getPath(), "r")) {
-            return new Tensor(file.getChannel().map(FileChannel.MapMode.READ_ONLY, 0, file.length(), ARENA), Tensor.ElementType.FLOAT, shape);
+            return new Tensor<>(file.getChannel().map(FileChannel.MapMode.READ_ONLY, 0, file.length(), ARENA),
+                    Tensor.ElementType.FLOAT, shape);
         }
     }
 
@@ -397,21 +400,25 @@ public class CNNTest {
         try (RandomAccessFile imagesF = new RandomAccessFile(IMAGES_PATH, "r");
              RandomAccessFile labelsF = new RandomAccessFile(LABELS_PATH, "r")) {
 
-            ByteBuffer imagesIn = imagesF.getChannel().map(FileChannel.MapMode.READ_ONLY, IMAGES_HEADER_SIZE, imagesF.length() - IMAGES_HEADER_SIZE);
-            ByteBuffer labelsIn = labelsF.getChannel().map(FileChannel.MapMode.READ_ONLY, LABELS_HEADER_SIZE, labelsF.length() - LABELS_HEADER_SIZE);
+            MemorySegment imagesIn = imagesF.getChannel().map(FileChannel.MapMode.READ_ONLY,
+                    IMAGES_HEADER_SIZE, imagesF.length() - IMAGES_HEADER_SIZE, ARENA);
+            MemorySegment labelsIn = labelsF.getChannel().map(FileChannel.MapMode.READ_ONLY,
+                    LABELS_HEADER_SIZE, labelsF.length() - LABELS_HEADER_SIZE, ARENA);
+            ByteBuffer labelsInBuffer = labelsIn.asByteBuffer().order(ByteOrder.nativeOrder());
 
-            Tensor<Byte> inputImage = new Tensor(MemorySegment.ofBuffer(imagesIn), Tensor.ElementType.UINT8, new long[]{imagesF.length() - IMAGES_HEADER_SIZE});
+            Tensor<Byte> inputImage = new Tensor<>(imagesIn, Tensor.ElementType.UINT8,
+                    new long[]{imagesF.length() - IMAGES_HEADER_SIZE});
+            MemorySegment result = executor.apply(inputImage).data();
 
-            FloatBuffer result = executor.apply(inputImage).asByteBuffer().asFloatBuffer();
-
+            FloatBuffer resultBuffer = result.asByteBuffer().order(ByteOrder.nativeOrder()).asFloatBuffer();
             int matched = 0, mismatched = 0;
-            while (result.remaining() > 0) {
-                int expected = labelsIn.get();
-                int actual = nextBestMatch(result);
+            while (resultBuffer.remaining() > 0) {
+                int expected = labelsInBuffer.get();
+                int actual = nextBestMatch(resultBuffer);
                 if (expected == actual) {
                     matched++;
                 } else {
-                    int imageIndex = labelsIn.position() - 1;
+                    int imageIndex = labelsInBuffer.position() - 1;
                     printImage(imageIndex, imagesIn);
                     System.out.println("expected: " + expected + " actual: " + actual);
                     System.out.println("-".repeat(28));

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
@@ -323,12 +323,12 @@ public class CNNTest {
         });
     }
 
-    static void printImage(int imageIndex, MemorySegment bb) {
+    static void printImage(int imageIndex, MemorySegment ms) {
         System.out.println("Image #" + imageIndex + " :");
         int offset = imageIndex * 28 * 28;
         for (int y = 0; y < 28; y++) {
             for (int x = 0; x < 28; x++) {
-                System.out.print(GREY_SCALE.charAt(GREY_SCALE.length() * (0xff & bb.get(ValueLayout.JAVA_BYTE, offset + y * 28 + x)) / 256));
+                System.out.print(GREY_SCALE.charAt(GREY_SCALE.length() * (0xff & ms.get(ValueLayout.JAVA_BYTE, offset + y * 28 + x)) / 256));
             }
             System.out.println();
         }


### PR DESCRIPTION
Replace many uses of `ByteBuffer` use with idiomatic `MemorySegment` use. This also tends to make clearer the life cycle of segments. Generally in any ONNX APIs we design i think we should avoid exposing `*Buffer`. The "escape hatch" for accessing the data of a `Tensor` should be `MemorySegment`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/328/head:pull/328` \
`$ git checkout pull/328`

Update a local copy of the PR: \
`$ git checkout pull/328` \
`$ git pull https://git.openjdk.org/babylon.git pull/328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 328`

View PR using the GUI difftool: \
`$ git pr show -t 328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/328.diff">https://git.openjdk.org/babylon/pull/328.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/328#issuecomment-2683026325)
</details>
