### PR TITLE
Merged ptx backend functionality into cuda backend

### DIFF
--- a/hat/backends/ffi/cuda/include/cuda_backend.h
+++ b/hat/backends/ffi/cuda/include/cuda_backend.h
@@ -51,7 +51,7 @@
 #include <iostream>
 #include <cuda.h>
 #include <builtin_types.h>
-#include <cuda_runtime_api.h>
+//#include <cuda_runtime_api.h>
 #define CUDA_TYPES
 
 #include "shared.h"
@@ -59,10 +59,6 @@
 #include <fstream>
 
 #include<vector>
-
-//extern void __checkCudaErrors(CUresult err, const char *file, const int line);
-
-//#define checkCudaErrors(err)  __checkCudaErrors (err, __FILE__, __LINE__)
 
 struct WHERE{
     const char* f;
@@ -84,6 +80,7 @@ class PtxSource: public Text  {
 public:
     PtxSource();
     PtxSource(size_t len);
+    PtxSource(size_t len, char *text);
     PtxSource(char *text);
     ~PtxSource() = default;
     static PtxSource *nvcc(const char *cudaSource, size_t len);

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -27,18 +27,31 @@ package hat.backend.ffi;
 
 import hat.ComputeContext;
 import hat.NDRange;
+import hat.buffer.Buffer;
 import hat.callgraph.KernelCallGraph;
+import hat.ifacemapper.BoundSchema;
+import hat.optools.FuncOpWrapper;
+import hat.optools.InvokeOpWrapper;
+import hat.optools.OpWrapper;
+import jdk.incubator.code.CopyContext;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Value;
+import jdk.incubator.code.op.CoreOp;
 
-import java.lang.invoke.MethodHandle;
-
-import static java.lang.foreign.ValueLayout.JAVA_INT;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class CudaBackend extends C99FFIBackend {
-   // final Config config;
-   // final FFILib.LongIntMethodPtr getBackend_MPtr;
-    //public long getBackend(int configBits) {
-      //  return backendBridge.handle = getBackend_MPtr.invoke(configBits);
-   // }
+    final int major = 7;
+    final int minor = 5;
+    final String target = "sm_52";
+    final int addressSize = 64;
+
+    final static HashMap<String, String> mathFns = new HashMap<>();
+    final Set<String> usedMathFns = new HashSet<>();
+
 
     public CudaBackend(String configSpec) {
         this(Config.of(configSpec));
@@ -55,20 +68,21 @@ public class CudaBackend extends C99FFIBackend {
     public void computeContextHandoff(ComputeContext computeContext) {
         //System.out.println("Cuda backend received computeContext");
         injectBufferTracking(computeContext.computeCallGraph.entrypoint, true,true);
-
     }
-
-
-
-
-
-
 
     @Override
     public void dispatchKernel(KernelCallGraph kernelCallGraph, NDRange ndRange, Object... args) {
         // System.out.println("Cuda backend dispatching kernel " + kernelCallGraph.entrypoint.method);
+       /* kernelCallGraph.kernelReachableResolvedStream()
+                .sorted((lhs, rhs) -> rhs.rank - lhs.rank)
+                .forEach(kernelReachableResolvedMethod ->
+                        System.out.println(" call to -> "+kernelReachableResolvedMethod.method.getName())
+                );
+        */
         CompiledKernel compiledKernel = kernelCallGraphCompiledCodeMap.computeIfAbsent(kernelCallGraph, (_) -> {
-            String code = createCode(kernelCallGraph, new CudaHatKernelBuilder(), args, true);
+            String code =config.isPTX()
+                    ? createCode(kernelCallGraph, new PTXHATKernelBuilder(), args, true)
+                    : createCode(kernelCallGraph, new CudaC99HATKernelBuilder(), args, true);
             var compilationUnit = backendBridge.compile(code);
             if (compilationUnit.ok()) {
                 var kernel = compilationUnit.getKernel(kernelCallGraph.entrypoint.method.getName());
@@ -78,5 +92,397 @@ public class CudaBackend extends C99FFIBackend {
             }
         });
         compiledKernel.dispatch(ndRange,args);
+    }
+
+
+    public String createCode(KernelCallGraph kernelCallGraph, PTXHATKernelBuilder builder, Object[] args, boolean show) {
+        StringBuilder out = new StringBuilder();
+        StringBuilder invokedMethods = new StringBuilder();
+        FuncOpWrapper f = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOpWrapper().op());
+        FuncOpWrapper lowered = f.lower();
+        HashMap<String, Object> argsMap = new HashMap<>();
+        for (int i = 0; i < args.length; i++) {
+            argsMap.put(f.paramTable().list().get(i).varOp.varName(), args[i]);
+        }
+
+        // printing out ptx header (device info)
+        builder.ptxHeader(major, minor, target, addressSize);
+        out.append(builder.getTextAndReset());
+
+        for (KernelCallGraph.KernelReachableResolvedMethodCall k : kernelCallGraph.kernelReachableResolvedStream().toList()) {
+            FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,k.funcOpWrapper().op());
+            FuncOpWrapper loweredFunc = calledFunc.lower();
+            loweredFunc = transformPtrs(loweredFunc, argsMap);
+            invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
+        }
+
+        lowered = transformPtrs(lowered, argsMap);
+        for (String s : usedMathFns) {
+            out.append("\n").append(mathFns.get(s)).append("\n");
+        }
+
+        out.append(invokedMethods);
+
+        out.append(createFunction(builder.nl().nl(), lowered, true));
+        if (show){
+            System.out.println("ptx follows\n"+out);
+        }
+
+        return out.toString();
+    }
+
+    public FuncOpWrapper transformPtrs(FuncOpWrapper func, HashMap<String, Object> argsMap) {
+        return FuncOpWrapper.wrap(func.lookup,func.op().transform((block, op) -> {
+            CopyContext cc = block.context();
+            // use first operand of invoke to figure out schema
+            if (op instanceof CoreOp.InvokeOp invokeOp
+                    && OpWrapper.wrap(func.lookup,invokeOp) instanceof InvokeOpWrapper invokeOpWrapper) {
+                if (invokeOpWrapper.isIfaceBufferMethod()
+                        && invokeOp.operands().getFirst() instanceof Op.Result invokeResult
+                        && invokeResult.op().operands().getFirst() instanceof Op.Result varLoadResult
+                        && varLoadResult.op() instanceof CoreOp.VarOp varOp
+                        && argsMap.get(varOp.varName()) instanceof Buffer buffer) {
+                    List<Value> inputOperands = invokeOp.operands();
+                    List<Value> outputOperands = cc.getValues(inputOperands);
+                    Op.Result inputResult = invokeOp.result();
+                    BoundSchema<?> boundSchema = Buffer.getBoundSchema(buffer);
+                    PTXPtrOp ptxOp = new PTXPtrOp(inputResult.type(), invokeOp.invokeDescriptor().name(), outputOperands, boundSchema);
+                    Op.Result outputResult = block.op(ptxOp);
+                    cc.mapValue(inputResult, outputResult);
+                } else if (invokeOpWrapper.op().invokeDescriptor().refType().toString().equals("java.lang.Math")
+                        && mathFns.containsKey(invokeOpWrapper.op().invokeDescriptor().name() + "_" + invokeOpWrapper.resultType().toString())){
+                    usedMathFns.add(invokeOpWrapper.op().invokeDescriptor().name() + "_" + invokeOpWrapper.resultType().toString());
+                    block.apply(op);
+                } else {
+                    block.apply(op);
+                }
+            } else {
+                block.apply(op);
+            }
+            return block;
+        }));
+    }
+
+    public String createFunction(PTXHATKernelBuilder builder, FuncOpWrapper lowered, boolean entry) {
+        FuncOpWrapper ssa = lowered.ssa();
+        String out, body;
+
+        // building fn info (name, params)
+        builder.functionHeader(lowered.functionName(), entry, lowered.op().body().yieldType());
+
+        // printing out params
+        builder.parameters(lowered.paramTable().list());
+
+        // building body of fn
+        builder.functionPrologue();
+
+        out = builder.getTextAndReset();
+        ssa.firstBody().blocks().forEach(block -> builder.blockBody(block, block.ops().stream().map(o->OpWrapper.wrap(lowered.lookup,o))));
+
+        builder.functionEpilogue();
+        body = builder.getTextAndReset();
+
+        builder.ptxRegisterDecl();
+        out += builder.getText() + body;
+        return out;
+    }
+
+    public static void loadMathFns() {
+        mathFns.put("log_float",
+                """
+                .func  (.param .b32 func_retval0) log(
+                    .param .b32 log_param_0
+                )
+                {
+                    .reg .pred %p<4>;
+                    .reg .f32 %f<36>;
+                    .reg .b32 %r<5>;
+                    ld.param.f32 %f5, [log_param_0];
+                    setp.lt.f32 %p1, %f5, 0f00800000;
+                    mul.f32 %f6, %f5, 0f4B000000;
+                    selp.f32 %f1, %f6, %f5, %p1;
+                    selp.f32 %f7, 0fC1B80000, 0f00000000, %p1;
+                    mov.b32 %r1, %f1;
+                    add.s32 %r2, %r1, -1059760811;
+                    and.b32  %r3, %r2, -8388608;
+                    sub.s32 %r4, %r1, %r3;
+                    mov.b32 %f8, %r4;
+                    cvt.rn.f32.s32 %f9, %r3;
+                    mov.f32 %f10, 0f34000000;
+                    fma.rn.f32 %f11, %f9, %f10, %f7;
+                    add.f32 %f12, %f8, 0fBF800000;
+                    mov.f32 %f13, 0f3E1039F6;
+                    mov.f32 %f14, 0fBE055027;
+                    fma.rn.f32 %f15, %f14, %f12, %f13;
+                    mov.f32 %f16, 0fBDF8CDCC;
+                    fma.rn.f32 %f17, %f15, %f12, %f16;
+                    mov.f32 %f18, 0f3E0F2955;
+                    fma.rn.f32 %f19, %f17, %f12, %f18;
+                    mov.f32 %f20, 0fBE2AD8B9;
+                    fma.rn.f32 %f21, %f19, %f12, %f20;
+                    mov.f32 %f22, 0f3E4CED0B;
+                    fma.rn.f32 %f23, %f21, %f12, %f22;
+                    mov.f32 %f24, 0fBE7FFF22;
+                    fma.rn.f32 %f25, %f23, %f12, %f24;
+                    mov.f32 %f26, 0f3EAAAA78;
+                    fma.rn.f32 %f27, %f25, %f12, %f26;
+                    mov.f32 %f28, 0fBF000000;
+                    fma.rn.f32 %f29, %f27, %f12, %f28;
+                    mul.f32 %f30, %f12, %f29;
+                    fma.rn.f32 %f31, %f30, %f12, %f12;
+                    mov.f32 %f32, 0f3F317218;
+                    fma.rn.f32 %f35, %f11, %f32, %f31;
+                    setp.lt.u32 %p2, %r1, 2139095040;
+                    @%p2 bra $L__BB0_2;
+                    mov.f32 %f33, 0f7F800000;
+                    fma.rn.f32 %f35, %f1, %f33, %f33;
+                $L__BB0_2:
+                    setp.eq.f32 %p3, %f1, 0f00000000;
+                    selp.f32 %f34, 0fFF800000, %f35, %p3;
+                    st.param.f32 [func_retval0+0], %f34;
+                    ret;
+                }"""
+        );
+        mathFns.put("log_double",
+                """
+                .func  (.param .b64 func_retval0) log(
+                    .param .b64 log_param_0
+                )
+                {
+                    .reg .pred %p<5>;
+                    .reg .f32 %f<2>;
+                    .reg .b32 %r<28>;
+                    .reg .f64 %fd<59>;
+                    ld.param.f64 %fd56, [log_param_0];
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%temp, %r24}, %fd56;
+                    }
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%r25, %temp}, %fd56;
+                    }
+                    setp.gt.s32 %p1, %r24, 1048575;
+                    mov.u32 %r26, -1023;
+                    @%p1 bra $L__BB0_2;
+                    mul.f64 %fd56, %fd56, 0d4350000000000000;
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%temp, %r24}, %fd56;
+                    }
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%r25, %temp}, %fd56;
+                    }
+                    mov.u32 %r26, -1077;
+                $L__BB0_2:
+                    add.s32 %r13, %r24, -1;
+                    setp.lt.u32 %p2, %r13, 2146435071;
+                    @%p2 bra $L__BB0_4;
+                    bra.uni $L__BB0_3;
+                $L__BB0_4:
+                    shr.u32 %r15, %r24, 20;
+                    add.s32 %r27, %r26, %r15;
+                    and.b32  %r16, %r24, -2146435073;
+                    or.b32  %r17, %r16, 1072693248;
+                    mov.b64 %fd57, {%r25, %r17};
+                    setp.lt.s32 %p4, %r17, 1073127583;
+                    @%p4 bra $L__BB0_6;
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%r18, %temp}, %fd57;
+                    }
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%temp, %r19}, %fd57;
+                    }
+                    add.s32 %r20, %r19, -1048576;
+                    mov.b64 %fd57, {%r18, %r20};
+                    add.s32 %r27, %r27, 1;
+                $L__BB0_6:
+                    add.f64 %fd12, %fd57, 0d3FF0000000000000;
+                    mov.f64 %fd13, 0d3FF0000000000000;
+                    rcp.approx.ftz.f64 %fd14, %fd12;
+                    neg.f64 %fd15, %fd12;
+                    fma.rn.f64 %fd16, %fd15, %fd14, %fd13;
+                    fma.rn.f64 %fd17, %fd16, %fd16, %fd16;
+                    fma.rn.f64 %fd18, %fd17, %fd14, %fd14;
+                    add.f64 %fd19, %fd57, 0dBFF0000000000000;
+                    mul.f64 %fd20, %fd19, %fd18;
+                    fma.rn.f64 %fd21, %fd19, %fd18, %fd20;
+                    mul.f64 %fd22, %fd21, %fd21;
+                    mov.f64 %fd23, 0d3ED0EE258B7A8B04;
+                    mov.f64 %fd24, 0d3EB1380B3AE80F1E;
+                    fma.rn.f64 %fd25, %fd24, %fd22, %fd23;
+                    mov.f64 %fd26, 0d3EF3B2669F02676F;
+                    fma.rn.f64 %fd27, %fd25, %fd22, %fd26;
+                    mov.f64 %fd28, 0d3F1745CBA9AB0956;
+                    fma.rn.f64 %fd29, %fd27, %fd22, %fd28;
+                    mov.f64 %fd30, 0d3F3C71C72D1B5154;
+                    fma.rn.f64 %fd31, %fd29, %fd22, %fd30;
+                    mov.f64 %fd32, 0d3F624924923BE72D;
+                    fma.rn.f64 %fd33, %fd31, %fd22, %fd32;
+                    mov.f64 %fd34, 0d3F8999999999A3C4;
+                    fma.rn.f64 %fd35, %fd33, %fd22, %fd34;
+                    mov.f64 %fd36, 0d3FB5555555555554;
+                    fma.rn.f64 %fd37, %fd35, %fd22, %fd36;
+                    sub.f64 %fd38, %fd19, %fd21;
+                    add.f64 %fd39, %fd38, %fd38;
+                    neg.f64 %fd40, %fd21;
+                    fma.rn.f64 %fd41, %fd40, %fd19, %fd39;
+                    mul.f64 %fd42, %fd18, %fd41;
+                    mul.f64 %fd43, %fd22, %fd37;
+                    fma.rn.f64 %fd44, %fd43, %fd21, %fd42;
+                    xor.b32  %r21, %r27, -2147483648;
+                    mov.u32 %r22, -2147483648;
+                    mov.u32 %r23, 1127219200;
+                    mov.b64 %fd45, {%r21, %r23};
+                    mov.b64 %fd46, {%r22, %r23};
+                    sub.f64 %fd47, %fd45, %fd46;
+                    mov.f64 %fd48, 0d3FE62E42FEFA39EF;
+                    fma.rn.f64 %fd49, %fd47, %fd48, %fd21;
+                    neg.f64 %fd50, %fd47;
+                    fma.rn.f64 %fd51, %fd50, %fd48, %fd49;
+                    sub.f64 %fd52, %fd51, %fd21;
+                    sub.f64 %fd53, %fd44, %fd52;
+                    mov.f64 %fd54, 0d3C7ABC9E3B39803F;
+                    fma.rn.f64 %fd55, %fd47, %fd54, %fd53;
+                    add.f64 %fd58, %fd49, %fd55;
+                    bra.uni $L__BB0_7;
+                $L__BB0_3:
+                    mov.f64 %fd10, 0d7FF0000000000000;
+                    fma.rn.f64 %fd11, %fd56, %fd10, %fd10;
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%temp, %r14}, %fd56;
+                    }
+                    mov.b32 %f1, %r14;
+                    setp.eq.f32 %p3, %f1, 0f00000000;
+                    selp.f64 %fd58, 0dFFF0000000000000, %fd11, %p3;
+                $L__BB0_7:
+                    st.param.f64 [func_retval0+0], %fd58;
+                    ret;
+                }"""
+        );
+        mathFns.put("exp_float",
+                """
+                .func  (.param .b32 func_retval0) exp(
+                    .param .b32 exp_param_0
+                )
+                {
+                    .reg .f32 %f<18>;
+                    .reg .b32 %r<3>;
+                    ld.param.f32 %f1, [exp_param_0];
+                    mov.f32 %f2, 0f3F000000;
+                    mov.f32 %f3, 0f3BBB989D;
+                    fma.rn.f32 %f4, %f1, %f3, %f2;
+                    mov.f32 %f5, 0f3FB8AA3B;
+                    mov.f32 %f6, 0f437C0000;
+                    cvt.sat.f32.f32 %f7, %f4;
+                    mov.f32 %f8, 0f4B400001;
+                    fma.rm.f32 %f9, %f7, %f6, %f8;
+                    add.f32 %f10, %f9, 0fCB40007F;
+                    neg.f32 %f11, %f10;
+                    fma.rn.f32 %f12, %f1, %f5, %f11;
+                    mov.f32 %f13, 0f32A57060;
+                    fma.rn.f32 %f14, %f1, %f13, %f12;
+                    mov.b32 %r1, %f9;
+                    shl.b32 %r2, %r1, 23;
+                    mov.b32 %f15, %r2;
+                    ex2.approx.ftz.f32 %f16, %f14;
+                    mul.f32 %f17, %f16, %f15;
+                    st.param.f32 [func_retval0+0], %f17;
+                    ret;
+                }"""
+        );
+        mathFns.put("exp_double",
+                """
+                .func  (.param .b64 func_retval0) exp(
+                    .param .b64 exp_param_0
+                )
+                {
+                    .reg .pred %p<4>;
+                    .reg .f32 %f<3>;
+                    .reg .b32 %r<16>;
+                    .reg .f64 %fd<41>;
+                    ld.param.f64 %fd5, [exp_param_0];
+                    mov.f64 %fd6, 0d4338000000000000;
+                    mov.f64 %fd7, 0d3FF71547652B82FE;
+                    fma.rn.f64 %fd8, %fd5, %fd7, %fd6;
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%r1, %temp}, %fd8;
+                    }
+                    mov.f64 %fd9, 0dC338000000000000;
+                    add.rn.f64 %fd10, %fd8, %fd9;
+                    mov.f64 %fd11, 0dBFE62E42FEFA39EF;
+                    fma.rn.f64 %fd12, %fd10, %fd11, %fd5;
+                    mov.f64 %fd13, 0dBC7ABC9E3B39803F;
+                    fma.rn.f64 %fd14, %fd10, %fd13, %fd12;
+                    mov.f64 %fd15, 0d3E928AF3FCA213EA;
+                    mov.f64 %fd16, 0d3E5ADE1569CE2BDF;
+                    fma.rn.f64 %fd17, %fd16, %fd14, %fd15;
+                    mov.f64 %fd18, 0d3EC71DEE62401315;
+                    fma.rn.f64 %fd19, %fd17, %fd14, %fd18;
+                    mov.f64 %fd20, 0d3EFA01997C89EB71;
+                    fma.rn.f64 %fd21, %fd19, %fd14, %fd20;
+                    mov.f64 %fd22, 0d3F2A01A014761F65;
+                    fma.rn.f64 %fd23, %fd21, %fd14, %fd22;
+                    mov.f64 %fd24, 0d3F56C16C1852B7AF;
+                    fma.rn.f64 %fd25, %fd23, %fd14, %fd24;
+                    mov.f64 %fd26, 0d3F81111111122322;
+                    fma.rn.f64 %fd27, %fd25, %fd14, %fd26;
+                    mov.f64 %fd28, 0d3FA55555555502A1;
+                    fma.rn.f64 %fd29, %fd27, %fd14, %fd28;
+                    mov.f64 %fd30, 0d3FC5555555555511;
+                    fma.rn.f64 %fd31, %fd29, %fd14, %fd30;
+                    mov.f64 %fd32, 0d3FE000000000000B;
+                    fma.rn.f64 %fd33, %fd31, %fd14, %fd32;
+                    mov.f64 %fd34, 0d3FF0000000000000;
+                    fma.rn.f64 %fd35, %fd33, %fd14, %fd34;
+                    fma.rn.f64 %fd36, %fd35, %fd14, %fd34;
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%r2, %temp}, %fd36;
+                    }
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%temp, %r3}, %fd36;
+                    }
+                    shl.b32 %r4, %r1, 20;
+                    add.s32 %r5, %r3, %r4;
+                    mov.b64 %fd40, {%r2, %r5};
+                    {
+                    .reg .b32 %temp;
+                    mov.b64 {%temp, %r6}, %fd5;
+                    }
+                    mov.b32 %f2, %r6;
+                    abs.f32 %f1, %f2;
+                    setp.lt.f32 %p1, %f1, 0f4086232B;
+                    @%p1 bra $L__BB0_3;
+
+                    setp.lt.f64 %p2, %fd5, 0d0000000000000000;
+                    add.f64 %fd37, %fd5, 0d7FF0000000000000;
+                    selp.f64 %fd40, 0d0000000000000000, %fd37, %p2;
+                    setp.geu.f32 %p3, %f1, 0f40874800;
+                    @%p3 bra $L__BB0_3;
+
+                    shr.u32 %r7, %r1, 31;
+                    add.s32 %r8, %r1, %r7;
+                    shr.s32 %r9, %r8, 1;
+                    shl.b32 %r10, %r9, 20;
+                    add.s32 %r11, %r3, %r10;
+                    mov.b64 %fd38, {%r2, %r11};
+                    sub.s32 %r12, %r1, %r9;
+                    shl.b32 %r13, %r12, 20;
+                    add.s32 %r14, %r13, 1072693248;
+                    mov.u32 %r15, 0;
+                    mov.b64 %fd39, {%r15, %r14};
+                    mul.f64 %fd40, %fd38, %fd39;
+                $L__BB0_3:
+                    st.param.f64 [func_retval0+0], %fd40;
+                    ret;
+                }"""
+        );
     }
 }

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaC99HATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaC99HATKernelBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.backend.ffi;
+
+import hat.backend.codebuilders.C99HATKernelBuilder;
+import hat.optools.OpWrapper;
+
+import jdk.incubator.code.Op;
+import jdk.incubator.code.type.JavaType;
+
+public class CudaC99HATKernelBuilder extends C99HATKernelBuilder<CudaC99HATKernelBuilder> {
+
+    @Override
+    public CudaC99HATKernelBuilder defines() {
+        return this
+                .hashDefine("NDRANGE_CUDA")
+                .hashDefine("__global");
+    }
+
+    @Override
+    public CudaC99HATKernelBuilder pragmas() {
+        return self();
+    }
+
+    public CudaC99HATKernelBuilder globalId() {
+        return identifier("blockIdx").dot().identifier("x")
+                .asterisk()
+                .identifier("blockDim").dot().identifier("x")
+                .plus()
+                .identifier("threadIdx").dot().identifier("x");
+    }
+
+    @Override
+    public CudaC99HATKernelBuilder globalSize() {
+        return identifier("gridDim").dot().identifier("x")
+                .asterisk()
+                .identifier("blockDim").dot().identifier("x");
+    }
+
+
+    @Override
+    public CudaC99HATKernelBuilder kernelDeclaration(String name) {
+        return externC().space().keyword("__global__").space().voidType().space().identifier(name);
+    }
+
+    @Override
+    public CudaC99HATKernelBuilder functionDeclaration(CodeBuilderContext codeBuilderContext, JavaType javaType, String name) {
+        return externC().space().keyword("__device__").space().keyword("inline").space().type(codeBuilderContext,javaType).space().identifier(name);
+    }
+
+    @Override
+    public CudaC99HATKernelBuilder globalPtrPrefix() {
+        return self();
+    }
+
+
+    @Override
+    public CudaC99HATKernelBuilder atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name){
+        return identifier("atomicAdd").paren(_ -> {
+             ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
+             rarrow().identifier(name).comma().literal(1);
+        });
+    }
+}

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
@@ -1,0 +1,942 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.backend.ffi;
+
+import hat.optools.*;
+import hat.text.CodeBuilder;
+import hat.util.StreamCounter;
+import jdk.incubator.code.Block;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.TypeElement;
+import jdk.incubator.code.Value;
+import jdk.incubator.code.op.CoreOp;
+import jdk.incubator.code.type.JavaType;
+
+import java.lang.foreign.MemoryLayout;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
+
+    Map<Value, PTXRegister> varToRegMap;
+    List<String> paramNames;
+    List<Block.Parameter> paramObjects;
+    Map<Field, PTXRegister> fieldToRegMap;
+
+    HashMap<PTXRegister.Type, Integer> ordinalMap;
+
+    PTXRegister returnReg;
+    private int addressSize;
+
+    public enum Field {
+        NTID_X ("ntid.x", false),
+        CTAID_X ("ctaid.x", false),
+        TID_X ("tid.x", false),
+        KC_X ("x", false),
+        KC_ADDR("kc", true),
+        KC_MAXX ("maxX", false);
+
+        private final String name;
+        private final boolean destination;
+
+        Field(String name, boolean destination) {
+            this.name = name;
+            this.destination = destination;
+        }
+        public String toString() {
+            return this.name;
+        }
+        public boolean isDestination() {return this.destination;}
+    }
+
+    public PTXHATKernelBuilder(int addressSize) {
+        varToRegMap = new HashMap<>();
+        paramNames = new ArrayList<>();
+        fieldToRegMap = new HashMap<>();
+        paramObjects = new ArrayList<>();
+        ordinalMap = new HashMap<>();
+        this.addressSize = addressSize;
+    }
+
+    public PTXHATKernelBuilder() {
+        this(32);
+    }
+
+    public void ptxHeader(int major, int minor, String target, int addressSize) {
+        this.addressSize = addressSize;
+        version().space().major(major).dot().minor(minor).nl();
+        target().space().target(target).nl();
+        addressSize().space().size(addressSize);
+    }
+
+    public void functionHeader(String funcName, boolean entry, TypeElement yieldType) {
+        if (entry) {
+            visible().space().entry().space();
+        } else {
+            func().space();
+        }
+        if (!yieldType.toString().equals("void")) {
+            returnReg = new PTXRegister(getOrdinal(getResultType(yieldType)), getResultType(yieldType));
+            returnReg.name("%retReg");
+            oparen().dot().param().space().paramType(yieldType);
+            space().regName(returnReg).cparen().space();
+        }
+        funcName(funcName);
+    }
+
+    public PTXHATKernelBuilder parameters(List<FuncOpWrapper.ParamTable.Info> infoList) {
+        paren(_ -> nl().commaNlSeparated(infoList, (info) -> {
+            ptxIndent().dot().param().space().paramType(info.javaType);
+            space().regName(info.varOp.varName());
+            paramNames.add(info.varOp.varName());
+        }).nl()).nl();
+        return this;
+    }
+
+    public void blockBody(Block block, Stream<OpWrapper<?>> ops) {
+        if (block.index() == 0) {
+            for (Block.Parameter p : block.parameters()) {
+                ptxIndent().ld().dot().param();
+                resultType(p.type(), false).ptxIndent().space();
+                reg(p, getResultType(p.type())).commaSpace().osbrace().regName(paramNames.get(p.index())).csbrace().semicolon().nl();
+                paramObjects.add(p);
+            }
+        }
+        nl();
+        block(block);
+        colon().nl();
+        ops.forEach(op -> {
+            if (op instanceof InvokeOpWrapper invoke && !invoke.isIfaceBufferMethod()) {
+                ptxIndent().convert(op).nl();
+            } else {
+                ptxIndent().convert(op).semicolon().nl();
+            }
+        });
+    }
+
+    public void ptxRegisterDecl() {
+        for (PTXRegister.Type t : ordinalMap.keySet()) {
+            ptxIndent().reg().space();
+            if (t.equals(PTXRegister.Type.U32)) {
+                b32();
+            } else if (t.equals(PTXRegister.Type.U64)) {
+                b64();
+            } else {
+                dot().regType(t);
+            }
+            ptxIndent().regTypePrefix(t).oabrace().intVal(ordinalMap.get(t)).cabrace().semicolon().nl();
+        }
+        nl();
+    }
+
+    public void functionPrologue() {
+        obrace().nl();
+    }
+
+    public void functionEpilogue() {
+        cbrace();
+    }
+
+    public PTXHATKernelBuilder convert(OpWrapper<?> wrappedOp) {
+        switch (wrappedOp) {
+            case FieldLoadOpWrapper op -> fieldLoad(op);
+            case FieldStoreOpWrapper op -> fieldStore(op);
+            case BinaryArithmeticOrLogicOperation op -> binaryOperation(op);
+            case BinaryTestOpWrapper op -> binaryTest(op);
+            case ConvOpWrapper op -> conv(op);
+            case ConstantOpWrapper op -> constant(op);
+            case YieldOpWrapper op -> javaYield(op);
+            case InvokeOpWrapper op -> methodCall(op);
+            case VarDeclarationOpWrapper op -> varDeclaration(op);
+            case VarFuncDeclarationOpWrapper op -> varFuncDeclaration(op);
+            case ReturnOpWrapper op -> ret(op);
+            case JavaBreakOpWrapper op -> javaBreak(op);
+            default -> {
+                switch (wrappedOp.op()){
+                    case CoreOp.BranchOp op -> branch(op);
+                    case CoreOp.ConditionalBranchOp op -> condBranch(op);
+                    case CoreOp.NegOp op -> neg(op);
+                    case PTXPtrOp op -> ptxPtr(op);
+                    default -> throw new IllegalStateException("op translation doesn't exist");
+                }
+            }
+        }
+        return this;
+    }
+
+    public void ptxPtr(PTXPtrOp op) {
+        PTXRegister source;
+        int offset = (int) op.boundSchema.groupLayout().byteOffset(MemoryLayout.PathElement.groupElement(op.fieldName));
+
+        if (op.fieldName.equals("array")) {
+            source = new PTXRegister(incrOrdinal(addressType()), addressType());
+            add().s64().space().regName(source).commaSpace().reg(op.operands().get(0)).commaSpace().reg(op.operands().get(1)).ptxNl();
+        } else {
+            source = getReg(op.operands().getFirst());
+        }
+
+        if (op.resultType.toString().equals("void")) {
+            st().global().dot().regType(op.operands().getLast()).space().address(source.name(), offset).commaSpace().reg(op.operands().getLast());
+        } else {
+            ld().global().resultType(op.resultType(), true).space().reg(op.result(), getResultType(op.resultType())).commaSpace().address(source.name(), offset);
+        }
+    }
+
+    public void fieldLoad(FieldLoadOpWrapper op) {
+        if (op.fieldName().equals(Field.KC_X.toString())) {
+            if (!fieldToRegMap.containsKey(Field.KC_X)) {
+                loadKcX(op.result());
+            } else {
+                mov().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().fieldReg(Field.KC_X);
+            }
+        } else if (op.fieldName().equals(Field.KC_MAXX.toString())) {
+            if (!fieldToRegMap.containsKey(Field.KC_X)) {
+                loadKcX(op.operandNAsValue(0));
+            }
+            ld().global().u32().space().fieldReg(Field.KC_MAXX, op.result()).commaSpace()
+                    .address(fieldToRegMap.get(Field.KC_ADDR).name(), 4);
+        } else {
+            ld().global().u32().space().resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.operandNAsValue(0));
+        }
+    }
+
+    public void loadKcX(Value value) {
+        cvta().to().global().size().space().fieldReg(Field.KC_ADDR).commaSpace()
+                .reg(paramObjects.get(paramNames.indexOf(Field.KC_ADDR.toString())), addressType()).ptxNl();
+        mov().u32().space().fieldReg(Field.NTID_X).commaSpace().percent().regName(Field.NTID_X.toString()).ptxNl();
+        mov().u32().space().fieldReg(Field.CTAID_X).commaSpace().percent().regName(Field.CTAID_X.toString()).ptxNl();
+        mov().u32().space().fieldReg(Field.TID_X).commaSpace().percent().regName(Field.TID_X.toString()).ptxNl();
+        mad().lo().s32().space().fieldReg(Field.KC_X, value).commaSpace().fieldReg(Field.CTAID_X)
+                .commaSpace().fieldReg(Field.NTID_X).commaSpace().fieldReg(Field.TID_X).ptxNl();
+        st().global().u32().space().address(fieldToRegMap.get(Field.KC_ADDR).name()).commaSpace().fieldReg(Field.KC_X);
+    }
+
+    public void fieldStore(FieldStoreOpWrapper op) {
+        // TODO: fix
+        st().global().u64().space().resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.operandNAsValue(0));
+    }
+
+    PTXHATKernelBuilder symbol(Op op) {
+        return switch (op) {
+            case CoreOp.ModOp _ -> rem();
+            case CoreOp.MulOp _ -> mul();
+            case CoreOp.DivOp _ -> div();
+            case CoreOp.AddOp _ -> add();
+            case CoreOp.SubOp _ -> sub();
+            case CoreOp.LtOp _ -> lt();
+            case CoreOp.GtOp _ -> gt();
+            case CoreOp.LeOp _ -> le();
+            case CoreOp.GeOp _ -> ge();
+            case CoreOp.NeqOp _ -> ne();
+            case CoreOp.EqOp _ -> eq();
+            case CoreOp.OrOp _ -> or();
+            case CoreOp.AndOp _ -> and();
+            case CoreOp.XorOp _ -> xor();
+            case CoreOp.LshlOp _ -> shl();
+            case CoreOp.AshrOp _, CoreOp.LshrOp _ -> shr();
+            default -> throw new IllegalStateException("Unexpected value");
+        };
+    }
+
+    public void binaryOperation(BinaryArithmeticOrLogicOperation op) {
+        symbol(op.op());
+        if (getResultType(op.resultType()).getBasicType().equals(PTXRegister.Type.BasicType.FLOATING)
+                && (op.op() instanceof CoreOp.DivOp || op.op() instanceof CoreOp.MulOp)) {
+            rn();
+        } else if (!getResultType(op.resultType()).getBasicType().equals(PTXRegister.Type.BasicType.FLOATING)
+                && op.op() instanceof CoreOp.MulOp) {
+            lo();
+        }
+        resultType(op.resultType(), true).space();
+        resultReg(op, getResultType(op.resultType()));
+        commaSpace();
+        reg(op.operandNAsValue(0));
+        commaSpace();
+        reg(op.operandNAsValue(1));
+    }
+
+    public void binaryTest(BinaryTestOpWrapper op) {
+        setp().dot();
+        symbol(op.op()).resultType(op.operandNAsValue(0).type(), true).space();
+        resultReg(op, PTXRegister.Type.PREDICATE);
+        commaSpace();
+        reg(op.operandNAsValue(0));
+        commaSpace();
+        reg(op.operandNAsValue(1));
+    }
+
+    public void conv(ConvOpWrapper op) {
+        if (op.resultJavaType().equals(JavaType.LONG)) {
+            if (isIndex(op)) {
+                mul().wide().s32().space().resultReg(op, PTXRegister.Type.U64).commaSpace()
+                        .reg(op.operandNAsValue(0)).commaSpace().intVal(4);
+            } else {
+                cvt().u64().dot().regType(op.operandNAsValue(0)).space()
+                        .resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.operandNAsValue(0)).ptxNl();
+            }
+        } else if (op.resultJavaType().equals(JavaType.FLOAT)) {
+            cvt().rn().f32().dot().regType(op.operandNAsValue(0)).space()
+                    .resultReg(op, PTXRegister.Type.F32).commaSpace().reg(op.operandNAsValue(0));
+        } else if (op.resultJavaType().equals(JavaType.DOUBLE)) {
+            cvt();
+            if (op.operandNAsValue(0).type().equals(JavaType.INT)) {
+                rn();
+            }
+            f64().dot().regType(op.operandNAsValue(0)).space()
+                    .resultReg(op, PTXRegister.Type.F64).commaSpace().reg(op.operandNAsValue(0));
+        } else if (op.resultJavaType().equals(JavaType.INT)) {
+            cvt();
+            if (op.operandNAsValue(0).type().equals(JavaType.DOUBLE) || op.operandNAsValue(0).type().equals(JavaType.FLOAT)) {
+                rzi();
+            } else {
+                rn();
+            }
+            s32().dot().regType(op.operandNAsValue(0)).space()
+                    .resultReg(op, PTXRegister.Type.S32).commaSpace().reg(op.operandNAsValue(0));
+        } else {
+            cvt().rn().s32().dot().regType(op.operandNAsValue(0)).space()
+                    .resultReg(op, PTXRegister.Type.S32).commaSpace().reg(op.operandNAsValue(0));
+        }
+    }
+
+    private boolean isIndex(ConvOpWrapper op) {
+        for (Op.Result r : op.result().uses()) {
+            if (r.op() instanceof PTXPtrOp) return true;
+        }
+        return false;
+    }
+
+    public void constant(ConstantOpWrapper op) {
+        mov().resultType(op.resultType(), false).space().resultReg(op, getResultType(op.resultType())).commaSpace();
+        if (op.resultType().toString().equals("float")) {
+            if (op.op().value().toString().equals("0.0")) {
+                floatVal("00000000");
+            } else {
+                floatVal(Integer.toHexString(Float.floatToIntBits(Float.parseFloat(op.op().value().toString()))).toUpperCase());
+            }
+        } else {
+            append(op.op().value().toString());
+        }
+    }
+
+    public void javaYield(YieldOpWrapper op) {
+        exit();
+    }
+
+    // S32Array and S32Array2D functions can be deleted after schema is done
+    public void methodCall(InvokeOpWrapper op) {
+        switch (op.methodRef().toString()) {
+            // S32Array functions
+            case "hat.buffer.S32Array::array(long)int" -> {
+                PTXRegister temp = new PTXRegister(incrOrdinal(addressType()), addressType());
+                add().s64().space().regName(temp).commaSpace().reg(op.operandNAsValue(0)).commaSpace().reg(op.operandNAsValue(1)).ptxNl();
+                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(temp.name(), 4);
+            }
+            case "hat.buffer.S32Array::array(long, int)void" -> {
+                PTXRegister temp = new PTXRegister(incrOrdinal(addressType()), addressType());
+                add().s64().space().regName(temp).commaSpace().reg(op.operandNAsValue(0)).commaSpace().reg(op.operandNAsValue(1)).ptxNl();
+                st().global().u32().space().address(temp.name(), 4).commaSpace().reg(op.operandNAsValue(2));
+            }
+            case "hat.buffer.S32Array::length()int" -> {
+                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.operandNAsValue(0)).name());
+            }
+            // S32Array2D functions
+            case "hat.buffer.S32Array2D::array(long, int)void" -> {
+                PTXRegister temp = new PTXRegister(incrOrdinal(addressType()), addressType());
+                add().s64().space().regName(temp).commaSpace().reg(op.operandNAsValue(0)).commaSpace().reg(op.operandNAsValue(1)).ptxNl();
+                st().global().u32().space().address(temp.name(), 8).commaSpace().reg(op.operandNAsValue(2));
+            }
+            case "hat.buffer.S32Array2D::width()int" -> {
+                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.operandNAsValue(0)).name());
+            }
+            case "hat.buffer.S32Array2D::height()int" -> {
+                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.operandNAsValue(0)).name(), 4);
+            }
+            // Java Math function
+            case "java.lang.Math::sqrt(double)double" -> {
+                sqrt().rn().f64().space().resultReg(op, PTXRegister.Type.F64).commaSpace().reg(op.operandNAsValue(0)).semicolon();
+            }
+            default -> {
+                obrace().nl().ptxIndent();
+                for (int i = 0; i < op.operands().size(); i++) {
+                    dot().param().space().paramType(op.operandNAsValue(i).type()).space().param().intVal(i).ptxNl();
+                    st().dot().param().paramType(op.operandNAsValue(i).type()).space().osbrace().param().intVal(i).csbrace().commaSpace().reg(op.operandNAsValue(i)).ptxNl();
+                }
+                dot().param().space().paramType(op.resultType()).space().retVal().ptxNl();
+                call().uni().space().oparen().retVal().cparen().commaSpace().append(op.method().getName()).commaSpace();
+                final int[] counter = {0};
+                paren(_ -> commaSeparated(op.operands(), _ -> param().intVal(counter[0]++))).ptxNl();
+                ld().dot().param().paramType(op.resultType()).space().resultReg(op, getResultType(op.resultType())).commaSpace().osbrace().retVal().csbrace();
+                ptxNl().cbrace();
+            }
+        }
+    }
+
+    public void varDeclaration(VarDeclarationOpWrapper op) {
+        ld().dot().param().resultType(op.resultType(), false).space().resultReg(op, addressType()).commaSpace().reg(op.operandNAsValue(0));
+    }
+
+    public void varFuncDeclaration(VarFuncDeclarationOpWrapper op) {
+        ld().dot().param().resultType(op.resultType(), false).space().resultReg(op, addressType()).commaSpace().reg(op.operandNAsValue(0));
+    }
+
+    public void ret(ReturnOpWrapper op) {
+        if (op.hasOperands()) {
+            st().dot().param();
+            if (returnReg.type().equals(PTXRegister.Type.U32)) {
+                b32();
+            } else if (returnReg.type().equals(PTXRegister.Type.U64)) {
+                b64();
+            } else {
+                dot().regType(returnReg.type());
+            }
+            space().osbrace().regName(returnReg).csbrace().commaSpace().reg(op.operandNAsValue(0)).ptxNl();
+        }
+        ret();
+    }
+
+    public void javaBreak(JavaBreakOpWrapper op) {
+        brkpt();
+    }
+
+    public void branch(CoreOp.BranchOp op) {
+        loadBlockParams(op.successors().getFirst());
+        bra().space().block(op.successors().getFirst().targetBlock());
+    }
+
+    public void condBranch(CoreOp.ConditionalBranchOp op) {
+        loadBlockParams(op.successors().getFirst());
+        loadBlockParams(op.successors().getLast());
+        at().reg(op.operands().getFirst()).space()
+                .bra().space().block(op.successors().getFirst().targetBlock()).ptxNl();
+        bra().space().block(op.successors().getLast().targetBlock());
+    }
+
+    public void neg(CoreOp.NegOp op) {
+        neg().resultType(op.resultType(), true).space().reg(op.result(), getResultType(op.resultType())).commaSpace().reg(op.operands().getFirst());
+    }
+
+    /*
+     * Helper functions for printing blocks and variables
+     */
+
+    public void loadBlockParams(Block.Reference block) {
+        for (int i = 0; i < block.arguments().size(); i++) {
+            Block.Parameter p = block.targetBlock().parameters().get(i);
+            mov().resultType(p.type(), false).space().reg(p, getResultType(p.type()))
+                    .commaSpace().reg(block.arguments().get(i)).ptxNl();
+        }
+    }
+
+    public PTXHATKernelBuilder block(Block block) {
+        return append("block_").intVal(block.index());
+    }
+
+    public PTXHATKernelBuilder fieldReg(Field ref) {
+        if (fieldToRegMap.containsKey(ref)) {
+            return regName(fieldToRegMap.get(ref));
+        }
+        if (ref.isDestination()) {
+            fieldToRegMap.putIfAbsent(ref, new PTXRegister(incrOrdinal(addressType()), addressType()));
+        } else {
+            fieldToRegMap.putIfAbsent(ref, new PTXRegister(incrOrdinal(PTXRegister.Type.U32), PTXRegister.Type.U32));
+        }
+        return regName(fieldToRegMap.get(ref));
+    }
+
+    public PTXHATKernelBuilder fieldReg(Field ref, Value value) {
+        if (fieldToRegMap.containsKey(ref)) {
+            return regName(fieldToRegMap.get(ref));
+        }
+        if (ref.isDestination()) {
+            fieldToRegMap.putIfAbsent(ref, new PTXRegister(getOrdinal(addressType()), addressType()));
+            return reg(value, addressType());
+        } else {
+            fieldToRegMap.putIfAbsent(ref, new PTXRegister(getOrdinal(PTXRegister.Type.U32), PTXRegister.Type.U32));
+            return reg(value, PTXRegister.Type.U32);
+        }
+    }
+
+    public Field getFieldObj(String fieldName) {
+        for (Field f : fieldToRegMap.keySet()) {
+            if (f.toString().equals(fieldName)) return f;
+        }
+        throw new IllegalStateException("no existing field");
+    }
+
+    public PTXHATKernelBuilder resultReg(OpWrapper<?> opWrapper, PTXRegister.Type type) {
+        return append(addReg(opWrapper.result(), type));
+    }
+
+    public PTXHATKernelBuilder reg(Value val, PTXRegister.Type type) {
+        if (varToRegMap.containsKey(val)) {
+            return regName(getReg(val));
+        } else {
+            return append(addReg(val, type));
+        }
+    }
+
+    public PTXHATKernelBuilder reg(Value val) {
+        return regName(getReg(val));
+    }
+
+    public PTXRegister getReg(Value val) {
+        if (varToRegMap.get(val) == null && val instanceof Op.Result result && result.op() instanceof CoreOp.FieldAccessOp.FieldLoadOp fieldLoadOp) {
+            return fieldToRegMap.get(getFieldObj(fieldLoadOp.fieldDescriptor().name()));
+        }
+        if (varToRegMap.containsKey(val)) {
+            return varToRegMap.get(val);
+        } else {
+            throw new IllegalStateException("var to reg mapping doesn't exist");
+        }
+    }
+
+    public String addReg(Value val, PTXRegister.Type type) {
+        if (varToRegMap.containsKey(val)) {
+            return varToRegMap.get(val).name();
+        }
+        varToRegMap.put(val, new PTXRegister(incrOrdinal(type), type));
+        return varToRegMap.get(val).name();
+    }
+
+    public Integer getOrdinal(PTXRegister.Type type) {
+        ordinalMap.putIfAbsent(type, 1);
+        return ordinalMap.get(type);
+    }
+
+    public Integer incrOrdinal(PTXRegister.Type type) {
+        ordinalMap.putIfAbsent(type, 1);
+        int out = ordinalMap.get(type);
+        ordinalMap.put(type, out + 1);
+        return out;
+    }
+
+    public PTXHATKernelBuilder size() {
+        return (addressSize == 32) ? u32() : u64();
+    }
+
+    public PTXRegister.Type addressType() {
+        return (addressSize == 32) ? PTXRegister.Type.U32 : PTXRegister.Type.U64;
+    }
+
+    public PTXHATKernelBuilder resultType(TypeElement type, boolean signedResult) {
+        PTXRegister.Type res = getResultType(type);
+        if (signedResult && (res == PTXRegister.Type.U32)) return s32();
+        return dot().append(getResultType(type).getName());
+    }
+
+    public PTXHATKernelBuilder paramType(TypeElement type) {
+        PTXRegister.Type res = getResultType(type);
+        if (res == PTXRegister.Type.U32) return b32();
+        if (res == PTXRegister.Type.U64) return b64();
+        return dot().append(getResultType(type).getName());
+    }
+
+    public PTXRegister.Type getResultType(TypeElement type) {
+        switch (type.toString()) {
+            case "float" -> {
+                return PTXRegister.Type.F32;
+            }
+            case "double" -> {
+                return PTXRegister.Type.F64;
+            }
+            case "int" -> {
+                return PTXRegister.Type.U32;
+            }
+            case "boolean" -> {
+                return PTXRegister.Type.PREDICATE;
+            }
+            default -> {
+                return PTXRegister.Type.U64;
+            }
+        }
+    }
+
+    /*
+     * Basic CodeBuilder functions
+     */
+
+    // used for parameter list
+    // prints out items separated by a comma then new line
+    public <I> PTXHATKernelBuilder commaNlSeparated(Iterable<I> iterable, Consumer<I> c) {
+        StreamCounter.of(iterable, (counter, t) -> {
+            if (counter.isNotFirst()) {
+                comma().nl();
+            }
+            c.accept(t);
+        });
+        return self();
+    }
+
+    public PTXHATKernelBuilder address(String address) {
+        return osbrace().append(address).csbrace();
+    }
+
+    public PTXHATKernelBuilder address(String address, int offset) {
+        osbrace().append(address);
+        if (offset == 0) {
+            return csbrace();
+        } else if (offset > 0) {
+            plus();
+        }
+        return intVal(offset).csbrace();
+    }
+
+    public PTXHATKernelBuilder ptxNl() {
+        return semicolon().nl().ptxIndent();
+    }
+
+    public PTXHATKernelBuilder commaSpace() {
+        return comma().space();
+    }
+
+    public PTXHATKernelBuilder param() {
+        return append("param");
+    }
+
+    public PTXHATKernelBuilder global() {
+        return dot().append("global");
+    }
+
+    public PTXHATKernelBuilder rn() {
+        return dot().append("rn");
+    }
+
+    public PTXHATKernelBuilder rm() {
+        return dot().append("rm");
+    }
+
+    public PTXHATKernelBuilder rzi() {
+        return dot().append("rzi");
+    }
+
+    public PTXHATKernelBuilder to() {
+        return dot().append("to");
+    }
+
+    public PTXHATKernelBuilder lo() {
+        return dot().append("lo");
+    }
+
+    public PTXHATKernelBuilder wide() {
+        return dot().append("wide");
+    }
+
+    public PTXHATKernelBuilder uni() {
+        return dot().append("uni");
+    }
+
+    public PTXHATKernelBuilder sat() {
+        return dot().append("sat");
+    }
+
+    public PTXHATKernelBuilder ftz() {
+        return dot().append("ftz");
+    }
+
+    public PTXHATKernelBuilder approx() {
+        return dot().append("approx");
+    }
+
+    public PTXHATKernelBuilder mov() {
+        return append("mov");
+    }
+
+    public PTXHATKernelBuilder setp() {
+        return append("setp");
+    }
+
+    public PTXHATKernelBuilder selp() {
+        return append("selp");
+    }
+
+    public PTXHATKernelBuilder ld() {
+        return append("ld");
+    }
+
+    public PTXHATKernelBuilder st() {
+        return append("st");
+    }
+
+    public PTXHATKernelBuilder cvt() {
+        return append("cvt");
+    }
+
+    public PTXHATKernelBuilder bra() {
+        return append("bra");
+    }
+
+    public PTXHATKernelBuilder ret() {
+        return append("ret");
+    }
+
+    public PTXHATKernelBuilder rem() {
+        return append("rem");
+    }
+
+    public PTXHATKernelBuilder mul() {
+        return append("mul");
+    }
+
+    public PTXHATKernelBuilder div() {
+        return append("div");
+    }
+
+    public PTXHATKernelBuilder rcp() {
+        return append("rcp");
+    }
+
+    public PTXHATKernelBuilder add() {
+        return append("add");
+    }
+
+    public PTXHATKernelBuilder sub() {
+        return append("sub");
+    }
+
+    public PTXHATKernelBuilder lt() {
+        return append("lt");
+    }
+
+    public PTXHATKernelBuilder gt() {
+        return append("gt");
+    }
+
+    public PTXHATKernelBuilder le() {
+        return append("le");
+    }
+
+    public PTXHATKernelBuilder ge() {
+        return append("ge");
+    }
+
+    public PTXHATKernelBuilder geu() {
+        return append("geu");
+    }
+
+    public PTXHATKernelBuilder ne() {
+        return append("ne");
+    }
+
+    public PTXHATKernelBuilder eq() {
+        return append("eq");
+    }
+
+    public PTXHATKernelBuilder xor() {
+        return append("xor");
+    }
+
+    public PTXHATKernelBuilder or() {
+        return append("or");
+    }
+
+    public PTXHATKernelBuilder and() {
+        return append("and");
+    }
+
+    public PTXHATKernelBuilder cvta() {
+        return append("cvta");
+    }
+
+    public PTXHATKernelBuilder mad() {
+        return append("mad");
+    }
+
+    public PTXHATKernelBuilder fma() {
+        return append("fma");
+    }
+
+    public PTXHATKernelBuilder sqrt() {
+        return append("sqrt");
+    }
+
+    public PTXHATKernelBuilder abs() {
+        return append("abs");
+    }
+
+    public PTXHATKernelBuilder ex2() {
+        return append("ex2");
+    }
+
+    public PTXHATKernelBuilder shl() {
+        return append("shl");
+    }
+
+    public PTXHATKernelBuilder shr() {
+        return append("shr");
+    }
+
+    public PTXHATKernelBuilder neg() {
+        return append("neg");
+    }
+
+    public PTXHATKernelBuilder call() {
+        return append("call");
+    }
+
+    public PTXHATKernelBuilder exit() {
+        return append("exit");
+    }
+
+    public PTXHATKernelBuilder brkpt() {
+        return append("brkpt");
+    }
+
+    public PTXHATKernelBuilder ptxIndent() {
+        return append("    ");
+    }
+
+    public PTXHATKernelBuilder u32() {
+        return dot().append(PTXRegister.Type.U32.getName());
+    }
+
+    public PTXHATKernelBuilder s32() {
+        return dot().append(PTXRegister.Type.S32.getName());
+    }
+
+    public PTXHATKernelBuilder f32() {
+        return dot().append(PTXRegister.Type.F32.getName());
+    }
+
+    public PTXHATKernelBuilder b32() {
+        return dot().append(PTXRegister.Type.B32.getName());
+    }
+
+    public PTXHATKernelBuilder u64() {
+        return dot().append(PTXRegister.Type.U64.getName());
+    }
+
+    public PTXHATKernelBuilder s64() {
+        return dot().append(PTXRegister.Type.S64.getName());
+    }
+
+    public PTXHATKernelBuilder f64() {
+        return dot().append(PTXRegister.Type.F64.getName());
+    }
+
+    public PTXHATKernelBuilder b64() {
+        return dot().append(PTXRegister.Type.B64.getName());
+    }
+
+    public PTXHATKernelBuilder version() {
+        return dot().append("version");
+    }
+
+    public PTXHATKernelBuilder target() {
+        return dot().append("target");
+    }
+
+    public PTXHATKernelBuilder addressSize() {
+        return dot().append("address_size");
+    }
+
+    public PTXHATKernelBuilder major(int major) {
+        return intVal(major);
+    }
+
+    public PTXHATKernelBuilder minor(int minor) {
+        return intVal(minor);
+    }
+
+    public PTXHATKernelBuilder target(String target) {
+        return append(target);
+    }
+
+    public PTXHATKernelBuilder size(int addressSize) {
+        return intVal(addressSize);
+    }
+
+    public PTXHATKernelBuilder funcName(String funcName) {
+        return append(funcName);
+    }
+
+    public PTXHATKernelBuilder visible() {
+        return dot().append("visible");
+    }
+
+    public PTXHATKernelBuilder entry() {
+        return dot().append("entry");
+    }
+
+    public PTXHATKernelBuilder func() {
+        return dot().append("func");
+    }
+
+    public PTXHATKernelBuilder oabrace() {
+        return append("<");
+    }
+
+    public PTXHATKernelBuilder cabrace() {
+        return append(">");
+    }
+
+    public PTXHATKernelBuilder regName(PTXRegister reg) {
+        return append(reg.name());
+    }
+
+    public PTXHATKernelBuilder regName(String regName) {
+        return append(regName);
+    }
+
+    public PTXHATKernelBuilder regType(Value val) {
+        return append(getReg(val).type().getName());
+    }
+
+    public PTXHATKernelBuilder regType(PTXRegister.Type t) {
+        return append(t.getName());
+    }
+
+    public PTXHATKernelBuilder regTypePrefix(PTXRegister.Type t) {
+        return append(t.getRegPrefix());
+    }
+
+    public PTXHATKernelBuilder reg() {
+        return dot().append("reg");
+    }
+
+    public PTXHATKernelBuilder retVal() {
+        return append("retval");
+    }
+
+    public PTXHATKernelBuilder temp() {
+        return append("temp");
+    }
+
+    public PTXHATKernelBuilder intVal(int i) {
+        return append(String.valueOf(i));
+    }
+
+    public PTXHATKernelBuilder floatVal(String s) {
+        return append("0f").append(s);
+    }
+
+    public PTXHATKernelBuilder doubleVal(String s) {
+        return append("0d").append(s);
+    }
+}

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXPtrOp.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXPtrOp.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.backend.ffi;
+
+import hat.ifacemapper.BoundSchema;
+import jdk.incubator.code.CopyContext;
+import jdk.incubator.code.OpTransformer;
+import jdk.incubator.code.TypeElement;
+import jdk.incubator.code.Value;
+import jdk.incubator.code.op.ExternalizableOp;
+
+import java.util.List;
+
+public class PTXPtrOp extends ExternalizableOp {
+    public String fieldName;
+    public static final String NAME = "ptxPtr";
+    final TypeElement resultType;
+    public BoundSchema<?> boundSchema;
+
+    PTXPtrOp(TypeElement resultType, String fieldName, List<Value> operands, BoundSchema<?> boundSchema) {
+        super(NAME, operands);
+        this.resultType = resultType;
+        this.fieldName = fieldName;
+        this.boundSchema = boundSchema;
+    }
+
+    PTXPtrOp(PTXPtrOp that, CopyContext cc) {
+        super(that, cc);
+        this.resultType = that.resultType;
+        this.fieldName = that.fieldName;
+        this.boundSchema = that.boundSchema;
+    }
+
+    @Override
+    public PTXPtrOp transform(CopyContext cc, OpTransformer ot) {
+        return new PTXPtrOp(this, cc);
+    }
+
+    @Override
+    public TypeElement resultType() {
+        return resultType;
+    }
+}

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXRegister.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXRegister.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.backend.ffi;
+
+public class PTXRegister {
+    private String name;
+    private final Type type;
+
+    public enum Type {
+        S8 (8, BasicType.SIGNED, "s8", "%s"),
+        S16 (16, BasicType.SIGNED, "s16", "%s"),
+        S32 (32, BasicType.SIGNED, "s32", "%s"),
+        S64 (64, BasicType.SIGNED, "s64", "%sd"),
+        U8 (8, BasicType.UNSIGNED, "u8", "%r"),
+        U16 (16, BasicType.UNSIGNED, "u16", "%r"),
+        U32 (32, BasicType.UNSIGNED, "u32", "%r"),
+        U64 (64, BasicType.UNSIGNED, "u64", "%rd"),
+        F16 (16, BasicType.FLOATING, "f16", "%f"),
+        F16X2 (16, BasicType.FLOATING, "f16", "%f"),
+        F32 (32, BasicType.FLOATING, "f32", "%f"),
+        F64 (64, BasicType.FLOATING, "f64", "%fd"),
+        B8 (8, BasicType.BIT, "b8", "%b"),
+        B16 (16, BasicType.BIT, "b16", "%b"),
+        B32 (32, BasicType.BIT, "b32", "%b"),
+        B64 (64, BasicType.BIT, "b64", "%bd"),
+        B128 (128, BasicType.BIT, "b128", "%b"),
+        PREDICATE (1, BasicType.PREDICATE, "pred", "%p");
+
+        public enum BasicType {
+            SIGNED,
+            UNSIGNED,
+            FLOATING,
+            BIT,
+            PREDICATE
+        }
+
+        private final int size;
+        private final BasicType basicType;
+        private final String name;
+        private final String regPrefix;
+
+        Type(int size, BasicType type, String name, String regPrefix) {
+            this.size = size;
+            this.basicType = type;
+            this.name = name;
+            this.regPrefix = regPrefix;
+        }
+
+        public int getSize() {
+            return this.size;
+        }
+
+        public BasicType getBasicType() {
+            return this.basicType;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public String getRegPrefix() {
+            return this.regPrefix;
+        }
+    }
+
+    public PTXRegister(int num, Type type) {
+        this.type = type;
+        this.name = type.regPrefix + num;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public void name(String name) {
+        this.name = name;
+    }
+
+    public Type type() {
+        return this.type;
+    }
+}

--- a/hat/backends/ffi/pom.xml
+++ b/hat/backends/ffi/pom.xml
@@ -41,7 +41,7 @@ questions.
         </dependency>
     </dependencies>
     <modules>
-        <module>ptx</module>
+        <!--<module>ptx</module>-->
         <module>cuda</module>
         <module>mock</module>
         <module>shared</module>

--- a/hat/backends/ffi/ptx/include/ptx_backend.h
+++ b/hat/backends/ffi/ptx/include/ptx_backend.h
@@ -135,5 +135,4 @@ public:
     bool getBufferFromDeviceIfDirty(void *memorySegment, long memorySegmentLength);
 
 };
-extern "C" long getPtxBackend(int mode);
 

--- a/hat/backends/ffi/shared/cpp/shared.cpp
+++ b/hat/backends/ffi/shared/cpp/shared.cpp
@@ -202,6 +202,7 @@ Backend::Config::Config(int configBits):
         profile((configBits&PROFILE_BIT)==PROFILE_BIT),
         showWhy((configBits&SHOW_WHY_BIT)==SHOW_WHY_BIT),
         showState((configBits&SHOW_STATE_BIT)==SHOW_STATE_BIT),
+        ptx((configBits&PTX_BIT)==PTX_BIT),
 
         platform((configBits&0xf)),
         device((configBits&0xf0)>>4){
@@ -218,6 +219,7 @@ Backend::Config::Config(int configBits):
         std::cout << "native profile " << profile<<std::endl;
         std::cout << "native showWhy " << showWhy<<std::endl;
         std::cout << "native showState " << showState<<std::endl;
+        std::cout << "native ptx " << ptx<<std::endl;
         std::cout << "native platform " << platform<<std::endl;
         std::cout << "native device " << device<<std::endl;
     }

--- a/hat/backends/ffi/shared/include/shared.h
+++ b/hat/backends/ffi/shared/include/shared.h
@@ -337,7 +337,8 @@ public:
         const static  int TRACE_CALLS_BIT = 1 <<26;
         const static  int SHOW_WHY_BIT = 1 <<27;
         const static  int SHOW_STATE_BIT = 1 <<28;
-        const static  int END_BIT_IDX = 29;
+        const static  int PTX_BIT = 1 <<29;
+        const static  int END_BIT_IDX = 30;
 
         const static  char *bitNames[]; // See below for out of line definition
         int configBits;
@@ -353,6 +354,7 @@ public:
         bool traceCalls;
         bool showWhy;
         bool showState;
+        bool ptx;
         int platform; //0..15
         int device; //0..15
         Config(int mode);

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/Config.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/Config.java
@@ -50,7 +50,8 @@ public record Config(int bits) {
     private static final int TRACE_CALLS_BIT = 1 << 26;
     private static final int SHOW_WHY_BIT = 1 << 27;
     private static final int SHOW_STATE_BIT = 1 << 28;
-    private static final int END_BIT_IDX = 29;
+    private static final int PTX_BIT = 1 << 29;
+    private static final int END_BIT_IDX = 30;
 
     private static String[] bitNames = {
             "MINIMIZE_COPIES",
@@ -66,6 +67,7 @@ public record Config(int bits) {
             "TRACE_CALLS",
             "SHOW_WHY",
             "SHOW_STATE",
+            "PTX"
     };
 
     public static Config of() {
@@ -139,6 +141,13 @@ public record Config(int bits) {
             System.exit(1);
             return Config.of(0);
         }
+    }
+    public static Config PTX() {
+        return new Config(PTX_BIT);
+    }
+
+    public boolean isPTX() {
+        return (bits & PTX_BIT) == PTX_BIT;
     }
     public static Config SHOW_STATE() {
         return new Config(SHOW_STATE_BIT);

--- a/hat/hat/bld.java
+++ b/hat/hat/bld.java
@@ -256,7 +256,7 @@ void main(String[] args) {
     );
 
     ffiBackends.subDirs()
-            .filter(backend -> backend.failsToMatch("^.*(spirv|hip|shared|target|cmake-build-debug|.idea)$"))
+            .filter(backend -> backend.failsToMatch("^.*(spirv|hip|ptx|shared|target|cmake-build-debug|.idea)$"))
             .forEach(backend -> {
                 var ffiBackendJarFile = buildDir.jarFile("hat-backend-ffi-" + backend.fileName() + "-1.0.jar");
                 backendJars.add(ffiBackendJarFile);


### PR DESCRIPTION
Moved the required PTX generation code into the more general CUDA backend.  

We can select PTX generation either by sending a config string including 'PTX' to the backend (default will be Cuda C99)

We can also add PTX to HAT env var at launch 

```
HAT=INFO,PTX java @hat/run ffi-cuda squares
```
vs
```
HAT=INFO java @hat/run ffi-cude squares
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ Could not determine the source for this merge. A Merge PR title must be specified in the format: `^Merge ([-/.\w:+]+)$` to allow verification of the merge contents.

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/383/head:pull/383` \
`$ git checkout pull/383`

Update a local copy of the PR: \
`$ git checkout pull/383` \
`$ git pull https://git.openjdk.org/babylon.git pull/383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 383`

View PR using the GUI difftool: \
`$ git pr show -t 383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/383.diff">https://git.openjdk.org/babylon/pull/383.diff</a>

</details>
