### PR TITLE
More lookup cleanup

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHatKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHatKernelBuilder.java
@@ -68,8 +68,8 @@ public class CudaHatKernelBuilder extends C99HATKernelBuilder<CudaHatKernelBuild
     }
 
     @Override
-    public CudaHatKernelBuilder functionDeclaration(MethodHandles.Lookup lookup,JavaType javaType, String name) {
-        return externC().space().keyword("__device__").space().keyword("inline").space().type(lookup,javaType).space().identifier(name);
+    public CudaHatKernelBuilder functionDeclaration(CodeBuilderContext codeBuilderContext,JavaType javaType, String name) {
+        return externC().space().keyword("__device__").space().keyword("inline").space().type(codeBuilderContext,javaType).space().identifier(name);
     }
 
     @Override
@@ -79,9 +79,9 @@ public class CudaHatKernelBuilder extends C99HATKernelBuilder<CudaHatKernelBuild
 
 
     @Override
-    public CudaHatKernelBuilder atomicInc(CodeBuilderContext buildContext, MethodHandles.Lookup lookup,Op.Result instanceResult, String name){
+    public CudaHatKernelBuilder atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name){
         return identifier("atomicAdd").paren(_ -> {
-             ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op(),lookup));
+             ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
              rarrow().identifier(name).comma().literal(1);
         });
     }

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHatKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHatKernelBuilder.java
@@ -65,8 +65,8 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder functionDeclaration(MethodHandles.Lookup lookup,JavaType type, String name) {
-        return keyword("inline").space().type(lookup,type).space().identifier(name);
+    public OpenCLHatKernelBuilder functionDeclaration(CodeBuilderContext codeBuilderContext,JavaType type, String name) {
+        return keyword("inline").space().type(codeBuilderContext,type).space().identifier(name);
     }
 
     @Override
@@ -75,9 +75,9 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext, MethodHandles.Lookup lookup, Op.Result instanceResult, String name){
+    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext,  Op.Result instanceResult, String name){
           return identifier("atomic_inc").paren(_ -> {
-              ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op(),lookup));
+              ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
               rarrow().identifier(name);
           });
     }

--- a/hat/backends/ffi/ptx/src/main/java/hat/backend/ffi/PTXCodeBuilder.java
+++ b/hat/backends/ffi/ptx/src/main/java/hat/backend/ffi/PTXCodeBuilder.java
@@ -386,7 +386,7 @@ public class PTXCodeBuilder extends CodeBuilder<PTXCodeBuilder> {
                     st().dot().param().paramType(op.operandNAsValue(i).type()).space().osbrace().param().intVal(i).csbrace().commaSpace().reg(op.operandNAsValue(i)).ptxNl();
                 }
                 dot().param().space().paramType(op.resultType()).space().retVal().ptxNl();
-                call().uni().space().oparen().retVal().cparen().commaSpace().append(op.methodNoLookup().getName()).commaSpace();
+                call().uni().space().oparen().retVal().cparen().commaSpace().append(op.method().getName()).commaSpace();
                 final int[] counter = {0};
                 paren(_ -> commaSeparated(op.operands(), _ -> param().intVal(counter[0]++))).ptxNl();
                 ld().dot().param().paramType(op.resultType()).space().resultReg(op, getResultType(op.resultType())).commaSpace().osbrace().retVal().csbrace();

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
@@ -64,8 +64,8 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder functionDeclaration(MethodHandles.Lookup lookup,JavaType type, String name) {
-        return keyword("inline").space().type(lookup,type).space().identifier(name);
+    public OpenCLHatKernelBuilder functionDeclaration(CodeBuilderContext codeBuilderContext,JavaType type, String name) {
+        return keyword("inline").space().type(codeBuilderContext,type).space().identifier(name);
     }
 
     @Override
@@ -74,9 +74,9 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext, MethodHandles.Lookup lookup, Op.Result instanceResult, String name){
+    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext,  Op.Result instanceResult, String name){
           return identifier("atomic_inc").paren(_ -> {
-              ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op(),lookup));
+              ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
               rarrow().identifier(name);
           });
     }

--- a/hat/examples/experiments/src/main/java/experiments/Chess.java
+++ b/hat/examples/experiments/src/main/java/experiments/Chess.java
@@ -31,6 +31,7 @@ import hat.KernelContext;
 import hat.backend.Backend;
 import hat.buffer.ChessState;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Scanner;
 import jdk.incubator.code.CodeReflection;
 import java.util.*;
@@ -319,8 +320,8 @@ public class Chess {
     }
 
     public static void main(String[] args) {
-        var lookup = java.lang.invoke.MethodHandles.lookup();
-        var accelerator = new Accelerator(lookup, Backend.FIRST);//new JavaMultiThreadedBackend());
+
+        var accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);//new JavaMultiThreadedBackend());
         var board = initBoard(accelerator);
         printBoard(board);
 

--- a/hat/examples/experiments/src/main/java/experiments/LambdaTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/LambdaTest.java
@@ -35,7 +35,7 @@ https://github.com/openjdk/babylon/tree/code-reflection/test/jdk/java/lang/refle
 
 public class LambdaTest {
     public static void main(String[] args) {
-        Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST_NATIVE);
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);
 
         // TODO: create a test case for these **/
         S32Array s32Array = S32Array.create(accelerator, 10);

--- a/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
@@ -80,7 +80,7 @@ public class QuotedTest {
         f.writeTo(System.out);
         MethodHandles.Lookup lookup =  MethodHandles.lookup();
         C99HATComputeBuilder codeBuilder = new C99HATComputeBuilder();
-        FuncOpWrapper wf = OpWrapper.wrap(f, lookup);
+        FuncOpWrapper wf = OpWrapper.wrap(lookup,f);
         codeBuilder.compute(wf);
         System.out.println(codeBuilder);
 

--- a/hat/examples/violajones/src/main/java/violajones/attic/ViolaJonesRaw.java
+++ b/hat/examples/violajones/src/main/java/violajones/attic/ViolaJonesRaw.java
@@ -39,7 +39,7 @@ public class ViolaJonesRaw {
 
     public static void main(String[] _args) throws IOException, ParserConfigurationException, SAXException {
 
-        Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.JAVA_MULTITHREADED);
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);
         Arena arena = Arena.global();
 
         XMLHaarCascadeModel haarCascade = XMLHaarCascadeModel.load(ViolaJonesRaw.class.getResourceAsStream("/cascades/haarcascade_frontalface_default.xml"));

--- a/hat/hat-core/src/main/java/hat/Accelerator.java
+++ b/hat/hat-core/src/main/java/hat/Accelerator.java
@@ -191,8 +191,8 @@ public class Accelerator implements BufferAllocator, BufferTracker {
 
     public void compute(QuotableComputeContextConsumer quotableComputeContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableComputeContextConsumer).orElseThrow();
-        LambdaOpWrapper lambda = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op(),lookup);
-        Method method = lambda.getQuotableTargetMethod(this.lookup);
+        LambdaOpWrapper lambda = OpWrapper.wrap(lookup,(CoreOp.LambdaOp) quoted.op());
+        Method method = lambda.getQuotableTargetMethod();
 
         // Create (or get cached) a compute context which closes over compute entryppint and reachable kernels.
         // The models of all compute and kernel methods are passed to the backend during creation

--- a/hat/hat-core/src/main/java/hat/ComputeContext.java
+++ b/hat/hat-core/src/main/java/hat/ComputeContext.java
@@ -110,7 +110,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
 
         // System.out.println(module.op().toText());
 
-        FuncOpWrapper funcOpWrapper = OpWrapper.wrap(Op.ofMethod(computeMethod).orElseThrow(),accelerator.lookup);
+        FuncOpWrapper funcOpWrapper = OpWrapper.wrap(accelerator.lookup,Op.ofMethod(computeMethod).orElseThrow());
 
         this.computeCallGraph = new ComputeCallGraph(this, computeMethod, funcOpWrapper);
 
@@ -127,7 +127,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
 
     public void dispatchKernel(int range, QuotableKernelContextConsumer quotableKernelContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableKernelContextConsumer).orElseThrow();
-        LambdaOpWrapper lambdaOpWrapper = OpWrapper.wrap((CoreOp.LambdaOp) quoted.op(),computeCallGraph.computeContext.accelerator.lookup);
+        LambdaOpWrapper lambdaOpWrapper = OpWrapper.wrap(computeCallGraph.computeContext.accelerator.lookup,(CoreOp.LambdaOp) quoted.op());
         MethodRef methodRef = lambdaOpWrapper.getQuotableTargetMethodRef();
         KernelCallGraph kernelCallGraph = computeCallGraph.kernelCallGraphMap.get(methodRef);
         try {

--- a/hat/hat-core/src/main/java/hat/OpsAndTypes.java
+++ b/hat/hat-core/src/main/java/hat/OpsAndTypes.java
@@ -126,7 +126,7 @@ public class OpsAndTypes {
                  */
 
                 if (op instanceof CoreOp.InvokeOp invokeOp
-                        && OpWrapper.wrap(invokeOp,lookup) instanceof InvokeOpWrapper invokeOpWrapper
+                        && OpWrapper.wrap(lookup, invokeOp) instanceof InvokeOpWrapper invokeOpWrapper
                         && invokeOpWrapper.hasOperands()
                         && invokeOpWrapper.isIfaceBufferMethod()
                         && invokeOpWrapper.getReceiver() instanceof Value iface // Is there a containing iface type Iface

--- a/hat/hat-core/src/main/java/hat/backend/codebuilders/C99HATComputeBuilder.java
+++ b/hat/hat-core/src/main/java/hat/backend/codebuilders/C99HATComputeBuilder.java
@@ -39,11 +39,12 @@ public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HA
     }
 
     public T compute(FuncOpWrapper funcOpWrapper) {
+        CodeBuilderContext buildContext = new CodeBuilderContext(funcOpWrapper);
         computeDeclaration(funcOpWrapper.functionReturnTypeDesc(), funcOpWrapper.functionName());
         parenNlIndented(_ ->
-                commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(funcOpWrapper.lookup,(JavaType) info.parameter.type()).space().varName(info.varOp))
+                commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );
-        CodeBuilderContext buildContext = new CodeBuilderContext(funcOpWrapper);
+
         braceNlIndented(_ ->
                 funcOpWrapper.wrappedRootOpStream(funcOpWrapper.firstBlockOfFirstBody()).forEach(root ->
                         recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>)).nl()

--- a/hat/hat-core/src/main/java/hat/backend/codebuilders/C99HATKernelBuilder.java
+++ b/hat/hat-core/src/main/java/hat/backend/codebuilders/C99HATKernelBuilder.java
@@ -85,8 +85,8 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     public abstract T globalPtrPrefix();
 
     @Override
-    public T type(MethodHandles.Lookup lookup,JavaType javaType) {
-        if (InvokeOpWrapper.isIface(lookup,javaType) && javaType instanceof ClassType classType) {
+    public T type(CodeBuilderContext buildContext,JavaType javaType) {
+        if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup(),javaType) && javaType instanceof ClassType classType) {
             globalPtrPrefix().space();
             String name = classType.toClassName();
             int dotIdx = name.lastIndexOf('.');
@@ -107,11 +107,11 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
         CodeBuilderContext buildContext = new CodeBuilderContext(kernelReachableResolvedMethodCall.funcOpWrapper());
         buildContext.scope(buildContext.funcOpWrapper, () -> {
             nl();
-            functionDeclaration(buildContext.funcOpWrapper.lookup,buildContext.funcOpWrapper.getReturnType(), buildContext.funcOpWrapper.functionName());
+            functionDeclaration(buildContext,buildContext.funcOpWrapper.getReturnType(), buildContext.funcOpWrapper.functionName());
 
             var list = buildContext.funcOpWrapper.paramTable.list();
             parenNlIndented(_ ->
-                    commaSeparated(list, (info) -> type(buildContext.funcOpWrapper.lookup,info.javaType).space().varName(info.varOp))
+                    commaSeparated(list, (info) -> type(buildContext,info.javaType).space().varName(info.varOp))
             );
 
             braceNlIndented(_ -> {
@@ -144,7 +144,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
             parenNlIndented(_ -> {
                         globalPtrPrefix().space().suffix_t("KernelContext").space().asterisk().identifier("global_kc");
                         list.stream().skip(1).forEach(info ->
-                                comma().space().type(buildContext.funcOpWrapper.lookup,info.javaType).space().varName(info.varOp)
+                                comma().space().type(buildContext,info.javaType).space().varName(info.varOp)
                         );
                     }
             );
@@ -166,7 +166,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
     public abstract T kernelDeclaration(String name);
 
-    public abstract T functionDeclaration(MethodHandles.Lookup lookup,JavaType javaType, String name);
+    public abstract T functionDeclaration(CodeBuilderContext codeBuilderContext,JavaType javaType, String name);
 
     public abstract T globalId();
 

--- a/hat/hat-core/src/main/java/hat/backend/codebuilders/HATCodeBuilder.java
+++ b/hat/hat-core/src/main/java/hat/backend/codebuilders/HATCodeBuilder.java
@@ -323,7 +323,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
 
          T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child);
 
-         T parencedence(CodeBuilderContext buildContext, MethodHandles.Lookup lookup, Op parent, Op child);
+         T parencedence(CodeBuilderContext buildContext,  Op parent, Op child);
 
          T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, Op child);
 
@@ -366,7 +366,9 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
     }
 
     public static class CodeBuilderContext {
-
+        public MethodHandles.Lookup lookup(){
+            return funcOpWrapper.lookup;
+        }
         public static class Scope<OW extends OpWrapper<?>> {
             final Scope<?> parent;
             final OW opWrapper;

--- a/hat/hat-core/src/main/java/hat/backend/ffi/FFIBackend.java
+++ b/hat/hat-core/src/main/java/hat/backend/ffi/FFIBackend.java
@@ -119,13 +119,13 @@ public abstract class FFIBackend extends FFIBackendDriver {
                     bldr.op(invokeOW.op());
                 } else {
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup, javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup, javaType))
                             .forEach(value ->
                                     bldr.op(CoreOp.invoke(ESCAPE.pre, cc, bldrCntxt.getValue(value)))
                             );
                     bldr.op(invokeOW.op());
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup,javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
                             .forEach(value -> bldr.op(
                                     CoreOp.invoke(ESCAPE.post, cc, bldrCntxt.getValue(value)))
                             );

--- a/hat/hat-core/src/main/java/hat/backend/jextracted/JExtractedBackend.java
+++ b/hat/hat-core/src/main/java/hat/backend/jextracted/JExtractedBackend.java
@@ -114,13 +114,13 @@ public abstract class JExtractedBackend extends FFIBackendDriver {
                     bldr.op(invokeOW.op());
                 } else {
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup,javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
                             .forEach(value ->
                                     bldr.op(CoreOp.invoke(ESCAPE.pre, cc, bldrCntxt.getValue(value)))
                             );
                     bldr.op(invokeOW.op());
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIface(prevFOW.lookup,javaType))
+                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
                             .forEach(value -> bldr.op(
                                     CoreOp.invoke(ESCAPE.post, cc, bldrCntxt.getValue(value)))
                             );

--- a/hat/hat-core/src/main/java/hat/callgraph/ComputeCallGraph.java
+++ b/hat/hat-core/src/main/java/hat/callgraph/ComputeCallGraph.java
@@ -99,7 +99,7 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
                     } else {
                         if (paramInfo.isPrimitive()) {
                             // OK
-                        } else if (InvokeOpWrapper.isIface(fow.lookup,paramInfo.javaType)) {
+                        } else if (InvokeOpWrapper.isIfaceUsingLookup(fow.lookup,paramInfo.javaType)) {
                             atLeastOneIfaceBufferParam.of(true);
                         } else {
                             hasOnlyPrimitiveAndIfaceBufferParams.of(false);
@@ -148,7 +148,7 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
         computeReachableResolvedMethodCall.funcOpWrapper().selectCalls((invokeWrapper) -> {
             MethodRef methodRef = invokeWrapper.methodRef();
             Class<?> javaRefClass = invokeWrapper.javaRefClass().orElseThrow();
-            Method invokeWrapperCalledMethod = invokeWrapper.method(this.computeContext.accelerator.lookup);
+            Method invokeWrapperCalledMethod = invokeWrapper.method();
             if (Buffer.class.isAssignableFrom(javaRefClass)) {
                 // System.out.println("iface mapped buffer call  -> " + methodRef);
                 computeReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
@@ -168,7 +168,7 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
             } else if (entrypoint.method.getDeclaringClass().equals(javaRefClass)) {
                 Optional<CoreOp.FuncOp> optionalFuncOp = Op.ofMethod(invokeWrapperCalledMethod);
                 if (optionalFuncOp.isPresent()) {
-                    FuncOpWrapper fow = OpWrapper.wrap(optionalFuncOp.get(),computeContext.accelerator.lookup);
+                    FuncOpWrapper fow = OpWrapper.wrap(computeContext.accelerator.lookup,optionalFuncOp.get());
                     if (isKernelDispatch(invokeWrapperCalledMethod, fow)) {
                         // System.out.println("A kernel reference (not a direct call) to a kernel " + methodRef);
                         kernelCallGraphMap.computeIfAbsent(methodRef, _ ->

--- a/hat/hat-core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/hat-core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -98,7 +98,7 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
         kernelReachableResolvedMethodCall.funcOpWrapper().selectCalls(invokeOpWrapper -> {
             MethodRef methodRef = invokeOpWrapper.methodRef();
             Class<?> javaRefTypeClass = invokeOpWrapper.javaRefClass().orElseThrow();
-            Method invokeOpCalledMethod = invokeOpWrapper.method(this.computeContext.accelerator.lookup);
+            Method invokeOpCalledMethod = invokeOpWrapper.method();
             if (Buffer.class.isAssignableFrom(javaRefTypeClass)) {
                 //System.out.println("kernel reachable iface mapped buffer call  -> " + methodRef);
                 kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
@@ -109,7 +109,7 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
                 if (optionalFuncOp.isPresent()) {
                     //System.out.println("A call to a method on the kernel class which we have code model for " + methodRef);
                     kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
-                            new KernelReachableResolvedMethodCall(this, methodRef, invokeOpCalledMethod, OpWrapper.wrap(optionalFuncOp.get(),computeContext.accelerator.lookup)
+                            new KernelReachableResolvedMethodCall(this, methodRef, invokeOpCalledMethod, OpWrapper.wrap(computeContext.accelerator.lookup,optionalFuncOp.get())
                             )));
                 } else {
                     // System.out.println("A call to a method on the compute class which we DO NOT have code model for " + methodRef);

--- a/hat/hat-core/src/main/java/hat/optools/BinaryArithmeticOrLogicOperation.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryArithmeticOrLogicOperation.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class BinaryArithmeticOrLogicOperation extends BinaryOpWrapper<CoreOp.BinaryOp> {
-    BinaryArithmeticOrLogicOperation(CoreOp.BinaryOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    BinaryArithmeticOrLogicOperation( MethodHandles.Lookup lookup, CoreOp.BinaryOp op) {
+        super(lookup, op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/BinaryLogicalOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryLogicalOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class BinaryLogicalOpWrapper extends BinaryOpWrapper<CoreOp.BinaryOp> {
-    BinaryLogicalOpWrapper(CoreOp.BinaryOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    BinaryLogicalOpWrapper( MethodHandles.Lookup lookup,CoreOp.BinaryOp op) {
+        super(lookup,op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/BinaryOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryOpWrapper.java
@@ -29,8 +29,8 @@ import jdk.incubator.code.Op;
 import java.lang.invoke.MethodHandles;
 
 public abstract class BinaryOpWrapper<T extends Op> extends OpWrapper<T> {
-    BinaryOpWrapper(T op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    BinaryOpWrapper( MethodHandles.Lookup lookup,T op) {
+        super(lookup, op);
     }
 
     public Op lhsAsOp() {

--- a/hat/hat-core/src/main/java/hat/optools/BinaryTestOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/BinaryTestOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class BinaryTestOpWrapper extends BinaryOpWrapper<CoreOp.BinaryTestOp> {
-    BinaryTestOpWrapper(CoreOp.BinaryTestOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    BinaryTestOpWrapper( MethodHandles.Lookup lookup,CoreOp.BinaryTestOp op) {
+        super(lookup, op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/ConstantOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ConstantOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class ConstantOpWrapper extends UnaryOpWrapper<CoreOp.ConstantOp> {
-    ConstantOpWrapper(CoreOp.ConstantOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    ConstantOpWrapper( MethodHandles.Lookup lookup,CoreOp.ConstantOp op) {
+        super(lookup,op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/ConvOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ConvOpWrapper.java
@@ -30,8 +30,8 @@ import jdk.incubator.code.type.JavaType;
 import java.lang.invoke.MethodHandles;
 
 public class ConvOpWrapper extends UnaryOpWrapper<CoreOp.ConvOp> {
-    public ConvOpWrapper(CoreOp.ConvOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public ConvOpWrapper( MethodHandles.Lookup lookup,CoreOp.ConvOp op) {
+        super(lookup,op);
     }
 
     public JavaType resultJavaType() {

--- a/hat/hat-core/src/main/java/hat/optools/FieldAccessOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FieldAccessOpWrapper.java
@@ -34,8 +34,8 @@ import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.type.PrimitiveType;
 
 public abstract class FieldAccessOpWrapper<T extends CoreOp.FieldAccessOp> extends OpWrapper<T> {
-    FieldAccessOpWrapper(T op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    FieldAccessOpWrapper( MethodHandles.Lookup lookup,T op) {
+        super(lookup,op);
     }
     public boolean isKernelContextAccess() {
         var refType = fieldRef().refType();

--- a/hat/hat-core/src/main/java/hat/optools/FieldLoadOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FieldLoadOpWrapper.java
@@ -32,20 +32,18 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 
 public class FieldLoadOpWrapper extends FieldAccessOpWrapper<CoreOp.FieldAccessOp.FieldLoadOp> implements LoadOpWrapper {
-    FieldLoadOpWrapper(CoreOp.FieldAccessOp.FieldLoadOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    FieldLoadOpWrapper( MethodHandles.Lookup lookup,CoreOp.FieldAccessOp.FieldLoadOp op) {
+        super(lookup,op);
     }
 
     public Object getStaticFinalPrimitiveValue() {
         if (fieldType() instanceof ClassType classType) {
-            Class<?> clazz = (Class<?>) classTypeToType(lookup,classType);
+            Class<?> clazz = (Class<?>) classTypeToType(classType);
             try {
                 Field field = clazz.getField(fieldName());
                 field.setAccessible(true);
                 return field.get(null);
-            } catch (NoSuchFieldException e) {
-                throw new RuntimeException(e);
-            } catch (IllegalAccessException e) {
+            } catch (NoSuchFieldException | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/hat/hat-core/src/main/java/hat/optools/FieldStoreOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FieldStoreOpWrapper.java
@@ -32,8 +32,8 @@ import java.lang.invoke.MethodHandles;
 public class FieldStoreOpWrapper extends FieldAccessOpWrapper<CoreOp.FieldAccessOp.FieldStoreOp> implements StoreOpWrapper {
 
 
-    FieldStoreOpWrapper(CoreOp.FieldAccessOp.FieldStoreOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    FieldStoreOpWrapper( MethodHandles.Lookup lookup,CoreOp.FieldAccessOp.FieldStoreOp op) {
+        super(lookup,op);
     }
 
     public boolean isKernelContextAccess() {

--- a/hat/hat-core/src/main/java/hat/optools/ForOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ForOpWrapper.java
@@ -30,8 +30,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class ForOpWrapper extends LoopOpWrapper<ExtendedOp.JavaForOp> {
-    ForOpWrapper(ExtendedOp.JavaForOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    ForOpWrapper( MethodHandles.Lookup lookup,ExtendedOp.JavaForOp op) {
+        super(lookup,op);
     }
 
     public Stream<OpWrapper<?>> initWrappedYieldOpStream() {

--- a/hat/hat-core/src/main/java/hat/optools/FuncCallOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/FuncCallOpWrapper.java
@@ -29,8 +29,8 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class FuncCallOpWrapper extends OpWrapper<CoreOp.FuncCallOp> {
-    public FuncCallOpWrapper(CoreOp.FuncCallOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public FuncCallOpWrapper( MethodHandles.Lookup lookup,CoreOp.FuncCallOp op) {
+        super(lookup,op);
     }
 
 

--- a/hat/hat-core/src/main/java/hat/optools/IfOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/IfOpWrapper.java
@@ -30,8 +30,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class IfOpWrapper extends StructuralOpWrapper<ExtendedOp.JavaIfOp> {
-    public IfOpWrapper(ExtendedOp.JavaIfOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public IfOpWrapper(MethodHandles.Lookup lookup,ExtendedOp.JavaIfOp op) {
+        super(lookup,op);
     }
 
     public boolean hasElseN(int idx) {

--- a/hat/hat-core/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -30,21 +30,18 @@ import hat.buffer.KernelContext;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
-import jdk.incubator.code.Block;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.ClassType;
 import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.type.MethodRef;
 import java.util.Optional;
-import java.util.stream.Stream;
 
-// Is this really a root?
 public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
 
 
-    public InvokeOpWrapper(CoreOp.InvokeOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public InvokeOpWrapper( MethodHandles.Lookup lookup,CoreOp.InvokeOp op) {
+        super(lookup,op);
     }
 
     public MethodRef methodRef() {
@@ -56,25 +53,23 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
     }
 
     public boolean isIfaceBufferMethod() {
-        return isIface(lookup,javaRefType());
+        return isIface(javaRefType());
     }
 
-
     public boolean isRawKernelCall() {
-        boolean isRawKernelCall = (operandCount() > 1 && operandNAsValue(0) instanceof Value value
+        return (operandCount() > 1 && operandNAsValue(0) instanceof Value value
                 && value.type() instanceof JavaType javaType
-                && (isAssignable(lookup,javaType, hat.KernelContext.class) || isAssignable(lookup,javaType, hat.buffer.KernelContext.class))
+                && (isAssignable(javaType, hat.KernelContext.class) || isAssignable(javaType, KernelContext.class))
         );
-        return isRawKernelCall;
     }
 
     public boolean isKernelContextMethod() {
-        return isAssignable(lookup,javaRefType(), KernelContext.class);
+        return isAssignable(javaRefType(), KernelContext.class);
 
     }
 
     public boolean isComputeContextMethod() {
-        return isAssignable(lookup,javaRefType(), ComputeContext.class);
+        return isAssignable(javaRefType(), ComputeContext.class);
 
     }
 
@@ -90,7 +85,7 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
     public boolean returnsVoid() {
         return javaReturnType().equals(JavaType.VOID);
     }
-
+/*
     public Method methodNoLookup() {
         Class<?> declaringClass = javaRefClass().orElseThrow();
         // TODO this is just matching the name....
@@ -108,13 +103,13 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
         } else {
             throw new IllegalStateException("what were we looking for ?"); // getClass causes this
         }
-    }
-    public Method method(MethodHandles.Lookup lookup) {
+    } */
+    public Method method() {
         Method invokedMethod = null;
         try {
-            invokedMethod = methodRef().resolveToMethod(lookup, op().invokeKind());
-            MethodRef methodRef = methodRef();
-            return invokedMethod;
+            return methodRef().resolveToMethod(lookup, op().invokeKind());
+          //  MethodRef methodRef = methodRef();
+         //   return invokedMethod;
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
@@ -153,7 +148,7 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
 
     public Optional<Class<?>> javaRefClass() {
         if (javaRefType() instanceof ClassType classType) {
-            return Optional.of((Class<?>)classTypeToType(lookup,classType));
+            return Optional.of((Class<?>)classTypeToType(classType));
         }else{
             return Optional.empty();
         }
@@ -161,7 +156,7 @@ public class InvokeOpWrapper extends OpWrapper<CoreOp.InvokeOp> {
 
     public Optional<Class<?>> javaReturnClass() {
         if (javaReturnType() instanceof ClassType classType) {
-            return Optional.of((Class<?>)classTypeToType(lookup,classType));
+            return Optional.of((Class<?>)classTypeToType(classType));
         }else{
             return Optional.empty();
         }

--- a/hat/hat-core/src/main/java/hat/optools/JavaBreakOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/JavaBreakOpWrapper.java
@@ -29,8 +29,8 @@ import jdk.incubator.code.op.ExtendedOp;
 import java.lang.invoke.MethodHandles;
 
 public class JavaBreakOpWrapper extends OpWrapper<ExtendedOp.JavaBreakOp> {
-    public JavaBreakOpWrapper(ExtendedOp.JavaBreakOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public JavaBreakOpWrapper( MethodHandles.Lookup lookup,ExtendedOp.JavaBreakOp op) {
+        super(lookup,op);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/JavaContinueOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/JavaContinueOpWrapper.java
@@ -29,8 +29,8 @@ import jdk.incubator.code.op.ExtendedOp;
 import java.lang.invoke.MethodHandles;
 
 public class JavaContinueOpWrapper extends OpWrapper<ExtendedOp.JavaContinueOp> {
-    public JavaContinueOpWrapper(ExtendedOp.JavaContinueOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public JavaContinueOpWrapper(MethodHandles.Lookup lookup,ExtendedOp.JavaContinueOp op) {
+        super(lookup,op);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/JavaLabeledOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/JavaLabeledOpWrapper.java
@@ -29,8 +29,8 @@ import jdk.incubator.code.op.ExtendedOp;
 import java.lang.invoke.MethodHandles;
 
 public class JavaLabeledOpWrapper extends StructuralOpWrapper<ExtendedOp.JavaLabeledOp> {
-    public JavaLabeledOpWrapper(ExtendedOp.JavaLabeledOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public JavaLabeledOpWrapper( MethodHandles.Lookup lookup,ExtendedOp.JavaLabeledOp op) {
+        super(lookup,op);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/LambdaOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/LambdaOpWrapper.java
@@ -38,8 +38,8 @@ import java.util.List;
 import java.util.Map;
 
 public class LambdaOpWrapper extends OpWrapper<CoreOp.LambdaOp> {
-    public LambdaOpWrapper(CoreOp.LambdaOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public LambdaOpWrapper( MethodHandles.Lookup lookup, CoreOp.LambdaOp op) {
+        super(lookup,op);
     }
 
     public InvokeOpWrapper getInvoke(int index) {
@@ -47,22 +47,22 @@ public class LambdaOpWrapper extends OpWrapper<CoreOp.LambdaOp> {
         selectOnlyBlockOfOnlyBody(blockWrapper ->
                 result.of(blockWrapper.op(index))
         );
-        return OpWrapper.wrap(result.get(),lookup);
+        return OpWrapper.wrap(lookup, result.get());
     }
 
     public List<Value> operands() {
         return op().operands();
     }
 
-    public Method getQuotableTargetMethod(MethodHandles.Lookup lookup) {
-        return getQuotableTargetInvokeOpWrapper().method(lookup);
+    public Method getQuotableTargetMethod() {
+        return getQuotableTargetInvokeOpWrapper().method();
     }
 
     public InvokeOpWrapper getQuotableTargetInvokeOpWrapper() {
-        return OpWrapper.wrap(op().body().entryBlock().ops().stream()
+        return OpWrapper.wrap(lookup, op().body().entryBlock().ops().stream()
                 .filter(op -> op instanceof CoreOp.InvokeOp)
                 .map(op -> (CoreOp.InvokeOp) op)
-                .findFirst().get(),lookup);
+                .findFirst().get());
     }
 
     public MethodRef getQuotableTargetMethodRef() {

--- a/hat/hat-core/src/main/java/hat/optools/LogicalOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/LogicalOpWrapper.java
@@ -30,8 +30,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class LogicalOpWrapper extends BinaryOpWrapper<ExtendedOp.JavaConditionalOp> {
-    LogicalOpWrapper(ExtendedOp.JavaConditionalOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    LogicalOpWrapper(MethodHandles.Lookup lookup,ExtendedOp.JavaConditionalOp op) {
+        super(lookup,op);
     }
 
     public Stream<OpWrapper<?>> lhsWrappedYieldOpStream() {

--- a/hat/hat-core/src/main/java/hat/optools/LoopOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/LoopOpWrapper.java
@@ -30,8 +30,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public abstract class LoopOpWrapper<T extends Op> extends StructuralOpWrapper<T> {
-    LoopOpWrapper(T op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    LoopOpWrapper(MethodHandles.Lookup lookup, T op ) {
+        super(lookup,op);
     }
 
     public abstract Stream<OpWrapper<?>> conditionWrappedYieldOpStream();

--- a/hat/hat-core/src/main/java/hat/optools/OpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/OpWrapper.java
@@ -47,57 +47,58 @@ import java.util.stream.Stream;
 
 public class OpWrapper<T extends Op> {
     @SuppressWarnings("unchecked")
-    public static <O extends Op, OW extends OpWrapper<O>> OW wrap(O op, MethodHandles.Lookup lookup) {
+    public static <O extends Op, OW extends OpWrapper<O>> OW wrap(MethodHandles.Lookup lookup,O op) {
         // We have one special case
         // This is possibly a premature optimization. But it allows us to treat vardeclarations differently from params.
         if (op instanceof CoreOp.VarOp varOp && !varOp.isUninitialized()) {
             // this gets called a lot and we can't wrap yet or we recurse so we
-            // use the raw model. Basically we want a different wrapper for VarDeclations
+            // use the raw model. Basically we want a different wrapper for VarDeclarations
             // which  relate to func parameters.
             // This saves us asking each time if a var is indeed a func param.
 
             if (varOp.operands().getFirst() instanceof Block.Parameter parameter &&
                     parameter.invokableOperation() instanceof CoreOp.FuncOp funcOp) {
-                return (OW) new VarFuncDeclarationOpWrapper(varOp, funcOp, parameter,lookup);
+                return (OW) new VarFuncDeclarationOpWrapper(lookup,varOp, funcOp, parameter);
             }
         }
         return switch (op) {
-            case CoreOp.ModuleOp $ -> (OW) new ModuleOpWrapper($,lookup);
-            case ExtendedOp.JavaForOp $ -> (OW) new ForOpWrapper($,lookup);
-            case ExtendedOp.JavaWhileOp $ -> (OW) new WhileOpWrapper($,lookup);
-            case ExtendedOp.JavaIfOp $ -> (OW) new IfOpWrapper($,lookup);
-            case CoreOp.NotOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper($,lookup);
-            case CoreOp.NegOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper($,lookup);
-            case CoreOp.BinaryOp $ -> (OW) new BinaryArithmeticOrLogicOperation($,lookup);
-            case CoreOp.BinaryTestOp $ -> (OW) new BinaryTestOpWrapper($,lookup);
-            case CoreOp.FuncOp $ -> (OW) new FuncOpWrapper($,lookup);
-            case CoreOp.VarOp $ -> (OW) new VarDeclarationOpWrapper($,lookup);
-            case CoreOp.YieldOp $ -> (OW) new YieldOpWrapper($,lookup);
-            case CoreOp.FuncCallOp $ -> (OW) new FuncCallOpWrapper($,lookup);
-            case CoreOp.ConvOp $ -> (OW) new ConvOpWrapper($,lookup);
-            case CoreOp.ConstantOp $ -> (OW) new ConstantOpWrapper($,lookup);
-            case CoreOp.ReturnOp $ -> (OW) new ReturnOpWrapper($,lookup);
-            case CoreOp.VarAccessOp.VarStoreOp $ -> (OW) new VarStoreOpWrapper($,lookup);
-            case CoreOp.VarAccessOp.VarLoadOp $ -> (OW) new VarLoadOpWrapper($,lookup);
-            case CoreOp.FieldAccessOp.FieldStoreOp $ -> (OW) new FieldStoreOpWrapper($,lookup);
-            case CoreOp.FieldAccessOp.FieldLoadOp $ -> (OW) new FieldLoadOpWrapper($,lookup);
-            case CoreOp.InvokeOp $ -> (OW) new InvokeOpWrapper($,lookup);
-            case CoreOp.TupleOp $ -> (OW) new TupleOpWrapper($,lookup);
-            case CoreOp.LambdaOp $ -> (OW) new LambdaOpWrapper($,lookup);
-            case ExtendedOp.JavaConditionalOp $ -> (OW) new LogicalOpWrapper($,lookup);
-            case ExtendedOp.JavaConditionalExpressionOp $ -> (OW) new TernaryOpWrapper($,lookup);
-            case ExtendedOp.JavaLabeledOp $ -> (OW) new JavaLabeledOpWrapper($,lookup);
-            case ExtendedOp.JavaBreakOp $ -> (OW) new JavaBreakOpWrapper($,lookup);
-            case ExtendedOp.JavaContinueOp $ -> (OW) new JavaContinueOpWrapper($,lookup);
-            default -> (OW) new OpWrapper<>(op,lookup);
+            case CoreOp.ModuleOp $ -> (OW) new ModuleOpWrapper(lookup, $);
+            case ExtendedOp.JavaForOp $ -> (OW) new ForOpWrapper(lookup, $);
+            case ExtendedOp.JavaWhileOp $ -> (OW) new WhileOpWrapper(lookup, $);
+            case ExtendedOp.JavaIfOp $ -> (OW) new IfOpWrapper(lookup, $);
+            case CoreOp.NotOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper(lookup, $);
+            case CoreOp.NegOp $ -> (OW) new UnaryArithmeticOrLogicOpWrapper(lookup, $);
+            case CoreOp.BinaryOp $ -> (OW) new BinaryArithmeticOrLogicOperation(lookup, $);
+            case CoreOp.BinaryTestOp $ -> (OW) new BinaryTestOpWrapper(lookup, $);
+            case CoreOp.FuncOp $ -> (OW) new FuncOpWrapper(lookup, $);
+            case CoreOp.VarOp $ -> (OW) new VarDeclarationOpWrapper(lookup, $);
+            case CoreOp.YieldOp $ -> (OW) new YieldOpWrapper(lookup, $);
+            case CoreOp.FuncCallOp $ -> (OW) new FuncCallOpWrapper(lookup, $);
+            case CoreOp.ConvOp $ -> (OW) new ConvOpWrapper(lookup, $);
+            case CoreOp.ConstantOp $ -> (OW) new ConstantOpWrapper(lookup, $);
+            case CoreOp.ReturnOp $ -> (OW) new ReturnOpWrapper(lookup, $);
+            case CoreOp.VarAccessOp.VarStoreOp $ -> (OW) new VarStoreOpWrapper(lookup, $);
+            case CoreOp.VarAccessOp.VarLoadOp $ -> (OW) new VarLoadOpWrapper(lookup, $);
+            case CoreOp.FieldAccessOp.FieldStoreOp $ -> (OW) new FieldStoreOpWrapper(lookup, $);
+            case CoreOp.FieldAccessOp.FieldLoadOp $ -> (OW) new FieldLoadOpWrapper(lookup, $);
+            case CoreOp.InvokeOp $ -> (OW) new InvokeOpWrapper(lookup, $);
+            case CoreOp.TupleOp $ -> (OW) new TupleOpWrapper(lookup, $);
+            case CoreOp.LambdaOp $ -> (OW) new LambdaOpWrapper(lookup, $);
+            case ExtendedOp.JavaConditionalOp $ -> (OW) new LogicalOpWrapper(lookup, $);
+            case ExtendedOp.JavaConditionalExpressionOp $ -> (OW) new TernaryOpWrapper(lookup, $);
+            case ExtendedOp.JavaLabeledOp $ -> (OW) new JavaLabeledOpWrapper(lookup, $);
+            case ExtendedOp.JavaBreakOp $ -> (OW) new JavaBreakOpWrapper(lookup, $);
+            case ExtendedOp.JavaContinueOp $ -> (OW) new JavaContinueOpWrapper(lookup, $);
+            default -> (OW) new OpWrapper<>(lookup,op);
         };
     }
 
     private final T op;
 public MethodHandles.Lookup lookup;
-    OpWrapper(T op, MethodHandles.Lookup lookup) {
-        this.op = op;
+    OpWrapper( MethodHandles.Lookup lookup,T op) {
         this.lookup= lookup;
+        this.op = op;
+
     }
 
     public T op() {
@@ -135,7 +136,7 @@ public MethodHandles.Lookup lookup;
     public void selectCalls(Consumer<InvokeOpWrapper> consumer) {
         this.op.traverse(null, (map, op) -> {
             if (op instanceof CoreOp.InvokeOp invokeOp) {
-                consumer.accept(wrap(invokeOp, lookup));
+                consumer.accept(wrap(lookup,invokeOp));
             }
             return map;
         });
@@ -143,7 +144,7 @@ public MethodHandles.Lookup lookup;
     public void selectAssignments(Consumer<VarOpWrapper> consumer) {
         this.op.traverse(null, (map, op) -> {
             if (op instanceof CoreOp.VarOp varOp) {
-                consumer.accept(wrap(varOp, lookup));
+                consumer.accept(wrap(lookup,varOp));
             }
             return map;
         });
@@ -211,7 +212,7 @@ public MethodHandles.Lookup lookup;
     }
 
     public Stream<OpWrapper<?>> wrappedOpStream(Block block) {
-        return block.ops().stream().map(o->wrap(o,lookup));
+        return block.ops().stream().map(o->wrap(lookup,o));
     }
 
     public Stream<OpWrapper<?>> wrappedYieldOpStream(Block block) {
@@ -220,7 +221,7 @@ public MethodHandles.Lookup lookup;
 
     private Stream<OpWrapper<?>> roots(Block block) {
         var rootSet = RootSet.getRootSet(block.ops().stream());
-        return block.ops().stream().filter(rootSet::contains).map(o->wrap(o, lookup));
+        return block.ops().stream().filter(rootSet::contains).map(o->wrap(lookup,o));
     }
 
     private Stream<OpWrapper<?>> rootsWithoutVarFuncDeclarations(Block block) {
@@ -250,16 +251,14 @@ public MethodHandles.Lookup lookup;
     public TypeElement resultType() {
         return op.resultType();
     }
-
-    public static boolean isIface(MethodHandles.Lookup lookup,JavaType javaType) {
-        return  (isAssignable(lookup,javaType, MappableIface.class));
+    public  static boolean isIfaceUsingLookup(MethodHandles.Lookup lookup,JavaType javaType) {
+        return  (isAssignableUsingLookup(lookup,javaType, MappableIface.class));
     }
-    //public static Type classTypeToType(ClassType classType){
+    public  boolean isIface(JavaType javaType) {
+        return  (isAssignable(javaType, MappableIface.class));
+    }
 
-      //  return classTypeToType(classType,MethodHandles.lookup());
-
-    //}
-    public static Type classTypeToType(MethodHandles.Lookup lookup,ClassType classType) {
+    public  static Type classTypeToTypeUsingLookup(MethodHandles.Lookup lookup,ClassType classType) {
         Type javaTypeClass = null;
         try {
             javaTypeClass = classType.resolve(lookup);
@@ -269,16 +268,23 @@ public MethodHandles.Lookup lookup;
         return javaTypeClass;
 
     }
-    public static boolean isAssignable(MethodHandles.Lookup lookup,JavaType javaType, Class<?> ... classes) {
+    public  Type classTypeToType(ClassType classType) {
+       return classTypeToTypeUsingLookup(lookup,classType);
+    }
+    public  static boolean isAssignableUsingLookup(MethodHandles.Lookup lookup,JavaType javaType, Class<?> ... classes) {
         if (javaType instanceof ClassType classType) {
-            Type type = classTypeToType(lookup,classType);
+            Type type = classTypeToTypeUsingLookup(lookup,classType);
             for (Class<?> clazz : classes) {
                 if (clazz.isAssignableFrom((Class<?>) type)) {
-                        return true;
+                    return true;
                 }
             }
         }
         return false;
+
+    }
+    public  boolean isAssignable(JavaType javaType, Class<?> ... classes) {
+       return isAssignableUsingLookup(lookup,javaType,classes);
 
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/ReturnOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/ReturnOpWrapper.java
@@ -29,8 +29,8 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class ReturnOpWrapper extends OpWrapper<CoreOp.ReturnOp> {
-    public ReturnOpWrapper(CoreOp.ReturnOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public ReturnOpWrapper( MethodHandles.Lookup lookup,CoreOp.ReturnOp op) {
+        super(lookup,op);
     }
 
 

--- a/hat/hat-core/src/main/java/hat/optools/StructuralOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/StructuralOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.Op;
 import java.lang.invoke.MethodHandles;
 
 public abstract class StructuralOpWrapper<T extends Op> extends OpWrapper<T> {
-    StructuralOpWrapper(T op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    StructuralOpWrapper(MethodHandles.Lookup lookup,T op) {
+        super(lookup,op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/TernaryOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/TernaryOpWrapper.java
@@ -31,8 +31,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
 
 public class TernaryOpWrapper extends OpWrapper<ExtendedOp.JavaConditionalExpressionOp> {
-    public TernaryOpWrapper(ExtendedOp.JavaConditionalExpressionOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public TernaryOpWrapper( MethodHandles.Lookup lookup,ExtendedOp.JavaConditionalExpressionOp op) {
+        super(lookup,op);
     }
 
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {

--- a/hat/hat-core/src/main/java/hat/optools/TupleOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/TupleOpWrapper.java
@@ -29,8 +29,8 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class TupleOpWrapper extends StructuralOpWrapper<CoreOp.TupleOp> {
-    public TupleOpWrapper(CoreOp.TupleOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public TupleOpWrapper( MethodHandles.Lookup lookup,CoreOp.TupleOp op) {
+        super(lookup,op);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/UnaryArithmeticOrLogicOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/UnaryArithmeticOrLogicOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class UnaryArithmeticOrLogicOpWrapper extends UnaryOpWrapper<CoreOp.UnaryOp> {
-    UnaryArithmeticOrLogicOpWrapper(CoreOp.UnaryOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    UnaryArithmeticOrLogicOpWrapper( MethodHandles.Lookup lookup,CoreOp.UnaryOp op) {
+        super(lookup,op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/UnaryOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/UnaryOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.Op;
 import java.lang.invoke.MethodHandles;
 
 public abstract class UnaryOpWrapper<T extends Op> extends OpWrapper<T> {
-    UnaryOpWrapper(T op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    UnaryOpWrapper(MethodHandles.Lookup lookup,T op) {
+        super(lookup,op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarAccessOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarAccessOpWrapper.java
@@ -31,8 +31,8 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public abstract class VarAccessOpWrapper<T extends CoreOp.VarAccessOp> extends OpWrapper<T> {
-    VarAccessOpWrapper(T op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    VarAccessOpWrapper( MethodHandles.Lookup lookup,T op) {
+        super(lookup, op);
     }
 
     public CoreOp.VarOp varOp() {

--- a/hat/hat-core/src/main/java/hat/optools/VarDeclarationOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarDeclarationOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class VarDeclarationOpWrapper extends VarOpWrapper implements StoreOpWrapper {
-    public VarDeclarationOpWrapper(CoreOp.VarOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public VarDeclarationOpWrapper( MethodHandles.Lookup lookup,CoreOp.VarOp op) {
+        super(lookup, op);
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarFuncDeclarationOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarFuncDeclarationOpWrapper.java
@@ -34,8 +34,8 @@ public class VarFuncDeclarationOpWrapper extends VarOpWrapper {
     final Block.Parameter blockParameter;
     final int idx;
 
-    public VarFuncDeclarationOpWrapper(CoreOp.VarOp op, CoreOp.FuncOp funcOp, Block.Parameter blockParameter, MethodHandles.Lookup lookup) {
-        super(op, lookup);
+    public VarFuncDeclarationOpWrapper( MethodHandles.Lookup lookup, CoreOp.VarOp op, CoreOp.FuncOp funcOp, Block.Parameter blockParameter) {
+        super(lookup,op);
         this.funcOp = funcOp;
         this.blockParameter = blockParameter;
         this.idx = blockParameter.index();

--- a/hat/hat-core/src/main/java/hat/optools/VarLoadOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarLoadOpWrapper.java
@@ -30,8 +30,8 @@ import java.lang.invoke.MethodHandles;
 
 public class VarLoadOpWrapper extends VarAccessOpWrapper<CoreOp.VarAccessOp.VarLoadOp> implements LoadOpWrapper {
 
-    VarLoadOpWrapper(CoreOp.VarAccessOp.VarLoadOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    VarLoadOpWrapper( MethodHandles.Lookup lookup,CoreOp.VarAccessOp.VarLoadOp op) {
+        super(lookup,op);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarOpWrapper.java
@@ -30,8 +30,8 @@ import jdk.incubator.code.type.JavaType;
 import java.lang.invoke.MethodHandles;
 
 public abstract class VarOpWrapper extends OpWrapper<CoreOp.VarOp> {
-    public VarOpWrapper(CoreOp.VarOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public VarOpWrapper(MethodHandles.Lookup lookup,CoreOp.VarOp op) {
+        super(lookup, op);
     }
 
     public JavaType javaType() {
@@ -43,6 +43,6 @@ public abstract class VarOpWrapper extends OpWrapper<CoreOp.VarOp> {
     }
 
     public boolean isIfaceAssignment() {
-        return isIface(lookup,javaType());
+        return isIface(javaType());
     }
 }

--- a/hat/hat-core/src/main/java/hat/optools/VarStoreOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/VarStoreOpWrapper.java
@@ -31,8 +31,8 @@ import java.lang.invoke.MethodHandles;
 public class VarStoreOpWrapper extends VarAccessOpWrapper<CoreOp.VarAccessOp.VarStoreOp> implements StoreOpWrapper {
 
 
-    VarStoreOpWrapper(CoreOp.VarAccessOp.VarStoreOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    VarStoreOpWrapper( MethodHandles.Lookup lookup,CoreOp.VarAccessOp.VarStoreOp op) {
+        super(lookup,op);
     }
 
 }

--- a/hat/hat-core/src/main/java/hat/optools/WhileOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/WhileOpWrapper.java
@@ -31,8 +31,8 @@ import java.util.stream.Stream;
 
 public class WhileOpWrapper extends LoopOpWrapper<ExtendedOp.JavaWhileOp> {
 
-    WhileOpWrapper(ExtendedOp.JavaWhileOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    WhileOpWrapper( MethodHandles.Lookup lookup,ExtendedOp.JavaWhileOp op) {
+        super(lookup,op);
     }
 
     @Override

--- a/hat/hat-core/src/main/java/hat/optools/YieldOpWrapper.java
+++ b/hat/hat-core/src/main/java/hat/optools/YieldOpWrapper.java
@@ -29,7 +29,7 @@ import jdk.incubator.code.op.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class YieldOpWrapper extends StructuralOpWrapper<CoreOp.YieldOp> {
-    public YieldOpWrapper(CoreOp.YieldOp op, MethodHandles.Lookup lookup) {
-        super(op,lookup);
+    public YieldOpWrapper(MethodHandles.Lookup lookup,CoreOp.YieldOp op) {
+        super(lookup,op);
     }
 }


### PR DESCRIPTION
After previous PR I realised that we were passing lookups, which could be extracted from context. 

This PR cleans that up. 

Also I made the parametr order consistant across opWrappers. 
  