### PR TITLE
Ensure this capture is noted for use in argument of JCNewClass

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -645,6 +645,7 @@ public class ReflectMethods extends TreeTranslator {
                         !seenClasses.contains(tree.type.tsym)) {
                     throw unsupported(tree);
                 }
+                super.visitNewClass(tree);
             }
 
             @Override

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -82,6 +82,38 @@ public class TestCaptureQuotable {
     }
 
     @Test
+    public void testCaptureThisInInvocationArg() {
+        Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + Integer.valueOf(hashCode());
+        Quoted quoted = Op.ofQuotable(quotable).get();
+        assertEquals(quoted.capturedValues().size(), 1);
+        Iterator<Object> it = quoted.capturedValues().values().iterator();
+        assertEquals(it.next(), this);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
+        int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
+                arguments);
+        assertEquals(res, 1 + hashCode());
+    }
+
+    record R(int i) {}
+
+    @Test
+    public void testCaptureThisInNewArg() {
+        Quotable quotable = (Quotable & ToIntFunction<Number>)y -> y.intValue() + new R(hashCode()).i;
+        Quoted quoted = Op.ofQuotable(quotable).get();
+        assertEquals(quoted.capturedValues().size(), 1);
+        Iterator<Object> it = quoted.capturedValues().values().iterator();
+        assertEquals(it.next(), this);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
+        int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
+                arguments);
+        assertEquals(res, 1 + hashCode());
+    }
+
+    @Test
     public void testCaptureMany() {
         int[] ia = new int[8];
         int i1 = ia[0] = 0;

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
@@ -101,6 +101,37 @@ public class TestCaptureQuoted {
         assertEquals(res, x + 1 + hashCode() + hello.length());
     }
 
+    @Test
+    public void testCaptureThisInInvocationArg() {
+        Quoted quoted = (Number y) -> y.intValue() + Integer.valueOf(hashCode());
+        assertEquals(quoted.capturedValues().size(), 1);
+        Iterator<Object> it = quoted.capturedValues().values().iterator();
+        assertEquals(it.next(), this);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
+        int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
+                arguments);
+        assertEquals(res, 1 + hashCode());
+    }
+
+    record R(int i) {}
+
+    @Test
+    public void testCaptureThisInNewArg() {
+        Quoted quoted = (Number y) -> y.intValue() + new R(hashCode()).i;
+        assertEquals(quoted.capturedValues().size(), 1);
+        Iterator<Object> it = quoted.capturedValues().values().iterator();
+        assertEquals(it.next(), this);
+        List<Object> arguments = new ArrayList<>();
+        arguments.add(1);
+        arguments.addAll(quoted.capturedValues().values());
+        int res = (int)Interpreter.invoke(MethodHandles.lookup(), (Op & Op.Invokable) quoted.op(),
+                arguments);
+        assertEquals(res, 1 + hashCode());
+    }
+
+
     @DataProvider(name = "ints")
     public Object[][] ints() {
         return IntStream.range(0, 50)


### PR DESCRIPTION
The `QuotableLambdaCaptureScanner` scanner neglected to visit the arguments of tree node `JCNewClass` so for say:

```
() -> new String(toString());
```

The implicit use of `this` in `this.toString()` would be skipped, and results in an exception later as there was no block parameter declared corresponding to `this`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/376/head:pull/376` \
`$ git checkout pull/376`

Update a local copy of the PR: \
`$ git checkout pull/376` \
`$ git pull https://git.openjdk.org/babylon.git pull/376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 376`

View PR using the GUI difftool: \
`$ git pr show -t 376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/376.diff">https://git.openjdk.org/babylon/pull/376.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/376#issuecomment-2767374929)
</details>
