### PR TITLE
Short cut for single method execution

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
@@ -4,18 +4,20 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import jdk.incubator.code.*;
 
 import jdk.incubator.code.op.CoreOp;
+import jdk.incubator.code.type.ClassType;
 import jdk.incubator.code.type.FunctionType;
+import jdk.incubator.code.type.MethodRef;
 import jdk.incubator.code.type.VarType;
 import oracle.code.onnx.compiler.OnnxTransformer;
 import oracle.code.onnx.foreign.OrtApi;
@@ -49,27 +51,143 @@ public final class OnnxRuntime {
         }
     }
 
-    public static <T, U extends Quotable & Supplier<Tensor<T>>> Tensor<T> execute(U codeLambda) {
+    @FunctionalInterface
+    public interface OnnxFunction<T> extends Supplier<T>, Quotable {
+    }
+
+    public static <T> Tensor<T> execute(MethodHandles.Lookup l, OnnxFunction<Tensor<T>> codeLambda) {
         var quotable = Op.ofQuotable(codeLambda).orElseThrow();
         var lambda = (CoreOp.LambdaOp) quotable.op();
-        var capturedValues = lambda.capturedValues();
-        var onnxFunc = OnnxTransformer.transform(MethodHandles.lookup(), CoreOp.func("onnxCode", FunctionType.functionType(
-                lambda.invokableType().returnType(),
-                capturedValues.stream().map(Value::type).map(t -> t instanceof VarType vt ? vt.valueType() : t).toList()))
-                .body(bb -> {
-                    bb.context().mapValues(capturedValues, bb.parameters());
-                    for (Op op : lambda.body().entryBlock().ops()) {
-                        int i;
-                        if (op instanceof CoreOp.VarAccessOp.VarLoadOp load && (i = capturedValues.indexOf(load.varOp().result())) >= 0) {
-                            bb.context().mapValue(op.result(), bb.parameters().get(i)); // remap var load result to block param
-                        } else {
-                            bb.apply(op);
+
+        CoreOp.FuncOp onnxFunc;
+        // Shortcut for lambda expressions that call just one method
+        if (singleMethodInvocation(lambda) instanceof CoreOp.InvokeOp iop) {
+            Method m;
+            try {
+                m = iop.invokeDescriptor().resolveToMethod(l, iop.invokeKind());
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+
+            CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
+            onnxFunc = OnnxTransformer.transform(l, f);
+        } else {
+            var capturedValues = lambda.capturedValues();
+            var functionType = FunctionType.functionType(lambda.invokableType().returnType(),
+                    capturedValues.stream().map(Value::type)
+                            .map(t -> t instanceof VarType vt ? vt.valueType() : t).toList());
+            onnxFunc = OnnxTransformer.transform(l, CoreOp.func("onnxCode", functionType)
+                    .body(bb -> {
+                        bb.context().mapValues(capturedValues, bb.parameters());
+                        for (Op op : lambda.body().entryBlock().ops()) {
+                            int i;
+                            if (op instanceof CoreOp.VarAccessOp.VarLoadOp load &&
+                                    (i = capturedValues.indexOf(load.varOp().result())) >= 0) {
+                                bb.context().mapValue(op.result(), bb.parameters().get(i)); // remap var load result to block param
+                            } else {
+                                bb.apply(op);
+                            }
                         }
-                    }
-                }));
-        try (var session = getInstance().createSession(OnnxProtoBuilder.build(onnxFunc.body().entryBlock()))) {
-            return session.run(quotable.capturedValues().values().stream().map(val -> (Tensor)(val instanceof CoreOp.Var v ? v.value() : val)).toList()).getFirst();
+                    }));
         }
+
+        try (var session = getInstance().createSession(OnnxProtoBuilder.build(onnxFunc.body().entryBlock()))) {
+            List<Tensor> arguments = quotable.capturedValues().values().stream()
+                    .map(val -> val instanceof CoreOp.Var<?> v ? v.value() : val)
+                    .map(val -> (Tensor) val)
+                    .toList();
+            return session.run(arguments).getFirst();
+        }
+    }
+
+    static CoreOp.InvokeOp singleMethodInvocation(CoreOp.LambdaOp lop) {
+        // Single block
+        if (lop.body().blocks().size() > 1) {
+            return null;
+        }
+
+        Map<Value, Value> valueMapping = new HashMap<>();
+        CoreOp.InvokeOp methodRefInvokeOp = extractMethodInvoke(valueMapping, lop.body().entryBlock().ops());
+        if (methodRefInvokeOp == null) {
+            return null;
+        }
+
+        return methodRefInvokeOp;
+    }
+
+    static CoreOp.InvokeOp extractMethodInvoke(Map<Value, Value> valueMapping, List<Op> ops) {
+        CoreOp.InvokeOp methodRefInvokeOp = null;
+        for (Op op : ops) {
+            switch (op) {
+                case CoreOp.VarOp varOp -> {
+                    if (isValueUsedWithOp(varOp.result(), o -> o instanceof CoreOp.VarAccessOp.VarStoreOp)) {
+                        return null;
+                    }
+                }
+                case CoreOp.VarAccessOp.VarLoadOp varLoadOp -> {
+                    Value v = varLoadOp.varOp().operands().getFirst();
+                    valueMapping.put(varLoadOp.result(), valueMapping.getOrDefault(v, v));
+                }
+                case CoreOp.InvokeOp iop when isBoxOrUnboxInvocation(iop) -> {
+                    Value v = iop.operands().getFirst();
+                    valueMapping.put(iop.result(), valueMapping.getOrDefault(v, v));
+                }
+                case CoreOp.InvokeOp iop -> {
+                    if (methodRefInvokeOp != null) {
+                        return null;
+                    }
+
+                    for (Value o : iop.operands()) {
+                        valueMapping.put(o, valueMapping.getOrDefault(o, o));
+                    }
+                    methodRefInvokeOp = iop;
+                }
+                case CoreOp.ReturnOp rop -> {
+                    if (methodRefInvokeOp == null) {
+                        return null;
+                    }
+                    Value r = rop.returnValue();
+                    if (!(valueMapping.getOrDefault(r, r) instanceof Op.Result invokeResult)) {
+                        return null;
+                    }
+                    if (invokeResult.op() != methodRefInvokeOp) {
+                        return null;
+                    }
+                    assert methodRefInvokeOp.result().uses().size() == 1;
+                }
+                default -> {
+                    return null;
+                }
+            }
+        }
+
+        return methodRefInvokeOp;
+    }
+
+    private static boolean isValueUsedWithOp(Value value, Predicate<Op> opPredicate) {
+        for (Op.Result user : value.uses()) {
+            if (opPredicate.test(user.op())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // @@@ Move to functionality on JavaType(s)
+    static final Set<String> UNBOX_NAMES = Set.of(
+            "byteValue",
+            "shortValue",
+            "charValue",
+            "intValue",
+            "longValue",
+            "floatValue",
+            "doubleValue",
+            "booleanValue");
+
+    private static boolean isBoxOrUnboxInvocation(CoreOp.InvokeOp iop) {
+        MethodRef mr = iop.invokeDescriptor();
+        return mr.refType() instanceof ClassType ct && ct.unbox().isPresent() &&
+                (UNBOX_NAMES.contains(mr.name()) || mr.name().equals("valueOf"));
     }
 
     public static OnnxRuntime getInstance() {


### PR DESCRIPTION
This allows us to retain the exact method declaration and simply wrap in a lambda (its like an optimization). The execute method requires the user pass the lookup, otherwise reflective access can fail. We can overload using the public lookup if need be later on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/329/head:pull/329` \
`$ git checkout pull/329`

Update a local copy of the PR: \
`$ git checkout pull/329` \
`$ git pull https://git.openjdk.org/babylon.git pull/329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 329`

View PR using the GUI difftool: \
`$ git pr show -t 329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/329.diff">https://git.openjdk.org/babylon/pull/329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/329#issuecomment-2686429025)
</details>
