### PR TITLE
replaced common ffi-cuda code with ffi-shared

### DIFF
--- a/hat/backends/ffi/cuda/cpp/cuda_backend_kernel.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend_kernel.cpp
@@ -32,7 +32,7 @@ CudaBackend::CudaModule::CudaKernel::CudaKernel(Backend::CompilationUnit *progra
 }
 
 CudaBackend::CudaModule::CudaKernel::~CudaKernel() = default;
-
+/*
 long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
 
     auto cudaBackend = CudaBackend::of(compilationUnit->backend);
@@ -114,11 +114,18 @@ long CudaBackend::CudaModule::CudaKernel::ndrange(void *argArray) {
     }
 
     return (long) 0;
-}
+} */
 
 CudaBackend::CudaModule::CudaKernel * CudaBackend::CudaModule::CudaKernel::of(long kernelHandle){
     return reinterpret_cast<CudaBackend::CudaModule::CudaKernel *>(kernelHandle);
 }
 CudaBackend::CudaModule::CudaKernel * CudaBackend::CudaModule::CudaKernel::of(Backend::CompilationUnit::Kernel *kernel){
     return dynamic_cast<CudaBackend::CudaModule::CudaKernel *>(kernel);
+}
+
+bool CudaBackend::CudaModule::CudaKernel::setArg(KernelArg *arg){
+    argslist[arg->idx] = static_cast<void *>(&arg->value);
+}
+bool CudaBackend::CudaModule::CudaKernel::setArg(KernelArg *arg, Buffer *buffer) {
+    argslist[arg->idx] = static_cast<void *>(&dynamic_cast<CudaBuffer *>(buffer)->devicePtr);
 }


### PR DESCRIPTION
Replaced common code in ffi-cuda backend with common code in ffi-shared.

This finally aligns the codebase for ptx, cuda and opencl. 

Also acts as stable API to refactor HIP and SPIRV backends.

At this time CUDA backend can not minimize buffer copies (JVM crash).  So that will be investigated in the next PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/389/head:pull/389` \
`$ git checkout pull/389`

Update a local copy of the PR: \
`$ git checkout pull/389` \
`$ git pull https://git.openjdk.org/babylon.git pull/389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 389`

View PR using the GUI difftool: \
`$ git pr show -t 389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/389.diff">https://git.openjdk.org/babylon/pull/389.diff</a>

</details>
