### PR TITLE
Support for Onnx functions

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxProtoBuilder.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxProtoBuilder.java
@@ -332,7 +332,7 @@ sealed class OnnxProtoBuilder<T extends OnnxProtoBuilder> {
         }
 
         private String baseName(Value value, int elementIndex) {
-            var name = baseNames.apply(value);
+            var name = "%" + baseNames.apply(value);
             return elementIndex > 0 ? name + '.' + elementIndex : name;
         }
 

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxProtoBuilder.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxProtoBuilder.java
@@ -365,7 +365,7 @@ sealed class OnnxProtoBuilder<T extends OnnxProtoBuilder> {
                                  expandTuples(indexer, f.body().entryBlock().terminatingOp().operands()),
                                  nodes(indexer, f.body().entryBlock().ops()))).toList());
 
-        OnnxProtoPrinter.printModel(model);
+//        OnnxProtoPrinter.printModel(model);
         return model;
     }
 
@@ -422,8 +422,9 @@ sealed class OnnxProtoBuilder<T extends OnnxProtoBuilder> {
     static GraphProto graph(Indexer indexer, Block block, List<oracle.code.onnx.Tensor> initializers, int scalarArgs) {
         var params = block.parameters();
         params.forEach(indexer::nameOf);
-        var args = initializers.isEmpty() ? params : params.subList(0, params.size() - 1);
-        return graph(IntStream.range(0, initializers.size()).mapToObj(i -> tensorProto(indexer.nameOf(params.getLast(), i), initializers.get(i))).toList(),
+        int firstInitializer = params.size() - initializers.size();
+        var args = params.subList(0, firstInitializer);
+        return graph(IntStream.range(0, initializers.size()).mapToObj(i -> tensorProto(indexer.nameOf(params.get(i + firstInitializer)), initializers.get(i))).toList(),
                 tensorInfos(indexer, args, scalarArgs),
                 nodes(indexer, block.ops()),
                 expandTuples(indexer, block.terminatingOp().operands()));
@@ -510,7 +511,7 @@ sealed class OnnxProtoBuilder<T extends OnnxProtoBuilder> {
     }
 
     static FunctionProto function(String domain, String functionName, List<String> inputNames, List<String> outputNames, List<NodeProto> ops) {
-        return new FunctionProto() // @@@ invalid mapping of initilizars
+        return new FunctionProto()
                 .name(functionName)
                 .forEach(inputNames, (f, i) -> f.input(i))
                 .forEach(outputNames, (f, o) -> f.output(o))

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
@@ -107,12 +107,13 @@ public final class OnnxRuntime {
                                     .filter(OnnxType.Initializer.class::isInstance)
                                     .map(OnnxType.Initializer.class::cast).toList();
 
-            byte[] protobufModel = OnnxProtoBuilder.build(module, getInitValues(l, initializers, q.capturedValues().sequencedValues()));
+            String domainName = type.getSimpleName().split("\\$")[0];
+            byte[] protobufModel = OnnxProtoBuilder.build(domainName, module, getInitValues(l, initializers, q.capturedValues().sequencedValues()));
 
             if (DEBUG) {
                 System.out.println(module.toText());
                 try {
-                    var export = Path.of(type.getSimpleName().split("\\$")[0] + ".onnx");
+                    var export = Path.of(domainName + ".onnx");
                     Files.write(export, protobufModel);
                     System.out.println("Onnx model exported to: " + export.toAbsolutePath());
                 } catch (IOException _) {}

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
@@ -97,8 +97,7 @@ public final class OnnxRuntime {
 
         @Override
         protected Session computeValue(Class<?> type) {
-            OnnxTransformer trans = OnnxTransformer.ofQuotedLambda(l, q);
-            CoreOp.ModuleOp module = trans.transform();
+            CoreOp.ModuleOp module = OnnxTransformer.transform(l, q);
 
             // initializers filtered from the model main function parameters
             List<OnnxType.Initializer> initializers =

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
@@ -82,13 +82,13 @@ public final class OnnxRuntime {
 
         @Override
         protected Session computeValue(Class<?> type) {
-            var trans = OnnxTransformer.ofQuotedLambda(l, q);
-            var func = trans.transform();
-            byte[] protobufModel = OnnxProtoBuilder.build(func.body().entryBlock(),
+            OnnxTransformer trans = OnnxTransformer.ofQuotedLambda(l, q);
+            CoreOp.ModuleOp module = trans.transform();
+            byte[] protobufModel = OnnxProtoBuilder.build(module,
                     trans.initializers(getReceiver(q.capturedValues().sequencedValues())));
 
             if (DEBUG) {
-                System.out.println(func.toText());
+                System.out.println(module.toText());
                 try {
                     var export = Path.of(type.getSimpleName().split("\\$")[0] + ".onnx");
                     Files.write(export, protobufModel);

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
@@ -19,7 +19,6 @@ import jdk.incubator.code.*;
 
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.ClassType;
-import jdk.incubator.code.type.FieldRef;
 import jdk.incubator.code.type.JavaType;
 import oracle.code.onnx.compiler.OnnxTransformer;
 import oracle.code.onnx.foreign.OrtApi;

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxPartialEvaluator.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxPartialEvaluator.java
@@ -482,6 +482,11 @@ final class OnnxPartialEvaluator {
                 unevaluatedOperations.add(o);
                 return null;
             }
+            case CoreOp.FuncOp funcOp -> {
+                interpretEntryBlock(l, funcOp.body().entryBlock(), oc, new HashMap<>());
+                unevaluatedOperations.add(o);
+                return null;
+            }
             case null, default -> throw interpreterException(
                     new UnsupportedOperationException("Unsupported operation: " + o.opName()));
         }

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxType.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxType.java
@@ -86,6 +86,14 @@ public abstract sealed class OnnxType implements TypeElement {
                             (OnnxElementType) constructType(tree.arguments().getFirst()),
                             List.of());
                 }
+                case Initializer.NAME: {
+                    if (tree.arguments().size() != 2) {
+                        throw new IllegalArgumentException();
+                    }
+                    return new Initializer(
+                            constructType(tree.arguments().getFirst()),
+                            tree.arguments().get(1).toString());
+                }
                 case Float16Type.NAME: {
                     if (!tree.arguments().isEmpty()) {
                         throw new IllegalArgumentException();
@@ -466,6 +474,30 @@ public abstract sealed class OnnxType implements TypeElement {
         }
     }
 
+    public static final class Initializer extends OnnxType {
+        static final String NAME = "init";
+
+        final OnnxType type;
+        final String name;
+
+        public Initializer(OnnxType type, String name) {
+            this.type = type;
+            this.name = name;
+        }
+
+        public OnnxType type() {
+            return type;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public ExternalizedTypeElement externalize() {
+            return new ExternalizedTypeElement(NAME, List.of(type.externalize(), ExternalizedTypeElement.ofString(name)));
+        }
+    }
 
     public static abstract sealed class OnnxElementType extends OnnxType {
         public abstract int id();

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
@@ -150,7 +150,7 @@ public class CNNTest {
         return prediction;
     }
 
-    static CoreOp.FuncOp cnnModel() {
+    static CoreOp.ModuleOp cnnModel() {
         // @@@ function type and result types with correct tensor element and shape
 
         FunctionType functionType = FunctionType.functionType(
@@ -168,7 +168,7 @@ public class CNNTest {
                 OnnxType.TENSOR_UINT8 // input
         );
 
-        return CoreOp.func("cnn", functionType).body(b -> {
+        return CoreOp.module(CoreOp.func("cnn", functionType).body(b -> {
             // weights & biases
             Block.Parameter conv1Weights = b.parameters().get(0);
             Block.Parameter conv1Biases = b.parameters().get(1);
@@ -298,7 +298,7 @@ public class CNNTest {
                     of(1L)));
 
             b.op(CoreOp._return(prediction));
-        });
+        }));
     }
 
     static void printImage(int imageIndex, MemorySegment data) {
@@ -325,7 +325,7 @@ public class CNNTest {
             var onnxModel = new OnnxTransformer(MethodHandles.lookup(), f).transform();
             System.out.println(onnxModel.toText());
 
-            CoreOp.FuncOp expectedOnnxModel = cnnModel();
+            var expectedOnnxModel = cnnModel();
             System.out.println(expectedOnnxModel.toText());
 
             Assertions.assertEquals(serialize(expectedOnnxModel), serialize(onnxModel));

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
@@ -322,7 +322,7 @@ public class CNNTest {
     public void testModels() {
         try (var arena = Arena.ofConfined()) {
             CoreOp.FuncOp f = getFuncOp("cnn");
-            var onnxModel = new OnnxTransformer(MethodHandles.lookup(), f).transform();
+            CoreOp.ModuleOp onnxModel = OnnxTransformer.transform(MethodHandles.lookup(), f);
             System.out.println(onnxModel.toText());
 
             var expectedOnnxModel = cnnModel();

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/RuntimeTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/RuntimeTest.java
@@ -67,11 +67,13 @@ public class RuntimeTest {
                     List.of(tensorInfo("cond", BOOL.id), tensorInfo("a", INT64.id), tensorInfo("b", INT64.id)),
                     List.of(node("If", List.of("cond"), List.of("y"), Map.of(
                             "then_branch", graph(
+                                    null,
                                     List.of(),
                                     List.of(),
                                     List.of(node("Identity", List.of("a"), List.of("y"), Map.of())),
                                     List.of("y")),
                             "else_branch", graph(
+                                    null,
                                     List.of(),
                                     List.of(),
                                     List.of(node("Identity", List.of("b"), List.of("y"), Map.of())),
@@ -94,6 +96,7 @@ public class RuntimeTest {
                     List.of(tensorInfo("max", INT64.id), tensorInfo("cond", BOOL.id), tensorInfo("a", INT64.id)),
                     List.of(node("Loop", List.of("max", "cond", "a"), List.of("a_out"), Map.of(
                             "body", graph(
+                                    null,
                                     List.of(),
                                     List.of(tensorInfo("i", INT64.id, true), tensorInfo("cond_in", BOOL.id, true), tensorInfo("a_in", INT64.id)),
                                     List.of(node("Identity", List.of("cond_in"), List.of("cond_out"), Map.of()),

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/RuntimeTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/RuntimeTest.java
@@ -105,4 +105,29 @@ public class RuntimeTest {
                     forOp.run(arena, List.of(Tensor.ofScalar(arena, 15l), Tensor.ofScalar(arena, true), Tensor.ofScalar(arena, 2l))).getFirst());
         }
     }
+
+
+    @Test
+    public void testCustomFunction() throws Exception {
+        String customDomain = RuntimeTest.class.getName();
+        var ort = OnnxRuntime.getInstance();
+        try (Arena arena = Arena.ofConfined()) {
+            var customFunction = ort.createSession(arena, build(
+                    List.of(),
+                    List.of(tensorInfo("x", INT64.id)),
+                    List.of(node(customDomain, "CustomFunction", List.of("x"), List.of("y"), Map.of())),
+                    List.of("y"),
+                    List.of(customDomain),
+                    List.of(new FunctionProto()
+                            .name("CustomFunction")
+                            .input("a")
+                            .output("b")
+                            .node(node("Identity", List.of("a"), List.of("b"), Map.of()))
+                            .opset_import(new OperatorSetIdProto().version(OPSET_VERSION))
+                            .domain(customDomain))));
+
+            var a = Tensor.ofScalar(arena, 1l);
+            SimpleTest.assertEquals(a, customFunction.run(arena, List.of(a)).getFirst());
+        }
+    }
 }

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/SimpleTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/SimpleTest.java
@@ -117,7 +117,7 @@ public class SimpleTest {
         var x = Tensor.ofShape(new long[]{2, 2, 2}, 1f, 2, 3, 4, 5, 6, 7, 8);
         assertEquals(
                 indicesOfMaxPool(x),
-                execute(() -> MaxPool(x, empty(), empty(), empty(), empty(), empty(), empty(),  new long[]{2}).Indices())); //@@@ problematic tuple in a function
+                execute(() -> indicesOfMaxPool(x)));
     }
 
     @CodeReflection
@@ -145,7 +145,7 @@ public class SimpleTest {
         var split = Tensor.ofFlat(5l);
         assertEquals(
                 split(input, split),
-                execute(()-> Split(input, Optional.of(split), empty(), empty()).get(0))); //@@@ problematic list in a function
+                execute(()-> split(input, split)));
     }
 
     @CodeReflection
@@ -165,7 +165,7 @@ public class SimpleTest {
         return If(cond, () -> new SingleValueTuple<>(Constant(1f)), () -> new SingleValueTuple<>(Constant(-1f)));
     }
 
-//    @Test @@@ problems with mapping to functions
+    @Test
     public void testIfConst() throws Exception {
         var condFalse = Tensor.ofScalar(false);
         var expFalse = Tensor.ofScalar(-1f);
@@ -234,7 +234,7 @@ public class SimpleTest {
                         () -> List.of(Identity(initialized4)))).get(0);
     }
 
-//    @Test @@@ problems with lists in functions
+    @Test
     public void testIfInitialized() throws Exception {
         var condFalse = Tensor.ofScalar(false);
         var condTrue = Tensor.ofScalar(true);

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/SimpleTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/SimpleTest.java
@@ -117,7 +117,7 @@ public class SimpleTest {
         var x = Tensor.ofShape(new long[]{2, 2, 2}, 1f, 2, 3, 4, 5, 6, 7, 8);
         assertEquals(
                 indicesOfMaxPool(x),
-                execute(() -> indicesOfMaxPool(x)));
+                execute(() -> MaxPool(x, empty(), empty(), empty(), empty(), empty(), empty(),  new long[]{2}).Indices())); //@@@ problematic tuple in a function
     }
 
     @CodeReflection
@@ -145,7 +145,7 @@ public class SimpleTest {
         var split = Tensor.ofFlat(5l);
         assertEquals(
                 split(input, split),
-                execute(()-> split(input, split)));
+                execute(()-> Split(input, Optional.of(split), empty(), empty()).get(0))); //@@@ problematic list in a function
     }
 
     @CodeReflection
@@ -165,7 +165,7 @@ public class SimpleTest {
         return If(cond, () -> new SingleValueTuple<>(Constant(1f)), () -> new SingleValueTuple<>(Constant(-1f)));
     }
 
-    @Test
+//    @Test @@@ problems with mapping to functions
     public void testIfConst() throws Exception {
         var condFalse = Tensor.ofScalar(false);
         var expFalse = Tensor.ofScalar(-1f);
@@ -234,7 +234,7 @@ public class SimpleTest {
                         () -> List.of(Identity(initialized4)))).get(0);
     }
 
-    @Test
+//    @Test @@@ problems with lists in functions
     public void testIfInitialized() throws Exception {
         var condFalse = Tensor.ofScalar(false);
         var condTrue = Tensor.ofScalar(true);

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/SimpleTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/SimpleTest.java
@@ -121,8 +121,8 @@ public class SimpleTest {
     }
 
     @CodeReflection
-    public Tensor<Float> concat(Tensor<Float> input1, Tensor<Float> input2, long axis) {
-        return Concat(List.of(input1, input2), axis);
+    public Tensor<Float> concat(Tensor<Float> input1, Tensor<Float> input2) {
+        return Concat(List.of(input1, input2), 0);
     }
 
     @Test
@@ -130,8 +130,8 @@ public class SimpleTest {
         var input1 = Tensor.ofFlat(1f, 2, 3);
         var input2 = Tensor.ofFlat(4f, 5);
         assertEquals(
-                concat(input1, input2, 0),
-                execute(()-> concat(input1, input2, 0)));
+                concat(input1, input2),
+                execute(()-> concat(input1, input2)));
     }
 
     @CodeReflection

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/WalkTheMazeTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/WalkTheMazeTest.java
@@ -142,7 +142,7 @@ public class WalkTheMazeTest {
         return outData.path();
     }
 
-    @Test
+//    @Test @@@ temprary disabled
     public void testWalkAroundTheMaze() throws Exception {
         try (var arena = Arena.ofConfined()) {
             var directions = execute(arena, MethodHandles.lookup(), () -> walkAroundTheMaze());

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/WalkTheMazeTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/WalkTheMazeTest.java
@@ -142,7 +142,7 @@ public class WalkTheMazeTest {
         return outData.path();
     }
 
-//    @Test @@@ temprary disabled
+    @Test
     public void testWalkAroundTheMaze() throws Exception {
         try (var arena = Arena.ofConfined()) {
             var directions = execute(arena, MethodHandles.lookup(), () -> walkAroundTheMaze());


### PR DESCRIPTION
Support for Onnx functions:
 - Onnx model is represented by `ModuleOp`.
 - Initializers are self-described by `OnnxType.Initializer` type (no more by-passing initializers values from `OnnxTransformer`).
 - `OnnxTransformer` is decomposed into small independent transformations.
- Single-use functions are inlined, multiple-use functions are declared in the model.
- Protobuf model is improved to better reflect Onnx model.

Sample Onnx model:
```
module ()void -> {
    func @"step" (%0 : tensor<int64>, %1 : tensor<int64>, %2 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionEast>, %3 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepEast>, %4 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionNorth>, %5 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepNorth>, %6 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionWest>, %7 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepWest>, %8 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepSouth>)tensor<int64> -> {
        %9 : tensor<bool> = Equal %1 %2;
        %10 : tensor<int64> = If %9
            ()tensor<int64> -> {
                %11 : tensor<int64> = Add %0 %3;
                return %11 @loc="102:17";
            }
            ()tensor<int64> -> {
                %12 : tensor<bool> = Equal %1 %4;
                %13 : tensor<int64> = If %12
                    ()tensor<int64> -> {
                        %14 : tensor<int64> = Add %0 %5;
                        return %14 @loc="104:25";
                    }
                    ()tensor<int64> -> {
                        %15 : tensor<bool> = Equal %1 %6;
                        %16 : tensor<int64> = If %15
                            ()tensor<int64> -> {
                                %17 : tensor<int64> = Add %0 %7;
                                return %17 @loc="106:29";
                            }
                            ()tensor<int64> -> {
                                %18 : tensor<int64> = Add %0 %8;
                                return %18 @loc="107:29";
                            };
                        return %16 @loc="105:25";
                    };
                return %13 @loc="103:17";
            };
        return %10 @loc="101:9";
    };
    func @"turnLeft" (%19 : tensor<int64>, %20 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionEast>, %21 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionNorth>, %22 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionWest>, %23 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionSouth>)tensor<int64> -> {
        %24 : tensor<bool> = Equal %19 %20;
        %25 : tensor<int64> = If %24
            ()tensor<int64> -> {
                %26 : tensor<int64> = Identity %21;
                return %26 @loc="80:17";
            }
            ()tensor<int64> -> {
                %27 : tensor<bool> = Equal %19 %21;
                %28 : tensor<int64> = If %27
                    ()tensor<int64> -> {
                        %29 : tensor<int64> = Identity %22;
                        return %29 @loc="82:25";
                    }
                    ()tensor<int64> -> {
                        %30 : tensor<bool> = Equal %19 %22;
                        %31 : tensor<int64> = If %30
                            ()tensor<int64> -> {
                                %32 : tensor<int64> = Identity %23;
                                return %32 @loc="84:29";
                            }
                            ()tensor<int64> -> {
                                %33 : tensor<int64> = Identity %20;
                                return %33 @loc="85:29";
                            };
                        return %31 @loc="83:25";
                    };
                return %28 @loc="81:17";
            };
        return %25 @loc="79:9";
    };
    func @"isWallAt" (%34 : tensor<int64>, %35 : init<tensor<uint8>, oracle.code.onnx.WalkTheMazeTest.maze>, %36 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.oneOne>, %37 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.wall>)tensor<bool> -> {
        %38 : tensor<int64> = Add %34 %36;
        %39 : tensor<uint8> = Slice %35 %34 %38;
        %40 : tensor<int64> = CastLike %39 %37;
        %41 : tensor<bool> = Equal %40 %37;
        return %41 @loc="96:9";
    };
    func @"walkAroundTheMaze" (%42 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionEast>, %43 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepEast>, %44 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionNorth>, %45 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepNorth>, %46 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionWest>, %47 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepWest>, %48 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.stepSouth>, %49 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionSouth>, %50 : init<tensor<uint8>, oracle.code.onnx.WalkTheMazeTest.maze>, %51 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.oneOne>, %52 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.wall>, %53 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.homePos>, %54 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.limit>, %55 : init<tensor<bool>, oracle.code.onnx.WalkTheMazeTest._true>, %56 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.three>, %57 : init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.scalarShape>)tensor<uint8> -> {
        %58 : tensor<uint8> = Cast %42 @to="2";
        %59 : Tuple<init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.homePos>, init<tensor<int64>, oracle.code.onnx.WalkTheMazeTest.directionEast>, tensor<uint8>> = tuple %53 %42 %58;
        %60 : Tuple<tensor<int64>, tensor<int64>, tensor<uint8>> = Loop %54 %55 %59 (%61 : tensor<int64>, %62 : tensor<bool>, %63 : Tuple<tensor<int64>, tensor<int64>, tensor<uint8>>)Tuple<tensor<bool>, Tuple<tensor<int64>, tensor<int64>, tensor<uint8>>> -> {
            %64 : tensor<int64> = tuple.load %63 @"0";
            %65 : tensor<int64> = tuple.load %63 @"1";
            %66 : tensor<int64> = func.call %64 %65 %42 %43 %44 %45 %46 %47 %48 @"step";
            %67 : tensor<int64> = tuple.load %63 @"1";
            %68 : tensor<int64> = Loop %56 %55 %67 (%69 : tensor<int64>, %70 : tensor<bool>, %71 : tensor<int64>)Tuple<tensor<bool>, tensor<int64>> -> {
                %72 : tensor<int64> = func.call %71 %42 %44 %46 %49 @"turnLeft";
                %73 : Tuple<tensor<bool>, tensor<int64>> = tuple %70 %72;
                return %73 @loc="90:46";
            };
            %74 : tensor<int64> = func.call %66 %68 %42 %43 %44 %45 %46 %47 %48 @"step";
            %75 : tensor<bool> = func.call %74 %50 %51 %52 @"isWallAt";
            %76 : tensor<bool> = Reshape %75 %57;
            %77 : tensor<int64> = Loop %54 %76 %68 (%78 : tensor<int64>, %79 : tensor<bool>, %80 : tensor<int64>)Tuple<tensor<bool>, tensor<int64>> -> {
                %81 : tensor<int64> = func.call %80 %42 %44 %46 %49 @"turnLeft";
                %82 : tensor<int64> = func.call %66 %81 %42 %43 %44 %45 %46 %47 %48 @"step";
                %83 : tensor<bool> = func.call %82 %50 %51 %52 @"isWallAt";
                %84 : Tuple<tensor<bool>, tensor<int64>> = tuple %83 %81;
                return %84 @loc="120:17";
            };
            %85 : tensor<bool> = Equal %66 %53;
            %86 : tensor<bool> = ReduceMin %85;
            %87 : tensor<bool> = Not %86;
            %88 : tensor<uint8> = tuple.load %63 @"2";
            %89 : tensor<uint8> = Cast %77 @to="2";
            %90 : tensor<uint8> = Concat %88 %89 @axis="0";
            %91 : Tuple<tensor<int64>, tensor<int64>, tensor<uint8>> = tuple %66 %77 %90;
            %92 : Tuple<tensor<bool>, Tuple<tensor<int64>, tensor<int64>, tensor<uint8>>> = tuple %87 %91;
            return %92 @loc="140:13";
        };
        %93 : tensor<uint8> = tuple.load %60 @"2";
        return %93 @loc="148:69";
    };
    unreachable;
};
```

Protobuf model fragment of the sample Onnx model:

![WalkTheMaze](https://github.com/user-attachments/assets/e953e0d4-ede4-4748-b87e-d5e19d153fb2)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/378/head:pull/378` \
`$ git checkout pull/378`

Update a local copy of the PR: \
`$ git checkout pull/378` \
`$ git pull https://git.openjdk.org/babylon.git pull/378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 378`

View PR using the GUI difftool: \
`$ git pr show -t 378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/378.diff">https://git.openjdk.org/babylon/pull/378.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/378#issuecomment-2793909945)
</details>
