### PR TITLE
switch all uses of runtime API cudaXXX for device API cuXXX - to trac…

### DIFF
--- a/hat/backends/ffi/cuda/cpp/cuda_backend_module.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend_module.cpp
@@ -46,13 +46,10 @@ CudaBackend::CudaModule::CudaKernel *CudaBackend::CudaModule::getCudaKernel(char
 }
 CudaBackend::CudaModule::CudaKernel *CudaBackend::CudaModule::getCudaKernel(int nameLen, char *name) {
     CUfunction function;
-    CUresult status= cuModuleGetFunction(&function, module, name);
-    if (CUDA_SUCCESS != status) {
-        std::cerr << "cuModuleGetFunction() CUDA error = " << status
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
-                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
-        exit(-1);
-    }
+    WHERE{.f=__FILE__, .l=__LINE__,
+          .e=cuModuleGetFunction(&function, module, name),
+          .t="cuModuleGetFunction"
+    }.report();
     return new CudaKernel(this,name, function);
 
 }

--- a/hat/backends/ffi/cuda/cpp/cuda_backend_queue.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend_queue.cpp
@@ -32,26 +32,23 @@ CudaBackend::CudaQueue::CudaQueue(Backend *backend)
 }
 void CudaBackend::CudaQueue::init(){
     auto status =  cuStreamCreate(&cuStream,CU_STREAM_DEFAULT);
-    if (CUDA_SUCCESS != status) {
-        std::cerr << "cudaStreamCreate() CUDA error = " << status
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
-                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
-        exit(-1);
-    }
+    WHERE{.f=__FILE__ , .l=__LINE__, .e=status, .t= "cuStreamCreate"}.report();
     }
 
+//void CudaBackend::CudaQueue::sync(const char *file, int line) const {
 
+//}
 
 void CudaBackend::CudaQueue::showEvents(int width) {
 
 }
 void CudaBackend::CudaQueue::wait(){
+    WHERE{.f=__FILE__, .l=__LINE__,
+          .e=cuStreamSynchronize(cuStream),
+          .t= "cuStreamSynchronize"
+    }.report();
     if (eventc > 0){
-      //  cl_int status = clWaitForEvents(eventc, events);
-      //  if (status != CL_SUCCESS) {
-          //  std::cerr << "failed clWaitForEvents" << CudaBackend::errorMsg(status) << std::endl;
-           // exit(1);
-       // }
+
     }
 }
 
@@ -162,13 +159,9 @@ void CudaBackend::CudaQueue::release(){
 }
 
 CudaBackend::CudaQueue::~CudaQueue(){
-   // clReleaseCommandQueue(command_queue);
    // delete []events;
-   auto status = cuStreamDestroy(cuStream);
-    if (CUDA_SUCCESS != status) {
-        std::cerr << "cuStreamDestroy() CUDA error = " << status
-                  <<" " << cudaGetErrorString(static_cast<cudaError_t>(status))
-                  <<" " << __FILE__ << " line " << __LINE__ << std::endl;
-        exit(-1);
-    }
+    WHERE{.f=__FILE__, .l=__LINE__,
+            .e=cuStreamDestroy(cuStream),
+            .t= "cuStreamDestroy"
+    }.report();
 }

--- a/hat/backends/ffi/cuda/include/cuda_backend.h
+++ b/hat/backends/ffi/cuda/include/cuda_backend.h
@@ -64,7 +64,22 @@
 
 //#define checkCudaErrors(err)  __checkCudaErrors (err, __FILE__, __LINE__)
 
-
+struct WHERE{
+    const char* f;
+    int l;
+    cudaError_enum e;
+    const char* t;
+    void report() const{
+        if (e == CUDA_SUCCESS){
+           // std::cout << t << "  OK at " << f << " line " << l << std::endl;
+        }else {
+            const char *buf;
+            cuGetErrorName(e, &buf);
+            std::cerr << t << " CUDA error = " << e << " " << buf <<std::endl<< "      " << f << " line " << l << std::endl;
+            exit(-1);
+        }
+    }
+};
 class PtxSource: public Text  {
 public:
     PtxSource();
@@ -112,8 +127,11 @@ class CudaQueue: public Backend::Queue {
         void markAsEndComputeAndInc();
         void markAsEnterKernelDispatchAndInc();
         void markAsLeaveKernelDispatchAndInc();
+      //  void sync(const char *file, int line) const;
         virtual ~CudaQueue();
-    };
+
+
+};
 
     class CudaBuffer : public Backend::Buffer {
     public:


### PR DESCRIPTION
Switch all uses of CUDA runtime API (cudaXXX) for device API (cuXXX) - to track bug uncovered by heal example which seems to access thread local data (native code) and thus get the incrroect stream/context.   

Bug only shows up in heal example. 

This checkin cleans up API usage and uses a common mechanism to trace cuXX calls

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/381/head:pull/381` \
`$ git checkout pull/381`

Update a local copy of the PR: \
`$ git checkout pull/381` \
`$ git pull https://git.openjdk.org/babylon.git pull/381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 381`

View PR using the GUI difftool: \
`$ git pr show -t 381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/381.diff">https://git.openjdk.org/babylon/pull/381.diff</a>

</details>
