### PR TITLE
Finally found and fixed cuda side CUstream bug

### DIFF
--- a/hat/backends/ffi/cuda/cpp/cuda_backend_kernel.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend_kernel.cpp
@@ -82,11 +82,11 @@ long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
     if (rangemod1024 > 0) {
         rangediv1024++;
     }
-    std::cout << "Running the kernel..." << std::endl;
-    std::cout << "   Requested range   = " << range << std::endl;
-    std::cout << "   Range mod 1024    = " << rangemod1024 << std::endl;
-    std::cout << "   Actual range 1024 = " << (rangediv1024 * 1024) << std::endl;
-    auto status= static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cudaStream));
+   // std::cout << "Running the kernel..." << std::endl;
+   // std::cout << "   Requested range   = " << range << std::endl;
+   // std::cout << "   Range mod 1024    = " << rangemod1024 << std::endl;
+   // std::cout << "   Actual range 1024 = " << (rangediv1024 * 1024) << std::endl;
+    auto status= static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cuStream));
     if (CUDA_SUCCESS != status) {
         std::cerr << "cudaStreamSynchronize() CUDA error = " << status
                   <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
@@ -101,11 +101,11 @@ long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);
     }
-    std::cout <<" function/kernel id= " << function << " stream = " << cudaBackend->cudaQueue.cudaStream<<std::endl;
+   // std::cout <<" function/kernel id= " << function << " stream = " << cudaBackend->cudaQueue.cuStream<<std::endl;
     status= cuLaunchKernel(function,
                                    rangediv1024, 1, 1,
                                    1024, 1, 1,
-                                   0, nullptr /*cudaBackend->cudaQueue.cudaStream */,
+                                   0, cudaBackend->cudaQueue.cuStream ,
                     argslist, nullptr);
     if (CUDA_SUCCESS != status) {
         std::cerr << "cuLaunchKernel() CUDA error = " << status
@@ -114,7 +114,7 @@ long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);
     }
-    status= static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cudaStream));
+    status= static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cuStream));
     if (CUDA_SUCCESS != status) {
         std::cerr << "cudaStreamSynchronize() CUDA error = " << status
                   <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
@@ -122,7 +122,7 @@ long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
         exit(-1);
     }
 
-    std::cout << "Kernel complete..."<<cudaGetErrorString(static_cast<cudaError_t>(status))<<std::endl;
+   // std::cout << "Kernel complete..."<<cudaGetErrorString(static_cast<cudaError_t>(status))<<std::endl;
 
     for (int i = 0; i < argSled.argc(); i++) {
         Arg_s *arg = argSled.arg(i);
@@ -132,7 +132,7 @@ long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
             cudaBuffer->copyFromDevice();
         }
     }
-    status=   static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cudaStream));
+    status=   static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cuStream));
     if (CUDA_SUCCESS != status) {
         std::cerr << "cudaStreamSynchronize() CUDA error = " << status
                   <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
@@ -143,9 +143,9 @@ long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
     for (int i = 0; i < argSled.argc(); i++) {
         Arg_s *arg = argSled.arg(i);
         if (arg->variant == '&') {
-            //auto bufferState = BufferState_s::of(arg)->vendorPtr;
-            //auto cudaBuffer = static_cast<CudaBuffer *>(bufferState);
-            //delete cudaBuffer;
+            auto bufferState = BufferState_s::of(arg)->vendorPtr;
+            auto cudaBuffer = static_cast<CudaBuffer *>(bufferState);
+            delete cudaBuffer;
 
         }
     }

--- a/hat/backends/ffi/cuda/cpp/cuda_backend_module.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend_module.cpp
@@ -36,10 +36,10 @@ CudaBackend::CudaModule::~CudaModule() = default;
 CudaBackend::CudaModule * CudaBackend::CudaModule::of(long moduleHandle){
     return reinterpret_cast<CudaBackend::CudaModule *>(moduleHandle);
 }
-long CudaBackend::CudaModule::getKernel(int len, char *name) {
+Backend::CompilationUnit::Kernel * CudaBackend::CudaModule::getKernel(int len, char *name) {
     CudaKernel* cudaKernel= getCudaKernel(len, name);
-    long kernelHandle =  reinterpret_cast<long>(cudaKernel);
-    return kernelHandle;
+    return dynamic_cast<Backend::CompilationUnit::Kernel *>(cudaKernel);
+
 }
 CudaBackend::CudaModule::CudaKernel *CudaBackend::CudaModule::getCudaKernel(char *name) {
     return getCudaKernel(std::strlen(name), name);

--- a/hat/backends/ffi/cuda/cpp/cuda_backend_queue.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend_queue.cpp
@@ -28,9 +28,11 @@
 #include "cuda_backend.h"
 
 CudaBackend::CudaQueue::CudaQueue(Backend *backend)
-        : Backend::Queue(backend),cudaStream(){
-    auto status =  cudaStreamCreate(&cudaStream);
-    if (::cudaSuccess != status) {
+        : Backend::Queue(backend),cuStream() {
+}
+void CudaBackend::CudaQueue::init(){
+    auto status =  cuStreamCreate(&cuStream,CU_STREAM_DEFAULT);
+    if (CUDA_SUCCESS != status) {
         std::cerr << "cudaStreamCreate() CUDA error = " << status
                   <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
@@ -162,9 +164,9 @@ void CudaBackend::CudaQueue::release(){
 CudaBackend::CudaQueue::~CudaQueue(){
    // clReleaseCommandQueue(command_queue);
    // delete []events;
-   auto status = cudaStreamDestroy(cudaStream);
-    if (::cudaSuccess != status) {
-        std::cerr << "cudaStreamDestroy() CUDA error = " << status
+   auto status = cuStreamDestroy(cuStream);
+    if (CUDA_SUCCESS != status) {
+        std::cerr << "cuStreamDestroy() CUDA error = " << status
                   <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
                   <<" " << __FILE__ << " line " << __LINE__ << std::endl;
         exit(-1);

--- a/hat/backends/ffi/cuda/cpp/squares.cpp
+++ b/hat/backends/ffi/cuda/cpp/squares.cpp
@@ -24,15 +24,23 @@
  */
 
 #include "cuda_backend.h"
+class KernelContext{
+public:
+int x;
+int maxX;
+BufferState_s bufferState;
+};
 struct ArgArray_2 {
     int argc;
     u8_t pad12[12];
     Arg_s argv[2];
 };
 
+
 struct S32Array1024_s {
     int length;
     int array[1024];
+    BufferState_s bufferState;
 };
 int main(int argc, char **argv) {
     CudaBackend cudaBackend(0
@@ -132,13 +140,13 @@ int main(int argc, char **argv) {
                ret;
        }
     )");
-
+int maxX = 1024;
     auto *module =cudaBackend.compile(cudaSource);
      auto  *ndrange = bufferOf<NDRange>("ndrange");
     ndrange->x=0;
-    ndrange->maxX=1024;
+    ndrange->maxX=maxX;
     auto *s32Array1024 = bufferOf<S32Array1024_s>("s32Arrayx1024");
-    s32Array1024->length=1024;
+    s32Array1024->length=maxX;
     for (int i=0; i<s32Array1024->length; i++){
         s32Array1024->array[i]=i;
     }
@@ -151,7 +159,8 @@ int main(int argc, char **argv) {
     std::cout << kernel->name <<std::endl;
     kernel->ndrange( reinterpret_cast<ArgArray_s *>(&args2Array));
     for (int i=0; i<s32Array1024->length; i++){
-        std::cout << i << " array["<<i<<"]="<<s32Array1024->array[i] <<std::endl;
+        int sq = s32Array1024->array[i];
+        std::cout << i << " sq="<<sq <<std::endl;
     }
 }
 

--- a/hat/backends/ffi/cuda/include/cuda_backend.h
+++ b/hat/backends/ffi/cuda/include/cuda_backend.h
@@ -91,8 +91,9 @@ class CudaConfig : public Backend::Config{
     };
 class CudaQueue: public Backend::Queue {
     public:
-        cudaStream_t cudaStream;
+        CUstream cuStream;
         CudaQueue(Backend *backend);
+        void init();
         void showEvents(int width);
         void wait();
         void release();
@@ -148,7 +149,7 @@ class CudaQueue: public Backend::Queue {
         ~CudaModule();
         static CudaModule * of(long moduleHandle);
         static CudaModule * of(Backend::CompilationUnit *compilationUnit);
-        long getKernel(int nameLen, char *name);
+        Kernel *getKernel(int nameLen, char *name);
         CudaKernel *getCudaKernel(char *name);
         CudaKernel *getCudaKernel(int nameLen, char *name);
         bool programOK();
@@ -157,6 +158,7 @@ class CudaQueue: public Backend::Queue {
     };
 
 private:
+    CUresult initStatus;
     CUdevice device;
     CUcontext context;
 
@@ -167,10 +169,10 @@ public:
     CudaModule * compile(CudaSource *cudaSource);
     CudaModule * compile(CudaSource &cudaSource);
     PtxSource *nvcc(CudaSource *cudaSource);
-    long compile(int len, char *source);
-    void computeStart();
-    void computeEnd();
-    bool getBufferFromDeviceIfDirty(void *memorySegment, long memorySegmentLength);
+    Backend::CompilationUnit * compile(int len, char *source) override;
+    void computeStart() override;
+    void computeEnd() override;
+    bool getBufferFromDeviceIfDirty(void *memorySegment, long memorySegmentLength) override;
 
     CudaBackend(int mode);
 

--- a/hat/backends/ffi/shared/cpp/shared.cpp
+++ b/hat/backends/ffi/shared/cpp/shared.cpp
@@ -238,15 +238,15 @@ Backend::Queue::~Queue() {
 }
 Text::Text(size_t len, char *text, bool isCopy)
         : len(len), text(text), isCopy(isCopy) {
-    std::cout << "in Text len="<<len<<" isCopy="<<isCopy << std::endl;
+   // std::cout << "in Text len="<<len<<" isCopy="<<isCopy << std::endl;
 }
 Text::Text(char *text, bool isCopy)
         : len(std::strlen(text)), text(text), isCopy(isCopy) {
-    std::cout << "in Text len="<<len<<" isCopy="<<isCopy << std::endl;
+   // std::cout << "in Text len="<<len<<" isCopy="<<isCopy << std::endl;
 }
 Text::Text(size_t len)
         : len(len), text(len > 0 ? new char[len] : nullptr), isCopy(true) {
-    std::cout << "in Text len="<<len<<" isCopy="<<isCopy << std::endl;
+  //  std::cout << "in Text len="<<len<<" isCopy="<<isCopy << std::endl;
 }
 void Text::write(std::string &filename) const{
     std::ofstream out;


### PR DESCRIPTION
Finally tracked down (and fixed) CUstream CUDA backend bug, which was halgting ability to minimize buffer copies. 

This checkin also includes a pure native raw opencl-squares and cuda-squares example code (no Java at all but using the ffi backend hooks to execute OpenCL/CUDA from native code)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/380/head:pull/380` \
`$ git checkout pull/380`

Update a local copy of the PR: \
`$ git checkout pull/380` \
`$ git pull https://git.openjdk.org/babylon.git pull/380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 380`

View PR using the GUI difftool: \
`$ git pr show -t 380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/380.diff">https://git.openjdk.org/babylon/pull/380.diff</a>

</details>
