### PR TITLE
Updated UIs for heal and violajones to use seven seg display widget

### DIFF
--- a/hat/examples/heal/src/main/java/heal/Compute.java
+++ b/hat/examples/heal/src/main/java/heal/Compute.java
@@ -55,6 +55,8 @@ import javax.swing.JTextField;
 import java.awt.Point;
 
 import static hat.ifacemapper.MappableIface.*;
+
+import hat.util.ui.SevenSegmentDisplay;
 import jdk.incubator.code.CodeReflection;
 import java.util.stream.IntStream;
 
@@ -90,8 +92,7 @@ public class Compute {
      *  }
      */
 
-    public static void heal(Accelerator accelerator, S32Array2D s32Array2D, Selection selection, Point bestMatchOffset,
-                            JTextField maskTB, JTextField healTB) {
+    public static void heal(Accelerator accelerator, S32Array2D s32Array2D, Selection selection, Point bestMatchOffset) {
         long start = System.currentTimeMillis();
         Selection.Mask mask = selection.getMask();
         var dest = new int[mask.maskRGBData.length];
@@ -104,7 +105,7 @@ public class Compute {
                     : s32Array2D.get( x,  y );
         });
 
-        maskTB.setText(Long.toString(System.currentTimeMillis() - start));
+        //maskTB.setText(Long.toString(System.currentTimeMillis() - start));
         /*   TODO .. Implement laplacian
          * int[] stencil = new int[]{-1, 1, -mask.width, mask.width};
          *
@@ -170,7 +171,7 @@ public class Compute {
             s32Array2D.set( x,  y, dest[i]);
         });
      //   System.out.println("heal2 " + (System.currentTimeMillis() - start) + "ms");
-        healTB.setText(Long.toString(System.currentTimeMillis() - start));
+      //  healTB.setText(Long.toString(System.currentTimeMillis() - start));
     }
 
     @CodeReflection
@@ -270,7 +271,7 @@ public class Compute {
         bestMatchOffset.setLocation(x - selectionBox.x1(),y - selectionBox.y1());
     }
 
-    public static Point getBestMatchOffset(Accelerator accelerator, S32Array2D s32Array2D, Selection selection, JTextField searchTB) {
+    public static Point getBestMatchOffset(Accelerator accelerator, S32Array2D s32Array2D, Selection selection, SevenSegmentDisplay searchSevenSegmentDisplay) {
         final Point bestMatchOffset  =new Point(0,0);
         if (!selection.pointList.isEmpty()) {
             long hatStart = System.currentTimeMillis();
@@ -322,7 +323,8 @@ public class Compute {
             accelerator.compute(cc->
                     Compute.bestFitCompute(cc, bestMatchOffset, s32Array2D, searchArea, selectionBox, xyrgbList
             ));
-            searchTB.setText(Long.toString(System.currentTimeMillis() - hatStart));
+            searchSevenSegmentDisplay.set((int)(System.currentTimeMillis() - hatStart));
+           // searchTB.setText(Long.toString(System.currentTimeMillis() - hatStart));
         }
         return bestMatchOffset;
     }

--- a/hat/examples/heal/src/main/java/heal/Viewer.java
+++ b/hat/examples/heal/src/main/java/heal/Viewer.java
@@ -46,6 +46,7 @@ package heal;
 
 import hat.Accelerator;
 import hat.buffer.S32Array2D;
+import hat.util.ui.SevenSegmentDisplay;
 
 import javax.swing.Box;
 import javax.swing.JButton;
@@ -104,8 +105,8 @@ public  class Viewer extends JFrame {
                 @Override
                 public void mouseReleased(MouseEvent e) {
                     if (SwingUtilities.isLeftMouseButton(e)) {
-                        bestMatchOffset = Compute.getBestMatchOffset(accelerator, s32Array2D, selection.close(), controls.search);
-                        Compute.heal(accelerator, s32Array2D, selection, bestMatchOffset, controls.mask, controls.heal);
+                        bestMatchOffset = Compute.getBestMatchOffset(accelerator, s32Array2D, selection.close(), controls.sevenSegmentDisplay);
+                        Compute.heal(accelerator, s32Array2D, selection, bestMatchOffset);
                         Timer t = new Timer(1000, new ActionListener() {
                             @Override
                             public void actionPerformed(ActionEvent e) {
@@ -224,23 +225,26 @@ public  class Viewer extends JFrame {
     }
     public static class Controls{
         JTextField search;
-        JTextField mask;
-        JTextField heal;
+       // JTextField mask;
+       // JTextField heal;
         JMenuBar menuBar;
+        SevenSegmentDisplay sevenSegmentDisplay;
         Controls(){
             menuBar = new JMenuBar();
             ((JButton) menuBar.add(new JButton("Exit"))).addActionListener(_ -> System.exit(0));
             menuBar.add(Box.createHorizontalStrut(40));
-            search = create ("Search ms");
-            mask = create ("Mask ms");
-            heal = create ("Heal ms");
+            menuBar.add(new JLabel("Search"));
+            sevenSegmentDisplay = (SevenSegmentDisplay) menuBar.add(new SevenSegmentDisplay(4,20));
+          // search = create ("Search ms");
+           // mask = create ("Mask ms");
+           // heal = create ("Heal ms");
         }
-         JTextField create (String name){
+        /* JTextField create (String name){
              menuBar.add(new JLabel(name));
              JTextField textField = (JTextField) menuBar.add(new JTextField("",5));
              textField.setEditable(false);
              return textField;
-         }
+         } */
     }
 
     Viewer(Accelerator accelerator, BufferedImage image) {

--- a/hat/examples/violajones/src/main/java/violajones/HaarViewer.java
+++ b/hat/examples/violajones/src/main/java/violajones/HaarViewer.java
@@ -26,17 +26,19 @@ package violajones;
 
 
 import hat.Accelerator;
-import hat.buffer.BufferAllocator;
 import hat.buffer.F32Array2D;
 import hat.buffer.S32Array;
 import hat.buffer.U16GreyImage;
 import hat.buffer.S08x3RGBImage;
+import hat.util.ui.SevenSegmentDisplay;
 import violajones.ifaces.Cascade;
 import violajones.ifaces.ResultTable;
 import violajones.ifaces.ScaleTable;
 
 import javax.swing.JComponent;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenuBar;
 import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 import java.awt.BasicStroke;
@@ -48,13 +50,13 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
-import java.lang.invoke.MethodHandles;
 
 public class HaarViewer extends JFrame {
    final Accelerator accelerator;
      final BufferedImage image;
     final S08x3RGBImage s08X3RGBImage;
-
+    private final SevenSegmentDisplay foundCountSevenSegment;
+    private final SevenSegmentDisplay timeSevenSegment;
 
     public static class IntegralWindow {
         final double integralScale = .25;
@@ -156,10 +158,11 @@ public class HaarViewer extends JFrame {
     S32Array resultIds;
     ScaleTable scaleTable;
 
-    public void showResults(ResultTable resultTable, ScaleTable scaleTable, S32Array resultIds) {
+    public void showResults(ResultTable resultTable, ScaleTable scaleTable, S32Array resultIds, long ms) {
         this.resultTable = resultTable;
         this.scaleTable = scaleTable;
         this.resultIds = resultIds;
+        this.timeSevenSegment.set((int)ms);
         this.imageView.repaint();
     }
 
@@ -196,7 +199,9 @@ public class HaarViewer extends JFrame {
                 if (resultTable != null && resultTable.atomicResultTableCount() > 0) {
                     g2.setStroke(new BasicStroke(2f));
                     g2.setColor(Color.red);
-                    for (int i = 0; i < resultTable.atomicResultTableCount(); i++) {
+                    var facesFound = resultTable.atomicResultTableCount();
+                    foundCountSevenSegment.set(facesFound);
+                    for (int i = 0; i < facesFound; i++) {
                         if (i < resultTable.length()) {
                             ResultTable.Result result = resultTable.result(i);
                             g2.drawString(Integer.toString(i), result.x() - 10, result.y() - 5);
@@ -244,6 +249,15 @@ public class HaarViewer extends JFrame {
                         (int) (HaarViewer.this.image.getHeight() * imageScale));
             }
         };
+        JMenuBar menuBar = new JMenuBar();
+        menuBar.add(new JLabel("Found"));
+        this.foundCountSevenSegment = (SevenSegmentDisplay)
+                menuBar.add(new SevenSegmentDisplay(6,30));
+        menuBar.add(new JLabel(" faces in "));
+        this.timeSevenSegment = (SevenSegmentDisplay)
+                menuBar.add(new SevenSegmentDisplay(6,30));
+        menuBar.add(new JLabel("ms"));
+        setJMenuBar(menuBar);
         JPanel gridPanel = new JPanel();
         JPanel imagePanel = new JPanel();
         gridPanel.add(imageView);

--- a/hat/examples/violajones/src/main/java/violajones/Main.java
+++ b/hat/examples/violajones/src/main/java/violajones/Main.java
@@ -75,11 +75,18 @@ public class Main {
 
         for (int i = 0; i < 10; i++) {
             resultTable.atomicResultTableCount(0);
+            long start = System.currentTimeMillis();
+
             accelerator.compute(cc -> ViolaJonesCoreCompute.compute(cc, cascade, rgbImage, resultTable,scaleTable));
-            System.out.println(resultTable.atomicResultTableCount()+ "faces found");
+            if (headless) {
+                System.out.print(resultTable.atomicResultTableCount() + "faces found in");
+                System.out.println((System.currentTimeMillis() - start)+"ms");
+            }else{
+                if (haarViewer != null) {
+                    haarViewer.showResults(resultTable, null, null, (System.currentTimeMillis() - start));
+                }
+            }
         }
-        if (haarViewer != null) {
-            haarViewer.showResults(resultTable, null, null);
-        }
+
     }
 }

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
@@ -308,7 +308,7 @@ public class ViolaJonesCoreCompute {
 
     @CodeReflection
     static public void compute(@RO final ComputeContext cc, @RO Cascade cascade, @RO S08x3RGBImage s08X3RGBImage, @RW ResultTable resultTable, @RO ScaleTable scaleTable) {
-        long start = System.currentTimeMillis();
+
         int width = s08X3RGBImage.width();
         int height = s08X3RGBImage.height();
 
@@ -325,7 +325,6 @@ public class ViolaJonesCoreCompute {
         cc.dispatchKernel(scaleTable.multiScaleAccumulativeRange(), kc ->
                 findFeaturesKernel(kc, cascade, integralImage, integralSqImage, scaleTable, resultTable));
 
-        System.out.println((System.currentTimeMillis() - start)+"ms");
     }
 
 

--- a/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
+++ b/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
@@ -339,8 +339,9 @@ public class ViolaJones {
                                 scaleTable,
                                 resultTable);
                     });
-            System.out.println("done " + (System.currentTimeMillis() - start) + "ms");
-            harViz.showResults(resultTable, null, null);
+            long ms = (System.currentTimeMillis() - start);
+            System.out.println("done " + ms + "ms");
+            harViz.showResults(resultTable, null, null, ms);
         }
         //   } else if (mode.equals("javaSegments")) {
 


### PR DESCRIPTION
For some consistency (prep for J1 demos) I am trying to use some common layouts for example UI's

Here we us use the seven seg widget (included in life example)  for violajones and heal examples.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/343/head:pull/343` \
`$ git checkout pull/343`

Update a local copy of the PR: \
`$ git checkout pull/343` \
`$ git pull https://git.openjdk.org/babylon.git pull/343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 343`

View PR using the GUI difftool: \
`$ git pr show -t 343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/343.diff">https://git.openjdk.org/babylon/pull/343.diff</a>

</details>
