### PR TITLE
Further cleanup of `CodeModelToAST` and regularize support for varargs instance creation expressions

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -84,9 +84,6 @@ public class CodeModelToAST {
         if (invokeOp.isVarArgs()) {
             setVarargs(methodInvocation, invokeOp.invokeDescriptor().type());
         }
-        if (invokeOp.result().uses().isEmpty()) {
-            return treeMaker.Exec(methodInvocation);
-        }
         return methodInvocation;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1495,7 +1495,7 @@ public class ReflectMethods extends TreeTranslator {
 
             args.addAll(scanMethodArguments(tree.args, tree.constructorType, tree.varargsElement));
 
-            result = append(CoreOp._new(typeToTypeElement(type), constructorType, args));
+            result = append(CoreOp._new(typeToTypeElement(type), tree.varargsElement != null, constructorType, args));
         }
 
         @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/op/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/op/CoreOp.java
@@ -27,6 +27,7 @@ package jdk.incubator.code.op;
 
 import java.lang.constant.ClassDesc;
 import jdk.incubator.code.*;
+import jdk.incubator.code.op.CoreOp.InvokeOp.InvokeKind;
 import jdk.incubator.code.type.FieldRef;
 import jdk.incubator.code.type.MethodRef;
 import jdk.incubator.code.type.*;
@@ -1650,8 +1651,19 @@ public sealed abstract class CoreOp extends ExternalizableOp {
             return new NewOp(def, constructorType, isVarArgs);
         }
 
+        static void validateArgCount(boolean isVarArgs, FunctionType constructorType, List<Value> operands) {
+            int paramCount = constructorType.parameterTypes().size();
+            int argCount = operands.size();
+            if ((!isVarArgs && argCount != paramCount)
+                    || argCount < paramCount - 1) {
+                throw new IllegalArgumentException(isVarArgs + " " + constructorType);
+            }
+        }
+
         NewOp(ExternalizedOp def, FunctionType constructorType, boolean isVarArgs) {
             super(def);
+
+            validateArgCount(isVarArgs, constructorType, def.operands());
 
             this.constructorType = constructorType;
             this.isVarArgs = isVarArgs;
@@ -1673,6 +1685,8 @@ public sealed abstract class CoreOp extends ExternalizableOp {
 
         NewOp(TypeElement resultType, boolean isVarArgs, FunctionType constructorType, List<Value> args) {
             super(NAME, args);
+
+            validateArgCount(isVarArgs, constructorType, args);
 
             this.constructorType = constructorType;
             this.isVarArgs = isVarArgs;

--- a/test/langtools/tools/javac/reflect/BoxingConversionTest.java
+++ b/test/langtools/tools/javac/reflect/BoxingConversionTest.java
@@ -616,7 +616,7 @@ public class BoxingConversionTest {
                 %2 : Var<int> = var %1 @"i";
                 %3 : int = var.load %2;
                 %4 : int = var.load %2;
-                %5 : BoxingConversionTest$Box2 = new %3 %4 @"func<BoxingConversionTest$Box2, int, int, java.lang.Integer[]>";
+                %5 : BoxingConversionTest$Box2 = new %3 %4 @"func<BoxingConversionTest$Box2, int, int, java.lang.Integer[]>" @new.varargs="true";
                 return;
             };
             """)
@@ -632,7 +632,7 @@ public class BoxingConversionTest {
                 %4 : int = var.load %2;
                 %5 : int = var.load %2;
                 %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                %7 : BoxingConversionTest$Box2 = new %3 %4 %6 @"func<BoxingConversionTest$Box2, int, int, java.lang.Integer[]>";
+                %7 : BoxingConversionTest$Box2 = new %3 %4 %6 @"func<BoxingConversionTest$Box2, int, int, java.lang.Integer[]>" @new.varargs="true";
                 return;
             };
             """)
@@ -650,7 +650,7 @@ public class BoxingConversionTest {
                 %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
                 %7 : int = var.load %2;
                 %8 : java.lang.Integer = invoke %7 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                %9 : BoxingConversionTest$Box2 = new %3 %4 %6 %8 @"func<BoxingConversionTest$Box2, int, int, java.lang.Integer[]>";
+                %9 : BoxingConversionTest$Box2 = new %3 %4 %6 %8 @"func<BoxingConversionTest$Box2, int, int, java.lang.Integer[]>" @new.varargs="true";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
+++ b/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
@@ -529,7 +529,7 @@ public class ImplicitConversionTest {
                 %2 : Var<int> = var %1 @"i";
                 %3 : int = var.load %2;
                 %4 : int = var.load %2;
-                %5 : ImplicitConversionTest$Box = new %3 %4 @"func<ImplicitConversionTest$Box, int, int, long[]>";
+                %5 : ImplicitConversionTest$Box = new %3 %4 @"func<ImplicitConversionTest$Box, int, int, long[]>" @new.varargs="true";
                 return;
             };
             """)
@@ -545,7 +545,7 @@ public class ImplicitConversionTest {
                %4 : int = var.load %2;
                %5 : int = var.load %2;
                %6 : long = conv %5;
-               %7 : ImplicitConversionTest$Box = new %3 %4 %6 @"func<ImplicitConversionTest$Box, int, int, long[]>";
+               %7 : ImplicitConversionTest$Box = new %3 %4 %6 @"func<ImplicitConversionTest$Box, int, int, long[]>" @new.varargs="true";
                return;
            };
            """)
@@ -563,7 +563,7 @@ public class ImplicitConversionTest {
                 %6 : long = conv %5;
                 %7 : int = var.load %2;
                 %8 : long = conv %7;
-                %9 : ImplicitConversionTest$Box = new %3 %4 %6 %8 @"func<ImplicitConversionTest$Box, int, int, long[]>";
+                %9 : ImplicitConversionTest$Box = new %3 %4 %6 %8 @"func<ImplicitConversionTest$Box, int, int, long[]>" @new.varargs="true";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -234,4 +234,86 @@ public class NewTest {
     void test11(int i) {
         String[][][] s = new String[i][i + 1][i + 2];
     }
+
+    static class V {
+        V(int i, int... values) { }
+    }
+
+
+    @CodeReflection
+    @IR("""
+            func @"test12" (%0 : NewTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                %3 : int = var.load %2;
+                %4 : NewTest$V = new %3 @"func<NewTest$V, int, int[]>" @new.varargs="true";
+                return;
+            };
+            """)
+    void test12(int i) {
+        new V(i);
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test13" (%0 : NewTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                %3 : int = var.load %2;
+                %4 : int = var.load %2;
+                %5 : NewTest$V = new %3 %4 @"func<NewTest$V, int, int[]>" @new.varargs="true";
+                return;
+            };
+            """)
+    void test13(int i) {
+        new V(i, i);
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test14" (%0 : NewTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                %3 : int = var.load %2;
+                %4 : int = var.load %2;
+                %5 : int = var.load %2;
+                %6 : NewTest$V = new %3 %4 %5 @"func<NewTest$V, int, int[]>" @new.varargs="true";
+                return;
+            };
+            """)
+    void test14(int i) {
+        new V(i, i, i);
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test15" (%0 : NewTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                %3 : int = var.load %2;
+                %4 : int[] = constant @null;
+                %5 : NewTest$V = new %3 %4 @"func<NewTest$V, int, int[]>";
+                return;
+            };
+            """)
+    void test15(int i) {
+        new V(i, null);
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"test16" (%0 : NewTest, %1 : int)void -> {
+                %2 : Var<int> = var %1 @"i";
+                %3 : int = var.load %2;
+                %4 : int = constant @"2";
+                %5 : int[] = new %4 @"func<int[], int>";
+                %6 : int = var.load %2;
+                %7 : int = constant @"0";
+                array.store %5 %7 %6;
+                %8 : int = var.load %2;
+                %9 : int = constant @"1";
+                array.store %5 %9 %8;
+                %10 : NewTest$V = new %3 %5 @"func<NewTest$V, int, int[]>";
+                return;
+            };
+            """)
+    void test16(int i) {
+        new V(i, new int[] { i, i});
+    }
 }

--- a/test/langtools/tools/javac/reflect/NullTest.java
+++ b/test/langtools/tools/javac/reflect/NullTest.java
@@ -488,7 +488,7 @@ public class NullTest {
     @IR("""
             func @"test19" (%0 : NullTest)void -> {
                 %1 : java.lang.String = constant @null;
-                %2 : NullTest$Box = new %1 @"func<NullTest$Box, java.lang.String, java.lang.String[]>";
+                %2 : NullTest$Box = new %1 @"func<NullTest$Box, java.lang.String, java.lang.String[]>" @new.varargs="true";
                 return;
             };
             """)
@@ -515,7 +515,7 @@ public class NullTest {
                 %1 : java.lang.String = constant @null;
                 %2 : java.lang.String = constant @null;
                 %3 : java.lang.String = constant @null;
-                %4 : NullTest$Box = new %1 %2 %3 @"func<NullTest$Box, java.lang.String, java.lang.String[]>";
+                %4 : NullTest$Box = new %1 %2 %3 @"func<NullTest$Box, java.lang.String, java.lang.String[]>" @new.varargs="true";
                 return;
             };
             """)


### PR DESCRIPTION
This PR makes the code in `CodeModelToAST` that deal with instance creation expression (`NewOp`) a bit closer to the code that deals with method calls (`InvokeOp`). I've added a method, called `constructorTypeToSymbol` which takes the constructor type of a `NewOp` and looks up the constructor symbol with that type.

Then I moved the logic that sets `varargElements` on the created `JCMethodInvocation` nodes into a separate, reusable routine. This is now called also for varargs instance creation expression.

Of course, to do that I had to add support for a new varargs attribute in the `NewOp` class -- which closely follows the one used by `InvokeOp`. This means that in `ReflectMethod` we can now reify in the model as to whether a constructor call was varargs or not.

I've also added some arg count validation in `NewOp`, very similar to the one that appears in `InvokeOp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/393/head:pull/393` \
`$ git checkout pull/393`

Update a local copy of the PR: \
`$ git checkout pull/393` \
`$ git pull https://git.openjdk.org/babylon.git pull/393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 393`

View PR using the GUI difftool: \
`$ git pr show -t 393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/393.diff">https://git.openjdk.org/babylon/pull/393.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/393#issuecomment-2796753846)
</details>
