### PR TITLE
Add return values to setArg kernel methods

### DIFF
--- a/hat/backends/ffi/cuda/cpp/cuda_backend_kernel.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend_kernel.cpp
@@ -125,7 +125,9 @@ CudaBackend::CudaModule::CudaKernel * CudaBackend::CudaModule::CudaKernel::of(Ba
 
 bool CudaBackend::CudaModule::CudaKernel::setArg(KernelArg *arg){
     argslist[arg->idx] = static_cast<void *>(&arg->value);
+    return true;
 }
 bool CudaBackend::CudaModule::CudaKernel::setArg(KernelArg *arg, Buffer *buffer) {
     argslist[arg->idx] = static_cast<void *>(&dynamic_cast<CudaBuffer *>(buffer)->devicePtr);
+    return true;
 }


### PR DESCRIPTION
Sadly introduced a bug in last PR. 

Added previously ommited return true for CudaKernel::setArgXX methods.  They both now return true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/390/head:pull/390` \
`$ git checkout pull/390`

Update a local copy of the PR: \
`$ git checkout pull/390` \
`$ git pull https://git.openjdk.org/babylon.git pull/390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 390`

View PR using the GUI difftool: \
`$ git pr show -t 390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/390.diff">https://git.openjdk.org/babylon/pull/390.diff</a>

</details>
