### PR TITLE
Remove the code model transformation: addVarsWhenNecessary.

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -190,7 +190,8 @@ public class CodeModelToAST {
                 var as = treeMaker.Assign(
                         treeMaker.Indexed(exprTree(array), exprTree(index)), exprTree(val)
                 );
-                yield treeMaker.Exec(as);
+                as.type = typeElementToType(((ArrayType) array.type()).componentType());
+                yield as;
                 // body builder are created but never passed when creating the op, why ?
             }
             default -> throw new IllegalStateException("Op -> JCTree not supported for :" + op.getClass().getName());

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -27,7 +27,7 @@ public class CodeModelToAST {
     private final Map<Value, JCTree> valueToTree = new HashMap<>();
     private final Map<JavaType, Type> jtToType;
     private Symbol.MethodSymbol ms;
-    private int c = 0; // used to name variables we introduce in the AST
+    private int localVarCount = 0; // used to name variables we introduce in the AST
 
     public CodeModelToAST(TreeMaker treeMaker, Names names, Symtab syms,
                           Symbol.ClassSymbol currClassSym, CodeReflectionSymbols crSym) {
@@ -204,7 +204,7 @@ public class CodeModelToAST {
             } else {
                 type = tree.type;
             }
-            var vs = new Symbol.VarSymbol(LocalVarFlags, names.fromString("_$" + c++), type, ms);
+            var vs = new Symbol.VarSymbol(LocalVarFlags, names.fromString("_$" + localVarCount++), type, ms);
             var varDef = treeMaker.VarDef(vs, expr);
             map(op.result(), varDef);
             return varDef;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -185,7 +185,6 @@ public class CodeModelToAST {
                 );
                 as.type = typeElementToType(((ArrayType) array.type()).componentType());
                 yield as;
-                // body builder are created but never passed when creating the op, why ?
             }
             default -> throw new IllegalStateException("Op -> JCTree not supported for :" + op.getClass().getName());
         };
@@ -240,9 +239,6 @@ public class CodeModelToAST {
 
         return treeMaker.MethodDef(ms, mb);
     }
-
-    // TODO see if we can use LET AST node
-    // TODO add vars in OpBuilder (later)
 
     VarSymbol fieldDescriptorToSymbol(FieldRef fieldRef) {
         Name name = names.fromString(fieldRef.name());

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -212,7 +212,6 @@ public class CodeModelToAST {
             map(op.result(), varDef);
             return varDef;
         } else {
-            map(op.result(), tree);
             return tree;
         }
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -127,9 +127,6 @@ public class CodeModelToAST {
             Assert.check(lastParam instanceof ArrayType);
             methodInvocation.varargsElement = typeElementToType(((ArrayType) lastParam).componentType());
         }
-        if (invokeOp.result().uses().isEmpty()) {
-            return treeMaker.Exec(methodInvocation);
-        }
         return methodInvocation;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -14,7 +14,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.sun.tools.javac.code.Flags.*;
 
@@ -28,6 +27,7 @@ public class CodeModelToAST {
     private final Map<Value, JCTree> valueToTree = new HashMap<>();
     private final Map<JavaType, Type> jtToType;
     private Symbol.MethodSymbol ms;
+    private int c = 0; // used to name variables we introduce in the AST
 
     public CodeModelToAST(TreeMaker treeMaker, Names names, Symtab syms,
                           Symbol.ClassSymbol currClassSym, CodeReflectionSymbols crSym) {
@@ -116,10 +116,10 @@ public class CodeModelToAST {
         var type = new Type.MethodType(paramTypes, restype, List.nil(), syms.methodClass);
         var methodSym = new Symbol.MethodSymbol(flags, name, type,
                 typeElementToType(invokeOp.invokeDescriptor().refType()).tsym);
-        var meth = receiver == null ? treeMaker.Ident(methodSym) : treeMaker.Select((JCTree.JCExpression) valueToTree.get(receiver), methodSym);
+        var meth = receiver == null ? treeMaker.Ident(methodSym) : treeMaker.Select(exprTree(receiver), methodSym);
         var args = new ListBuffer<JCTree.JCExpression>();
         for (Value operand : arguments) {
-            args.add((JCTree.JCExpression) valueToTree.get(operand));
+            args.add(exprTree(operand));
         }
         var methodInvocation = treeMaker.App(meth, args.toList());
         if (invokeOp.isVarArgs()) {
@@ -144,7 +144,7 @@ public class CodeModelToAST {
                     var elemType = treeMaker.Ident(typeElementToType(at.componentType()).tsym);
                     var dims = new ListBuffer<JCTree.JCExpression>();
                     for (int d = 0; d < at.dimensions(); d++) {
-                        dims.add(((JCTree.JCExpression) valueToTree.get(newOp.operands().get(d))));
+                        dims.add(exprTree(newOp.operands().get(d)));
                     }
                     var na = treeMaker.NewArray(elemType, dims.toList(), null);
                     na.type = typeElementToType(at);
@@ -154,7 +154,7 @@ public class CodeModelToAST {
                 var clazz = treeMaker.Ident(ownerType.tsym);
                 var args = new ListBuffer<JCTree.JCExpression>();
                 for (Value operand : newOp.operands()) {
-                    args.add((JCTree.JCExpression) valueToTree.get(operand));
+                    args.add(exprTree(operand));
                 }
                 var nc = treeMaker.NewClass(null, null, clazz, args.toList(), null);
                 var argTypes = new ListBuffer<Type>();
@@ -167,18 +167,7 @@ public class CodeModelToAST {
                 yield nc;
             }
             case CoreOp.ReturnOp returnOp ->
-                    treeMaker.Return((JCTree.JCExpression) valueToTree.get(returnOp.returnValue()));
-            case CoreOp.VarOp varOp when varOp.initOperand() instanceof Block.Parameter p -> valueToTree.get(p);
-            case CoreOp.VarOp varOp -> {
-                var name = names.fromString(varOp.varName());
-                var type = typeElementToType(varOp.varValueType());
-                var v = new Symbol.VarSymbol(LocalVarFlags, name, type, ms);
-                yield treeMaker.VarDef(v, (JCTree.JCExpression) valueToTree.get(varOp.initOperand()));
-            }
-            case CoreOp.VarAccessOp.VarLoadOp varLoadOp
-                    when varLoadOp.varOp().initOperand() instanceof Block.Parameter p2 -> valueToTree.get(p2);
-            case CoreOp.VarAccessOp.VarLoadOp varLoadOp ->
-                    treeMaker.Ident((JCTree.JCVariableDecl) valueToTree.get(varLoadOp.varOperand()));
+                    treeMaker.Return(exprTree(returnOp.returnValue()));
             case CoreOp.FieldAccessOp.FieldLoadOp fieldLoadOp -> {
                 // Type.fieldName
                 // if instance field we will use the same thechnique as in invokeOpToTree
@@ -199,16 +188,48 @@ public class CodeModelToAST {
                 var val = arrayStoreOp.operands().get(1);
                 var index = arrayStoreOp.operands().get(2);
                 var as = treeMaker.Assign(
-                        treeMaker.Indexed((JCTree.JCExpression) valueToTree.get(array), (JCTree.JCExpression) valueToTree.get(index)),
-                        (JCTree.JCExpression) valueToTree.get(val)
+                        treeMaker.Indexed(exprTree(array), exprTree(index)), exprTree(val)
                 );
                 yield treeMaker.Exec(as);
                 // body builder are created but never passed when creating the op, why ?
             }
             default -> throw new IllegalStateException("Op -> JCTree not supported for :" + op.getClass().getName());
         };
-        valueToTree.put(op.result(), tree);
-        return tree;
+        if (tree instanceof JCTree.JCExpression expr) {
+            // introduce a local variable to hold the expr, to make sure an op's tree is inserted right away
+            // for some operations this is essential, e.g. to ensure the correct order of operations
+            Type type;
+            if (op instanceof CoreOp.ConstantOp cop && cop.value() == null) {
+                // if ConstantOp value is null, tree.type will be null_type
+                // if null_type is used to create a VarSymbol, an exception will be thrown
+                type = typeElementToType(cop.resultType());
+            } else {
+                type = tree.type;
+            }
+            var vs = new Symbol.VarSymbol(LocalVarFlags, names.fromString("_$" + c++), type, ms);
+            var varDef = treeMaker.VarDef(vs, expr);
+            map(op.result(), varDef);
+            return varDef;
+        } else {
+            map(op.result(), tree);
+            return tree;
+        }
+    }
+
+    private JCTree.JCExpression exprTree(Value v) {
+        JCTree tree = valueToTree.get(v);
+        if (tree instanceof JCTree.JCVariableDecl vd) {
+            return treeMaker.Ident(vd);
+        } else if (tree instanceof JCTree.JCExpressionStatement exprStat) {
+            return exprStat.expr;
+        } else if (tree instanceof JCTree.JCExpression expr) {
+            return expr;
+        }
+        throw new IllegalStateException("Value not mapped to VariableDeclaration nor to an ExpressionStatement");
+    }
+
+    private void map(Value v, JCTree t) {
+        valueToTree.put(v, t);
     }
 
     public JCTree.JCMethodDecl transformFuncOpToAST(CoreOp.FuncOp funcOp, Name methodName) {
@@ -219,11 +240,8 @@ public class CodeModelToAST {
         ms = new Symbol.MethodSymbol(PUBLIC | STATIC | SYNTHETIC, methodName, mt, currClassSym);
         currClassSym.members().enter(ms);
 
-        // TODO add VarOps in OpBuilder
-        funcOp = addVarsWhenNecessary(funcOp);
-        funcOp.writeTo(System.out);
         for (int i = 0; i < funcOp.parameters().size(); i++) {
-            valueToTree.put(funcOp.parameters().get(i), treeMaker.Ident(ms.params().get(i)));
+            map(funcOp.parameters().get(i), treeMaker.Ident(ms.params().get(i)));
         }
 
         var stats = new ListBuffer<JCTree.JCStatement>();
@@ -236,49 +254,6 @@ public class CodeModelToAST {
         var mb = treeMaker.Block(0, stats.toList());
 
         return treeMaker.MethodDef(ms, mb);
-    }
-
-    public static CoreOp.FuncOp addVarsWhenNecessary(CoreOp.FuncOp funcOp) {
-        // using cc only is not possible
-        // because at first opr --> varOpRes
-        // at the first usage we would have to opr --> varLoad
-        // meaning we would have to back up the mapping, update it, then restore it before transforming the next op
-
-        Map<Value, CoreOp.VarOp> valueToVar = new HashMap<>();
-        AtomicInteger varCounter = new AtomicInteger();
-
-        return CoreOp.func(funcOp.funcName(), funcOp.body().bodyType()).body(block -> {
-            var newParams = block.parameters();
-            var oldParams = funcOp.parameters();
-            for (int i = 0; i < newParams.size(); i++) {
-                Op.Result var = block.op(CoreOp.var("_$" + varCounter.getAndIncrement(), newParams.get(i)));
-                valueToVar.put(oldParams.get(i), ((CoreOp.VarOp) var.op()));
-            }
-
-            block.transformBody(funcOp.body(), java.util.List.of(), (Block.Builder b, Op op) -> {
-                var cc = b.context();
-                for (Value operand : op.operands()) {
-                    if (valueToVar.containsKey(operand)) {
-                        var varLoadRes = b.op(CoreOp.varLoad(valueToVar.get(operand).result()));
-                        cc.mapValue(operand, varLoadRes);
-                    }
-                }
-                var opr = b.op(op);
-                var M_BLOCK_BUILDER_OP = MethodRef.method(Block.Builder.class, "op", Op.Result.class, Op.class);
-                var M_BLOCK_BUILDER_PARAM = MethodRef.method(Block.Builder.class, "parameter", Block.Parameter.class, TypeElement.class);
-                // we introduce VarOp to hold an opr that's used multiple times
-                // or to mark that an InvokeOp must be mapped to a Statement
-                // specifically call to Bloc.Builder#op, we want this call to map to a statement so that it get added
-                // to the opMethod body immediately to ensure correct order of operations
-                var isBlockOpInvocation = op instanceof CoreOp.InvokeOp invokeOp && M_BLOCK_BUILDER_OP.equals(invokeOp.invokeDescriptor());
-                var isBlockParamInvocation = op instanceof CoreOp.InvokeOp invokeOp && M_BLOCK_BUILDER_PARAM.equals(invokeOp.invokeDescriptor());
-                if (!(op instanceof CoreOp.VarOp) && (op.result().uses().size() > 1 || isBlockOpInvocation || isBlockParamInvocation)) {
-                    var varOpRes = b.op(CoreOp.var("_$" + varCounter.getAndIncrement(), opr));
-                    valueToVar.put(op.result(), ((CoreOp.VarOp) varOpRes.op()));
-                }
-                return b;
-            });
-        });
     }
 
     // TODO see if we can use LET AST node

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -217,8 +217,6 @@ public class CodeModelToAST {
         JCTree tree = valueToTree.get(v);
         if (tree instanceof JCTree.JCVariableDecl vd) {
             return treeMaker.Ident(vd);
-        } else if (tree instanceof JCTree.JCExpressionStatement exprStat) {
-            return exprStat.expr;
         } else if (tree instanceof JCTree.JCExpression expr) {
             return expr;
         }


### PR DESCRIPTION
We remove the code model transformation: `addVarsWhenNecessary`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/387/head:pull/387` \
`$ git checkout pull/387`

Update a local copy of the PR: \
`$ git checkout pull/387` \
`$ git pull https://git.openjdk.org/babylon.git pull/387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 387`

View PR using the GUI difftool: \
`$ git pr show -t 387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/387.diff">https://git.openjdk.org/babylon/pull/387.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/387#issuecomment-2786943827)
</details>
