### PR TITLE
IAE catch fix for recurrent inlining

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
@@ -90,7 +90,7 @@ public class OnnxTransformer {
             if (res.isPresent()) {
                 return SSA.transform(res.get());
             }
-        } catch (ReflectiveOperationException _) {}
+        } catch (ReflectiveOperationException | IllegalArgumentException _) {}
         return null;
     }
 


### PR DESCRIPTION
Recurrent inlining may cause IAE from `resolveToDirectMethod`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/371/head:pull/371` \
`$ git checkout pull/371`

Update a local copy of the PR: \
`$ git checkout pull/371` \
`$ git pull https://git.openjdk.org/babylon.git pull/371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 371`

View PR using the GUI difftool: \
`$ git pr show -t 371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/371.diff">https://git.openjdk.org/babylon/pull/371.diff</a>

</details>
