### PR TITLE
Removed annotation references ValueBased and Stable and cleaned bld a…

### DIFF
--- a/hat/backends/ffi/opencl/cpp/info.cpp
+++ b/hat/backends/ffi/opencl/cpp/info.cpp
@@ -25,7 +25,7 @@
 #include "opencl_backend.h"
 
 int main(){
-    OpenCLBackend backend(OpenCLBackend::OpenCLConfig::GPU_BIT,0,0);
+    OpenCLBackend backend(OpenCLBackend::OpenCLConfig::GPU_BIT);
     backend.info();
 }
 

--- a/hat/backends/ffi/opencl/cpp/opencl_backend.cpp
+++ b/hat/backends/ffi/opencl/cpp/opencl_backend.cpp
@@ -25,20 +25,24 @@
 #define opencl_backend_cpp
 #include "opencl_backend.h"
 
-OpenCLBackend::OpenCLConfig::OpenCLConfig(int mode):
-       mode(mode),
-       gpu((mode&GPU_BIT)==GPU_BIT),
-       cpu((mode&CPU_BIT)==CPU_BIT),
-       minimizeCopies((mode&MINIMIZE_COPIES_BIT)==MINIMIZE_COPIES_BIT),
+OpenCLBackend::OpenCLConfig::OpenCLConfig(int configBits):
+       configBits(configBits),
+       gpu((configBits&GPU_BIT)==GPU_BIT),
+       cpu((configBits&CPU_BIT)==CPU_BIT),
+       minimizeCopies((configBits&MINIMIZE_COPIES_BIT)==MINIMIZE_COPIES_BIT),
        alwaysCopy(!minimizeCopies),
-       trace((mode&TRACE_BIT)==TRACE_BIT),
-       traceCopies((mode&TRACE_COPIES_BIT)==TRACE_COPIES_BIT),
-       traceEnqueues((mode&TRACE_ENQUEUES_BIT)==TRACE_ENQUEUES_BIT),
-       traceCalls((mode&TRACE_CALLS_BIT)==TRACE_CALLS_BIT),
-       traceSkippedCopies((mode&TRACE_SKIPPED_COPIES_BIT)==TRACE_SKIPPED_COPIES_BIT),
-       info((mode&INFO_BIT)==INFO_BIT),
-       showCode((mode&SHOW_CODE_BIT)==SHOW_CODE_BIT),
-       profile((mode&PROFILE_BIT)==PROFILE_BIT){
+       trace((configBits&TRACE_BIT)==TRACE_BIT),
+       traceCopies((configBits&TRACE_COPIES_BIT)==TRACE_COPIES_BIT),
+       traceEnqueues((configBits&TRACE_ENQUEUES_BIT)==TRACE_ENQUEUES_BIT),
+       traceCalls((configBits&TRACE_CALLS_BIT)==TRACE_CALLS_BIT),
+       traceSkippedCopies((configBits&TRACE_SKIPPED_COPIES_BIT)==TRACE_SKIPPED_COPIES_BIT),
+       info((configBits&INFO_BIT)==INFO_BIT),
+       showCode((configBits&SHOW_CODE_BIT)==SHOW_CODE_BIT),
+       profile((configBits&PROFILE_BIT)==PROFILE_BIT),
+       platform((configBits&0xf)),
+       device((configBits&0xf0)>>4)
+
+       {
        if (info){
           std::cout << "native show_code " << showCode <<std::endl;
           std::cout << "native info " << info<<std::endl;
@@ -52,6 +56,8 @@ OpenCLBackend::OpenCLConfig::OpenCLConfig(int mode):
           std::cout << "native traceCopies " << traceCopies<<std::endl;
           std::cout << "native traceEnqueues " << traceEnqueues<<std::endl;
           std::cout << "native profile " << profile<<std::endl;
+          std::cout << "native platform " << platform<<std::endl;
+          std::cout << "native device " << device<<std::endl;
        }
  }
  OpenCLBackend::OpenCLConfig::~OpenCLConfig(){
@@ -212,8 +218,8 @@ bool OpenCLBackend::getBufferFromDeviceIfDirty(void *memorySegment, long memoryS
     return true;
 }
 
-OpenCLBackend::OpenCLBackend(int mode, int platform, int device )
-        : Backend(mode), openclConfig(mode), openclQueue(this) {
+OpenCLBackend::OpenCLBackend(int configBits )
+        : Backend(configBits), openclConfig(mode), openclQueue(this) {
     if (openclConfig.trace){
         std::cout << "openclConfig->gpu" << (openclConfig.gpu ? "true" : "false") << std::endl;
         std::cout << "openclConfig->minimizeCopies" << (openclConfig.minimizeCopies ? "true" : "false") << std::endl;
@@ -612,10 +618,10 @@ const char *OpenCLBackend::errorMsg(cl_int status) {
 }
 
 
-long getOpenCLBackend(int mode, int platform, int device, int unused) {
+long getOpenCLBackend(int configBits) {
  // std::cerr << "Opencl Driver mode=" << mode << " platform=" << platform << " device=" << device << std::endl;
 
-    return reinterpret_cast<long>(new OpenCLBackend(mode, platform, device));
+    return reinterpret_cast<long>(new OpenCLBackend(configBits));
 }
 
 

--- a/hat/backends/ffi/opencl/include/opencl_backend.h
+++ b/hat/backends/ffi/opencl/include/opencl_backend.h
@@ -65,7 +65,7 @@ public:
         const static  int END_BIT_IDX = 29;
 
         const static  char *bitNames[]; // See below for out of line definition
-        int mode;
+        int configBits;
         bool gpu;
         bool cpu;
         bool minimizeCopies;
@@ -78,6 +78,8 @@ public:
         bool traceSkippedCopies;
         bool traceEnqueues;
         bool traceCalls;
+        int platform; //0..15
+        int device; //0..15
         OpenCLConfig(int mode);
         virtual ~OpenCLConfig();
     };
@@ -162,7 +164,7 @@ public:
     cl_device_id device_id;
     OpenCLConfig openclConfig;
     OpenCLQueue openclQueue;
-    OpenCLBackend(int mode, int platform, int device);
+    OpenCLBackend(int configBits);
     ~OpenCLBackend();
     int getMaxComputeUnits();
     bool getBufferFromDeviceIfDirty(void *memorySegment, long memorySegmentLength);
@@ -180,7 +182,7 @@ public:
 public:
     static const char *errorMsg(cl_int status);
 };
-extern "C" long getOpenCLBackend(int mode, int platform, int device, int unused);
+extern "C" long getOpenCLBackend(int configBits);
 #ifdef opencl_backend_cpp
 const  char *OpenCLBackend::OpenCLConfig::bitNames[] = {
               "GPU",

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/Config.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/Config.java
@@ -5,7 +5,10 @@ import java.util.Arrays;
 import java.util.List;
 
 public record Config(int bits) {
-    record Bit(int index, String name){};
+    record Bit(int index, String name) {
+    }
+
+    ;
     // These must sync with hat/backends/ffi/opencl/include/opencl_backend.h
     // Bits 0-3 select platform id 0..5
     // Bits 4-7 select device id 0..15
@@ -26,20 +29,21 @@ public record Config(int bits) {
     private static final int END_BIT_IDX = 29;
 
     private static String[] bitNames = {
-      "GPU",
-      "CPU",
-      "MINIMIZE_COPIES",
-      "TRACE",
-      "PROFILE",
-      "SHOW_CODE",
-      "SHOW_KERNEL_MODEL",
-      "SHOW_COMPUTE_MODEL",
-      "INFO",
-      "TRACE_COPIES",
-      "TRACE_SKIPPED_COPIES",
-      "TRACE_ENQUEUES",
-      "TRACE_CALLS"
+            "GPU",
+            "CPU",
+            "MINIMIZE_COPIES",
+            "TRACE",
+            "PROFILE",
+            "SHOW_CODE",
+            "SHOW_KERNEL_MODEL",
+            "SHOW_COMPUTE_MODEL",
+            "INFO",
+            "TRACE_COPIES",
+            "TRACE_SKIPPED_COPIES",
+            "TRACE_ENQUEUES",
+            "TRACE_CALLS"
     };
+
     public static Config of() {
         if ((((System.getenv("HAT") instanceof String e) ? e : "") +
                 ((System.getProperty("HAT") instanceof String p) ? p : "")) instanceof String opts) {
@@ -75,37 +79,61 @@ public record Config(int bits) {
     public static Config of(String name) {
         for (int i = 0; i < bitNames.length; i++) {
             if (bitNames[i].equals(name)) {
-                return new Config(1<<(i+START_BIT_IDX));
+                return new Config(1 << (i + START_BIT_IDX));
             }
         }
 
-                if (name.contains(",")) {
-                    List<Config> configs = new ArrayList<>();
-                    Arrays.stream(name.split(",")).forEach(opt ->
-                            configs.add(of(opt))
-                    );
-                    return of(configs);
-                } else {
+
+
+        if (name.contains(",")) {
+            List<Config> configs = new ArrayList<>();
+            Arrays.stream(name.split(",")).forEach(opt ->
+                    configs.add(of(opt))
+            );
+            return of(configs);
+        }else if (name.contains(":")){
+            var tokens=name.split(":");
+            if (tokens.length == 2) {
+                if (tokens[0].equals("PLATFORM")) {
+                    int value = Integer.parseInt(tokens[1]);
+                    return new Config(value);
+                }else  if (tokens[0].equals("DEVICE")) {
+                    int value = Integer.parseInt(tokens[1]);
+                    return new Config(value<<4);
+                }else{
                     System.out.println("Unexpected opt '" + name + "'");
                     return Config.of(0);
                 }
+            }else{
+                System.out.println("Unexpected opt '" + name + "'");
+                return Config.of(0);
+            }
+        } else {
+            System.out.println("Unexpected opt '" + name + "'");
+            return Config.of(0);
+        }
     }
 
     public static Config TRACE_COPIES() {
         return new Config(TRACE_COPIES_BIT);
     }
+
     public boolean isTRACE_COPIES() {
         return (bits & TRACE_COPIES_BIT) == TRACE_COPIES_BIT;
     }
+
     public static Config TRACE_CALLS() {
         return new Config(TRACE_CALLS_BIT);
     }
+
     public boolean isTRACE_CALLS() {
         return (bits & TRACE_CALLS_BIT) == TRACE_CALLS_BIT;
     }
+
     public static Config TRACE_ENQUEUES() {
         return new Config(TRACE_ENQUEUES_BIT);
     }
+
     public boolean isTRACE_ENQUEUES() {
         return (bits & TRACE_ENQUEUES_BIT) == TRACE_ENQUEUES_BIT;
     }
@@ -114,6 +142,7 @@ public record Config(int bits) {
     public static Config TRACE_SKIPPED_COPIES() {
         return new Config(TRACE_SKIPPED_COPIES_BIT);
     }
+
     public boolean isTRACE_SKIPPED_COPIES() {
         return (bits & TRACE_SKIPPED_COPIES_BIT) == TRACE_SKIPPED_COPIES_BIT;
     }
@@ -121,6 +150,7 @@ public record Config(int bits) {
     public static Config INFO() {
         return new Config(INFO_BIT);
     }
+
     public boolean isINFO() {
         return (bits & INFO_BIT) == INFO_BIT;
     }
@@ -128,6 +158,7 @@ public record Config(int bits) {
     public static Config CPU() {
         return new Config(CPU_BIT);
     }
+
     public boolean isCPU() {
         return (bits & CPU_BIT) == CPU_BIT;
     }
@@ -135,6 +166,7 @@ public record Config(int bits) {
     public static Config GPU() {
         return new Config(GPU_BIT);
     }
+
     public boolean isGPU() {
         return (bits & GPU_BIT) == GPU_BIT;
     }
@@ -142,6 +174,7 @@ public record Config(int bits) {
     public static Config PROFILE() {
         return new Config(PROFILE_BIT);
     }
+
     public boolean isPROFILE() {
         return (bits & PROFILE_BIT) == PROFILE_BIT;
     }
@@ -149,6 +182,7 @@ public record Config(int bits) {
     public static Config TRACE() {
         return new Config(TRACE_BIT);
     }
+
     public boolean isTRACE() {
         return (bits & TRACE_BIT) == TRACE_BIT;
     }
@@ -156,6 +190,7 @@ public record Config(int bits) {
     public static Config MINIMIZE_COPIES() {
         return new Config(MINIMIZE_COPIES_BIT);
     }
+
     public boolean isMINIMIZE_COPIES() {
         String hex = Integer.toHexString(bits);
         return (bits & MINIMIZE_COPIES_BIT) == MINIMIZE_COPIES_BIT;
@@ -164,6 +199,7 @@ public record Config(int bits) {
     public static Config SHOW_CODE() {
         return new Config(SHOW_CODE_BIT);
     }
+
     public boolean isSHOW_CODE() {
         return (bits & SHOW_CODE_BIT) == SHOW_CODE_BIT;
     }
@@ -171,6 +207,7 @@ public record Config(int bits) {
     public static Config SHOW_KERNEL_MODEL() {
         return new Config(SHOW_KERNEL_MODEL_BIT);
     }
+
     public boolean isSHOW_KERNEL_MODEL() {
         return (bits & SHOW_KERNEL_MODEL_BIT) == SHOW_KERNEL_MODEL_BIT;
     }
@@ -178,6 +215,7 @@ public record Config(int bits) {
     public static Config SHOW_COMPUTE_MODEL() {
         return new Config(SHOW_COMPUTE_MODEL_BIT);
     }
+
     public boolean isSHOW_COMPUTE_MODEL() {
         return (bits & SHOW_COMPUTE_MODEL_BIT) == SHOW_COMPUTE_MODEL_BIT;
     }
@@ -186,11 +224,11 @@ public record Config(int bits) {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         for (int bitIdx = START_BIT_IDX; bitIdx < END_BIT_IDX; bitIdx++) {
-            if ((bits&(1<<bitIdx))==(1<<bitIdx)) {
+            if ((bits & (1 << bitIdx)) == (1 << bitIdx)) {
                 if (!builder.isEmpty()) {
                     builder.append("|");
                 }
-                builder.append(bitNames[bitIdx-START_BIT_IDX]);
+                builder.append(bitNames[bitIdx - START_BIT_IDX]);
 
             }
         }

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
@@ -40,9 +40,9 @@ public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
     final Config config;
 
     final MethodHandle getBackend_MH;
-    public long getBackend(int mode, int platform, int device, int unused) {
+    public long getBackend(int configBits) {
         try {
-            backendHandle = (long) getBackend_MH.invoke(mode, platform, device, unused);
+            backendHandle = (long) getBackend_MH.invoke(configBits);
         } catch (Throwable throwable) {
             throw new IllegalStateException(throwable);
         }
@@ -54,8 +54,8 @@ public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
     public OpenCLBackend(Config config) {
         super("opencl_backend");
         this.config = config;
-        getBackend_MH  =  nativeLibrary.longFunc("getOpenCLBackend",JAVA_INT,JAVA_INT, JAVA_INT, JAVA_INT);
-        getBackend(config.bits(),0, 0, 0 );
+        getBackend_MH  =  nativeLibrary.longFunc("getOpenCLBackend",JAVA_INT);
+        getBackend(config.bits());
         if (config.isINFO()) {
             System.out.println("CONFIG = "+config);
             info();

--- a/hat/bld
+++ b/hat/bld
@@ -35,12 +35,25 @@ void main(String[] args) {
      *    |    +--cmake-build-debug/    All intermediate cmake artifacts
      *    |
      *    +--stage/
-     *    |    +--repo/                 All downloaded maven assets
+     *    |    +--repo/                 All downloaded maven assets (if any)
      *    |    |
      *    |    +--jextract/             All jextracted files
      *    |    |    +--opencl
      *    |    |    +--opengl
      *    |    |    +--cuda
+     *    |
+     *    +--wrap/
+     *    |    +--wrap/                 All downloaded maven assets
+     *    |    |    +--wrap/                (*)
+     *    |    |    +--clwrap/              (*)
+     *    |    |    +--glwrap/              (*)
+     *    |    |    +--cuwrap/              (*)
+     *    |    |
+     *    |
+     *    +--extractions/
+     *    |    +--opencl/ 
+     *    |    +--opengl/
+     *    |    +--cuda/
      *    |
      *    +--hat-core                        * Note maven style layout
      *    |    +--src/main/java
@@ -56,19 +69,21 @@ void main(String[] args) {
      *    |    +--jextracted
      *    |    |    +--opencl                (*)
      *    |    +--ffi
-     *    |    |    +--opencl                (*)
-     *    |    |    +--ptx                   (*)
-     *    |    |    +--mock                  (*)
-     *    |    |    +--spirv                 (*)
-     *    |    |    +--cuda                  (*)
-     *    |    |    +--hip                   (*)
+     *    |         +--opencl                (*)
+     *    |         +--ptx                   (*)
+     *    |         +--mock                  (*)
+     *    |         +--spirv                 (*)
+     *    |         +--cuda                  (*)
+     *    |         +--hip                   (*)
      *    |
      *    +--examples
-     *    |    +--mandel                (*)
-     *    |    +--squares               (*)
-     *    |    +--heal                  (*)
-     *    |    +--life                  (*)
-     *    |    +--violajones            (*)
+     *    |    +--mandel                     (*)
+     *    |    +--squares                    (*)
+     *    |    +--heal                       (*)
+     *    |    +--life                       (*)
+     *    |    +--nbody                      (*)
+     *    |    +--experiments                (*)
+     *    |    +--violajones                 (*)
      *
      */
 
@@ -107,7 +122,7 @@ void main(String[] args) {
  var hatJavacOpts = javacBuilder($ -> $
             .enable_preview()
             .add_modules("jdk.incubator.code")
-            .add_exports_to_all_unnamed("java.base", "jdk.internal", "jdk.internal.vm.annotation")
+          //  .add_exports_to_all_unnamed("java.base", "jdk.internal", "jdk.internal.vm.annotation")
             .current_source()
     );
 

--- a/hat/bldr/tst
+++ b/hat/bldr/tst
@@ -1,0 +1,5 @@
+--add-modules jdk.incubator.code
+--enable-preview
+-cp build/hat-core-1.0.jar:build/hat-backend-ffi-opencl-1.0.jar
+--enable-native-access=ALL-UNNAMED
+-Djava.library.path=build

--- a/hat/hat-core/src/main/java/hat/ifacemapper/AbstractSegmentMapper.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/AbstractSegmentMapper.java
@@ -26,7 +26,7 @@
 package hat.ifacemapper;
 
 import hat.ifacemapper.accessor.Accessors;
-import jdk.internal.vm.annotation.Stable;
+//import jdk.internal.vm.annotation.Stable;
 
 import java.lang.foreign.GroupLayout;
 import java.lang.invoke.MethodHandle;
@@ -36,11 +36,11 @@ import java.util.function.UnaryOperator;
 
 abstract class AbstractSegmentMapper<T> implements SegmentMapper<T> {
 
-    @Stable
+   // @Stable
     private final MethodHandles.Lookup lookup;
-    @Stable
+  //  @Stable
     private final Class<T> type;
-    @Stable
+  //  @Stable
     private final GroupLayout layout;
     private final BoundSchema<?> boundSchema;
     private final boolean leaf;

--- a/hat/hat-core/src/main/java/hat/ifacemapper/ByteCodeGenerator.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/ByteCodeGenerator.java
@@ -28,7 +28,8 @@ package hat.ifacemapper;
 import hat.ifacemapper.accessor.AccessorInfo;
 import hat.ifacemapper.accessor.ArrayInfo;
 import hat.ifacemapper.accessor.ScalarInfo;
-import jdk.internal.ValueBased;
+//import jdk.internal.ValueBased;
+//import jdk.internal.ValueBased;
 
 
 import java.lang.classfile.Annotation;
@@ -74,7 +75,7 @@ import static java.lang.constant.ConstantDescs.INIT_NAME;
 import static java.lang.constant.ConstantDescs.MTD_void;
 import static java.lang.constant.ConstantDescs.ofCallsiteBootstrap;
 
-@ValueBased
+//@ValueBased
 final class ByteCodeGenerator {
 
     static final String SEGMENT_FIELD_NAME = "segment";
@@ -102,8 +103,8 @@ final class ByteCodeGenerator {
 
     void classDefinition() {
         // @ValueBased
-        Annotation valueBased = Annotation.of(desc(ValueBased.class));
-        cb.with(RuntimeVisibleAnnotationsAttribute.of(valueBased));
+       // Annotation valueBased = Annotation.of(desc(ValueBased.class));
+        //cb.with(RuntimeVisibleAnnotationsAttribute.of(valueBased));
         // public final
         cb.withFlags(ACC_PUBLIC | ACC_FINAL | ACC_SUPER);
         // extends Object

--- a/hat/hat-core/src/main/java/hat/ifacemapper/MapperCache.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/MapperCache.java
@@ -26,7 +26,7 @@
 package hat.ifacemapper;
 
 import hat.ifacemapper.accessor.AccessorInfo;
-import jdk.internal.ValueBased;
+//import jdk.internal.ValueBased;
 
 
 import java.lang.foreign.GroupLayout;
@@ -40,7 +40,7 @@ import java.util.function.Consumer;
  * This class maintains a cache of seen sub-mappers, so they do not have to be created more
  * than once. Creating a sub-mapper is a relatively expensive operation.
  */
-@ValueBased
+//@ValueBased
 final class MapperCache {
 
     private final MethodHandles.Lookup lookup;

--- a/hat/hat-core/src/main/java/hat/ifacemapper/SegmentInterfaceMapper.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/SegmentInterfaceMapper.java
@@ -30,7 +30,7 @@ import hat.ifacemapper.accessor.AccessorInfo;
 import hat.ifacemapper.accessor.Accessors;
 import hat.ifacemapper.accessor.ValueType;
 import hat.ifacemapper.component.Util;
-import jdk.internal.vm.annotation.Stable;
+//import jdk.internal.vm.annotation.Stable;
 
 import java.io.IOException;
 import java.lang.classfile.ClassFile;
@@ -63,16 +63,16 @@ public final class SegmentInterfaceMapper<T>
 
     private static final MethodHandles.Lookup LOCAL_LOOKUP = MethodHandles.lookup();
 
-    @Stable
+   // @Stable
     private final Class<T> implClass;
-    @Stable
+   // @Stable
     private final MethodHandle getHandle;
-    @Stable
+   // @Stable
     private final MethodHandle setHandle;
-    @Stable
+   // @Stable
     // Capability to extract the segment from an instance of the generated implClass
     private final MethodHandle segmentGetHandle;
-    @Stable
+   // @Stable
     // Capability to extract the offset from an instance of the generated implClass
     private final MethodHandle offsetGetHandle;
     private final List<AffectedMemory> affectedMemories;

--- a/hat/hat-core/src/main/java/hat/ifacemapper/accessor/Accessors.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/accessor/Accessors.java
@@ -26,7 +26,7 @@
 package hat.ifacemapper.accessor;
 
 import hat.ifacemapper.MapperUtil;
-import jdk.internal.ValueBased;
+//import jdk.internal.ValueBased;
 
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * This class is used to create MethodInfo objects (which hold extensive additional information
  * for a method) and to organize them in a way they can easily be retrieved.
  */
-@ValueBased
+//@ValueBased
 public final class Accessors {
 
     private final Map<AccessorInfo.Key, List<AccessorInfo>> keyToAccessorMap;

--- a/hat/hatrun
+++ b/hat/hatrun
@@ -53,12 +53,13 @@ void main(String[] argv) {
   var wrapJar = buildDir.jarFile("hat-wrap-1.0.jar");
   var clwrapJar = buildDir.jarFile("hat-clwrap-1.0.jar");
   var glwrapJar = buildDir.jarFile("hat-glwrap-1.0.jar");
+  var verbose = false;
 
   var args = new ArrayList<>(List.of(argv));
   java(java -> java
      .enable_preview()
-     .verbose()
-     .add_exports("java.base", "jdk.internal", "ALL-UNNAMED")
+     .verbose(verbose)
+     //.add_exports("java.base", "jdk.internal", "ALL-UNNAMED")
      .enable_native_access("ALL-UNNAMED")
      .library_path(buildDir)
      .class_path(buildDir.jarFile("hat-core-1.0.jar"))

--- a/hat/pom.xml
+++ b/hat/pom.xml
@@ -55,8 +55,8 @@ questions.
                     <compilerArgs>
                         <arg>--add-modules=jdk.incubator.code</arg>
                         <arg>--enable-preview</arg>
-                        <arg>--add-exports=java.base/jdk.internal=ALL-UNNAMED</arg>
-                        <arg>--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</arg>
+                        <!-- <arg>- -add-exports=java.base/jdk.internal=ALL-UNNAMED</arg> -->
+                        <!-- <arg>- -add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</arg> -->
                     </compilerArgs>
                     <source>24</source>
                     <target>24</target>

--- a/hat/tst/MinBufferTest.java
+++ b/hat/tst/MinBufferTest.java
@@ -1,0 +1,53 @@
+package tst;
+import hat.Accelerator;
+import hat.ComputeContext;
+import hat.KernelContext;
+import hat.backend.ffi.OpenCLBackend;
+import hat.buffer.S32Array;
+import static hat.ifacemapper.MappableIface.*;
+import jdk.incubator.code.CodeReflection;
+
+import java.lang.invoke.MethodHandles;
+
+import static hat.backend.ffi.Config.*;
+
+public class MinBufferTest {
+    public static class Compute {
+        @CodeReflection
+        public static void inc(@RO KernelContext kc, @RW S32Array s32Array, int len) {
+            if (kc.x < kc.maxX) {
+                s32Array.array(kc.x, s32Array.array(kc.x) + 1);
+            }
+        }
+
+        @CodeReflection
+        public static void add(ComputeContext cc, @RW S32Array s32Array, int len, int n) {
+            for (int i = 0; i < n; i++) {
+                cc.dispatchKernel(len, kc -> inc(kc, s32Array, len));
+                System.out.println(i);//s32Array.array(0));
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(),
+                new OpenCLBackend(of(
+                      //  TRACE(),
+                        TRACE_COPIES(),
+                        GPU(),
+                        MINIMIZE_COPIES()
+                ))
+
+        );
+        int len = 10000000;
+        int valueToAdd = 10;
+        S32Array s32Array = S32Array.create(accelerator, len,i->i);
+        accelerator.compute(
+                cc -> Compute.add(cc, s32Array, len, valueToAdd)
+        );
+        // Quite an expensive way of adding 20 to each array alement
+        for (int i = 0; i < 20; i++) {
+            System.out.println(i + "=" + s32Array.array(i));
+        }
+    }
+}


### PR DESCRIPTION
Chasing an issue with runnig scripts Paul suggested we can skip teh @Stable and @ValueBased annotations which will allow us to simplify the build and run scripts.  

This PR has the changes to support this.  

Also simplified the passing of configBits to ffi-backend.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/350/head:pull/350` \
`$ git checkout pull/350`

Update a local copy of the PR: \
`$ git checkout pull/350` \
`$ git pull https://git.openjdk.org/babylon.git pull/350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 350`

View PR using the GUI difftool: \
`$ git pr show -t 350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/350.diff">https://git.openjdk.org/babylon/pull/350.diff</a>

</details>
