### PR TITLE
fixup hatrun for life dependencies, allow nbody to default to HAT

### DIFF
--- a/hat/examples/nbody/src/main/java/nbody/Main.java
+++ b/hat/examples/nbody/src/main/java/nbody/Main.java
@@ -32,7 +32,7 @@ import java.lang.foreign.Arena;
 public class Main {
     public static void main(String[] args)  {
         int particleCount = args.length > 2 ? Integer.parseInt(args[2]) : 32768;
-        Mode mode = Mode.of(args.length > 3 ? args[3] : Mode.OpenCL.toString());
+        Mode mode = Mode.of(args.length > 3 ? args[3] : Mode.HAT.toString());
         try (var arena = mode.equals(Mode.JavaMT4) || mode.equals(Mode.JavaMT) ? Arena.ofShared() : Arena.ofConfined()) {
             var particleTexture = new GLTexture(arena, Main.class.getResourceAsStream("/particle.png"));
             new OpenCLNBodyGLWindow( arena, 1000, 1000, particleTexture, particleCount, mode).bindEvents().mainLoop();

--- a/hat/hatrun
+++ b/hat/hatrun
@@ -57,6 +57,7 @@ void main(String[] argv) {
   var args = new ArrayList<>(List.of(argv));
   java(java -> java
      .enable_preview()
+     .verbose()
      .add_exports("java.base", "jdk.internal", "ALL-UNNAMED")
      .enable_native_access("ALL-UNNAMED")
      .library_path(buildDir)
@@ -81,6 +82,9 @@ void main(String[] argv) {
               .when(jextractedOpenCLJar.exists() && jextractedOpenGLJar.exists() && exampleName.equals("nbody"), _->{ haveBackend
                   .class_path(jextractedOpenCLJar,jextractedOpenGLJar, wrapJar, clwrapJar, glwrapJar )
                   .start_on_first_thread();
+              })
+              .when(jextractedOpenCLJar.exists()  && exampleName.equals("life"), _->{ haveBackend
+                  .class_path(jextractedOpenCLJar, wrapJar, clwrapJar);
               })
               .main_class(exampleName + ".Main")
               .args(args);


### PR DESCRIPTION
Switched nbody and life examples to use HAT (instead of jextracted opencl) for J1

Also fixed up hatrun if we specified `java-mt`.   It still needed OpenCL wrapper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/349/head:pull/349` \
`$ git checkout pull/349`

Update a local copy of the PR: \
`$ git checkout pull/349` \
`$ git pull https://git.openjdk.org/babylon.git pull/349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 349`

View PR using the GUI difftool: \
`$ git pr show -t 349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/349.diff">https://git.openjdk.org/babylon/pull/349.diff</a>

</details>
