### PR TITLE
Hat UI updates and iml fixes

### DIFF
--- a/hat/backends/ffi/cuda/pom.xml
+++ b/hat/backends/ffi/cuda/pom.xml
@@ -63,7 +63,7 @@ questions.
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="target/hat-backend-ffi-cuda-1.0.jar" toDir="${hat.build}"/>
+                                <copy file="target/${project.artifactId}-${project.version}.jar" toDir="${hat.build}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/hat/backends/ffi/mock/pom.xml
+++ b/hat/backends/ffi/mock/pom.xml
@@ -63,7 +63,7 @@ questions.
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="target/hat-backend-ffi-mock-1.0.jar" toDir="${hat.build}"/>
+                                <copy file="target/${project.artifactId}-${project.version}.jar" toDir="${hat.build}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/hat/backends/ffi/opencl/CMakeLists.txt
+++ b/hat/backends/ffi/opencl/CMakeLists.txt
@@ -36,6 +36,7 @@ if(OPENCL_FOUND)
         ${SHARED_BACKEND}/cpp/shared.cpp
         ${OPENCL_BACKEND}/cpp/opencl_backend.cpp
         ${OPENCL_BACKEND}/cpp/opencl_backend_queue.cpp
+        ${OPENCL_BACKEND}/cpp/opencl_backend_kernel_dispatch.cpp
     )
 
     target_link_libraries(opencl_backend

--- a/hat/backends/ffi/opencl/cpp/opencl_backend_kernel_dispatch.cpp
+++ b/hat/backends/ffi/opencl/cpp/opencl_backend_kernel_dispatch.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include "opencl_backend.h"
+/*
+void dispatchKernel(Kernel kernel, KernelContext kc, Arg ... args) {
+    for (int argn = 0; argn<args.length; argn++){
+      Arg arg = args[argn];
+      if (!minimizingBuffers || (((arg.flags &JavaDirty)==JavaDirty) && kernel.readsFrom(arg))) {
+         enqueueCopyToDevice(arg);
+      }
+    }
+    enqueueKernel(kernel);
+    waitForKernel();
+
+    for (int argn = 0; argn<args.length; argn++){
+      Arg arg = args[argn];
+      if (!minimizingBuffers){
+         enqueueCopyFromDevice(arg);
+         arg.flags = 0;
+      }else{
+          if (kernel.writesTo(arg)) {
+             arg.flags = DeviceDirty;
+          }else{
+             arg.flags = 0;
+          }
+      }
+    }
+
+}
+*/
+bool shouldCopyToDevice(BufferState_s *bufferState, Arg_s *arg ){
+   bool kernelReadsFromThisArg = (arg->value.buffer.access==RW_BYTE) || (arg->value.buffer.access==RO_BYTE);
+   bool isHostDirtyOrNew = bufferState->isHostDirty() | bufferState->isHostNew();
+
+   bool result=  (kernelReadsFromThisArg & isHostDirtyOrNew);
+   if (result && bufferState->isDeviceDirty()){
+         std::cout << "already still on GPU!"<<std::endl;
+         result= false;
+   }
+   return result;
+}
+bool shouldCopyFromDevice( BufferState_s *bufferState, Arg_s *arg ){
+   bool kernelWroteToThisArg = (arg->value.buffer.access==WO_BYTE) |  (arg->value.buffer.access==RW_BYTE);
+   bool result = kernelWroteToThisArg;
+   //if (!result){
+    //  std::cout << "shouldCopyFromDevice false"<<std::endl;
+  // }
+   return result;
+}
+
+long OpenCLBackend::OpenCLProgram::OpenCLKernel::ndrange(void *argArray) {
+
+   // std::cout << "ndrange(" << range << ") " << std::endl;
+    ArgSled argSled(static_cast<ArgArray_s *>(argArray));
+    OpenCLBackend *openclBackend = dynamic_cast<OpenCLBackend*>(program->backend);
+  //  std::cout << "Kernel name '"<< (dynamic_cast<Backend::Program::Kernel*>(this))->name<<"'"<<std::endl;
+    openclBackend->openclQueue.marker(openclBackend->openclQueue.EnterKernelDispatchBits,
+     (dynamic_cast<Backend::Program::Kernel*>(this))->name);
+    if (openclBackend->openclConfig.trace){
+       Sled::show(std::cout, argArray);
+    }
+    NDRange *ndrange = nullptr;
+    for (int i = 0; i < argSled.argc(); i++) {
+        Arg_s *arg = argSled.arg(i);
+        switch (arg->variant) {
+            case '&': {
+               if (arg->idx == 0){
+                   ndrange = static_cast<NDRange *>(arg->value.buffer.memorySegment);
+               }
+               if (openclBackend->openclConfig.trace){
+                  std::cout << "arg["<<i<<"] = "<< std::hex << (int)(arg->value.buffer.access);
+                  switch (arg->value.buffer.access){
+                      case RO_BYTE: std::cout << " RO";break;
+                      case WO_BYTE: std::cout << " WO";break;
+                      case RW_BYTE: std::cout << " RW"; break;
+                  }
+                  std::cout << std::endl;
+               }
+
+               BufferState_s * bufferState = BufferState_s::of(arg);
+               OpenCLBuffer * openclBuffer =nullptr;
+               if (bufferState->isHostNew()){
+                  openclBuffer = new OpenCLBuffer(this, arg);
+                  if (openclBackend->openclConfig.trace){
+                     std::cout << "We allocated arg "<<i<<" buffer "<<std::endl;
+                  }
+                  bufferState->clearHostNew();
+               }else{
+                  if (openclBackend->openclConfig.trace){
+                      std::cout << "Were reusing  arg "<<i<<" buffer "<<std::endl;
+                  }
+                  openclBuffer=  static_cast<OpenCLBuffer*>(bufferState->vendorPtr);
+                }
+                if (!openclBackend->openclConfig.minimizeCopies
+                   || shouldCopyToDevice(bufferState, arg)){
+
+                       if (openclBackend->openclConfig.traceCopies){
+                        //  std::cout << "We are not minimising copies OR (HOST is JAVA dirty and the kernel is READS this arg) so copying arg " << arg->idx <<" to device "<< std::endl;
+                       }
+                       bufferState->clearHostDirty();
+                       openclBuffer->copyToDevice();
+
+                    }else{
+                     if (openclBackend->openclConfig.traceSkippedCopies){
+                                          std::cout << "NOT copying arg " << arg->idx <<" to device "<< std::endl;
+                                                       // bufferState->dump("After copy from device");
+                                     }
+                    }
+
+                cl_int status = clSetKernelArg(kernel, arg->idx, sizeof(cl_mem), &openclBuffer->clMem);
+                if (status != CL_SUCCESS) {
+                    std::cerr << OpenCLBackend::errorMsg(status) << std::endl;
+                    exit(1);
+                }
+                if (openclBackend->openclConfig.trace){
+                   std::cout << "set buffer arg " << arg->idx << std::endl;
+                }
+                break;
+            }
+             case 'B':
+             case 'S':
+             case 'C':
+             case 'I':
+             case 'F':
+             case 'J':
+             case 'D':
+             {
+                cl_int status = clSetKernelArg(kernel, arg->idx, arg->size(), (void *) &arg->value);
+                if (status != CL_SUCCESS) {
+                    std::cerr << OpenCLBackend::errorMsg(status) << std::endl;
+                    exit(1);
+                }
+                if (openclBackend->openclConfig.trace){
+                   std::cerr << "set " <<arg->variant << " " << arg->idx << std::endl;
+                }
+                break;
+            }
+            default: {
+                std::cerr << "unexpected variant setting args in OpenCLkernel::ndrange " << (char) arg->variant << std::endl;
+                exit(1);
+            }
+        }
+    }
+
+    size_t globalSize = ndrange->maxX;
+    if (openclBackend->openclConfig.trace){
+       std::cout << "ndrange = " << ndrange->maxX << std::endl;
+    }
+    size_t dims = 1;
+    cl_int status = clEnqueueNDRangeKernel(
+            openclBackend->openclQueue.command_queue,
+            kernel,
+            dims,
+            nullptr,
+            &globalSize,
+            nullptr,
+            openclBackend->openclQueue.eventc,
+            openclBackend->openclQueue.eventListPtr(),
+            openclBackend->openclQueue.nextEventPtr());
+    openclBackend->openclQueue.markAsNDRangeAndInc();
+    if (status != CL_SUCCESS) {
+        std::cerr << OpenCLBackend::errorMsg(status) << std::endl;
+        exit(1);
+    }
+    if (openclBackend->openclConfig.trace){
+       std::cout << "enqueued kernel dispatch globalSize=" << globalSize << std::endl;
+    }
+
+
+       for (int i = 1; i < argSled.argc(); i++) { // note i = 1... we don't need to copy back the KernelContext
+          Arg_s *arg = argSled.arg(i);
+          if (arg->variant == '&') {
+             BufferState_s * bufferState = BufferState_s::of(arg );
+             if (!openclBackend->openclConfig.minimizeCopies || shouldCopyFromDevice(bufferState,arg)){
+                static_cast<OpenCLBuffer *>(bufferState->vendorPtr)->copyFromDevice();
+                //if (openclBackend->openclConfig.traceCopies){
+                    //std::cout << "copying arg " << arg->idx <<" from device "<< std::endl;
+                   // bufferState->dump("After copy from device");
+                //}
+                bufferState->setDeviceDirty();
+             }else{
+                 if (openclBackend->openclConfig.traceSkippedCopies){
+                      std::cout << "NOT copying arg " << arg->idx <<" from device "<< std::endl;
+                                   // bufferState->dump("After copy from device");
+                 }
+             }
+          }
+       }
+
+
+
+      openclBackend->openclQueue.marker(openclBackend->openclQueue.LeaveKernelDispatchBits,
+           (dynamic_cast<Backend::Program::Kernel*>(this))->name
+      );
+      openclBackend->openclQueue.wait();
+      openclBackend->openclQueue.release();
+    return 0;
+}

--- a/hat/backends/ffi/opencl/include/opencl_backend.h
+++ b/hat/backends/ffi/opencl/include/opencl_backend.h
@@ -55,6 +55,7 @@ public:
         const static  int SHOW_COMPUTE_MODEL_BIT = 1 <<8;
         const static  int INFO_BIT = 1 <<9;
         const static  int TRACE_COPIES_BIT = 1 <<10;
+        const static  int TRACE_SKIPPED_COPIES_BIT = 1 <<11;
         int mode;
         bool gpu;
         bool cpu;
@@ -64,6 +65,7 @@ public:
         bool showCode;
         bool info;
         bool traceCopies;
+         bool traceSkippedCopies;
         OpenCLConfig(int mode);
         virtual ~OpenCLConfig();
     };
@@ -111,7 +113,9 @@ public:
     };
 
     class OpenCLProgram : public Backend::Program {
+        public:
         class OpenCLKernel : public Backend::Program::Kernel {
+            public:
             class OpenCLBuffer : public Backend::Program::Kernel::Buffer {
             public:
                 cl_mem clMem;

--- a/hat/backends/ffi/opencl/pom.xml
+++ b/hat/backends/ffi/opencl/pom.xml
@@ -56,14 +56,14 @@ questions.
                 <version>1.8</version>
                 <executions>
                     <execution>
-                        <id>1</id>
+                        <id>copyJarToBuildDir</id>
                         <phase>install</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="target/hat-backend-ffi-opencl-1.0.jar" toDir="${hat.build}"/>
+                                <copy file="target/${project.artifactId}-${project.version}.jar" toDir="${hat.build}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/hat/backends/ffi/pom.xml
+++ b/hat/backends/ffi/pom.xml
@@ -54,7 +54,7 @@ questions.
                 <version>3.1.0</version>
                 <executions>
                     <execution>
-                        <id>1</id>
+                        <id>cmake-B</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>exec</goal>
@@ -69,7 +69,7 @@ questions.
                         </configuration>
                     </execution>
                     <execution>
-                        <id>2</id>
+                        <id>cmake--build</id>
                         <phase>install</phase>
                         <goals>
                             <goal>exec</goal>

--- a/hat/backends/ffi/ptx/pom.xml
+++ b/hat/backends/ffi/ptx/pom.xml
@@ -63,7 +63,7 @@ questions.
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="target/hat-backend-ffi-ptx-1.0.jar" toDir="${hat.build}"/>
+                                <copy file="target/${project.artifactId}-${project.version}.jar" toDir="${hat.build}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/hat/backends/ffi/shared/include/shared.h
+++ b/hat/backends/ffi/shared/include/shared.h
@@ -119,10 +119,12 @@ extern void hexdump(void *ptr, int buflen);
 
  struct BufferState_s{
    static const long  MAGIC =0x4a71facebffab175;
-   static const int   BIT_HOST_NEW =0x00000004;
-   static const int   BIT_DEVICE_NEW =0x00000008;
-   static const int   BIT_HOST_DIRTY =0x00000001;
-   static const int   BIT_DEVICE_DIRTY =0x00000002;
+   static const int   NONE = 0;
+   static const int   BIT_HOST_NEW =1<<0;
+   static const int   BIT_DEVICE_NEW =1<<1;
+   static const int   BIT_HOST_DIRTY =1<<2;
+   static const int   BIT_DEVICE_DIRTY =1<<3;
+   static const int   BIT_HOST_CHECKED =1<<4;
 
 
    long magic1;
@@ -164,6 +166,12 @@ extern void hexdump(void *ptr, int buflen);
    }
    void clearHostDirty(){
       resetBits(BIT_HOST_DIRTY);
+   }
+   void clearHostChecked(){
+      resetBits(BIT_HOST_CHECKED);
+   }
+   void clear(){
+       bits=0;
    }
    bool isHostNew(){
       return  areBitsSet(BIT_HOST_NEW);

--- a/hat/docs/hat-00.md
+++ b/hat/docs/hat-00.md
@@ -15,6 +15,6 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
-
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 ---
 

--- a/hat/docs/hat-01-01-project-layout.md
+++ b/hat/docs/hat-01-01-project-layout.md
@@ -15,6 +15,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ---
 

--- a/hat/docs/hat-01-02-building-babylon.md
+++ b/hat/docs/hat-01-02-building-babylon.md
@@ -15,6 +15,7 @@
   * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
   * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+  * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ---
 

--- a/hat/docs/hat-01-03-building-hat-with-maven.md
+++ b/hat/docs/hat-01-03-building-hat-with-maven.md
@@ -14,7 +14,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
-
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 ---
 
 # Building HAT

--- a/hat/docs/hat-01-03-building-hat.md
+++ b/hat/docs/hat-01-03-building-hat.md
@@ -14,6 +14,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ---
 

--- a/hat/docs/hat-01-04-intellij.md
+++ b/hat/docs/hat-01-04-intellij.md
@@ -14,6 +14,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ---
 

--- a/hat/docs/hat-03-programming-model.md
+++ b/hat/docs/hat-03-programming-model.md
@@ -14,6 +14,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ---
 

--- a/hat/docs/hat-04-01-interface-mapping.md
+++ b/hat/docs/hat-04-01-interface-mapping.md
@@ -15,6 +15,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ----
 # Interface Mapping

--- a/hat/docs/hat-04-02-cascade-interface-mapping.md
+++ b/hat/docs/hat-04-02-cascade-interface-mapping.md
@@ -15,6 +15,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ----
 

--- a/hat/docs/hat-05-accelerator-compute.md
+++ b/hat/docs/hat-05-accelerator-compute.md
@@ -14,6 +14,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ----
 

--- a/hat/docs/hat-06-kernel-analysis.md
+++ b/hat/docs/hat-06-kernel-analysis.md
@@ -15,6 +15,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ----
 

--- a/hat/docs/hat-minimizing-buffer-transfers.md
+++ b/hat/docs/hat-minimizing-buffer-transfers.md
@@ -1,0 +1,293 @@
+
+# Minimizing Buffer Transfers
+
+----
+
+* [Contents](hat-00.md)
+* House Keeping
+    * [Project Layout](hat-01-01-project-layout.md)
+    * [Building Babylon](hat-01-02-building-babylon.md)
+    * [Building HAT](hat-01-03-building-hat.md)
+* Programming Model
+    * [Programming Model](hat-03-programming-model.md)
+* Interface Mapping
+    * [Interface Mapping Overview](hat-04-01-interface-mapping.md)
+    * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
+* Implementation Detail
+    * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
+
+----
+
+## Using buffer marking to minimize data transfers
+
+### The naive approach
+The default execution model is that at each kernel
+dispatch the backend just copy all arg buffers to 
+the device and after the dispatch it copies all arg
+buffers back.
+
+### Using kernel arg buffer access patterns
+If we knew how each kernel accesses it's args (via static analysis of code model or 
+by marking the args RO, RW or WO with annotations) we can avoid some copies by only 
+copying in if the kernel 'reads' the arg buffer and only copying out if the
+kernel writes to the arg buffer.
+
+Lets use the game of life as an example. 
+
+We assume that the UI only needs updating at some 'rate' (say 5 fps), but the kernels can generate
+generations faster that 5 generations per second. code to generate eact 
+
+So not every generation needs to be copied to the device. 
+
+We'll ignore the detail regarding the `life` kernel, and we will assume the kernel args Mostly we care ab
+are appropriately annotated as RO, RW or WO.
+
+```java
+ @CodeReflection
+public static void life(@RO KernelContext kc, @RO Control control, @RW CellGrid cellGrid) {
+  if (kc.x < kc.maxX) {
+    Compute.lifePerIdx(kc.x, control, cellGrid);
+  }
+}
+
+@CodeReflection
+static public void compute(final @RO ComputeContext cc,
+                           Viewer viewer, @RO Control control, @RW CellGrid cellGrid) {
+  var timeOfLastUIUpdate = System.currentTimeMillis();
+  var msPerFrame = 1000/5; // we want 5 fps
+  while (viewer.state.generation < viewer.state.maxGenerations) {
+    long now = System.currentTimeMillis();
+    var msSinceLastUpdate = (now - timeOfLastUIUpdate);
+    var updateNeeded =  (msSinceLastUpdate > msPerFrame);
+    
+    cc.dispatchKernel(cellGrid.width() * cellGrid.height(),
+            kc -> Compute.life(kc, control, cellGrid)
+    );
+    
+    // Here we are swapping from<->to on the control buffer
+    int to = control.from();
+    control.from(control.to());
+    control.to(to);
+    
+    if (updateNeeded) {
+      viewer.update(now, to, cellGrid);
+      timeOfLastUIUpdate = now;
+    }
+  }
+}
+```
+
+First lets assume there were no automatic transfers, assume we had to define them. we had to explicitly control transfers so we will insert code 
+
+What would our code look like 
+
+
+```java
+ @CodeReflection
+public static void life(@RO KernelContext kc, @RO Control control, @RW CellGrid cellGrid) {
+  if (kc.x < kc.maxX) {
+    Compute.lifePerIdx(kc.x, control, cellGrid);
+  }
+}
+
+@CodeReflection
+static public void compute(final @RO ComputeContext cc,
+                           Viewer viewer, @RO Control control, @RW CellGrid cellGrid) {
+  var timeOfLastUIUpdate = System.currentTimeMillis();
+  var msPerFrame = 1000/5; // we want 5 fps
+  var cellGridIsJavaDirty = true;
+  var controlIsJavaDirty = true;
+  var cellGridIsDeviceDirty = true;
+  var controlIsDeviceDirty = true;
+  while (true) {
+    long now = System.currentTimeMillis();
+    var msSinceLastUpdate = (now - timeOfLastUIUpdate);
+    var updateNeeded =  (msSinceLastUpdate > msPerFrame);
+    
+    if (cellGridIsJavaDirty){
+        cc.copyToDevice(cellGrid);
+    }
+    if (controlIsJavaDirty){
+        cc.copyToDevice(control);
+    }
+    cc.dispatchKernel(cellGrid.width() * cellGrid.height(),
+            kc -> Compute.life(kc, control, cellGrid)
+    );
+    controlIsDeviceDirty = false; // Compute.life marked control as @RO
+    cellGridIsDeviceDirty = true; // Compute.life marjed cellGrid as @RW
+    
+    // Here we are swapping from<->to on the control buffer
+    if (controlIsDeviceDirty){
+      cc.copyFromDevice(control);
+    }
+    int to = control.from();
+    control.from(control.to());
+    control.to(to);
+    controlIsJavaDirty = true;
+    
+    if (updateNeeded) {
+      if (cellGridIsDeviceDirty){
+        cc.copyFromDevice(cellGrid);
+      }
+      viewer.update(now, to, cellGrid);
+      timeOfLastUIUpdate = now;
+    }
+  }
+}
+```
+
+Alternatively what if the buffers themselves could hold the deviceDirty flags javaDirty?
+
+
+```java
+ @CodeReflection
+public static void life(@RO KernelContext kc, @RO Control control, @RW CellGrid cellGrid) {
+  if (kc.x < kc.maxX) {
+    Compute.lifePerIdx(kc.x, control, cellGrid);
+  }
+}
+
+@CodeReflection
+static public void compute(final @RO ComputeContext cc,
+                           Viewer viewer, @RO Control control, @RW CellGrid cellGrid) {
+  control.flags =JavaDirty; // not ideal but necessary
+  cellGrid.flags = JavaDirty; // not ideal but necessary
+  
+  var timeOfLastUIUpdate = System.currentTimeMillis();
+  var msPerFrame = 1000/5; // we want 5 fps
+
+  while (true) {
+    long now = System.currentTimeMillis();
+    var msSinceLastUpdate = (now - timeOfLastUIUpdate);
+    var updateNeeded =  (msSinceLastUpdate > msPerFrame);
+    
+    if ((cellGrid.flags & JavaDirty) == JavaDirty){
+        cc.copyToDevice(cellGrid);
+    }
+    if ((control.flags & JavaDirty) == JavaDirty){
+        cc.copyToDevice(control);
+    }
+    cc.dispatchKernel(cellGrid.width() * cellGrid.height(),
+            kc -> Compute.life(kc, control, cellGrid)
+    );
+    control.flags = JavaDirty; // Compute.life marked control as @RO
+    cellGrid.flags = DeviceDirty; // Compute.life marjed cellGrid as @RW
+    
+    // Here we are swapping from<->to on the control buffer
+    if ((control.flags & DeviceDirty)==DeviceDirty){
+      cc.copyFromDevice(control);
+    }
+    int to = control.from();
+    control.from(control.to());
+    control.to(to);
+    control.flags = JavaDirty;
+    
+    if (updateNeeded) {
+      if ((cellGrid.flags & DeviceDirty)==DeviceDirty){
+        cc.copyFromDevice(cellGrid);
+      }
+      viewer.update(now, to, cellGrid);
+      // update does not mutate cellGrid so cellGrid.flags = DeviceDirty
+      timeOfLastUIUpdate = now;
+    }
+  }
+}
+```
+
+Essentially we defer to the kernel dispatch to determine whether buffers are
+copied to the device and to mark buffers accordingly if the dispatch mutated the buffer.   
+
+Psuedo code for dispatch is essentially 
+```java
+
+void dispatchKernel(Kernel kernel, KernelContext kc, Arg ... args) {
+    for (int argn = 0; argn<args.length; argn++){
+      Arg arg = args[argn];
+      if (((arg.flags &JavaDirty)==JavaDirty) && kernel.readsFrom(arg)) {
+         enqueueCopyToDevice(arg);
+      }
+    }
+    enqueueKernel(kernel);
+    for (int argn = 0; argn<args.length; argn++){
+       Arg arg = args[argn];
+       if (kernel.writesTo(arg)) {
+          arg.flags = DeviceDirty;
+       }
+    }
+}
+```
+We rely on babylon to mark each buffer passed to it as JavaDirty
+
+```java
+
+@CodeReflection
+static public void compute(final @RO ComputeContext cc,
+                           Viewer viewer, @RO Control control, @RW CellGrid cellGrid) {
+    control.flags = JavaDirty;
+    cellGrid.flags = JavaDirty;
+    // yada yada
+}
+```
+
+We also rely on babylon to inject calls before each buffer access from java in the compute code.
+
+So the injected code would look like this. 
+
+
+```java
+
+@CodeReflection
+static public void compute(final @RO ComputeContext cc,
+                           Viewer viewer, @RO Control control, @RW CellGrid cellGrid) {
+  control.flags =JavaDirty; // injected by bablyon
+  cellGrid.flags = JavaDirty; // injected by babylon
+  
+  var timeOfLastUIUpdate = System.currentTimeMillis();
+  var msPerFrame = 1000/5; // we want 5 fps
+  while (true) {
+    long now = System.currentTimeMillis();
+    var msSinceLastUpdate = (now - timeOfLastUIUpdate);
+    var updateNeeded =  (msSinceLastUpdate > msPerFrame);
+   
+    // See the psuedo code above to see how dispatchKernel
+    // Only copies buffers that need copying, and marks
+    // buffers it has mutate as dirty
+    cc.dispatchKernel(cellGrid.width() * cellGrid.height(),
+            kc -> Compute.life(kc, control, cellGrid)
+    );
+  
+    // injected by babylon
+    if ((control.flags & DeviceDirty)==DeviceDirty){
+      cc.copyFromDevice(control);
+    }
+    // Here we are swapping from<->to on the control buffer
+    int to = control.from();
+    
+    control.from(control.to());
+    control.flags = JavaDirty; // injected 
+    control.to(to);
+    control.flags = JavaDirty; // injected, but can be avoided
+    
+    if (updateNeeded) {
+        // Injected by babylon because cellGrid escapes cpmpute 
+        // and because viewer.update marks cellGrid as @RO
+        if ((cellGrid.flags & DeviceDirty)==DeviceDirty){
+          cc.copyFromDevice(cellGrid);
+        }
+        viewer.update(now, to, cellGrid);
+        // We don't copy cellgrid back after escape because 
+        // viewer.update annotates cellGrdi access as RO
+         timeOfLastUIUpdate = now;
+    }
+  }
+}
+```
+
+
+
+
+
+
+
+

--- a/hat/docs/hat-minimizing-buffer-transfers.md
+++ b/hat/docs/hat-minimizing-buffer-transfers.md
@@ -23,22 +23,22 @@
 
 ### The naive approach
 The default execution model is that at each kernel
-dispatch the backend just copy all arg buffers to 
+dispatch the backend just copy all arg buffers togc
 the device and after the dispatch it copies all arg
 buffers back.
 
 ### Using kernel arg buffer access patterns
-If we knew how each kernel accesses it's args (via static analysis of code model or 
-by marking the args RO, RW or WO with annotations) we can avoid some copies by only 
+If we knew how each kernel accesses it's args (via static analysis of code model orgc
+by marking the args RO, RW or WO with annotations) we can avoid some copies by onlygc
 copying in if the kernel 'reads' the arg buffer and only copying out if the
 kernel writes to the arg buffer.
 
-Lets use the game of life as an example. 
+Lets use the game of life as an example.gc
 
 We assume that the UI only needs updating at some 'rate' (say 5 fps), but the kernels can generate
-generations faster that 5 generations per second. code to generate eact 
+generations faster that 5 generations per second. code to generate eactgc
 
-So not every generation needs to be copied to the device. 
+So not every generation needs to be copied to the device.gc
 
 We'll ignore the detail regarding the `life` kernel, and we will assume the kernel args Mostly we care ab
 are appropriately annotated as RO, RW or WO.
@@ -60,16 +60,16 @@ static public void compute(final @RO ComputeContext cc,
     long now = System.currentTimeMillis();
     var msSinceLastUpdate = (now - timeOfLastUIUpdate);
     var updateNeeded =  (msSinceLastUpdate > msPerFrame);
-    
+gc
     cc.dispatchKernel(cellGrid.width() * cellGrid.height(),
             kc -> Compute.life(kc, control, cellGrid)
     );
-    
+gc
     // Here we are swapping from<->to on the control buffer
     int to = control.from();
     control.from(control.to());
     control.to(to);
-    
+gc
     if (updateNeeded) {
       viewer.update(now, to, cellGrid);
       timeOfLastUIUpdate = now;
@@ -78,9 +78,9 @@ static public void compute(final @RO ComputeContext cc,
 }
 ```
 
-First lets assume there were no automatic transfers, assume we had to define them. we had to explicitly control transfers so we will insert code 
+First lets assume there were no automatic transfers, assume we had to define them. we had to explicitly control transfers so we will insert codegc
 
-What would our code look like 
+What would our code look likegc
 
 
 ```java
@@ -104,7 +104,7 @@ static public void compute(final @RO ComputeContext cc,
     long now = System.currentTimeMillis();
     var msSinceLastUpdate = (now - timeOfLastUIUpdate);
     var updateNeeded =  (msSinceLastUpdate > msPerFrame);
-    
+gc
     if (cellGridIsJavaDirty){
         cc.copyToDevice(cellGrid);
     }
@@ -116,7 +116,7 @@ static public void compute(final @RO ComputeContext cc,
     );
     controlIsDeviceDirty = false; // Compute.life marked control as @RO
     cellGridIsDeviceDirty = true; // Compute.life marjed cellGrid as @RW
-    
+gc
     // Here we are swapping from<->to on the control buffer
     if (controlIsDeviceDirty){
       cc.copyFromDevice(control);
@@ -125,7 +125,7 @@ static public void compute(final @RO ComputeContext cc,
     control.from(control.to());
     control.to(to);
     controlIsJavaDirty = true;
-    
+gc
     if (updateNeeded) {
       if (cellGridIsDeviceDirty){
         cc.copyFromDevice(cellGrid);
@@ -153,7 +153,7 @@ static public void compute(final @RO ComputeContext cc,
                            Viewer viewer, @RO Control control, @RW CellGrid cellGrid) {
   control.flags =JavaDirty; // not ideal but necessary
   cellGrid.flags = JavaDirty; // not ideal but necessary
-  
+gc
   var timeOfLastUIUpdate = System.currentTimeMillis();
   var msPerFrame = 1000/5; // we want 5 fps
 
@@ -161,7 +161,7 @@ static public void compute(final @RO ComputeContext cc,
     long now = System.currentTimeMillis();
     var msSinceLastUpdate = (now - timeOfLastUIUpdate);
     var updateNeeded =  (msSinceLastUpdate > msPerFrame);
-    
+gc
     if ((cellGrid.flags & JavaDirty) == JavaDirty){
         cc.copyToDevice(cellGrid);
     }
@@ -173,7 +173,7 @@ static public void compute(final @RO ComputeContext cc,
     );
     control.flags = JavaDirty; // Compute.life marked control as @RO
     cellGrid.flags = DeviceDirty; // Compute.life marjed cellGrid as @RW
-    
+gc
     // Here we are swapping from<->to on the control buffer
     if ((control.flags & DeviceDirty)==DeviceDirty){
       cc.copyFromDevice(control);
@@ -182,7 +182,7 @@ static public void compute(final @RO ComputeContext cc,
     control.from(control.to());
     control.to(to);
     control.flags = JavaDirty;
-    
+gc
     if (updateNeeded) {
       if ((cellGrid.flags & DeviceDirty)==DeviceDirty){
         cc.copyFromDevice(cellGrid);
@@ -196,9 +196,9 @@ static public void compute(final @RO ComputeContext cc,
 ```
 
 Essentially we defer to the kernel dispatch to determine whether buffers are
-copied to the device and to mark buffers accordingly if the dispatch mutated the buffer.   
+copied to the device and to mark buffers accordingly if the dispatch mutated the buffer.gc
 
-Psuedo code for dispatch is essentially 
+Psuedo code for dispatch is essentiallygc
 ```java
 
 void dispatchKernel(Kernel kernel, KernelContext kc, Arg ... args) {
@@ -232,7 +232,7 @@ static public void compute(final @RO ComputeContext cc,
 
 We also rely on babylon to inject calls before each buffer access from java in the compute code.
 
-So the injected code would look like this. 
+So the injected code would look like this.gc
 
 
 ```java
@@ -242,41 +242,41 @@ static public void compute(final @RO ComputeContext cc,
                            Viewer viewer, @RO Control control, @RW CellGrid cellGrid) {
   control.flags =JavaDirty; // injected by bablyon
   cellGrid.flags = JavaDirty; // injected by babylon
-  
+gc
   var timeOfLastUIUpdate = System.currentTimeMillis();
   var msPerFrame = 1000/5; // we want 5 fps
   while (true) {
     long now = System.currentTimeMillis();
     var msSinceLastUpdate = (now - timeOfLastUIUpdate);
     var updateNeeded =  (msSinceLastUpdate > msPerFrame);
-   
+gc
     // See the psuedo code above to see how dispatchKernel
     // Only copies buffers that need copying, and marks
     // buffers it has mutate as dirty
     cc.dispatchKernel(cellGrid.width() * cellGrid.height(),
             kc -> Compute.life(kc, control, cellGrid)
     );
-  
+gc
     // injected by babylon
     if ((control.flags & DeviceDirty)==DeviceDirty){
       cc.copyFromDevice(control);
     }
     // Here we are swapping from<->to on the control buffer
     int to = control.from();
-    
+gc
     control.from(control.to());
-    control.flags = JavaDirty; // injected 
+    control.flags = JavaDirty; // injectedgc
     control.to(to);
     control.flags = JavaDirty; // injected, but can be avoided
-    
+gc
     if (updateNeeded) {
-        // Injected by babylon because cellGrid escapes cpmpute 
+        // Injected by babylon because cellGrid escapes cpmputegc
         // and because viewer.update marks cellGrid as @RO
         if ((cellGrid.flags & DeviceDirty)==DeviceDirty){
           cc.copyFromDevice(cellGrid);
         }
         viewer.update(now, to, cellGrid);
-        // We don't copy cellgrid back after escape because 
+        // We don't copy cellgrid back after escape becausegc
         // viewer.update annotates cellGrdi access as RO
          timeOfLastUIUpdate = now;
     }

--- a/hat/docs/hat-notes-and-links.md
+++ b/hat/docs/hat-notes-and-links.md
@@ -16,6 +16,7 @@
     * [Cascade Interface Mapping](hat-04-02-cascade-interface-mapping.md)
 * Implementation Detail
     * [Walkthrough Of Accelerator.compute()](hat-accelerator-compute.md)
+    * [How we minimize buffer transfers](hat-minimizing-buffer-transfers.md)
 
 ---
 

--- a/hat/examples/heal/src/main/java/heal/Viewer.java
+++ b/hat/examples/heal/src/main/java/heal/Viewer.java
@@ -234,7 +234,8 @@ public  class Viewer extends JFrame {
             ((JButton) menuBar.add(new JButton("Exit"))).addActionListener(_ -> System.exit(0));
             menuBar.add(Box.createHorizontalStrut(40));
             menuBar.add(new JLabel("Search"));
-            sevenSegmentDisplay = (SevenSegmentDisplay) menuBar.add(new SevenSegmentDisplay(4,20));
+            sevenSegmentDisplay = (SevenSegmentDisplay) menuBar.add(
+                    new SevenSegmentDisplay(4,20, menuBar.getForeground(),menuBar.getBackground()));
           // search = create ("Search ms");
            // mask = create ("Mask ms");
            // heal = create ("Heal ms");

--- a/hat/examples/life/src/main/java/life/Main.java
+++ b/hat/examples/life/src/main/java/life/Main.java
@@ -242,8 +242,8 @@ public class Main {
 
     public static void main(String[] args) {
         Accelerator accelerator = new Accelerator(MethodHandles.lookup(),
-                new OpenCLBackend("GPU,MINIMIZE_COPIES")
-               // new OpenCLBackend("GPU")
+               // new OpenCLBackend("GPU,MINIMIZE_COPIES")
+                new OpenCLBackend("GPU")
                 //new JavaMultiThreadedBackend()
                // new JavaSequentialBackend()
         );
@@ -273,7 +273,8 @@ public class Main {
 
         var program = context.buildProgram(Compute.codeHeader + Compute.codeVal + Compute.codeLifePerIdx);
         CLPlatform.CLDevice.CLContext.CLProgram.CLKernel kernel = program.getKernel("life");
-        Viewer.State state = new Viewer.State(true);
+        // Set following true to use HAT
+        Viewer.State state = new Viewer.State(false);
         Viewer viewer = new Viewer("Life", cellGrid, state);
         var tempFrom = control.from();
         control.from(control.to());

--- a/hat/examples/life/src/main/java/life/Viewer.java
+++ b/hat/examples/life/src/main/java/life/Viewer.java
@@ -36,7 +36,6 @@ import javax.swing.JMenuBar;
 import javax.swing.JPanel;
 import javax.swing.JToggleButton;
 import javax.swing.WindowConstants;
-import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -44,7 +43,6 @@ import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
 import java.awt.MouseInfo;
 import java.awt.Point;
-import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -53,27 +51,24 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
 import java.awt.image.ImageObserver;
-import java.util.Arrays;
 
 public class Viewer extends JFrame {
 
     public static class State {
-        public final long requiredFrameRate = 20;
+        public final long requiredFrameRate = 10;
         public final long msPerFrame = 1000/requiredFrameRate;
         public final long maxGenerations = 1000000;
         private final Object doorBell = new Object();
-        public long generation = 0;
+        public long generations = 0;
         public volatile boolean minimizingCopies = false;
         public volatile boolean usingGPU = false;
         volatile private boolean started = false;
         public long generationsSinceLastChange = 0;
         public long timeOfLastChange = 0;
-        public long timeOfLastFrame;
-
-        public enum RedrawState {RepaintRequested, RepaintCompleted};
-        public volatile RedrawState redrawState = RedrawState.RepaintCompleted;
+        public long timeOfLastUIUpdate;
+        public volatile boolean lastUIUpdateCompleted = false;
         public final boolean useHat;
-        public volatile boolean updated = false;
+        public volatile boolean deviceOrModeModified = false;
 
         State(boolean useHat) {
             this.useHat = useHat;
@@ -152,7 +147,7 @@ public class Viewer extends JFrame {
         @Override
         public void paintComponent(Graphics g) {
             super.paintComponent(g);
-            state.redrawState = State.RedrawState.RepaintCompleted;
+            state.lastUIUpdateCompleted =  true;
         }
 
         @Override
@@ -244,7 +239,7 @@ public final JMenuBar menuBar;
                 } else {
                     ((JToggleButton) event.getSource()).setText(def);
                 }
-                state.updated = true;
+                state.deviceOrModeModified = true;
             });
             return toggleButton;
         }

--- a/hat/examples/violajones/src/main/java/violajones/Main.java
+++ b/hat/examples/violajones/src/main/java/violajones/Main.java
@@ -26,7 +26,6 @@ package violajones;
 
 import hat.Accelerator;
 import hat.backend.Backend;
-import hat.buffer.Buffer;
 import org.xml.sax.SAXException;
 import violajones.attic.ViolaJones;
 import violajones.attic.ViolaJonesRaw;
@@ -66,9 +65,9 @@ public class Main {
         rgbImage.syncFromRaster(nasa1996);
         ResultTable resultTable = ResultTable.create(accelerator,1000);
        // System.out.println("result table layout "+Buffer.getLayout(resultTable));
-        HaarViewer haarViewer = null;
+        Viewer viewer = null;
         if (!headless){
-            haarViewer = new HaarViewer(accelerator, nasa1996, rgbImage, cascade, null, null);
+            viewer = new Viewer(accelerator, nasa1996, rgbImage, cascade, null, null);
         }
 
         ScaleTable scaleTable = ScaleTable.createFrom(accelerator,new ScaleTable.Constraints(cascade,rgbImage.width(),rgbImage.height()));
@@ -82,8 +81,8 @@ public class Main {
                 System.out.print(resultTable.atomicResultTableCount() + "faces found in");
                 System.out.println((System.currentTimeMillis() - start)+"ms");
             }else{
-                if (haarViewer != null) {
-                    haarViewer.showResults(resultTable, null, null, (System.currentTimeMillis() - start));
+                if (viewer != null) {
+                    viewer.showResults(resultTable, null, null, (System.currentTimeMillis() - start));
                 }
             }
         }

--- a/hat/examples/violajones/src/main/java/violajones/Viewer.java
+++ b/hat/examples/violajones/src/main/java/violajones/Viewer.java
@@ -35,6 +35,9 @@ import violajones.ifaces.Cascade;
 import violajones.ifaces.ResultTable;
 import violajones.ifaces.ScaleTable;
 
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -51,7 +54,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 
-public class HaarViewer extends JFrame {
+public class Viewer extends JFrame {
    final Accelerator accelerator;
      final BufferedImage image;
     final S08x3RGBImage s08X3RGBImage;
@@ -175,12 +178,12 @@ public class HaarViewer extends JFrame {
     final double imageScale = .5;
 
 
-    public HaarViewer(Accelerator accelerator,
-                      BufferedImage image,
-                      S08x3RGBImage s08X3RGBImage,
-                      Cascade cascade,
-                      F32Array2D integralImageF32,
-                      F32Array2D integralSqImageF32
+    public Viewer(Accelerator accelerator,
+                  BufferedImage image,
+                  S08x3RGBImage s08X3RGBImage,
+                  Cascade cascade,
+                  F32Array2D integralImageF32,
+                  F32Array2D integralSqImageF32
     ) {
         super("HaarViz");
         this.accelerator = accelerator;
@@ -194,7 +197,7 @@ public class HaarViewer extends JFrame {
             public void paint(Graphics g) {
                 Graphics2D g2 = (Graphics2D) g;
                 g2.scale(imageScale, imageScale);
-                g2.drawImage(HaarViewer.this.image, 0, 0, null);
+                g2.drawImage(Viewer.this.image, 0, 0, null);
 
                 if (resultTable != null && resultTable.atomicResultTableCount() > 0) {
                     g2.setStroke(new BasicStroke(2f));
@@ -245,19 +248,27 @@ public class HaarViewer extends JFrame {
 
             @Override
             public Dimension getPreferredSize() {
-                return new Dimension((int) (HaarViewer.this.image.getWidth() * imageScale),
-                        (int) (HaarViewer.this.image.getHeight() * imageScale));
+                return new Dimension((int) (Viewer.this.image.getWidth() * imageScale),
+                        (int) (Viewer.this.image.getHeight() * imageScale));
             }
         };
-        JMenuBar menuBar = new JMenuBar();
-        menuBar.add(new JLabel("Found"));
+        JMenuBar toolBar = new JMenuBar();
+        JPanel panel= new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        ((JButton) panel.add(new JButton("Exit"))).addActionListener(_ -> System.exit(0));
+
+        panel.add(new JLabel("Found"));
         this.foundCountSevenSegment = (SevenSegmentDisplay)
-                menuBar.add(new SevenSegmentDisplay(6,30));
-        menuBar.add(new JLabel(" faces in "));
+                panel.add(new SevenSegmentDisplay(6,30, panel.getForeground(),panel.getBackground()));
+        panel.add(new JLabel(" faces in "));
         this.timeSevenSegment = (SevenSegmentDisplay)
-                menuBar.add(new SevenSegmentDisplay(6,30));
-        menuBar.add(new JLabel("ms"));
-        setJMenuBar(menuBar);
+                panel.add(new SevenSegmentDisplay(6,30, panel.getForeground(),panel.getBackground()));
+        panel.add(new JLabel("ms"));
+
+        panel.add(Box.createHorizontalStrut(700));
+        toolBar.add(panel);
+        setJMenuBar(toolBar);
+
         JPanel gridPanel = new JPanel();
         JPanel imagePanel = new JPanel();
         gridPanel.add(imageView);

--- a/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
+++ b/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
@@ -30,7 +30,7 @@ import hat.backend.java.JavaMultiThreadedBackend;
 import hat.backend.java.WorkStealer;
 import hat.buffer.F32Array2D;
 import org.xml.sax.SAXException;
-import violajones.HaarViewer;
+import violajones.Viewer;
 import violajones.XMLHaarCascadeModel;
 import hat.buffer.S08x3RGBImage;
 import violajones.ifaces.Cascade;
@@ -72,7 +72,7 @@ public class ViolaJones {
         CoreJavaViolaJones.rgbToGreyScale(rgbImage, greyImageF32);
         CoreJavaViolaJones.createIntegralImage(greyImageF32, integralImageF32, integralSqImageF32);
 
-        HaarViewer harViz = new HaarViewer(accelerator, nasa, rgbImage, cascade, integralImageF32, integralSqImageF32);
+        Viewer harViz = new Viewer(accelerator, nasa, rgbImage, cascade, integralImageF32, integralSqImageF32);
 
         harViz.showIntegrals();
 

--- a/hat/hat-core/src/main/java/hat/buffer/Buffer.java
+++ b/hat/hat-core/src/main/java/hat/buffer/Buffer.java
@@ -43,13 +43,19 @@ public interface Buffer extends MappableIface {
     default boolean isDeviceDirty(){
         return SegmentMapper.BufferState.of(this).isDeviceDirty();
     }
+    default boolean isHostChecked(){
+        return SegmentMapper.BufferState.of(this).isHostChecked();
+    }
 
     default void clearDeviceDirty(){
          SegmentMapper.BufferState.of(this).clearDeviceDirty();
     }
-
     default void setHostDirty(){
         SegmentMapper.BufferState.of(this).setHostDirty(true);
+    }
+
+    default void setHostChecked(){
+        SegmentMapper.BufferState.of(this).setHostChecked(true);
     }
 
     interface Union extends MappableIface {

--- a/hat/hat-core/src/main/java/hat/buffer/S32Array.java
+++ b/hat/hat-core/src/main/java/hat/buffer/S32Array.java
@@ -30,6 +30,7 @@ import hat.ifacemapper.Schema;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
 import java.lang.invoke.MethodHandles;
+import java.util.function.Function;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -45,6 +46,9 @@ public interface S32Array extends Buffer {
     static S32Array create(Accelerator accelerator, int length){
         return schema.allocate(accelerator, length);
     }
+    static S32Array create(Accelerator accelerator, int length, Function<Integer,Integer> filler){
+        return schema.allocate(accelerator, length).fill(filler);
+    }
     static S32Array createFrom(Accelerator accelerator, int[] arr){
         return create( accelerator, arr.length).copyfrom(arr);
     }
@@ -54,6 +58,12 @@ public interface S32Array extends Buffer {
     }
     default S32Array copyTo(int[] ints) {
         MemorySegment.copy(Buffer.getMemorySegment(this), JAVA_INT, 4, ints, 0, length());
+        return this;
+    }
+    default S32Array fill(Function<Integer, Integer> filler) {
+        for (int i = 0; i < length(); i++) {
+            array(i, filler.apply(i));
+        }
         return this;
     }
 }

--- a/hat/hat-core/src/main/java/hat/ifacemapper/SegmentMapper.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/SegmentMapper.java
@@ -373,11 +373,12 @@ public interface SegmentMapper<T> {
         // hat iface bffa   bitz
         // 4a7 1face bffa   b175
         public static final long MAGIC = 0x4a71facebffab175L;
-        public static int BIT_HOST_NEW = 0x00000004;
-        public static int BIT_DEVICE_NEW = 0x00000008;
-        public static int BIT_HOST_DIRTY = 0x00000001;
-        public static int BIT_DEVICE_DIRTY = 0x00000002;
-
+        public static int NONE = 0;
+        public static int BIT_HOST_NEW = 1<<0;
+        public static int BIT_DEVICE_NEW = 1<<1;
+        public static int BIT_HOST_DIRTY = 1<<2;
+        public static int BIT_DEVICE_DIRTY = 1<<3;
+        public static int BIT_HOST_CHECKED = 1<<4;
 
         static final MemoryLayout stateMemoryLayout = MemoryLayout.structLayout(
                 ValueLayout.JAVA_LONG.withName("magic1"),
@@ -471,6 +472,14 @@ public interface SegmentMapper<T> {
             }
             return this;
         }
+        public BufferState setHostChecked(boolean checked) {
+            if (checked){
+                or(BIT_HOST_CHECKED);
+            }else{
+                andNot(BIT_HOST_CHECKED); // this is wrong we want bits&=!BIT_DEVICE_DIRTY
+            }
+            return this;
+        }
         public BufferState setDeviceDirty(boolean dirty) {
             if (dirty){
                 or(BIT_DEVICE_DIRTY);
@@ -485,11 +494,17 @@ public interface SegmentMapper<T> {
         public boolean isHostDirty() {
             return all(BIT_HOST_DIRTY);
         }
+        public boolean isHostChecked() {
+            return all(BIT_HOST_CHECKED);
+        }
         public boolean isHostNewOrDirty() {
             return all(BIT_HOST_NEW|BIT_HOST_DIRTY);
         }
         public boolean isDeviceDirty() {
             return all(BIT_DEVICE_DIRTY);
+        }
+        public BufferState clearHostChecked() {
+            return xor(BIT_HOST_CHECKED);
         }
         public BufferState clearDeviceDirty() {
             return xor(BIT_DEVICE_DIRTY);

--- a/hat/hat-core/src/main/java/hat/util/ui/SevenSegmentDisplay.java
+++ b/hat/hat-core/src/main/java/hat/util/ui/SevenSegmentDisplay.java
@@ -36,6 +36,9 @@ public class SevenSegmentDisplay extends JComponent {
 
     private static final boolean OFF = false;
     private static final boolean ON = true;
+    private final Color digitColor;
+    private final Color backgroundColor;
+
     record Digit(boolean[] segments) {
         /*
             <  a  >
@@ -97,22 +100,25 @@ public class SevenSegmentDisplay extends JComponent {
     private final Digit[] digits;
     private final float digitScale;
 
-    public SevenSegmentDisplay(int digitCount, int digitWidth) {
+    public SevenSegmentDisplay(int digitCount, int digitWidth, Color digitColor, Color backgroundColor) {
         digitScale = (float)digitWidth/defaultDigitSize.width;
         digitSize = new Dimension(digitWidth, (int) (defaultDigitSize.height*digitScale));
+        this.digitColor = digitColor;
+        this.backgroundColor = backgroundColor;
         var preferredSize = new Dimension(digitSize.width*digitCount,digitSize.height);
         setPreferredSize(preferredSize);
         setSize(preferredSize);
+
         setOpaque(true);
-        setBackground(Color.black);
+        setBackground(backgroundColor );
         this.digits = new Digit[digitCount];
         Arrays.fill(digits, blankDigit);
         digits[digitCount-1]=digits0to9[0];
         repaint();
     }
 
-    public SevenSegmentDisplay(int digitCount) {
-        this(digitCount, defaultDigitSize.width);
+    public SevenSegmentDisplay(int digitCount, Color digitColor, Color backgroundColor) {
+        this(digitCount, defaultDigitSize.width,  digitColor, backgroundColor);
     }
 
     public void set(int n) {
@@ -136,8 +142,8 @@ public class SevenSegmentDisplay extends JComponent {
     @Override
     public void paintComponent(Graphics g) {
         super.paintComponent(g);
-        final Color off = Color.green.darker().darker().darker().darker();
-        final Color on = Color.green.brighter().brighter().brighter().brighter().brighter();
+        final Color off = this.getBackground();
+        final Color on = Color.black.brighter().brighter();
         ((Graphics2D)g).scale(digitScale,digitScale);
         for (int x=0; x<digits.length; x++) {
             for (int i = 0; i < segments.length; i++) {

--- a/hat/intellij/backend_jextracted_opencl.iml
+++ b/hat/intellij/backend_jextracted_opencl.iml
@@ -14,7 +14,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/opencl.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opencl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/hat/intellij/clwrap.iml
+++ b/hat/intellij/clwrap.iml
@@ -9,15 +9,15 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="wrap" />
+    <orderEntry type="module" module-name="hat-core" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/opencl.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opencl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="module" module-name="hat-core" />
   </component>
 </module>

--- a/hat/intellij/glwrap.iml
+++ b/hat/intellij/glwrap.iml
@@ -12,7 +12,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/opengl.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opengl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/hat/intellij/nbody.iml
+++ b/hat/intellij/nbody.iml
@@ -9,27 +9,27 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="hat-core" />
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/opengl.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
     <orderEntry type="module" module-name="backend_ffi_opencl" />
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/opencl.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
     <orderEntry type="module" module-name="wrap" />
     <orderEntry type="module" module-name="glwrap" />
     <orderEntry type="module" module-name="clwrap" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opencl-1.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opengl-1.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/hat/maven-build.bash
+++ b/hat/maven-build.bash
@@ -25,5 +25,5 @@ cat >/dev/null<<LICENSE
  */
 LICENSE
 
-#mvn -X -U -e clean compile jar:jar install
-mvn -e clean compile jar:jar install
+#mvn -X -U -e clean compile package install
+mvn -e clean compile package install


### PR DESCRIPTION
Lots of small changes. 

Some cleanup of ui's for demos. 

.iml changes (intellij) to align with move of hat -> hat-core

.pom changes (allowing maven to build hat-core, backends and examples) 

Added bit checks in ndrange to avoid buffer moves.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/346/head:pull/346` \
`$ git checkout pull/346`

Update a local copy of the PR: \
`$ git checkout pull/346` \
`$ git pull https://git.openjdk.org/babylon.git pull/346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 346`

View PR using the GUI difftool: \
`$ git pr show -t 346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/346.diff">https://git.openjdk.org/babylon/pull/346.diff</a>

</details>
