### PR TITLE
Hat replace bitfield min bufffer with state machine

### DIFF
--- a/hat/backends/ffi/opencl/include/opencl_backend.h
+++ b/hat/backends/ffi/opencl/include/opencl_backend.h
@@ -61,9 +61,8 @@ public:
         const static  int TRACE_ENQUEUES_BIT = 1 <<25;
         const static  int TRACE_CALLS_BIT = 1 <<26;
         const static  int SHOW_WHY_BIT = 1 <<27;
-        const static  int USE_STATE_BIT = 1 <<28;
-        const static  int SHOW_STATE_BIT = 1 <<29;
-        const static  int END_BIT_IDX = 30;
+        const static  int SHOW_STATE_BIT = 1 <<28;
+        const static  int END_BIT_IDX = 29;
 
         const static  char *bitNames[]; // See below for out of line definition
         int configBits;
@@ -78,7 +77,6 @@ public:
         bool traceEnqueues;
         bool traceCalls;
         bool showWhy;
-        bool useState;
         bool showState;
         int platform; //0..15
         int device; //0..15

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
@@ -41,6 +41,7 @@ public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
     final OpenCLConfig config;
 
     final MethodHandle getBackend_MH;
+
     public long getBackend(int configBits) {
         try {
             backendHandle = (long) getBackend_MH.invoke(configBits);
@@ -49,16 +50,18 @@ public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
         }
         return backendHandle;
     }
+
     public OpenCLBackend(String configSpec) {
         this(OpenCLConfig.of(configSpec));
     }
+
     public OpenCLBackend(OpenCLConfig config) {
         super("opencl_backend");
         this.config = config;
-        getBackend_MH  =  nativeLibrary.longFunc("getOpenCLBackend",JAVA_INT);
-        getBackend(config.bits());
-        if (config.isINFO()) {
-            System.out.println("CONFIG = "+config);
+        getBackend_MH = nativeLibrary.longFunc("getOpenCLBackend", JAVA_INT);
+        getBackend(this.config.bits());
+        if (this.config.isINFO()) {
+            System.out.println("CONFIG = " + this.config);
             info();
         }
     }
@@ -71,7 +74,7 @@ public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
 
     @Override
     public void computeContextHandoff(ComputeContext computeContext) {
-       // System.out.println("OpenCL backend received computeContext minimizing = "+ config.isMINIMIZE_COPIES());
+        // System.out.println("OpenCL backend received computeContext minimizing = "+ config.isMINIMIZE_COPIES());
         injectBufferTracking(computeContext.computeCallGraph.entrypoint, config.isSHOW_COMPUTE_MODEL(), config.isMINIMIZE_COPIES());
     }
 
@@ -91,192 +94,123 @@ public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
                 throw new IllegalStateException("opencl failed to compile ");
             }
         });
-        compiledKernel.dispatch(ndRange,args);
+        compiledKernel.dispatch(ndRange, args);
 
     }
 
     @Override
     public void preMutate(Buffer b) {
-
-        if (!config.isMINIMIZE_COPIES()) {
-            throw new IllegalStateException("why is premutate being called if we are not minimizing buffer copies");
-            //System.exit(1);
-        }
-        if (config.isUSE_STATE() ) {
-
-            switch (b.getState()){
-                case BufferState.NO_STATE:
-                case BufferState.NEW_STATE :
-                case BufferState.HOST_OWNED :
-                case BufferState.DEVICE_VALID_HOST_HAS_COPY:{
-                    if (config.isSHOW_STATE()) {
-                        System.out.println("in preMutate state = " + b.getStateString() + " no action to take");
-                    }
+        switch (b.getState()) {
+            case BufferState.NO_STATE:
+            case BufferState.NEW_STATE:
+            case BufferState.HOST_OWNED:
+            case BufferState.DEVICE_VALID_HOST_HAS_COPY: {
+                if (config.isSHOW_STATE()) {
+                    System.out.println("in preMutate state = " + b.getStateString() + " no action to take");
+                }
                 break;
-                }
-                case BufferState.DEVICE_OWNED:{
-                    getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
-
-                    if (config.isSHOW_STATE()) {
-                        System.out.print("in preMutate state = " + b.getStateString() + " we pulled from device ");
-                    }
-                    b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
-                    if (config.isSHOW_STATE()) {
-                        System.out.println("and switched to " + b.getStateString());
-                    }
-                    break;
-                }
-                default:
-                    throw new IllegalStateException("Not expecting this state ");
             }
-        }else {
-            if (b.isDeviceDirty()) {
-                if (!b.isHostChecked()) {
-                    getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
-                    b.setHostChecked();
+            case BufferState.DEVICE_OWNED: {
+                getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
+                if (config.isSHOW_STATE()) {
+                    System.out.print("in preMutate state = " + b.getStateString() + " we pulled from device ");
                 }
-                b.clearDeviceDirty();
+                b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
+                if (config.isSHOW_STATE()) {
+                    System.out.println("and switched to " + b.getStateString());
+                }
+                break;
             }
+            default:
+                throw new IllegalStateException("Not expecting this state ");
         }
-
     }
 
     @Override
     public void postMutate(Buffer b) {
-        if (!config.isMINIMIZE_COPIES()) {
-            throw new IllegalStateException("why is postmutate being called if we are not minimizing buffer copies");
+        if (config.isSHOW_STATE()) {
+            System.out.print("in postMutate state = " + b.getStateString() + " no action to take ");
         }
-        if (config.isUSE_STATE()) {
-            if (config.isSHOW_STATE()) {
-                System.out.print("in postMutate state = " + b.getStateString() + " no action to take ");
-            }
-            b.setState(BufferState.HOST_OWNED);
-            if (config.isSHOW_STATE()) {
-                System.out.println("and switched to (or stayed on) " + b.getStateString());
-            }
-        }else {
-            b.setHostDirty();
+        b.setState(BufferState.HOST_OWNED);
+        if (config.isSHOW_STATE()) {
+            System.out.println("and switched to (or stayed on) " + b.getStateString());
         }
-
     }
 
     @Override
     public void preAccess(Buffer b) {
-        if (!config.isMINIMIZE_COPIES()) {
-            throw new IllegalStateException("why is pre access being called if we are not minimizing buffer copies");
-        }
-        if (config.isUSE_STATE() ) {
-
-            switch (b.getState()){
-                case BufferState.NO_STATE:
-                case BufferState.NEW_STATE :
-                case BufferState.HOST_OWNED :
-                case BufferState.DEVICE_VALID_HOST_HAS_COPY:{
-                    if (config.isSHOW_STATE()) {
-                        System.out.println("in preAccess state = " + b.getStateString() + " no action to take");
-                    }
-                    break;
+        switch (b.getState()) {
+            case BufferState.NO_STATE:
+            case BufferState.NEW_STATE:
+            case BufferState.HOST_OWNED:
+            case BufferState.DEVICE_VALID_HOST_HAS_COPY: {
+                if (config.isSHOW_STATE()) {
+                    System.out.println("in preAccess state = " + b.getStateString() + " no action to take");
                 }
-                case BufferState.DEVICE_OWNED:{
-                    getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
+                break;
+            }
+            case BufferState.DEVICE_OWNED: {
+                getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
 
-                    if (config.isSHOW_STATE()) {
-                        System.out.print("in preAccess state = " + b.getStateString() + " we pulled from device ");
-                    }
-                    b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
-                    if (config.isSHOW_STATE()) {
-                        System.out.println("and switched to " + b.getStateString());
-                    }
-                    break;
+                if (config.isSHOW_STATE()) {
+                    System.out.print("in preAccess state = " + b.getStateString() + " we pulled from device ");
                 }
-                default:
-                    throw new IllegalStateException("Not expecting this state ");
+                b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
+                if (config.isSHOW_STATE()) {
+                    System.out.println("and switched to " + b.getStateString());
+                }
+                break;
             }
-        }else {
-            if (b.isDeviceDirty() && !b.isHostChecked()) {
-                getBufferFromDeviceIfDirty(b); // calls through FFI and might block when fetching from device
-                // We don't call clearDeviceDirty() if we did then 'just reading on the host' would force copy in next dispatch
-                //so buffer is still considered deviceDirty
-                b.setHostChecked();
-            }
+            default:
+                throw new IllegalStateException("Not expecting this state ");
         }
     }
 
 
     @Override
     public void postAccess(Buffer b) {
-        if (!config.isMINIMIZE_COPIES()) {
-            throw new IllegalStateException("why is postaccess being called if we are not minimizing buffer copies");
-        }
-        if (config.isUSE_STATE() && config.isSHOW_STATE()) {
+        if (config.isSHOW_STATE()) {
             System.out.println("in postAccess state = " + b.getStateString());
         }
-       // a no op buffer may well still be deviceDirty
     }
 
     @Override
     public void preEscape(Buffer b) {
-        if (!config.isMINIMIZE_COPIES()) {
-            throw new IllegalStateException("why is preEscape being called if we are not minimizing buffer copies");
-        }
-        if (config.isUSE_STATE() ) {
-
-            switch (b.getState()){
-                case BufferState.NO_STATE:
-                case BufferState.NEW_STATE :
-                case BufferState.HOST_OWNED :
-                case BufferState.DEVICE_VALID_HOST_HAS_COPY:{
-                    if (config.isSHOW_STATE()) {
-                        System.out.println("in preEscape state = " + b.getStateString() + " no action to take");
-                    }
-                    break;
+        switch (b.getState()) {
+            case BufferState.NO_STATE:
+            case BufferState.NEW_STATE:
+            case BufferState.HOST_OWNED:
+            case BufferState.DEVICE_VALID_HOST_HAS_COPY: {
+                if (config.isSHOW_STATE()) {
+                    System.out.println("in preEscape state = " + b.getStateString() + " no action to take");
                 }
-                case BufferState.DEVICE_OWNED:{
-                    getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
-
-                    if (config.isSHOW_STATE()) {
-                        System.out.print("in preEscape state = " + b.getStateString() + " we pulled from device ");
-                    }
-                    b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
-                    if (config.isSHOW_STATE()) {
-                        System.out.println("and switched to " + b.getStateString());
-                    }
-                    break;
-                }
-                default:
-                    throw new IllegalStateException("Not expecting this state ");
+                break;
             }
-        }else {
-            if (b.isDeviceDirty()) {
-                if (!b.isHostChecked()) {
-                    getBufferFromDeviceIfDirty(b);
-                    b.setHostChecked();
+            case BufferState.DEVICE_OWNED: {
+                getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
+                if (config.isSHOW_STATE()) {
+                    System.out.print("in preEscape state = " + b.getStateString() + " we pulled from device ");
                 }
-                // b.clearDeviceDirty();
+                b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
+                if (config.isSHOW_STATE()) {
+                    System.out.println("and switched to " + b.getStateString());
+                }
+                break;
             }
+            default:
+                throw new IllegalStateException("Not expecting this state ");
         }
 
     }
 
     @Override
     public void postEscape(Buffer b) {
-        if (!config.isMINIMIZE_COPIES()) {
-            throw new IllegalStateException("why is postEscape being called if we are not minimizing buffer copies");
+        if (config.isSHOW_STATE()) {
+            System.out.print("in postEscape state = " + b.getStateString() + " we pulled from device ");
         }
-        if (config.isUSE_STATE() ) {
-
-                    if (config.isSHOW_STATE()) {
-                        System.out.print("in postEscape state = " + b.getStateString() + " we pulled from device ");
-                    }
-                    b.setState(BufferState.HOST_OWNED);
-                    if (config.isSHOW_STATE()) {
-                        System.out.println("and switched to " + b.getStateString());
-                    }
-
-        }else {
-
-            b.setHostDirty();
-        }// We have no choice but to assume escapee was modified by the call
-
+        b.setState(BufferState.HOST_OWNED);
+        if (config.isSHOW_STATE()) {
+            System.out.println("and switched to " + b.getStateString());
+        }
     }
 }

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLConfig.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLConfig.java
@@ -24,9 +24,8 @@ public record OpenCLConfig(int bits) {
     private static final int TRACE_ENQUEUES_BIT = 1 << 25;
     private static final int TRACE_CALLS_BIT = 1 << 26;
     private static final int SHOW_WHY_BIT = 1 << 27;
-    private static final int USE_STATE_BIT = 1 << 28;
-    private static final int SHOW_STATE_BIT = 1 << 29;
-    private static final int END_BIT_IDX = 28;
+    private static final int SHOW_STATE_BIT = 1 << 28;
+    private static final int END_BIT_IDX = 29;
 
     private static String[] bitNames = {
             "MINIMIZE_COPIES",
@@ -41,7 +40,6 @@ public record OpenCLConfig(int bits) {
             "TRACE_ENQUEUES",
             "TRACE_CALLS",
             "SHOW_WHY",
-            "USE_STATE",
             "SHOW_STATE",
     };
 
@@ -92,12 +90,10 @@ public record OpenCLConfig(int bits) {
         }else if (name.contains(":")){
             var tokens=name.split(":");
             if (tokens.length == 2) {
-                if (tokens[0].equals("PLATFORM")) {
+                var token = tokens[0];
+                if (token.equals("PLATFORM") || token.equals("DEVICE")) {
                     int value = Integer.parseInt(tokens[1]);
-                    return new OpenCLConfig(value);
-                }else  if (tokens[0].equals("DEVICE")) {
-                    int value = Integer.parseInt(tokens[1]);
-                    return new OpenCLConfig(value<<4);
+                    return new OpenCLConfig(value<<(token.equals("DEVICE")?4:0));
                 }else{
                     System.out.println("Unexpected opt '" + name + "'");
                     return OpenCLConfig.of(0);
@@ -108,15 +104,9 @@ public record OpenCLConfig(int bits) {
             }
         } else {
             System.out.println("Unexpected opt '" + name + "'");
+            System.exit(1);
             return OpenCLConfig.of(0);
         }
-    }
-    public static OpenCLConfig USE_STATE() {
-        return new OpenCLConfig(USE_STATE_BIT);
-    }
-
-    public boolean isUSE_STATE() {
-        return (bits & USE_STATE_BIT) == USE_STATE_BIT;
     }
     public static OpenCLConfig SHOW_STATE() {
         return new OpenCLConfig(SHOW_STATE_BIT);

--- a/hat/backends/ffi/shared/include/shared.h
+++ b/hat/backends/ffi/shared/include/shared.h
@@ -117,14 +117,6 @@ extern void hexdump(void *ptr, int buflen);
 
  struct BufferState_s{
    static const long  MAGIC =0x4a71facebffab175;
-   static const int   NONE = 0;
-   static const int   BIT_HOST_NEW =1<<0;
-   static const int   BIT_DEVICE_NEW =1<<1;
-   static const int   BIT_HOST_DIRTY =1<<2;
-   static const int   BIT_DEVICE_DIRTY =1<<3;
-   static const int   BIT_HOST_CHECKED =1<<4;
-
-
    static const int NO_STATE = 0;
    static const int NEW_STATE = 1;
    static const int HOST_OWNED = 2;
@@ -133,6 +125,7 @@ extern void hexdump(void *ptr, int buflen);
    const static  char *stateNames[]; // See below for out of line definition
 
    long magic1;
+   void *ptr;
    long length;
    int bits;
    int state;
@@ -147,72 +140,14 @@ extern void hexdump(void *ptr, int buflen);
    int getState() {
       return state;
    }
-   void assignBits(int bitBits) {
-      bits=bitBits;
-   }
-   void setBits(int bitBits) {
-      bits|=bitBits;
-   }
-   void  xorBits(int bitsToReset) {
-      // say bits = 0b0111 (7) and bitz = 0b0100 (4)
-      int xored = bits^bitsToReset;  // xored = 0b0011 (3)
-      bits =  xored;
-   }
-    void  resetBits(int bitsToReset) {
-         // say bits = 0b0111 (7) and bitz = 0b0100 (4)
-         bits = bits&~bitsToReset;  // xored = 0b0011 (3)
-         //bits =  xored;
-      }
-   int getBits() {
-      return bits;
-   }
-   bool areBitsSet(int bitBits) {
-      return (bits&bitBits)==bitBits;
-   }
-   void setHostDirty(){
-      setBits(BIT_HOST_DIRTY);
-   }
-   bool isHostDirty(){
-      return  areBitsSet(BIT_HOST_DIRTY);
-   }
-   void clearHostDirty(){
-      resetBits(BIT_HOST_DIRTY);
-   }
-   void clearHostChecked(){
-      resetBits(BIT_HOST_CHECKED);
-   }
-   void clear(){
-       bits=0;
-   }
-   bool isHostNew(){
-      return  areBitsSet(BIT_HOST_NEW);
-   }
-   void clearHostNew(){
-      resetBits(BIT_HOST_NEW);
-   }
-   bool isHostNewOrDirty() {
-      return areBitsSet(BIT_HOST_NEW|BIT_HOST_DIRTY);
-   }
-
-   void setDeviceDirty(){
-      setBits(BIT_DEVICE_DIRTY);
-   }
-
-   bool isDeviceDirty(){
-      return areBitsSet(BIT_DEVICE_DIRTY);
-   }
-   void clearDeviceDirty(){
-      resetBits(BIT_DEVICE_DIRTY);
-   }
-
 
    void dump(const char *msg){
      if (ok()){
-        printf("{%s,length: %016lx, bits:%08x, state:%08x, vendorPtr:%016lx}\n", msg, length, bits, state, (long)vendorPtr);
+        printf("{%s,ptr:%016lx,length: %016lx,  state:%08x, vendorPtr:%016lx}\n", msg, (long)ptr, length,  state, (long)vendorPtr);
      }else{
         printf("%s bad magic \n", msg);
         printf("(magic1:%016lx,", magic1);
-        printf("{%s, length: %016lx, bits:%08x, state:%08x, vendorPtr:%016lx}", msg, length, bits, state, (long)vendorPtr);
+        printf("{%s, ptr:%016lx, length: %016lx,  state:%08x, vendorPtr:%016lx}", msg, (long)ptr, length,  state, (long)vendorPtr);
         printf("magic2:%016lx)\n", magic2);
      }
    }
@@ -363,10 +298,6 @@ public:
 
 };
 
-
-//extern "C" void dumpArgArray(void *ptr);
-
-
 extern void hexdump(void *ptr, int buflen);
 
 class Sled {
@@ -448,13 +379,13 @@ public:
     };
     int mode;
 
-    Backend(int mode)
-            : mode(mode){}
+    Backend(int mode): mode(mode){}
 
     virtual void info() = 0;
 
-     virtual void computeStart() = 0;
-      virtual void computeEnd() = 0;
+    virtual void computeStart() = 0;
+
+    virtual void computeEnd() = 0;
 
     virtual int getMaxComputeUnits() = 0;
 

--- a/hat/examples/life/src/main/java/life/Main.java
+++ b/hat/examples/life/src/main/java/life/Main.java
@@ -238,9 +238,16 @@ public class Main {
 
                 if (viewer.state.usingGPU) {
                     BufferState bufferState = BufferState.of(cellGrid);
-                    bufferState.setHostDirty(!viewer.state.minimizingCopies || (viewer.state.generations == 0)); // only first
-                    bufferState.setDeviceDirty(!viewer.state.minimizingCopies || shouldUpdateUI);
+                    if (!viewer.state.minimizingCopies || (viewer.state.generations == 0)){
+                        bufferState.setState(BufferState.HOST_OWNED);
+                    }
+                    BufferState.of(control).setState(BufferState.HOST_OWNED);
                     kernel.run(clWrapComputeContext, range, cellGrid, control);
+
+                 //   bufferState.setHostDirty(!viewer.state.minimizingCopies || (viewer.state.generations == 0)); // only first
+                 //   bufferState.setDeviceDirty(!viewer.state.minimizingCopies || shouldUpdateUI);
+
+
                 } else {
                     IntStream.range(0, range).parallel().forEach(kcx ->
                             Compute.lifePerIdx(kcx, control, cellGrid)

--- a/hat/examples/life/src/main/java/life/Main.java
+++ b/hat/examples/life/src/main/java/life/Main.java
@@ -27,6 +27,7 @@ package life;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
+import hat.backend.ffi.OpenCLBackend;
 import hat.buffer.Buffer;
 import hat.ifacemapper.BufferState;
 import hat.ifacemapper.Schema;
@@ -244,9 +245,6 @@ public class Main {
                     BufferState.of(control).setState(BufferState.HOST_OWNED);
                     kernel.run(clWrapComputeContext, range, cellGrid, control);
 
-                 //   bufferState.setHostDirty(!viewer.state.minimizingCopies || (viewer.state.generations == 0)); // only first
-                 //   bufferState.setDeviceDirty(!viewer.state.minimizingCopies || shouldUpdateUI);
-
 
                 } else {
                     IntStream.range(0, range).parallel().forEach(kcx ->
@@ -264,7 +262,7 @@ public class Main {
 
 
     public static void main(String[] args) {
-        Accelerator accelerator = new Accelerator(MethodHandles.lookup());
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup());//,new OpenCLBackend("INFO,MINIMIZE_COPIES,SHOW_COMPUTE_MODEL"));
 
         Arena arena = Arena.global();
         PatternData patternData = RleParser.readPatternData(

--- a/hat/examples/nbody/src/main/java/nbody/opencl/OpenCLNBodyGLWindow.java
+++ b/hat/examples/nbody/src/main/java/nbody/opencl/OpenCLNBodyGLWindow.java
@@ -295,10 +295,6 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
                 long elapsed = System.currentTimeMillis() - startTime;
                 float secs = elapsed / 1000f;
                 var FPS = "Mode: " + mode.toString() + " Bodies " + bodyCount + " FPS: " + ((frameCount / secs));
-                // System.out.print(" gw "+glutGet(GLUT_SCREEN_WIDTH())+" gh "+glutGet(GLUT_SCREEN_HEIGHT()));
-                // System.out.print(" a "+aspect+",s "+size);
-                // System.out.println(" w "+width+" h"+height);
-
                 glRasterPos2f(-.8f, .7f);
                 for (int c : FPS.getBytes()) {
                     glutBitmapCharacter(font, c);
@@ -315,13 +311,9 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
     @Override
     protected void moveBodies() {
         if (frameCount == 0) {
-            BufferState.of(universe).setHostDirty(true).setDeviceDirty(true);
-            // vel.copyToDevice = true;
-            // pos.copyToDevice = true;
+            BufferState.of(universe).setState(BufferState.HOST_OWNED);
         } else {
-            BufferState.of(universe).setHostDirty(false).setDeviceDirty(true);
-            // vel.copyToDevice = false;
-            //pos.copyToDevice = false;
+            BufferState.of(universe).setState(BufferState.DEVICE_OWNED);
         }
         if (mode.equals(Mode.HAT)) {
             float cmass = mass;
@@ -330,17 +322,6 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
             Universe cuniverse = universe;
             accelerator.compute(cc -> nbodyCompute(cc, cuniverse, cmass, cdelT, cespSqr));
         } else if (mode.equals(Mode.OpenCL4) || mode.equals(Mode.OpenCL)) {
-        //    if (frameCount == 0) {
-              //  SegmentMapper.BufferState.of(universe).setHostDirty(true).setDeviceDirty(true);
-               // vel.copyToDevice = true;
-               // pos.copyToDevice = true;
-          //  } else {
-            //    SegmentMapper.BufferState.of(universe).setHostDirty(false).setDeviceDirty(true);
-               // vel.copyToDevice = false;
-                //pos.copyToDevice = false;
-           // }
-           // vel.copyFromDevice = false;
-          //  pos.copyFromDevice = true;
 
             kernel.run(clWrapComputeContext, bodyCount, universe, mass, delT, espSqr);
         } else {
@@ -349,14 +330,5 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
     }
 }
 
-   /* public static void main(String[] args) throws IOException {
-        int particleCount = args.length > 2 ? Integer.parseInt(args[2]) : 32768;
-        Mode mode = Mode.of(args.length > 3 ? args[3] : Mode.OpenCL4.toString());
-        System.out.println("mode" + mode);
-        try (var arena = mode.equals(Mode.JavaMT4) || mode.equals(Mode.JavaMT) ? Arena.ofShared() : Arena.ofConfined()) {
-            var particleTexture = new GLTexture(arena, NBody.class.getResourceAsStream("/particle.png"));
-            new CLNBodyGLWindow( arena, 1000, 1000, particleTexture, particleCount, mode).bindEvents().mainLoop();
-        }
-    } */
 
 

--- a/hat/hat-core/src/main/java/hat/buffer/Buffer.java
+++ b/hat/hat-core/src/main/java/hat/buffer/Buffer.java
@@ -50,23 +50,23 @@ public interface Buffer extends MappableIface {
     default String getStateString(){
         return BufferState.of(this).getStateString();
     }
-    default boolean isDeviceDirty(){
-        return BufferState.of(this).isDeviceDirty();
-    }
-    default boolean isHostChecked(){
-        return BufferState.of(this).isHostChecked();
-    }
+  //  default boolean isDeviceDirty(){
+    //    return BufferState.of(this).isDeviceDirty();
+   // }
+   // default boolean isHostChecked(){
+     //   return BufferState.of(this).isHostChecked();
+   // }
 
-    default void clearDeviceDirty(){
-         BufferState.of(this).clearDeviceDirty();
-    }
-    default void setHostDirty(){
-        BufferState.of(this).setHostDirty(true);
-    }
+   // default void clearDeviceDirty(){
+   //      BufferState.of(this).clearDeviceDirty();
+   // }
+    //default void setHostDirty(){
+      //  BufferState.of(this).setHostDirty(true);
+   // }
 
-    default void setHostChecked(){
-        BufferState.of(this).setHostChecked(true);
-    }
+   // default void setHostChecked(){
+     //   BufferState.of(this).setHostChecked(true);
+   // }
 
     interface Union extends MappableIface {
     }

--- a/hat/hat-core/src/main/java/hat/ifacemapper/MappableIface.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/MappableIface.java
@@ -29,10 +29,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-public interface MappableIface {
+public interface MappableIface  {
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.PARAMETER)
-    @interface RW {}
+    @interface RW  {}
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.PARAMETER)
     @interface RO {}

--- a/hat/hat-core/src/main/java/hat/ifacemapper/SegmentMapper.java
+++ b/hat/hat-core/src/main/java/hat/ifacemapper/SegmentMapper.java
@@ -349,17 +349,13 @@ public interface SegmentMapper<T> {
         }
         //System.out.println("Alloc 16 byte aligned layout + 16 bytes padded to next 16 bytes "+byteSize+"=>"+extendedByteSizePaddedTo16Bytes);
         var segment = arena.allocate(BufferState.getLayoutSizeAfterPadding(layout()) + BufferState.byteSize(), BufferState.alignment);
-        new BufferState(segment, BufferState.getLayoutSizeAfterPadding(layout())).setMagic().setLength(layout().byteSize()).setState(BufferState.NEW_STATE).assignBits(BufferState.BIT_HOST_NEW| BufferState.BIT_HOST_DIRTY);
+        new BufferState(segment, BufferState.getLayoutSizeAfterPadding(layout()))
+                .setMagic()
+                .setPtr(segment)
+                .setLength(layout().byteSize())
+                .setState(BufferState.NEW_STATE);
+               // .assignBits(BufferState.BIT_HOST_NEW| BufferState.BIT_HOST_DIRTY);
         T returnValue=  get(segment, layout(), boundSchema);
-        // Uncomment if you want to check the State
-        /*
-        State state = State.of(returnValue);
-        if (state.ok() &&!state.isDeviceDirty() &&!state.isJavaDirty()){
-            System.out.println("OK");
-        }else{
-            throw new IllegalArgumentException("BAD TAIL");
-        }
-         */
         return returnValue;
     }
 

--- a/hat/hat/debug
+++ b/hat/hat/debug
@@ -1,0 +1,1 @@
+-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=y --enable-preview --source 24 hat/run.java

--- a/hat/wrap/clwrap/src/main/java/wrap/clwrap/CLPlatform.java
+++ b/hat/wrap/clwrap/src/main/java/wrap/clwrap/CLPlatform.java
@@ -255,7 +255,7 @@ public class CLPlatform implements ArenaHolder {
                                                 memorySegment,
                                                 status.ptr()))
                                 );
-                                if (bufferState.isHostDirty()) {
+                                if (bufferState.getState()==BufferState.HOST_OWNED) {
 
                                     //System.out.println("arg " + args[i] + " isHostDirty copying in");
                                     status.set(opencl_h.clEnqueueWriteBuffer(program.context.queue,
@@ -347,7 +347,7 @@ public class CLPlatform implements ArenaHolder {
                                 MemorySegment memorySegment = Buffer.getMemorySegment(buffer);
                                 CLWrapComputeContext.ClMemPtr clmem = clWrapComputeContext.clMemMap.get(memorySegment);
                                 // System.out.println("Before possible read "+ bufferState);
-                                if (bufferState.isDeviceDirty()) {
+                                if (bufferState.getState() == BufferState.HOST_OWNED) {
                                   //  System.out.println("arg " + args[i] + " isDeviceDirty copying out");
                                     status.set(opencl_h.clEnqueueReadBuffer(program.context.queue,
                                             clmem.get(),


### PR DESCRIPTION
The previous bitfield based state info replaced by a simpler state machine. 

Also here we are able to minimize copies when buffers 'escape'.  If the escaping function annotates its buffer arg RO,RW or WO then HAT can avoid at leas one copy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/366/head:pull/366` \
`$ git checkout pull/366`

Update a local copy of the PR: \
`$ git checkout pull/366` \
`$ git pull https://git.openjdk.org/babylon.git pull/366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 366`

View PR using the GUI difftool: \
`$ git pr show -t 366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/366.diff">https://git.openjdk.org/babylon/pull/366.diff</a>

</details>
