### PR TITLE
Sync ONNX code gen

### DIFF
--- a/cr-examples/onnx/opgen/src/main/java/oracle/code/json/JsonNumberImpl.java
+++ b/cr-examples/onnx/opgen/src/main/java/oracle/code/json/JsonNumberImpl.java
@@ -25,6 +25,8 @@
 
 package oracle.code.json;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Objects;
 
 /**
@@ -88,34 +90,50 @@ final class JsonNumberImpl implements JsonNumber, JsonValueImpl {
     }
 
     Number toNum(String numStr) {
-        // Determine if fp
-        boolean fp = false;
-        for (char c : numStr.toCharArray()) {
-            if (c == 'e' || c == 'E' || c =='.') {
-                fp = true;
-                break;
-            }
+        try {
+            return Long.parseLong(numStr);
+        } catch (NumberFormatException e) {
         }
 
-        // Make conversion
-        if (!fp) {
-            // integral numbers
-            try {
-                return Integer.valueOf(numStr);
-            } catch (NumberFormatException _) {
-                // int overflow. try long
-                try {
-                    return Long.valueOf(numStr);
-                } catch (NumberFormatException _) {
-                    // long overflow. convert to Double
-                }
-            }
+        try {
+            return new BigInteger(numStr);
+        } catch (NumberFormatException e) {
         }
-        var num = Double.valueOf(numStr);
-        if (Double.isInfinite(num)) {
-            throw new NumberFormatException("The number is infinitely large in magnitude");
+
+        if (Double.valueOf(numStr) instanceof double d && !Double.isInfinite(d)) {
+            return d;
         }
-        return num;
+
+        return new BigDecimal(numStr);
+
+//        // Determine if fp
+//        boolean fp = false;
+//        for (char c : numStr.toCharArray()) {
+//            if (c == 'e' || c == 'E' || c =='.') {
+//                fp = true;
+//                break;
+//            }
+//        }
+//
+//        // Make conversion
+//        if (!fp) {
+//            // integral numbers
+//            try {
+//                return Integer.valueOf(numStr);
+//            } catch (NumberFormatException _) {
+//                // int overflow. try long
+//                try {
+//                    return Long.valueOf(numStr);
+//                } catch (NumberFormatException _) {
+//                    // long overflow. convert to Double
+//                }
+//            }
+//        }
+//        var num = Double.valueOf(numStr);
+//        if (Double.isInfinite(num)) {
+//            throw new NumberFormatException("The number is infinitely large in magnitude");
+//        }
+//        return num;
     }
 
     @Override

--- a/cr-examples/onnx/opgen/src/main/java/oracle/code/onnx/opgen/OpGen.java
+++ b/cr-examples/onnx/opgen/src/main/java/oracle/code/onnx/opgen/OpGen.java
@@ -100,7 +100,7 @@ public class OpGen {
         w.write("\n");
 
         w.write("@SuppressWarnings({\"OptionalUsedAsFieldOrParameterType\", \"unused\", \"SequencedCollectionMethodCanBeUsed\"})\n");
-        w.write("public final class " + ONNX_OPS_CLASS + " {\n");
+        w.write("public final class " + ONNX_OPS_CLASS + " extends ExplicitOnnxOps {\n");
 
         w.in();
 

--- a/cr-examples/onnx/opgen/src/main/java/oracle/code/onnx/opgen/OpSchemaParser.java
+++ b/cr-examples/onnx/opgen/src/main/java/oracle/code/onnx/opgen/OpSchemaParser.java
@@ -94,8 +94,11 @@ public class OpSchemaParser {
             case JsonString s when c == String.class -> (T) s.value();
             case JsonString s when c == Object.class -> (T) s.value();
 
+            // Coerce to int when int is declared
             case JsonNumber n when c == int.class -> (T) (Integer) n.value().intValue();
-            case JsonNumber n when n.value() instanceof Integer i && c == Object.class -> (T) i;
+            // Coerce to int when Object is declared and when integral JSON number
+            case JsonNumber n when n.value() instanceof Long i && c == Object.class -> (T) (Integer) i.intValue();
+            // Coerce to float when Object is declared and when real JSON number
             case JsonNumber n when n.value() instanceof Double d && c == Object.class -> (T) (Float) d.floatValue();
 
             case JsonArray a when c == List.class -> switch (gt) {


### PR DESCRIPTION
Ensure code generation of ONNX ops is in sync with generated code.

Also, update the `JsonNumber.toNumber` implementation, testing out an alternative approach (slow and functional, performance is not an issue for now).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/369/head:pull/369` \
`$ git checkout pull/369`

Update a local copy of the PR: \
`$ git checkout pull/369` \
`$ git pull https://git.openjdk.org/babylon.git pull/369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 369`

View PR using the GUI difftool: \
`$ git pr show -t 369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/369.diff">https://git.openjdk.org/babylon/pull/369.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/369#issuecomment-2755779174)
</details>
