### PR TITLE
Enabled MINIMIZE_COPIES for ffi-cuda backend

### DIFF
--- a/hat/backends/ffi/cuda/include/cuda_backend.h
+++ b/hat/backends/ffi/cuda/include/cuda_backend.h
@@ -59,6 +59,7 @@
 #include <fstream>
 
 #include<vector>
+#include <thread>
 
 struct WHERE{
     const char* f;
@@ -98,6 +99,7 @@ class CudaBackend : public Backend {
 public:
 class CudaQueue: public Backend::Queue {
     public:
+         std::thread::id streamCreationThread;
         CUstream cuStream;
         CudaQueue(Backend *backend);
         void init();

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
@@ -32,7 +32,7 @@ import hat.buffer.BufferTracker;
 import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.BufferState;
 
-public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
+public class OpenCLBackend extends C99FFIBackend {
 
    // final Config config;
 
@@ -78,81 +78,4 @@ public class OpenCLBackend extends C99FFIBackend implements BufferTracker {
 
     }
 
-    @Override
-    public void preMutate(Buffer b) {
-        switch (b.getState()) {
-            case BufferState.NO_STATE:
-            case BufferState.NEW_STATE:
-            case BufferState.HOST_OWNED:
-            case BufferState.DEVICE_VALID_HOST_HAS_COPY: {
-                if (config.isSHOW_STATE()) {
-                    System.out.println("in preMutate state = " + b.getStateString() + " no action to take");
-                }
-                break;
-            }
-            case BufferState.DEVICE_OWNED: {
-                backendBridge.getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
-                if (config.isSHOW_STATE()) {
-                    System.out.print("in preMutate state = " + b.getStateString() + " we pulled from device ");
-                }
-                b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
-                if (config.isSHOW_STATE()) {
-                    System.out.println("and switched to " + b.getStateString());
-                }
-                break;
-            }
-            default:
-                throw new IllegalStateException("Not expecting this state ");
-        }
-    }
-
-    @Override
-    public void postMutate(Buffer b) {
-        if (config.isSHOW_STATE()) {
-            System.out.print("in postMutate state = " + b.getStateString() + " no action to take ");
-        }
-        if (b.getState() != BufferState.NEW_STATE) {
-            b.setState(BufferState.HOST_OWNED);
-        }
-        if (config.isSHOW_STATE()) {
-            System.out.println("and switched to (or stayed on) " + b.getStateString());
-        }
-    }
-
-    @Override
-    public void preAccess(Buffer b) {
-        switch (b.getState()) {
-            case BufferState.NO_STATE:
-            case BufferState.NEW_STATE:
-            case BufferState.HOST_OWNED:
-            case BufferState.DEVICE_VALID_HOST_HAS_COPY: {
-                if (config.isSHOW_STATE()) {
-                    System.out.println("in preAccess state = " + b.getStateString() + " no action to take");
-                }
-                break;
-            }
-            case BufferState.DEVICE_OWNED: {
-                backendBridge.getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
-
-                if (config.isSHOW_STATE()) {
-                    System.out.print("in preAccess state = " + b.getStateString() + " we pulled from device ");
-                }
-                b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
-                if (config.isSHOW_STATE()) {
-                    System.out.println("and switched to " + b.getStateString());
-                }
-                break;
-            }
-            default:
-                throw new IllegalStateException("Not expecting this state ");
-        }
-    }
-
-
-    @Override
-    public void postAccess(Buffer b) {
-        if (config.isSHOW_STATE()) {
-            System.out.println("in postAccess state = " + b.getStateString());
-        }
-    }
 }


### PR DESCRIPTION
I enabled minimize copies mode for ffi-cuda.  Some apps seem to benefit (mandel and violajones). 


Healing brush still an issue, it seems the driver backends do not like enqueuing copies (to or from device) on a thread different from the one where thee 'cuStream' was created (heal example is the only one that does this - as it creates backend in main thread but dispatches kernels in the swing thread). 

More investigation is needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/392/head:pull/392` \
`$ git checkout pull/392`

Update a local copy of the PR: \
`$ git checkout pull/392` \
`$ git pull https://git.openjdk.org/babylon.git pull/392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 392`

View PR using the GUI difftool: \
`$ git pr show -t 392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/392.diff">https://git.openjdk.org/babylon/pull/392.diff</a>

</details>
