### PR TITLE
Tweak order of arena parameter in OnnxRuntime::execute

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
@@ -132,10 +132,10 @@ public final class OnnxRuntime {
     private static final CachedModelClassValue MODEL_CACHE = new CachedModelClassValue();
 
     public static <T> Tensor<T> execute(MethodHandles.Lookup l, OnnxFunction<Tensor<T>> codeLambda) {
-        return execute(l, codeLambda, Arena.ofAuto());
+        return execute(l, Arena.ofAuto(), codeLambda);
     }
 
-    public static <T> Tensor<T> execute(MethodHandles.Lookup l, OnnxFunction<Tensor<T>> codeLambda, Arena sessionArena) {
+    public static <T> Tensor<T> execute(MethodHandles.Lookup l, Arena sessionArena, OnnxFunction<Tensor<T>> codeLambda) {
         var q = Op.ofQuotable(codeLambda).orElseThrow();
 
         var model = MODEL_CACHE.computeIfAbsent(codeLambda.getClass(), l, q);

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/mnist/MNISTDemo.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/mnist/MNISTDemo.java
@@ -110,8 +110,8 @@ public class MNISTDemo {
         try (Arena arena = Arena.ofConfined()) {
             var imageTensor = Tensor.ofShape(new long[]{1, 1, IMAGE_SIZE, IMAGE_SIZE}, imageData);
 
-            var predictionTensor = OnnxRuntime.execute(MethodHandles.lookup(),
-                    () -> cnn(imageTensor), arena);
+            var predictionTensor = OnnxRuntime.execute(MethodHandles.lookup(), arena,
+                    () -> cnn(imageTensor));
 
             return predictionTensor.data().toArray(ValueLayout.JAVA_FLOAT);
         }


### PR DESCRIPTION
As the subject say, this is a trivial change to make the code lambda the last parameter of the `OnnxRuntime::execute` methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/334/head:pull/334` \
`$ git checkout pull/334`

Update a local copy of the PR: \
`$ git checkout pull/334` \
`$ git pull https://git.openjdk.org/babylon.git pull/334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 334`

View PR using the GUI difftool: \
`$ git pr show -t 334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/334.diff">https://git.openjdk.org/babylon/pull/334.diff</a>

</details>
