### PR TITLE
Removal of OnnxType.Initializer type

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/OnnxRuntime.java
@@ -19,6 +19,7 @@ import jdk.incubator.code.*;
 
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.type.ClassType;
+import jdk.incubator.code.type.FieldRef;
 import jdk.incubator.code.type.JavaType;
 import oracle.code.onnx.compiler.OnnxTransformer;
 import oracle.code.onnx.foreign.OrtApi;
@@ -76,16 +77,15 @@ public final class OnnxRuntime {
             }
         }
 
-        static List<Tensor> getInitValues(MethodHandles.Lookup lookup, List<OnnxType.Initializer> initializers, SequencedCollection<Object> possibleReceivers) {
+        static List<Tensor> getInitValues(MethodHandles.Lookup lookup, SequencedCollection<FieldRef> initializers, SequencedCollection<Object> possibleReceivers) {
             return initializers.stream().map(i -> {
                 try {
-                    int split = i.name().lastIndexOf('.');
-                    Class<?> initializerClass = lookup.findClass(i.name().substring(0, split));
-                    Field initializerField = initializerClass.getDeclaredField(i.name().substring(split + 1, i.name().length()));
+                    Field initializerField = i.resolveToMember(lookup);
                     VarHandle handle = lookup.unreflectVarHandle(initializerField);
                     if (initializerField.accessFlags().contains(AccessFlag.STATIC)) {
                         return (Tensor)handle.get();
                     } else {
+                        Class<?> initializerClass = initializerField.getDeclaringClass();
                         return (Tensor)handle.get(possibleReceivers.stream().filter(initializerClass::isInstance).findFirst().orElseThrow());
                     }
                 } catch (ReflectiveOperationException ex) {
@@ -96,21 +96,13 @@ public final class OnnxRuntime {
 
         @Override
         protected Session computeValue(Class<?> type) {
-            CoreOp.ModuleOp module = OnnxTransformer.transform(l, q);
-
-            // initializers filtered from the model main function parameters
-            List<OnnxType.Initializer> initializers =
-                    module.functionTable().sequencedValues().getLast()
-                            .parameters().stream()
-                                    .map(Block.Parameter::type)
-                                    .filter(OnnxType.Initializer.class::isInstance)
-                                    .map(OnnxType.Initializer.class::cast).toList();
+            OnnxTransformer.ModuleAndInitializers mi = OnnxTransformer.transform(l, q);
 
             String domainName = type.getSimpleName().split("\\$")[0];
-            byte[] protobufModel = OnnxProtoBuilder.build(domainName, module, getInitValues(l, initializers, q.capturedValues().sequencedValues()));
+            byte[] protobufModel = OnnxProtoBuilder.build(domainName, mi.module(), getInitValues(l, mi.initializers(), q.capturedValues().sequencedValues()));
 
             if (DEBUG) {
-                System.out.println(module.toText());
+                System.out.println(mi.module().toText());
                 try {
                     var export = Path.of(domainName + ".onnx");
                     Files.write(export, protobufModel);

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxType.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxType.java
@@ -86,14 +86,6 @@ public abstract sealed class OnnxType implements TypeElement {
                             (OnnxElementType) constructType(tree.arguments().getFirst()),
                             List.of());
                 }
-                case Initializer.NAME: {
-                    if (tree.arguments().size() != 2) {
-                        throw new IllegalArgumentException();
-                    }
-                    return new Initializer(
-                            constructType(tree.arguments().getFirst()),
-                            tree.arguments().get(1).toString());
-                }
                 case Float16Type.NAME: {
                     if (!tree.arguments().isEmpty()) {
                         throw new IllegalArgumentException();
@@ -471,31 +463,6 @@ public abstract sealed class OnnxType implements TypeElement {
             }
             args.add(eType.externalize());
             return new ExternalizedTypeElement(NAME, args);
-        }
-    }
-
-    public static final class Initializer extends OnnxType {
-        static final String NAME = "init";
-
-        final OnnxType type;
-        final String name;
-
-        public Initializer(OnnxType type, String name) {
-            this.type = type;
-            this.name = name;
-        }
-
-        public OnnxType type() {
-            return type;
-        }
-
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public ExternalizedTypeElement externalize() {
-            return new ExternalizedTypeElement(NAME, List.of(type.externalize(), ExternalizedTypeElement.ofString(name)));
         }
     }
 

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
@@ -322,7 +322,7 @@ public class CNNTest {
     public void testModels() {
         try (var arena = Arena.ofConfined()) {
             CoreOp.FuncOp f = getFuncOp("cnn");
-            CoreOp.ModuleOp onnxModel = OnnxTransformer.transform(MethodHandles.lookup(), f);
+            CoreOp.ModuleOp onnxModel = OnnxTransformer.transform(MethodHandles.lookup(), f).module();
             System.out.println(onnxModel.toText());
 
             var expectedOnnxModel = cnnModel();


### PR DESCRIPTION
This PR removes `OnnxType.Initializer` type and it passes sequence of `FieldRef` of the initializers directly from `OnnxTransformer` to `OnnxRuntime` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/396/head:pull/396` \
`$ git checkout pull/396`

Update a local copy of the PR: \
`$ git checkout pull/396` \
`$ git pull https://git.openjdk.org/babylon.git pull/396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 396`

View PR using the GUI difftool: \
`$ git pr show -t 396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/396.diff">https://git.openjdk.org/babylon/pull/396.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/396#issuecomment-2809031054)
</details>
