### PR TITLE
Fixed bug selecting opencl device

### DIFF
--- a/hat/backends/ffi/opencl/cpp/opencl_backend.cpp
+++ b/hat/backends/ffi/opencl/cpp/opencl_backend.cpp
@@ -264,7 +264,7 @@ OpenCLBackend::OpenCLBackend(int configBits )
 
     cl_command_queue_properties queue_props = CL_QUEUE_PROFILING_ENABLE;
 
-    if ((openclQueue.command_queue = clCreateCommandQueue(context, device_ids[0], queue_props, &status)) == NULL ||
+    if ((openclQueue.command_queue = clCreateCommandQueue(context, device_ids[openclConfig.device], queue_props, &status)) == NULL ||
         status != CL_SUCCESS) {
         std::cerr << "clCreateCommandQueue failed " << errorMsg(status)<<std::endl;
         clReleaseContext(context);


### PR DESCRIPTION
Found a bug on older mac trying to select opencl device. 

Was always selcting device 0  ;

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/356/head:pull/356` \
`$ git checkout pull/356`

Update a local copy of the PR: \
`$ git checkout pull/356` \
`$ git pull https://git.openjdk.org/babylon.git pull/356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 356`

View PR using the GUI difftool: \
`$ git pr show -t 356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/356.diff">https://git.openjdk.org/babylon/pull/356.diff</a>

</details>
