### PR TITLE
removed jextracted opencl dependency on life example

### DIFF
--- a/hat/examples/life/pom.xml
+++ b/hat/examples/life/pom.xml
@@ -44,16 +44,6 @@ questions.
             <artifactId>hat-backend-ffi-opencl</artifactId>
             <version>1.0</version>
         </dependency>
-        <dependency>
-            <groupId>oracle.code</groupId>
-            <artifactId>hat-clwrap</artifactId>
-            <version>1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>oracle.code</groupId>
-            <artifactId>hat-jextracted-opencl</artifactId>
-            <version>1.0</version>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/hat/examples/life/src/main/java/life/Viewer.java
+++ b/hat/examples/life/src/main/java/life/Viewer.java
@@ -96,11 +96,11 @@ public class Viewer extends JFrame {
         public long timeOfLastChange = 0;
         public long timeOfLastUIUpdate;
         public volatile boolean lastUIUpdateCompleted = false;
-        public final boolean useHat;
+
         public volatile boolean deviceOrModeModified = false;
 
-        State(boolean useHat) {
-            this.useHat = useHat;
+        State() {
+
         }
     }
     final Controls controls;
@@ -230,23 +230,7 @@ public class Viewer extends JFrame {
 
             ((JButton) panel.add(new JButton("Exit"))).addActionListener(_ -> System.exit(0));
             this.startButton = (JButton) panel.add(new JButton("Start"));
-             if (!state.useHat) {
-                this.useGPUToggleButton = addToggle(panel, "Java", "GPU");
-                this.minimizeCopiesToggleButton = addToggle(panel, "Always Copy", "Minimize Moves");
-                this.minimizeCopiesToggleButton.setEnabled(state.minimizingCopies);
-                minimizeCopiesToggleButton.addChangeListener(event -> {
-                    this.state.minimizingCopies = minimizeCopiesToggleButton.isSelected();
-                   // System.out.println("Minimizing Copies " + state.minimizingCopies);
-                  //  System.out.println("Use GPU " + state.usingGPU);
-                });
-                useGPUToggleButton.addChangeListener(event -> {
-                    this.state.usingGPU = useGPUToggleButton.isSelected();
-                    this.minimizeCopiesToggleButton.setEnabled(this.state.usingGPU);
-                    this.state.minimizingCopies = minimizeCopiesToggleButton.isSelected();
-                    System.out.println("Minimizing Copies " + state.minimizingCopies);
-                    System.out.println("Use GPU " + state.usingGPU);
-                });
-            }
+
             panel.add(new JLabel("Generation"));
             this.generationSevenSegment = (SevenSegmentDisplay)
                     panel.add(new SevenSegmentDisplay(6,30,panel.getForeground(),panel.getBackground()));

--- a/hat/examples/pom.xml
+++ b/hat/examples/pom.xml
@@ -46,6 +46,7 @@ questions.
         <module>heal</module>
         <module>violajones</module>
         <module>squares</module>
-        <!--<module>life</module>-->
+        <module>life</module>
+        <!-- <module>nbody</module>  sadly we need jextracted cl and gl for this -->
     </modules>
 </project>

--- a/hat/hat/bld.java
+++ b/hat/hat/bld.java
@@ -323,17 +323,14 @@ void main(String[] args) {
                         .maven_style_root(example.dir)
                         .javac(hatJavacOpts, javac ->
                                 javac.class_path(targets.hatJar)
-                                        .when(example.dir.matches("^.*(life|nbody)$") && jextractCapability.available() && openclCapability.available(), _ ->
+                                        .when(example.dir.matches("^.*(nbody)$")
+                                           && jextractCapability.available()
+                                           && openclCapability.available()
+                                            && openglCapability.available(), _ ->
                                                 javac.class_path(targets.wrapJar,
-                                                        targets.clWrapJar,
-                                                        openclCapability.jarFile(buildDir),
-                                                        buildDir.jarFile("hat-backend-ffi-opencl-1.0.jar")
-                                                )
-                                        )
-                                        .when(example.dir.matches("^.*(nbody)$") && jextractCapability.available() && openclCapability.available() && openglCapability.available(), _ ->
-                                                javac.class_path(targets.wrapJar,
-                                                        targets.glWrapJar,
-                                                        openglCapability.jarFile(buildDir)
+                                                        targets.clWrapJar, openclCapability.jarFile(buildDir),
+                                                        buildDir.jarFile("hat-backend-ffi-opencl-1.0.jar"),
+                                                        targets.glWrapJar, openglCapability.jarFile(buildDir)
 
                                                 )
                                         )

--- a/hat/hat/run.java
+++ b/hat/hat/run.java
@@ -87,9 +87,6 @@ void main(String[] argv) {
                   .class_path(jextractedOpenCLJar,jextractedOpenGLJar, wrapJar, clwrapJar, glwrapJar )
                   .start_on_first_thread();
               })
-              .when(jextractedOpenCLJar.exists()  && exampleName.equals("life"), _->{ haveBackend
-                  .class_path(jextractedOpenCLJar, wrapJar, clwrapJar);
-              })
               .main_class(exampleName + ".Main")
               .args(args);
            } else {


### PR DESCRIPTION
Removed the jextracted opencl dependencies on life example. 

We used the game of life example to prove the algorithm for minimizing buffer transfers using jextracted opencl

Now we seem to have a stable version of the algorithm in HAT itself we can now remove the jexctracted opencl dependency. 

This also means we can build and run on cuda and test the algorithm there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/382/head:pull/382` \
`$ git checkout pull/382`

Update a local copy of the PR: \
`$ git checkout pull/382` \
`$ git pull https://git.openjdk.org/babylon.git pull/382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 382`

View PR using the GUI difftool: \
`$ git pr show -t 382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/382.diff">https://git.openjdk.org/babylon/pull/382.diff</a>

</details>
