### PR TITLE
Removed unneeded MethodHandles.lookup()

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHatKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHatKernelBuilder.java
@@ -30,6 +30,8 @@ import hat.optools.OpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.type.JavaType;
 
+import java.lang.invoke.MethodHandles;
+
 public class CudaHatKernelBuilder extends C99HATKernelBuilder<CudaHatKernelBuilder> {
 
     @Override
@@ -66,8 +68,8 @@ public class CudaHatKernelBuilder extends C99HATKernelBuilder<CudaHatKernelBuild
     }
 
     @Override
-    public CudaHatKernelBuilder functionDeclaration(JavaType javaType, String name) {
-        return externC().space().keyword("__device__").space().keyword("inline").space().type(javaType).space().identifier(name);
+    public CudaHatKernelBuilder functionDeclaration(MethodHandles.Lookup lookup,JavaType javaType, String name) {
+        return externC().space().keyword("__device__").space().keyword("inline").space().type(lookup,javaType).space().identifier(name);
     }
 
     @Override
@@ -77,9 +79,9 @@ public class CudaHatKernelBuilder extends C99HATKernelBuilder<CudaHatKernelBuild
 
 
     @Override
-    public CudaHatKernelBuilder atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name){
+    public CudaHatKernelBuilder atomicInc(CodeBuilderContext buildContext, MethodHandles.Lookup lookup,Op.Result instanceResult, String name){
         return identifier("atomicAdd").paren(_ -> {
-             ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
+             ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op(),lookup));
              rarrow().identifier(name).comma().literal(1);
         });
     }

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHatKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHatKernelBuilder.java
@@ -30,6 +30,8 @@ import hat.optools.OpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.type.JavaType;
 
+import java.lang.invoke.MethodHandles;
+
 public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelBuilder> {
     @Override
     public OpenCLHatKernelBuilder defines() {
@@ -63,8 +65,8 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder functionDeclaration(JavaType type, String name) {
-        return keyword("inline").space().type(type).space().identifier(name);
+    public OpenCLHatKernelBuilder functionDeclaration(MethodHandles.Lookup lookup,JavaType type, String name) {
+        return keyword("inline").space().type(lookup,type).space().identifier(name);
     }
 
     @Override
@@ -73,9 +75,9 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name){
+    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext, MethodHandles.Lookup lookup, Op.Result instanceResult, String name){
           return identifier("atomic_inc").paren(_ -> {
-              ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
+              ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op(),lookup));
               rarrow().identifier(name);
           });
     }

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
@@ -29,6 +29,8 @@ import hat.optools.OpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.type.JavaType;
 
+import java.lang.invoke.MethodHandles;
+
 public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelBuilder> {
     @Override
     public OpenCLHatKernelBuilder defines() {
@@ -62,8 +64,8 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder functionDeclaration(JavaType type, String name) {
-        return keyword("inline").space().type(type).space().identifier(name);
+    public OpenCLHatKernelBuilder functionDeclaration(MethodHandles.Lookup lookup,JavaType type, String name) {
+        return keyword("inline").space().type(lookup,type).space().identifier(name);
     }
 
     @Override
@@ -72,9 +74,9 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name){
+    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext, MethodHandles.Lookup lookup, Op.Result instanceResult, String name){
           return identifier("atomic_inc").paren(_ -> {
-              ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
+              ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op(),lookup));
               rarrow().identifier(name);
           });
     }

--- a/hat/examples/experiments/src/main/java/experiments/InvokeToPtr.java
+++ b/hat/examples/experiments/src/main/java/experiments/InvokeToPtr.java
@@ -92,12 +92,12 @@ public class InvokeToPtr {
         System.out.println(ssaInvokeForm.toText());
         System.out.println("------------------");
 
-        FunctionType functionType = OpsAndTypes.transformTypes(MethodHandles.lookup(), ssaInvokeForm);
+        FunctionType functionType = OpsAndTypes.transformTypes(accelerator.lookup, ssaInvokeForm);
         System.out.println("SSA form with types transformed args");
         System.out.println(ssaInvokeForm.toText());
         System.out.println("------------------");
 
-        CoreOp.FuncOp ssaPtrForm = OpsAndTypes.transformInvokesToPtrs(MethodHandles.lookup(), ssaInvokeForm, functionType);
+        CoreOp.FuncOp ssaPtrForm = OpsAndTypes.transformInvokesToPtrs(accelerator.lookup,  ssaInvokeForm, functionType);
         System.out.println("SSA form with invokes replaced by ptrs");
         System.out.println(ssaPtrForm.toText());
     }

--- a/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
+++ b/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
@@ -101,6 +101,7 @@ public class LayoutExample {
 
 
     public static void main(String[] args) {
+        var lookup =     MethodHandles.lookup();
         Optional<Method> om = Stream.of(LayoutExample.class.getDeclaredMethods())
                 .filter(m -> m.getName().equals("m"))
                 .findFirst();
@@ -109,9 +110,9 @@ public class LayoutExample {
         CoreOp.FuncOp f= Op.ofMethod(m).orElseThrow();
         f = SSA.transform(f);
         System.out.println(f.toText());
-        FunctionType functionType = transformStructClassToPtr(MethodHandles.lookup(), f);
+        FunctionType functionType = transformStructClassToPtr(lookup, f);
         System.out.println(f.toText());
-        CoreOp.FuncOp pm = transformInvokesToPtrs(MethodHandles.lookup(), f, functionType);
+        CoreOp.FuncOp pm = transformInvokesToPtrs(lookup, f, functionType);
         System.out.println(pm.toText());
     }
     static FunctionType transformStructClassToPtr(MethodHandles.Lookup l,

--- a/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
+++ b/hat/examples/experiments/src/main/java/experiments/PointyHatArray.java
@@ -115,7 +115,8 @@ public class PointyHatArray {
 
 
     public static void main(String[] args) {
-        Accelerator accelerator = new Accelerator(MethodHandles.lookup(), new BackendAdaptor() {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Accelerator accelerator = new Accelerator(lookup, new BackendAdaptor() {
             @Override
             public void dispatchKernel(KernelCallGraph kernelCallGraph, NDRange ndRange, Object... args) {
                 var highLevelForm = Op.ofMethod(kernelCallGraph.entrypoint.method).orElseThrow();
@@ -132,12 +133,12 @@ public class PointyHatArray {
                 System.out.println(ssaInvokeForm.toText());
                 System.out.println("------------------");
 
-                FunctionType functionType = OpsAndTypes.transformTypes(MethodHandles.lookup(), ssaInvokeForm);
+                FunctionType functionType = OpsAndTypes.transformTypes(lookup, ssaInvokeForm);
                 System.out.println("SSA form with types transformed args");
                 System.out.println(ssaInvokeForm.toText());
                 System.out.println("------------------");
 
-                CoreOp.FuncOp ssaPtrForm = OpsAndTypes.transformInvokesToPtrs(MethodHandles.lookup(), ssaInvokeForm, functionType);
+                CoreOp.FuncOp ssaPtrForm = OpsAndTypes.transformInvokesToPtrs(lookup, ssaInvokeForm, functionType);
                 System.out.println("SSA form with invokes replaced by ptrs");
                 System.out.println(ssaPtrForm.toText());
             }

--- a/hat/examples/experiments/src/main/java/experiments/PrePostInc.java
+++ b/hat/examples/experiments/src/main/java/experiments/PrePostInc.java
@@ -55,14 +55,15 @@ public class PrePostInc {
         }
 
         static public void main(String[] args) throws Exception {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
             Method pre = PrePostInc.class.getDeclaredMethod("preInc",  int.class);
             Method post = PrePostInc.class.getDeclaredMethod("postInc",  int.class);
             CoreOp.FuncOp preFunc = Op.ofMethod(pre).get();
             CoreOp.FuncOp postFunc = Op.ofMethod(post).get();
 
-            Object preResult = Interpreter.invoke(MethodHandles.lookup(),preFunc,5);
+            Object preResult = Interpreter.invoke(lookup,preFunc,5);
             System.out.println("Pre "+ preResult);
-            Object postResult = Interpreter.invoke(MethodHandles.lookup(),postFunc,5);
+            Object postResult = Interpreter.invoke(lookup,postFunc,5);
             System.out.println("Pre "+ postResult);
           //  javaFunc.writeTo(System.out);
 

--- a/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
@@ -33,6 +33,8 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.Quoted;
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 import static jdk.incubator.code.op.CoreOp._return;
 import static jdk.incubator.code.op.CoreOp.add;
 import static jdk.incubator.code.op.CoreOp.closureCall;
@@ -76,8 +78,9 @@ public class QuotedTest {
                 });
 
         f.writeTo(System.out);
+        MethodHandles.Lookup lookup =  MethodHandles.lookup();
         C99HATComputeBuilder codeBuilder = new C99HATComputeBuilder();
-        FuncOpWrapper wf = OpWrapper.wrap(f);
+        FuncOpWrapper wf = OpWrapper.wrap(f, lookup);
         codeBuilder.compute(wf);
         System.out.println(codeBuilder);
 

--- a/hat/examples/experiments/src/main/java/experiments/RawLayout.java
+++ b/hat/examples/experiments/src/main/java/experiments/RawLayout.java
@@ -117,11 +117,12 @@ public class RawLayout {
 
 
     public static void main(String[] args) {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
         CoreOp.FuncOp m = getFuncOp("m");
         m = SSA.transform(m);
         System.out.println(m.toText());
 
-        CoreOp.FuncOp pm = transformInvokesToPtrs(MethodHandles.lookup(), m);
+        CoreOp.FuncOp pm = transformInvokesToPtrs(lookup, m);
         System.out.println(pm.toText());
     }
 

--- a/hat/examples/squares/src/main/java/squares/Main.java
+++ b/hat/examples/squares/src/main/java/squares/Main.java
@@ -33,6 +33,8 @@ import hat.buffer.S32Array;
 import static hat.ifacemapper.MappableIface.*;
 import jdk.incubator.code.CodeReflection;
 
+import java.lang.invoke.MethodHandles;
+
 public class Main {
     @CodeReflection
     public static int squareit(int v) {
@@ -57,8 +59,8 @@ public class Main {
 
 
     public static void main(String[] args) {
-        var lookup = java.lang.invoke.MethodHandles.lookup();
-        var accelerator = new Accelerator(lookup, Backend.FIRST);//new JavaMultiThreadedBackend());
+
+        var accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);//new JavaMultiThreadedBackend());
         var arr = S32Array.create(accelerator, 32);
         for (int i = 0; i < arr.length(); i++) {
             arr.array(i, i);

--- a/hat/hat-core/src/main/java/hat/Accelerator.java
+++ b/hat/hat-core/src/main/java/hat/Accelerator.java
@@ -191,7 +191,7 @@ public class Accelerator implements BufferAllocator, BufferTracker {
 
     public void compute(QuotableComputeContextConsumer quotableComputeContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableComputeContextConsumer).orElseThrow();
-        LambdaOpWrapper lambda = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op());
+        LambdaOpWrapper lambda = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op(),lookup);
         Method method = lambda.getQuotableTargetMethod(this.lookup);
 
         // Create (or get cached) a compute context which closes over compute entryppint and reachable kernels.

--- a/hat/hat-core/src/main/java/hat/ComputeContext.java
+++ b/hat/hat-core/src/main/java/hat/ComputeContext.java
@@ -110,7 +110,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
 
         // System.out.println(module.op().toText());
 
-        FuncOpWrapper funcOpWrapper = OpWrapper.wrap(Op.ofMethod(computeMethod).orElseThrow());
+        FuncOpWrapper funcOpWrapper = OpWrapper.wrap(Op.ofMethod(computeMethod).orElseThrow(),accelerator.lookup);
 
         this.computeCallGraph = new ComputeCallGraph(this, computeMethod, funcOpWrapper);
 
@@ -127,7 +127,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
 
     public void dispatchKernel(int range, QuotableKernelContextConsumer quotableKernelContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableKernelContextConsumer).orElseThrow();
-        LambdaOpWrapper lambdaOpWrapper = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op());
+        LambdaOpWrapper lambdaOpWrapper = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op(),computeCallGraph.computeContext.accelerator.lookup);
         MethodRef methodRef = lambdaOpWrapper.getQuotableTargetMethodRef();
         KernelCallGraph kernelCallGraph = computeCallGraph.kernelCallGraphMap.get(methodRef);
         try {

--- a/hat/hat-core/src/main/java/hat/OpsAndTypes.java
+++ b/hat/hat-core/src/main/java/hat/OpsAndTypes.java
@@ -126,7 +126,7 @@ public class OpsAndTypes {
                  */
 
                 if (op instanceof CoreOp.InvokeOp invokeOp
-                        && OpWrapper.wrap(invokeOp) instanceof InvokeOpWrapper invokeOpWrapper
+                        && OpWrapper.wrap(invokeOp,lookup) instanceof InvokeOpWrapper invokeOpWrapper
                         && invokeOpWrapper.hasOperands()
                         && invokeOpWrapper.isIfaceBufferMethod()
                         && invokeOpWrapper.getReceiver() instanceof Value iface // Is there a containing iface type Iface

--- a/hat/hat-core/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/hat-core/src/main/java/hat/backend/DebugBackend.java
@@ -159,12 +159,12 @@ public class DebugBackend extends BackendAdaptor {
                 System.out.println(ssaInvokeForm.toText());
                 System.out.println("------------------");
 
-                FunctionType functionType = OpsAndTypes.transformTypes(MethodHandles.lookup(), ssaInvokeForm);
+                FunctionType functionType = OpsAndTypes.transformTypes(kernelCallGraph.computeContext.accelerator.lookup, ssaInvokeForm);
                 System.out.println("SSA form with types transformed args");
                 System.out.println(ssaInvokeForm.toText());
                 System.out.println("------------------");
 
-                CoreOp.FuncOp ssaPtrForm = OpsAndTypes.transformInvokesToPtrs(MethodHandles.lookup(), ssaInvokeForm, functionType);
+                CoreOp.FuncOp ssaPtrForm = OpsAndTypes.transformInvokesToPtrs(kernelCallGraph.computeContext.accelerator.lookup, ssaInvokeForm, functionType);
                 System.out.println("SSA form with invokes replaced by ptrs");
                 System.out.println(ssaPtrForm.toText());
             }

--- a/hat/hat-core/src/main/java/hat/backend/codebuilders/C99HATComputeBuilder.java
+++ b/hat/hat-core/src/main/java/hat/backend/codebuilders/C99HATComputeBuilder.java
@@ -41,7 +41,7 @@ public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HA
     public T compute(FuncOpWrapper funcOpWrapper) {
         computeDeclaration(funcOpWrapper.functionReturnTypeDesc(), funcOpWrapper.functionName());
         parenNlIndented(_ ->
-                commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type((JavaType) info.parameter.type()).space().varName(info.varOp))
+                commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(funcOpWrapper.lookup,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );
         CodeBuilderContext buildContext = new CodeBuilderContext(funcOpWrapper);
         braceNlIndented(_ ->

--- a/hat/hat-core/src/main/java/hat/backend/codebuilders/HATCodeBuilder.java
+++ b/hat/hat-core/src/main/java/hat/backend/codebuilders/HATCodeBuilder.java
@@ -58,6 +58,7 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -322,7 +323,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
 
          T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child);
 
-         T parencedence(CodeBuilderContext buildContext, Op parent, Op child);
+         T parencedence(CodeBuilderContext buildContext, MethodHandles.Lookup lookup, Op parent, Op child);
 
          T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, Op child);
 

--- a/hat/hat-core/src/main/java/hat/backend/ffi/FFIBackend.java
+++ b/hat/hat-core/src/main/java/hat/backend/ffi/FFIBackend.java
@@ -119,13 +119,13 @@ public abstract class FFIBackend extends FFIBackendDriver {
                     bldr.op(invokeOW.op());
                 } else {
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup, javaType))
                             .forEach(value ->
                                     bldr.op(CoreOp.invoke(ESCAPE.pre, cc, bldrCntxt.getValue(value)))
                             );
                     bldr.op(invokeOW.op());
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup,javaType))
                             .forEach(value -> bldr.op(
                                     CoreOp.invoke(ESCAPE.post, cc, bldrCntxt.getValue(value)))
                             );

--- a/hat/hat-core/src/main/java/hat/backend/jextracted/JExtractedBackend.java
+++ b/hat/hat-core/src/main/java/hat/backend/jextracted/JExtractedBackend.java
@@ -114,13 +114,13 @@ public abstract class JExtractedBackend extends FFIBackendDriver {
                     bldr.op(invokeOW.op());
                 } else {
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup,javaType))
                             .forEach(value ->
                                     bldr.op(CoreOp.invoke(ESCAPE.pre, cc, bldrCntxt.getValue(value)))
                             );
                     bldr.op(invokeOW.op());
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup,javaType))
                             .forEach(value -> bldr.op(
                                     CoreOp.invoke(ESCAPE.post, cc, bldrCntxt.getValue(value)))
                             );

--- a/hat/hat-core/src/main/java/hat/callgraph/ComputeCallGraph.java
+++ b/hat/hat-core/src/main/java/hat/callgraph/ComputeCallGraph.java
@@ -99,7 +99,7 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
                     } else {
                         if (paramInfo.isPrimitive()) {
                             // OK
-                        } else if (InvokeOpWrapper.isIface(paramInfo.javaType)) {
+                        } else if (InvokeOpWrapper.isIface(fow.lookup,paramInfo.javaType)) {
                             atLeastOneIfaceBufferParam.of(true);
                         } else {
                             hasOnlyPrimitiveAndIfaceBufferParams.of(false);
@@ -168,7 +168,7 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
             } else if (entrypoint.method.getDeclaringClass().equals(javaRefClass)) {
                 Optional<CoreOp.FuncOp> optionalFuncOp = Op.ofMethod(invokeWrapperCalledMethod);
                 if (optionalFuncOp.isPresent()) {
-                    FuncOpWrapper fow = OpWrapper.wrap(optionalFuncOp.get());
+                    FuncOpWrapper fow = OpWrapper.wrap(optionalFuncOp.get(),computeContext.accelerator.lookup);
                     if (isKernelDispatch(invokeWrapperCalledMethod, fow)) {
                         // System.out.println("A kernel reference (not a direct call) to a kernel " + methodRef);
                         kernelCallGraphMap.computeIfAbsent(methodRef, _ ->

--- a/hat/hat-core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/hat-core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -109,7 +109,7 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
                 if (optionalFuncOp.isPresent()) {
                     //System.out.println("A call to a method on the kernel class which we have code model for " + methodRef);
                     kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
-                            new KernelReachableResolvedMethodCall(this, methodRef, invokeOpCalledMethod, OpWrapper.wrap(optionalFuncOp.get())
+                            new KernelReachableResolvedMethodCall(this, methodRef, invokeOpCalledMethod, OpWrapper.wrap(optionalFuncOp.get(),computeContext.accelerator.lookup)
                             )));
                 } else {
                     // System.out.println("A call to a method on the compute class which we DO NOT have code model for " + methodRef);

--- a/hat/hat-core/src/main/java/hat/optools/BinaryArithmeticOrLogicOperation.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryArithmeticOrLogicOperation.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class BinaryArithmeticOrLogicOperation extends BinaryOpWrapper<CoreOp.BinaryOp> {
-    BinaryArithmeticOrLogicOperation(CoreOp.BinaryOp op) {
-        super(op);
+    BinaryArithmeticOrLogicOperation(CoreOp.BinaryOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/BinaryLogicalOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryLogicalOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class BinaryLogicalOpWrapper extends BinaryOpWrapper<CoreOp.BinaryOp> {
-    BinaryLogicalOpWrapper(CoreOp.BinaryOp op) {
-        super(op);
+    BinaryLogicalOpWrapper(CoreOp.BinaryOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/BinaryOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryOpWrapper.java
@@ -26,9 +26,11 @@ package hat.optools;
 
 import jdk.incubator.code.Op;
 
+import java.lang.invoke.MethodHandles;
+
 public abstract class BinaryOpWrapper<T extends Op> extends OpWrapper<T> {
-    BinaryOpWrapper(T op) {
-        super(op);
+    BinaryOpWrapper(T op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public Op lhsAsOp() {

--- a/hat/hat-core/src/main/java/hat/optools/BinaryTestOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryTestOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class BinaryTestOpWrapper extends BinaryOpWrapper<CoreOp.BinaryTestOp> {
-    BinaryTestOpWrapper(CoreOp.BinaryTestOp op) {
-        super(op);
+    BinaryTestOpWrapper(CoreOp.BinaryTestOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/ConstantOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ConstantOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class ConstantOpWrapper extends UnaryOpWrapper<CoreOp.ConstantOp> {
-    ConstantOpWrapper(CoreOp.ConstantOp op) {
-        super(op);
+    ConstantOpWrapper(CoreOp.ConstantOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/ConvOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ConvOpWrapper.java
@@ -27,9 +27,11 @@ package hat.optools;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.JavaType;
 
+import java.lang.invoke.MethodHandles;
+
 public class ConvOpWrapper extends UnaryOpWrapper<CoreOp.ConvOp> {
-    public ConvOpWrapper(CoreOp.ConvOp op) {
-        super(op);
+    public ConvOpWrapper(CoreOp.ConvOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public JavaType resultJavaType() {

--- a/hat/hat-core/src/main/java/hat/optools/FieldAccessOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FieldAccessOpWrapper.java
@@ -34,10 +34,9 @@ import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.type.PrimitiveType;
 
 public abstract class FieldAccessOpWrapper<T extends CoreOp.FieldAccessOp> extends OpWrapper<T> {
-    FieldAccessOpWrapper(T op) {
-        super(op);
+    FieldAccessOpWrapper(T op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
-
     public boolean isKernelContextAccess() {
         var refType = fieldRef().refType();
         if (refType instanceof ClassType classType) {

--- a/hat/hat-core/src/main/java/hat/optools/FieldLoadOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FieldLoadOpWrapper.java
@@ -28,16 +28,17 @@ import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.ClassType;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 
 public class FieldLoadOpWrapper extends FieldAccessOpWrapper<CoreOp.FieldAccessOp.FieldLoadOp> implements LoadOpWrapper {
-    FieldLoadOpWrapper(CoreOp.FieldAccessOp.FieldLoadOp op) {
-        super(op);
+    FieldLoadOpWrapper(CoreOp.FieldAccessOp.FieldLoadOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public Object getStaticFinalPrimitiveValue() {
         if (fieldType() instanceof ClassType classType) {
-            Class<?> clazz = (Class<?>) classTypeToType(classType);
+            Class<?> clazz = (Class<?>) classTypeToType(lookup,classType);
             try {
                 Field field = clazz.getField(fieldName());
                 field.setAccessible(true);

--- a/hat/hat-core/src/main/java/hat/optools/FieldStoreOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FieldStoreOpWrapper.java
@@ -27,11 +27,13 @@ package hat.optools;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.ClassType;
 
+import java.lang.invoke.MethodHandles;
+
 public class FieldStoreOpWrapper extends FieldAccessOpWrapper<CoreOp.FieldAccessOp.FieldStoreOp> implements StoreOpWrapper {
 
 
-    FieldStoreOpWrapper(CoreOp.FieldAccessOp.FieldStoreOp op) {
-        super(op);
+    FieldStoreOpWrapper(CoreOp.FieldAccessOp.FieldStoreOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public boolean isKernelContextAccess() {

--- a/hat/hat-core/src/main/java/hat/optools/ForOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ForOpWrapper.java
@@ -25,11 +25,13 @@
 package hat.optools;
 
 import jdk.incubator.code.op.ExtendedOp;
+
+import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class ForOpWrapper extends LoopOpWrapper<ExtendedOp.JavaForOp> {
-    ForOpWrapper(ExtendedOp.JavaForOp op) {
-        super(op);
+    ForOpWrapper(ExtendedOp.JavaForOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public Stream<OpWrapper<?>> initWrappedYieldOpStream() {

--- a/hat/hat-core/src/main/java/hat/optools/FuncCallOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FuncCallOpWrapper.java
@@ -26,9 +26,11 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class FuncCallOpWrapper extends OpWrapper<CoreOp.FuncCallOp> {
-    public FuncCallOpWrapper(CoreOp.FuncCallOp op) {
-        super(op);
+    public FuncCallOpWrapper(CoreOp.FuncCallOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 

--- a/hat/hat-core/src/main/java/hat/optools/FuncOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FuncOpWrapper.java
@@ -38,6 +38,8 @@ import jdk.incubator.code.analysis.SSA;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.type.PrimitiveType;
+
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -163,8 +165,9 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
     public BiMap<Block.Parameter, CoreOp.VarOp> parameterVarOpMap = new BiMap<>();
     public BiMap<Block.Parameter, CoreOp.InvokeOp> parameterInvokeOpMap = new BiMap<>();
     public BiMap<Block.Parameter, OpsAndTypes.HatPtrOp> parameterHatPtrOpMap = new BiMap<>();
-    public FuncOpWrapper(CoreOp.FuncOp op) {
-        super(op);
+    public FuncOpWrapper(CoreOp.FuncOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
+
         op().parameters().forEach(parameter -> {
             Optional<Op.Result> optionalResult = parameter.uses().stream().findFirst();
             optionalResult.ifPresentOrElse(result -> {
@@ -193,11 +196,11 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
                 block.op(op);
                 return block;
             }
-        }));
+        }),lookup);
     }
 
     public FuncOpWrapper ssa() {
-        return OpWrapper.wrap(SSA.transform(op()));
+        return OpWrapper.wrap(SSA.transform(op()),lookup);
     }
 
 
@@ -226,18 +229,18 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
     public FuncOpWrapper transformInvokes(WrappedInvokeOpTransformer wrappedOpTransformer) {
         return OpWrapper.wrap(op().transform((b, op) -> {
             if (op instanceof CoreOp.InvokeOp invokeOp) {
-                wrappedOpTransformer.apply(b, OpWrapper.wrap(invokeOp));
+                wrappedOpTransformer.apply(b, OpWrapper.wrap(invokeOp,lookup));
             } else {
                 b.op(op);
             }
             return b;
-        }));
+        }),lookup);
     }
 
     public FuncOpWrapper transformIfaceInvokes(BiConsumer<Block.Builder,InvokeOpWrapper> wrappedOpTransformer) {
         return OpWrapper.wrap(op().transform((b, op) -> {
             if (op instanceof CoreOp.InvokeOp invokeOp) {
-                InvokeOpWrapper wrapped = OpWrapper.wrap(invokeOp);
+                InvokeOpWrapper wrapped = OpWrapper.wrap(invokeOp,lookup);
                 if (wrapped.isIfaceBufferMethod()) {
                     wrappedOpTransformer.accept(b,wrapped);
                 }else{
@@ -247,7 +250,7 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
                 b.op(op);
             }
             return b;
-        }));
+        }),lookup);
     }
     public static class WrappedOpReplacer<T extends Op, WT extends OpWrapper<T>>{
 
@@ -280,13 +283,13 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
 
     public FuncOpWrapper replace(Consumer<WrappedOpReplacer<?,OpWrapper<?>>> wrappedOpTransformer) {
         return OpWrapper.wrap(op().transform((b, op) -> {
-            var replacer = new WrappedOpReplacer(b, OpWrapper.wrap(op));
+            var replacer = new WrappedOpReplacer(b, OpWrapper.wrap(op,lookup));
             wrappedOpTransformer.accept(replacer);
             if (!replacer.replaced) {
                b.op(op);
             }
             return b;
-        }));
+        }),lookup);
     }
 
     public  <T extends Op, WT extends OpWrapper<T>>FuncOpWrapper findMapAndReplace(
@@ -294,7 +297,7 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
             Function<OpWrapper<?>, WT> mapper,
             Consumer<WrappedOpReplacer<T,WT>> wrappedOpTransformer) {
         return OpWrapper.wrap(op().transform((b, op) -> {
-            var opWrapper = OpWrapper.wrap(op);
+            var opWrapper = OpWrapper.wrap(op,lookup);
             if (predicate.test(opWrapper)) {
                 var replacer = new WrappedOpReplacer<T,WT>(b, mapper.apply(opWrapper));
                 wrappedOpTransformer.accept(replacer);
@@ -305,7 +308,7 @@ public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
                 b.op(op);
             }
             return b;
-        }));
+        }),lookup);
     }
     public String functionName() {
         return op().funcName();

--- a/hat/hat-core/src/main/java/hat/optools/IfOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/IfOpWrapper.java
@@ -25,11 +25,13 @@
 package hat.optools;
 
 import jdk.incubator.code.op.ExtendedOp;
+
+import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class IfOpWrapper extends StructuralOpWrapper<ExtendedOp.JavaIfOp> {
-    public IfOpWrapper(ExtendedOp.JavaIfOp op) {
-        super(op);
+    public IfOpWrapper(ExtendedOp.JavaIfOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public boolean hasElseN(int idx) {

--- a/hat/hat-core/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -43,8 +43,8 @@ import java.util.stream.Stream;
 public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
 
 
-    public InvokeOpWrapper(CoreOp.InvokeOp op) {
-        super(op);
+    public InvokeOpWrapper(CoreOp.InvokeOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public MethodRef methodRef() {
@@ -56,25 +56,25 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
     }
 
     public boolean isIfaceBufferMethod() {
-        return isIface(javaRefType());
+        return isIface(lookup,javaRefType());
     }
 
 
     public boolean isRawKernelCall() {
         boolean isRawKernelCall = (operandCount() > 1 && operandNAsValue(0) instanceof Value value
                 && value.type() instanceof JavaType javaType
-                && (isAssignable(javaType, hat.KernelContext.class) || isAssignable(javaType, hat.buffer.KernelContext.class))
+                && (isAssignable(lookup,javaType, hat.KernelContext.class) || isAssignable(lookup,javaType, hat.buffer.KernelContext.class))
         );
         return isRawKernelCall;
     }
 
     public boolean isKernelContextMethod() {
-        return isAssignable(javaRefType(), KernelContext.class);
+        return isAssignable(lookup,javaRefType(), KernelContext.class);
 
     }
 
     public boolean isComputeContextMethod() {
-        return isAssignable(javaRefType(), ComputeContext.class);
+        return isAssignable(lookup,javaRefType(), ComputeContext.class);
 
     }
 
@@ -153,7 +153,7 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
 
     public Optional<Class<?>> javaRefClass() {
         if (javaRefType() instanceof ClassType classType) {
-            return Optional.of((Class<?>)classTypeToType(classType));
+            return Optional.of((Class<?>)classTypeToType(lookup,classType));
         }else{
             return Optional.empty();
         }
@@ -161,7 +161,7 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
 
     public Optional<Class<?>> javaReturnClass() {
         if (javaReturnType() instanceof ClassType classType) {
-            return Optional.of((Class<?>)classTypeToType(classType));
+            return Optional.of((Class<?>)classTypeToType(lookup,classType));
         }else{
             return Optional.empty();
         }

--- a/hat/hat-core/src/main/java/hat/optools/JavaBreakOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/JavaBreakOpWrapper.java
@@ -26,9 +26,11 @@ package hat.optools;
 
 import jdk.incubator.code.op.ExtendedOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class JavaBreakOpWrapper extends OpWrapper<ExtendedOp.JavaBreakOp> {
-    public JavaBreakOpWrapper(ExtendedOp.JavaBreakOp op) {
-        super(op);
+    public JavaBreakOpWrapper(ExtendedOp.JavaBreakOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/JavaContinueOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/JavaContinueOpWrapper.java
@@ -26,9 +26,11 @@ package hat.optools;
 
 import jdk.incubator.code.op.ExtendedOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class JavaContinueOpWrapper extends OpWrapper<ExtendedOp.JavaContinueOp> {
-    public JavaContinueOpWrapper(ExtendedOp.JavaContinueOp op) {
-        super(op);
+    public JavaContinueOpWrapper(ExtendedOp.JavaContinueOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/JavaLabeledOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/JavaLabeledOpWrapper.java
@@ -26,9 +26,11 @@ package hat.optools;
 
 import jdk.incubator.code.op.ExtendedOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class JavaLabeledOpWrapper extends StructuralOpWrapper<ExtendedOp.JavaLabeledOp> {
-    public JavaLabeledOpWrapper(ExtendedOp.JavaLabeledOp op) {
-        super(op);
+    public JavaLabeledOpWrapper(ExtendedOp.JavaLabeledOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/LambdaOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/LambdaOpWrapper.java
@@ -38,8 +38,8 @@ import java.util.List;
 import java.util.Map;
 
 public class LambdaOpWrapper extends OpWrapper<CoreOp.LambdaOp> {
-    public LambdaOpWrapper(CoreOp.LambdaOp op) {
-        super(op);
+    public LambdaOpWrapper(CoreOp.LambdaOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public InvokeOpWrapper getInvoke(int index) {
@@ -47,7 +47,7 @@ public class LambdaOpWrapper extends OpWrapper<CoreOp.LambdaOp> {
         selectOnlyBlockOfOnlyBody(blockWrapper ->
                 result.of(blockWrapper.op(index))
         );
-        return OpWrapper.wrap(result.get());
+        return OpWrapper.wrap(result.get(),lookup);
     }
 
     public List<Value> operands() {
@@ -62,7 +62,7 @@ public class LambdaOpWrapper extends OpWrapper<CoreOp.LambdaOp> {
         return OpWrapper.wrap(op().body().entryBlock().ops().stream()
                 .filter(op -> op instanceof CoreOp.InvokeOp)
                 .map(op -> (CoreOp.InvokeOp) op)
-                .findFirst().get());
+                .findFirst().get(),lookup);
     }
 
     public MethodRef getQuotableTargetMethodRef() {

--- a/hat/hat-core/src/main/java/hat/optools/LogicalOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/LogicalOpWrapper.java
@@ -25,11 +25,13 @@
 package hat.optools;
 
 import jdk.incubator.code.op.ExtendedOp;
+
+import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class LogicalOpWrapper extends BinaryOpWrapper<ExtendedOp.JavaConditionalOp> {
-    LogicalOpWrapper(ExtendedOp.JavaConditionalOp op) {
-        super(op);
+    LogicalOpWrapper(ExtendedOp.JavaConditionalOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public Stream<OpWrapper<?>> lhsWrappedYieldOpStream() {

--- a/hat/hat-core/src/main/java/hat/optools/LoopOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/LoopOpWrapper.java
@@ -25,11 +25,13 @@
 package hat.optools;
 
 import jdk.incubator.code.Op;
+
+import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public abstract class LoopOpWrapper<T extends Op> extends StructuralOpWrapper<T> {
-    LoopOpWrapper(T op) {
-        super(op);
+    LoopOpWrapper(T op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public abstract Stream<OpWrapper<?>> conditionWrappedYieldOpStream();

--- a/hat/hat-core/src/main/java/hat/optools/ModuleOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ModuleOpWrapper.java
@@ -39,8 +39,8 @@ import java.util.List;
 import java.util.Optional;
 
 public class ModuleOpWrapper extends OpWrapper<CoreOp.ModuleOp> {
-    ModuleOpWrapper(CoreOp.ModuleOp op) {
-        super(op);
+    ModuleOpWrapper(CoreOp.ModuleOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     record MethodRefToEntryFuncOpCall(MethodRef methodRef, CoreOp.FuncOp funcOp) {
@@ -54,9 +54,9 @@ public class ModuleOpWrapper extends OpWrapper<CoreOp.ModuleOp> {
                                                                Method entryPoint) {
         Optional<CoreOp.FuncOp> codeModel = Op.ofMethod(entryPoint);
         if (codeModel.isPresent()) {
-            return OpWrapper.wrap(createTransitiveInvokeModule(lookup, MethodRef.method(entryPoint), codeModel.get()));
+            return OpWrapper.wrap(createTransitiveInvokeModule(lookup, MethodRef.method(entryPoint), codeModel.get()),lookup);
         } else {
-            return OpWrapper.wrap(CoreOp.module(List.of()));
+            return OpWrapper.wrap(CoreOp.module(List.of()),lookup);
         }
     }
    /* static Method resolveToMethod(MethodHandles.Lookup lookup, MethodRef invokedMethodRef){
@@ -78,10 +78,10 @@ public class ModuleOpWrapper extends OpWrapper<CoreOp.ModuleOp> {
             if (closure.funcsVisited.add(methodRefToEntryFuncOpCall.methodRef)) {
                 CoreOp.FuncOp tf = methodRefToEntryFuncOpCall.funcOp.transform(
                         methodRefToEntryFuncOpCall.methodRef.toString(), (blockBuilder, op) -> {
-                            if (op instanceof CoreOp.InvokeOp invokeOp && OpWrapper.wrap(invokeOp) instanceof InvokeOpWrapper invokeOpWrapper) {
+                            if (op instanceof CoreOp.InvokeOp invokeOp && OpWrapper.wrap(invokeOp,lookup) instanceof InvokeOpWrapper invokeOpWrapper) {
                                 Method invokedMethod = invokeOpWrapper.method(lookup);
                                 Optional<CoreOp.FuncOp> optionalInvokedFuncOp = Op.ofMethod(invokedMethod);
-                                if (optionalInvokedFuncOp.isPresent() && OpWrapper.wrap(optionalInvokedFuncOp.get()) instanceof FuncOpWrapper funcOpWrapper) {
+                                if (optionalInvokedFuncOp.isPresent() && OpWrapper.wrap(optionalInvokedFuncOp.get(),lookup) instanceof FuncOpWrapper funcOpWrapper) {
                                     MethodRefToEntryFuncOpCall call =
                                             new MethodRefToEntryFuncOpCall(invokeOpWrapper.methodRef(), funcOpWrapper.op());
                                     closure.work.push(call);

--- a/hat/hat-core/src/main/java/hat/optools/OpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/OpWrapper.java
@@ -37,6 +37,7 @@ import jdk.incubator.code.op.ExtendedOp;
 import jdk.incubator.code.type.ClassType;
 import jdk.incubator.code.type.JavaType;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ import java.util.stream.Stream;
 
 public class OpWrapper<T extends Op> {
     @SuppressWarnings("unchecked")
-    public static <O extends Op, OW extends OpWrapper<O>> OW wrap(O op) {
+    public static <O extends Op, OW extends OpWrapper<O>> OW wrap(O op, MethodHandles.Lookup lookup) {
         // We have one special case
         // This is possibly a premature optimization. But it allows us to treat vardeclarations differently from params.
         if (op instanceof CoreOp.VarOp varOp && !varOp.isUninitialized()) {
@@ -57,45 +58,46 @@ public class OpWrapper<T extends Op> {
 
             if (varOp.operands().getFirst() instanceof Block.Parameter parameter &&
                     parameter.invokableOperation() instanceof CoreOp.FuncOp funcOp) {
-                return (OW) new VarFuncDeclarationOpWrapper(varOp, funcOp, parameter);
+                return (OW) new VarFuncDeclarationOpWrapper(varOp, funcOp, parameter,lookup);
             }
         }
         return switch (op) {
-            case CoreOp.ModuleOp $ -> (OW) new ModuleOpWrapper($);
-            case ExtendedOp.JavaForOp $ -> (OW) new ForOpWrapper($);
-            case ExtendedOp.JavaWhileOp $ -> (OW) new WhileOpWrapper($);
-            case ExtendedOp.JavaIfOp $ -> (OW) new IfOpWrapper($);
-            case CoreOp.NotOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper($);
-            case CoreOp.NegOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper($);
-            case CoreOp.BinaryOp $ -> (OW) new BinaryArithmeticOrLogicOperation($);
-            case CoreOp.BinaryTestOp $ -> (OW) new BinaryTestOpWrapper($);
-            case CoreOp.FuncOp $ -> (OW) new FuncOpWrapper($);
-            case CoreOp.VarOp $ -> (OW) new VarDeclarationOpWrapper($);
-            case CoreOp.YieldOp $ -> (OW) new YieldOpWrapper($);
-            case CoreOp.FuncCallOp $ -> (OW) new FuncCallOpWrapper($);
-            case CoreOp.ConvOp $ -> (OW) new ConvOpWrapper($);
-            case CoreOp.ConstantOp $ -> (OW) new ConstantOpWrapper($);
-            case CoreOp.ReturnOp $ -> (OW) new ReturnOpWrapper($);
-            case CoreOp.VarAccessOp.VarStoreOp $ -> (OW) new VarStoreOpWrapper($);
-            case CoreOp.VarAccessOp.VarLoadOp $ -> (OW) new VarLoadOpWrapper($);
-            case CoreOp.FieldAccessOp.FieldStoreOp $ -> (OW) new FieldStoreOpWrapper($);
-            case CoreOp.FieldAccessOp.FieldLoadOp $ -> (OW) new FieldLoadOpWrapper($);
-            case CoreOp.InvokeOp $ -> (OW) new InvokeOpWrapper($);
-            case CoreOp.TupleOp $ -> (OW) new TupleOpWrapper($);
-            case CoreOp.LambdaOp $ -> (OW) new LambdaOpWrapper($);
-            case ExtendedOp.JavaConditionalOp $ -> (OW) new LogicalOpWrapper($);
-            case ExtendedOp.JavaConditionalExpressionOp $ -> (OW) new TernaryOpWrapper($);
-            case ExtendedOp.JavaLabeledOp $ -> (OW) new JavaLabeledOpWrapper($);
-            case ExtendedOp.JavaBreakOp $ -> (OW) new JavaBreakOpWrapper($);
-            case ExtendedOp.JavaContinueOp $ -> (OW) new JavaContinueOpWrapper($);
-            default -> (OW) new OpWrapper<>(op);
+            case CoreOp.ModuleOp $ -> (OW) new ModuleOpWrapper($,lookup);
+            case ExtendedOp.JavaForOp $ -> (OW) new ForOpWrapper($,lookup);
+            case ExtendedOp.JavaWhileOp $ -> (OW) new WhileOpWrapper($,lookup);
+            case ExtendedOp.JavaIfOp $ -> (OW) new IfOpWrapper($,lookup);
+            case CoreOp.NotOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper($,lookup);
+            case CoreOp.NegOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper($,lookup);
+            case CoreOp.BinaryOp $ -> (OW) new BinaryArithmeticOrLogicOperation($,lookup);
+            case CoreOp.BinaryTestOp $ -> (OW) new BinaryTestOpWrapper($,lookup);
+            case CoreOp.FuncOp $ -> (OW) new FuncOpWrapper($,lookup);
+            case CoreOp.VarOp $ -> (OW) new VarDeclarationOpWrapper($,lookup);
+            case CoreOp.YieldOp $ -> (OW) new YieldOpWrapper($,lookup);
+            case CoreOp.FuncCallOp $ -> (OW) new FuncCallOpWrapper($,lookup);
+            case CoreOp.ConvOp $ -> (OW) new ConvOpWrapper($,lookup);
+            case CoreOp.ConstantOp $ -> (OW) new ConstantOpWrapper($,lookup);
+            case CoreOp.ReturnOp $ -> (OW) new ReturnOpWrapper($,lookup);
+            case CoreOp.VarAccessOp.VarStoreOp $ -> (OW) new VarStoreOpWrapper($,lookup);
+            case CoreOp.VarAccessOp.VarLoadOp $ -> (OW) new VarLoadOpWrapper($,lookup);
+            case CoreOp.FieldAccessOp.FieldStoreOp $ -> (OW) new FieldStoreOpWrapper($,lookup);
+            case CoreOp.FieldAccessOp.FieldLoadOp $ -> (OW) new FieldLoadOpWrapper($,lookup);
+            case CoreOp.InvokeOp $ -> (OW) new InvokeOpWrapper($,lookup);
+            case CoreOp.TupleOp $ -> (OW) new TupleOpWrapper($,lookup);
+            case CoreOp.LambdaOp $ -> (OW) new LambdaOpWrapper($,lookup);
+            case ExtendedOp.JavaConditionalOp $ -> (OW) new LogicalOpWrapper($,lookup);
+            case ExtendedOp.JavaConditionalExpressionOp $ -> (OW) new TernaryOpWrapper($,lookup);
+            case ExtendedOp.JavaLabeledOp $ -> (OW) new JavaLabeledOpWrapper($,lookup);
+            case ExtendedOp.JavaBreakOp $ -> (OW) new JavaBreakOpWrapper($,lookup);
+            case ExtendedOp.JavaContinueOp $ -> (OW) new JavaContinueOpWrapper($,lookup);
+            default -> (OW) new OpWrapper<>(op,lookup);
         };
     }
 
     private final T op;
-
-    OpWrapper(T op) {
+public MethodHandles.Lookup lookup;
+    OpWrapper(T op, MethodHandles.Lookup lookup) {
         this.op = op;
+        this.lookup= lookup;
     }
 
     public T op() {
@@ -133,7 +135,7 @@ public class OpWrapper<T extends Op> {
     public void selectCalls(Consumer<InvokeOpWrapper> consumer) {
         this.op.traverse(null, (map, op) -> {
             if (op instanceof CoreOp.InvokeOp invokeOp) {
-                consumer.accept(wrap(invokeOp));
+                consumer.accept(wrap(invokeOp, lookup));
             }
             return map;
         });
@@ -141,7 +143,7 @@ public class OpWrapper<T extends Op> {
     public void selectAssignments(Consumer<VarOpWrapper> consumer) {
         this.op.traverse(null, (map, op) -> {
             if (op instanceof CoreOp.VarOp varOp) {
-                consumer.accept(wrap(varOp));
+                consumer.accept(wrap(varOp, lookup));
             }
             return map;
         });
@@ -209,7 +211,7 @@ public class OpWrapper<T extends Op> {
     }
 
     public Stream<OpWrapper<?>> wrappedOpStream(Block block) {
-        return block.ops().stream().map(OpWrapper::wrap);
+        return block.ops().stream().map(o->wrap(o,lookup));
     }
 
     public Stream<OpWrapper<?>> wrappedYieldOpStream(Block block) {
@@ -218,7 +220,7 @@ public class OpWrapper<T extends Op> {
 
     private Stream<OpWrapper<?>> roots(Block block) {
         var rootSet = RootSet.getRootSet(block.ops().stream());
-        return block.ops().stream().filter(rootSet::contains).map(OpWrapper::wrap);
+        return block.ops().stream().filter(rootSet::contains).map(o->wrap(o, lookup));
     }
 
     private Stream<OpWrapper<?>> rootsWithoutVarFuncDeclarations(Block block) {
@@ -249,22 +251,27 @@ public class OpWrapper<T extends Op> {
         return op.resultType();
     }
 
-    public static boolean isIface(JavaType javaType){
-        return  (isAssignable(javaType, MappableIface.class));
+    public static boolean isIface(MethodHandles.Lookup lookup,JavaType javaType) {
+        return  (isAssignable(lookup,javaType, MappableIface.class));
     }
-    public static Type classTypeToType(ClassType classType){
+    //public static Type classTypeToType(ClassType classType){
+
+      //  return classTypeToType(classType,MethodHandles.lookup());
+
+    //}
+    public static Type classTypeToType(MethodHandles.Lookup lookup,ClassType classType) {
         Type javaTypeClass = null;
         try {
-            javaTypeClass = classType.resolve(MethodHandles.lookup());
+            javaTypeClass = classType.resolve(lookup);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
         return javaTypeClass;
 
     }
-    public static boolean isAssignable(JavaType javaType, Class<?> ... classes) {
+    public static boolean isAssignable(MethodHandles.Lookup lookup,JavaType javaType, Class<?> ... classes) {
         if (javaType instanceof ClassType classType) {
-            Type type = classTypeToType(classType);
+            Type type = classTypeToType(lookup,classType);
             for (Class<?> clazz : classes) {
                 if (clazz.isAssignableFrom((Class<?>) type)) {
                         return true;

--- a/hat/hat-core/src/main/java/hat/optools/ReturnOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ReturnOpWrapper.java
@@ -26,9 +26,11 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class ReturnOpWrapper extends OpWrapper<CoreOp.ReturnOp> {
-    public ReturnOpWrapper(CoreOp.ReturnOp op) {
-        super(op);
+    public ReturnOpWrapper(CoreOp.ReturnOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 

--- a/hat/hat-core/src/main/java/hat/optools/StructuralOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/StructuralOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.Op;
 
+import java.lang.invoke.MethodHandles;
+
 public abstract class StructuralOpWrapper<T extends Op> extends OpWrapper<T> {
-    StructuralOpWrapper(T op) {
-        super(op);
+    StructuralOpWrapper(T op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/TernaryOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/TernaryOpWrapper.java
@@ -26,11 +26,13 @@ package hat.optools;
 
 
 import jdk.incubator.code.op.ExtendedOp;
+
+import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class TernaryOpWrapper extends OpWrapper<ExtendedOp.JavaConditionalExpressionOp> {
-    public TernaryOpWrapper(ExtendedOp.JavaConditionalExpressionOp op) {
-        super(op);
+    public TernaryOpWrapper(ExtendedOp.JavaConditionalExpressionOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {

--- a/hat/hat-core/src/main/java/hat/optools/TupleOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/TupleOpWrapper.java
@@ -26,9 +26,11 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class TupleOpWrapper extends StructuralOpWrapper<CoreOp.TupleOp> {
-    public TupleOpWrapper(CoreOp.TupleOp op) {
-        super(op);
+    public TupleOpWrapper(CoreOp.TupleOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/UnaryArithmeticOrLogicOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/UnaryArithmeticOrLogicOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class UnaryArithmeticOrLogicOpWrapper extends UnaryOpWrapper<CoreOp.UnaryOp> {
-    UnaryArithmeticOrLogicOpWrapper(CoreOp.UnaryOp op) {
-        super(op);
+    UnaryArithmeticOrLogicOpWrapper(CoreOp.UnaryOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/UnaryOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/UnaryOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.Op;
 
+import java.lang.invoke.MethodHandles;
+
 public abstract class UnaryOpWrapper<T extends Op> extends OpWrapper<T> {
-    UnaryOpWrapper(T op) {
-        super(op);
+    UnaryOpWrapper(T op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarAccessOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarAccessOpWrapper.java
@@ -28,9 +28,11 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public abstract class VarAccessOpWrapper<T extends CoreOp.VarAccessOp> extends OpWrapper<T> {
-    VarAccessOpWrapper(T op) {
-        super(op);
+    VarAccessOpWrapper(T op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public CoreOp.VarOp varOp() {

--- a/hat/hat-core/src/main/java/hat/optools/VarDeclarationOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarDeclarationOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class VarDeclarationOpWrapper extends VarOpWrapper implements StoreOpWrapper {
-    public VarDeclarationOpWrapper(CoreOp.VarOp op) {
-        super(op);
+    public VarDeclarationOpWrapper(CoreOp.VarOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarFuncDeclarationOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarFuncDeclarationOpWrapper.java
@@ -27,13 +27,15 @@ package hat.optools;
 import jdk.incubator.code.Block;
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class VarFuncDeclarationOpWrapper extends VarOpWrapper {
     final CoreOp.FuncOp funcOp;
     final Block.Parameter blockParameter;
     final int idx;
 
-    public VarFuncDeclarationOpWrapper(CoreOp.VarOp op, CoreOp.FuncOp funcOp, Block.Parameter blockParameter) {
-        super(op);
+    public VarFuncDeclarationOpWrapper(CoreOp.VarOp op, CoreOp.FuncOp funcOp, Block.Parameter blockParameter, MethodHandles.Lookup lookup) {
+        super(op, lookup);
         this.funcOp = funcOp;
         this.blockParameter = blockParameter;
         this.idx = blockParameter.index();

--- a/hat/hat-core/src/main/java/hat/optools/VarLoadOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarLoadOpWrapper.java
@@ -26,10 +26,12 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class VarLoadOpWrapper extends VarAccessOpWrapper<CoreOp.VarAccessOp.VarLoadOp> implements LoadOpWrapper {
 
-    VarLoadOpWrapper(CoreOp.VarAccessOp.VarLoadOp op) {
-        super(op);
+    VarLoadOpWrapper(CoreOp.VarAccessOp.VarLoadOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarOpWrapper.java
@@ -27,9 +27,11 @@ package hat.optools;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.JavaType;
 
+import java.lang.invoke.MethodHandles;
+
 public abstract class VarOpWrapper extends OpWrapper<CoreOp.VarOp> {
-    public VarOpWrapper(CoreOp.VarOp op) {
-        super(op);
+    public VarOpWrapper(CoreOp.VarOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     public JavaType javaType() {
@@ -41,6 +43,6 @@ public abstract class VarOpWrapper extends OpWrapper<CoreOp.VarOp> {
     }
 
     public boolean isIfaceAssignment() {
-        return OpWrapper.isIface(javaType());
+        return isIface(lookup,javaType());
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarStoreOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarStoreOpWrapper.java
@@ -26,11 +26,13 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class VarStoreOpWrapper extends VarAccessOpWrapper<CoreOp.VarAccessOp.VarStoreOp> implements StoreOpWrapper {
 
 
-    VarStoreOpWrapper(CoreOp.VarAccessOp.VarStoreOp op) {
-        super(op);
+    VarStoreOpWrapper(CoreOp.VarAccessOp.VarStoreOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/WhileOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/WhileOpWrapper.java
@@ -25,12 +25,14 @@
 package hat.optools;
 
 import jdk.incubator.code.op.ExtendedOp;
+
+import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class WhileOpWrapper extends LoopOpWrapper<ExtendedOp.JavaWhileOp> {
 
-    WhileOpWrapper(ExtendedOp.JavaWhileOp op) {
-        super(op);
+    WhileOpWrapper(ExtendedOp.JavaWhileOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 
     @Override

--- a/hat/hat-core/src/main/java/hat/optools/YieldOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/YieldOpWrapper.java
@@ -26,8 +26,10 @@ package hat.optools;
 
 import jdk.incubator.code.op.CoreOp;
 
+import java.lang.invoke.MethodHandles;
+
 public class YieldOpWrapper extends StructuralOpWrapper<CoreOp.YieldOp> {
-    public YieldOpWrapper(CoreOp.YieldOp op) {
-        super(op);
+    public YieldOpWrapper(CoreOp.YieldOp op, MethodHandles.Lookup lookup) {
+        super(op,lookup);
     }
 }

--- a/hat/hat-core/src/main/test/hat/SquaresTest.java
+++ b/hat/hat-core/src/main/test/hat/SquaresTest.java
@@ -30,6 +30,8 @@ import org.testng.annotations.Test;
 
 import jdk.incubator.code.CodeReflection;
 
+import java.lang.invoke.MethodHandles;
+
 
 /*
  * @test
@@ -54,8 +56,8 @@ public class SquaresTest {
 
   @Test
        void    testSquares(){
-        var lookup = java.lang.invoke.MethodHandles.lookup();
-        var accelerator = new Accelerator(lookup, new JavaMultiThreadedBackend());
+
+        var accelerator = new Accelerator(MethodHandles.lookup(), new JavaMultiThreadedBackend());
         var arr = S32Array.create(accelerator, 32);
         for (int i = 0; i < arr.length(); i++) {
             arr.array(i, i);


### PR DESCRIPTION
Exception  running script indicated mayble issues usig local MethodHandles.lookup() calls. 

Purged the code to reuse the accelerator lookup (from the app). 

Lots of code changes. ;)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/352/head:pull/352` \
`$ git checkout pull/352`

Update a local copy of the PR: \
`$ git checkout pull/352` \
`$ git pull https://git.openjdk.org/babylon.git pull/352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 352`

View PR using the GUI difftool: \
`$ git pr show -t 352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/352.diff">https://git.openjdk.org/babylon/pull/352.diff</a>

</details>
