### PR TITLE
Shape auto-dimension calculation from data size

### DIFF
--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
@@ -375,6 +375,8 @@ public class CNNTest {
         }
     }
 
+    private static final long[] IMAGE_SHAPE = new long[]{-1, 1, 28, 28};
+
     private void test(Arena arena, Function<Tensor<Byte>, Tensor<Float>> executor) throws Exception {
         try (RandomAccessFile imagesF = new RandomAccessFile(IMAGES_PATH, "r");
              RandomAccessFile labelsF = new RandomAccessFile(LABELS_PATH, "r")) {
@@ -382,8 +384,7 @@ public class CNNTest {
             MemorySegment imagesIn = imagesF.getChannel().map(FileChannel.MapMode.READ_ONLY, IMAGES_HEADER_SIZE, imagesF.length() - IMAGES_HEADER_SIZE, arena);
             MemorySegment labelsIn = labelsF.getChannel().map(FileChannel.MapMode.READ_ONLY, LABELS_HEADER_SIZE, labelsF.length() - LABELS_HEADER_SIZE, arena);
 
-            long size = imagesF.length() - IMAGES_HEADER_SIZE;
-            Tensor<Byte> inputImage = new Tensor(arena, imagesIn, Tensor.ElementType.UINT8, new long[]{size / (28 * 28), 1, 28, 28});
+            Tensor<Byte> inputImage = new Tensor(arena, imagesIn, Tensor.ElementType.UINT8, IMAGE_SHAPE);
 
             MemorySegment result = executor.apply(inputImage).data();
 


### PR DESCRIPTION
Implemented auto-dimension calculation from data size.

Shaped tensors construction required manual shape calculation based on the actual tensor data.
This patch allows to set one of the shape dimensions to -1 and its size is automatically calculated from the actual tensor data size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/347/head:pull/347` \
`$ git checkout pull/347`

Update a local copy of the PR: \
`$ git checkout pull/347` \
`$ git pull https://git.openjdk.org/babylon.git pull/347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 347`

View PR using the GUI difftool: \
`$ git pr show -t 347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/347.diff">https://git.openjdk.org/babylon/pull/347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/347#issuecomment-2716724020)
</details>
