### PR TITLE
Add tensor factories that accept an external arena

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/Tensor.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/Tensor.java
@@ -96,17 +96,29 @@ public class Tensor<T> extends OnnxNumber {
     }
 
     public static Tensor<Byte> ofShape(long[] shape, byte... values) {
-        var data = Arena.ofAuto().allocateFrom(ValueLayout.JAVA_BYTE, values);
-        return new Tensor(data, ElementType.UINT8, shape);
+        return ofShape(Arena.ofAuto(), shape, values);
     }
 
     public static Tensor<Long> ofShape(long[] shape, long... values) {
-        var data = Arena.ofAuto().allocateFrom(ValueLayout.JAVA_LONG, values);
-        return new Tensor(data, ElementType.INT64, shape);
+        return ofShape(Arena.ofAuto(), shape, values);
     }
 
     public static Tensor<Float> ofShape(long[] shape, float... values) {
-        var data = Arena.ofAuto().allocateFrom(ValueLayout.JAVA_FLOAT, values);
+        return ofShape(Arena.ofAuto(), shape, values);
+    }
+
+    public static Tensor<Byte> ofShape(Arena arena, long[] shape, byte... values) {
+        var data = arena.allocateFrom(ValueLayout.JAVA_BYTE, values);
+        return new Tensor(data, ElementType.UINT8, shape);
+    }
+
+    public static Tensor<Long> ofShape(Arena arena, long[] shape, long... values) {
+        var data = arena.allocateFrom(ValueLayout.JAVA_LONG, values);
+        return new Tensor(data, ElementType.INT64, shape);
+    }
+
+    public static Tensor<Float> ofShape(Arena arena, long[] shape, float... values) {
+        var data = arena.allocateFrom(ValueLayout.JAVA_FLOAT, values);
         return new Tensor(data, ElementType.FLOAT, shape);
     }
 

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/mnist/MNISTDemo.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/mnist/MNISTDemo.java
@@ -43,6 +43,7 @@ import static oracle.code.onnx.OnnxOperators.*;
 public class MNISTDemo {
 
     static final int IMAGE_SIZE = 28;
+    static final long[] IMAGE_SHAPE = { 1, 1, IMAGE_SIZE, IMAGE_SIZE };
 
     public static float[] loadConstant(String resource) {
         try (var in = MNISTDemo.class.getResourceAsStream(resource)) {
@@ -108,7 +109,7 @@ public class MNISTDemo {
 
     public static float[] classify(float[] imageData) {
         try (Arena arena = Arena.ofConfined()) {
-            var imageTensor = Tensor.ofShape(new long[]{1, 1, IMAGE_SIZE, IMAGE_SIZE}, imageData);
+            var imageTensor = Tensor.ofShape(arena, IMAGE_SHAPE, imageData);
 
             var predictionTensor = OnnxRuntime.execute(MethodHandles.lookup(),
                     () -> cnn(imageTensor), arena);


### PR DESCRIPTION
This PR adds three overloaded `Tensor::ofShape` factories which take an external arena. The existing factories have been rewired to call the new ones with a new automatic arena.

This allows us to make a small improvement in the MNISTDemo, where we can now allocate a tensor whose lifetime is managed by the arena that is also used to manage the lifetime of all the resources created within onnx session.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/335/head:pull/335` \
`$ git checkout pull/335`

Update a local copy of the PR: \
`$ git checkout pull/335` \
`$ git pull https://git.openjdk.org/babylon.git pull/335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 335`

View PR using the GUI difftool: \
`$ git pr show -t 335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/335.diff">https://git.openjdk.org/babylon/pull/335.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/335#issuecomment-2697182519)
</details>
