### PR TITLE
updated cuda build to use cmake extractions

### DIFF
--- a/hat/backends/ffi/cuda/CMakeLists.txt
+++ b/hat/backends/ffi/cuda/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_CXX_STANDARD 14)
 find_package(CUDAToolkit)
 if(CUDAToolkit_FOUND)
     message("CUDA")
-
     if ("${CUDA_BACKEND}EMPTY" STREQUAL "EMPTY")
 	    set (CUDA_BACKEND "${CMAKE_SOURCE_DIR}")
 	    message("CUDA_BACKEND=${CUDA_BACKEND}")
@@ -54,7 +53,6 @@ if(CUDAToolkit_FOUND)
     )
 
     target_link_libraries(cuda_backend
-            -lcudart
             -lcuda
     )
 
@@ -68,13 +66,11 @@ if(CUDAToolkit_FOUND)
 
     target_link_libraries(cuda_squares
             cuda_backend
-            -lcudart
             -lcuda
     )
 
     target_link_libraries(cuda_info
             cuda_backend
-            -lcudart
             -lcuda
     )
 endif()

--- a/hat/extractions/CMakeLists.txt
+++ b/hat/extractions/CMakeLists.txt
@@ -1,10 +1,17 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(extractions)
 
-set(OSX_SDK ${CMAKE_OSX_SYSROOT})
-set(OSX_SDK_LIBRARY_FRAMEWORKS ${OSX_SDK}/System/Library/Frameworks)
-set(OSX_SYS_LIBRARY_FRAMEWORKS /System/Library/Frameworks)
+if (Apple)
+   set(OSX_SDK ${CMAKE_OSX_SYSROOT})
+   set(OSX_SDK_LIBRARY_FRAMEWORKS ${OSX_SDK}/System/Library/Frameworks)
+   set(OSX_SYS_LIBRARY_FRAMEWORKS /System/Library/Frameworks)
+else()
 
+endif()
+get_cmake_property(_variableNames VARIABLES)
+foreach (_variableName ${_variableNames})
+    message(STATUS "${_variableName}=${${_variableName}}")
+endforeach()
 set(EXTRACTIONS "")
 
 find_package(OpenGL)
@@ -23,8 +30,8 @@ else()
    message("NO OPENCL")
 endif()
 
-find_package(CUDA)
-if(CUDA_FOUND)
+find_package(CUDAToolkit)
+if(CUDATOOLKIT_FOUND)
    add_subdirectory(cuda)
    set(EXTRACTIONS ${EXTRACTIONS} extract_cuda)
 else()
@@ -32,5 +39,3 @@ else()
 endif()
 
 add_custom_target(extract DEPENDS ${EXTRACTIONS})
-
-

--- a/hat/extractions/cuda/CMakeLists.txt
+++ b/hat/extractions/cuda/CMakeLists.txt
@@ -7,17 +7,23 @@ set(JEXTRACT_PACKAGE cuda)
 set(JEXTRACT_SOURCE ${CMAKE_SOURCE_DIR}/${JEXTRACT_PACKAGE}/src/main/java)
 set(JEXTRACT_HEADER ${JEXTRACT_SOURCE}/${JEXTRACT_PACKAGE}/${JEXTRACT_PACKAGE}_h.java)  
 
+if (Apple)
+
+else()
 add_custom_command(OUTPUT  ${JEXTRACT_HEADER}
    COMMAND mkdir -p ${JEXTRACT_SOURCE}
-   #COMMAND echo -F${OSX_SDK_LIBRARY_FRAMEWORKS} > ${CMAKE_BINARY_DIR}/compile_flags.txt
    COMMAND jextract 
        --target-package ${JEXTRACT_PACKAGE} 
        --output ${JEXTRACT_SOURCE} 
-       --library :${OSX_SYS_LIBRARY_FRAMEWORKS}/OpenCL.framework/OpenCL 
+       --library :${CUDA_cuda_driver_LIBRARY}
        --header-class-name ${JEXTRACT_PACKAGE}_h
-       ${OSX_SDK_LIBRARY_FRAMEWORKS}/OpenCL.framework/Headers/opencl.h
+       ${CUDAToolkit_INCLUDE_DIR}/cuda.h
        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
        VERBATIM
    )
+#CUDAToolkit_INCLUDE_DIR=/usr/local/cuda-12.2/include
+#CUDA_cuda_driver_LIBRARY =/usr/lib/aarch64-linux-gnu/libcuda.so
 
-add_custom_target(extract_opencl DEPENDS  ${JEXTRACT_HEADER})
+endif()
+
+add_custom_target(extract_cuda DEPENDS  ${JEXTRACT_HEADER})

--- a/hat/extractions/opengl/CMakeLists.txt
+++ b/hat/extractions/opengl/CMakeLists.txt
@@ -6,7 +6,8 @@ project(extract_opengl)
 set(JEXTRACT_PACKAGE opengl)
 set(JEXTRACT_SOURCE ${CMAKE_SOURCE_DIR}/${JEXTRACT_PACKAGE}/src/main/java)
 set(JEXTRACT_HEADER ${JEXTRACT_SOURCE}/${JEXTRACT_PACKAGE}/${JEXTRACT_PACKAGE}_h.java)  
-    
+
+if (APPLE)
 add_custom_command(OUTPUT  ${JEXTRACT_HEADER}
    COMMAND mkdir -p ${JEXTRACT_SOURCE}
    COMMAND echo -F${OSX_SDK_LIBRARY_FRAMEWORKS} > ${CMAKE_BINARY_DIR}/compile_flags.txt
@@ -20,5 +21,27 @@ add_custom_command(OUTPUT  ${JEXTRACT_HEADER}
    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
    VERBATIM
 )
+else()
+add_custom_command(OUTPUT  ${JEXTRACT_HEADER}
+   COMMAND mkdir -p ${JEXTRACT_SOURCE}
+   COMMAND jextract 
+       --target-package ${JEXTRACT_PACKAGE} 
+       --output ${JEXTRACT_SOURCE} 
+       --library :/usr/lib/aarch64-linux-gnu/libOpenGL.so
+       --library :/usr/lib/aarch64-linux-gnu/libGLU.so
+       --header-class-name ${JEXTRACT_PACKAGE}_h
+       /usr/include/GL/glut.h
+   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+   VERBATIM
+)
+
+# --target-package opengl \
+#    --output /home/gfrost/github/grfrost/babylon-grfrost-fork/hat/stage/jextract \
+#    --library :/usr/lib/aarch64-linux-gnu/libOpenGL.so:/usr/lib/aarch64-linux-gnu/libGLU.so\
+#     /usr/include/GL/glut.h
+
+#    --library :/usr/lib/aarch64-linux-gnu/libOpenGL.so:/usr/lib/aarch64-linux-gnu/libGLX.so:/usr/lib/aarch64-linux-gnu/libGLU.so/libOpenGL.so \ /usr/include/GL/glut.h
+
+endif()
 
 add_custom_target(extract_opengl DEPENDS  ${JEXTRACT_HEADER})

--- a/hat/hat/bld.java
+++ b/hat/hat/bld.java
@@ -137,17 +137,19 @@ void main(String[] args) {
            │        ├── lib*_backend.[dylib|so]        // ffi library backends
            │        └── *(no suffix)                   // various generated executables (opencl_info, cuda_info, cuda_squares)
            ├──stage/
-           │   ├── repo/
-           │   │   └── *                               // Maven artifacts (poms and jars)
-           │   ├── opencl_jextracted/                  // All jextracted files (created using java @hat/extract
-           │   │   ├── compile_flags.txt
-           │   │   └── opencl
-           │   ├── cuda_jextracted/
-           │   │   ├── compile_flags.txt
-           │   │   └── cuda
-           │   └── opengl_jextracted/
-           │       ├── compile_flags.txt
-           │       └── opengl
+           │   └── repo/
+           │       └── *                               // Maven artifacts (poms and jars)
+           ├──extractions/
+           │   ├──CMakeFiles.txt
+           │   ├── opencl/                             // Maven style layout
+           │   │   ├── CMakeFiles.txt
+           │   │   └── src/main/java/opencl            // created by cmake
+           │   ├── cuda/                               // Maven style layout
+           │   │   ├── CMakeFiles.txt
+           │   │   └── src/main/java/cuda              // created by cmake
+           │   └── opengl/                             // Maven style layout
+           │       ├── CMakeFiles.txt
+           │       └── src/main/java/opengl            // created by cmake
            ├──wrap/
            │    └──wrap/
            │         ├──wrap/                          // Maven style layout
@@ -220,15 +222,23 @@ void main(String[] args) {
     );
     var jextractedOpenCLDir = extractionsDir.dir("opencl");
     var extractedOpenCLJar = buildDir.jarFile("hat-jextracted-opencl-1.0.jar");
-    if (jextractedOpenCLDir.exists()) {
+    if (jextractedOpenCLDir.dir("src").exists()) {
         MavenStyleProject.of(jextractedOpenCLDir,extractedOpenCLJar).build();
     }
+
     var extractedOpenGLJar = buildDir.jarFile("hat-jextracted-opengl-1.0.jar");
 
     var jextractedOpenGLDir = extractionsDir.dir("opengl");
-    if (jextractedOpenGLDir.exists()) {
+    if (jextractedOpenGLDir.dir("src").exists()) {
         MavenStyleProject.of(jextractedOpenGLDir,extractedOpenGLJar).build();
     }
+
+    var extractedCudaJar = buildDir.jarFile("hat-jextracted-cuda-1.0.jar");
+    var jextractedCudaDir = extractionsDir.dir("cuda");
+    if (jextractedCudaDir.dir("src").exists()) {
+        MavenStyleProject.of(jextractedCudaDir,extractedCudaJar).build();
+    }
+
     var clWrap = MavenStyleProject.of(wrapsDir.dir("clwrap"), buildDir.jarFile("hat-clwrap-1.0.jar"),
             wrap, hatCore, extractedOpenCLJar
     ).build();
@@ -251,10 +261,9 @@ void main(String[] args) {
         println(glWrap.jarFile.fileName()+" OK");
     }
 
-    var extractedCudaJar = buildDir.jarFile("hat-jextracted-cuda-1.0.jar");
-    var cuWrap = MavenStyleProject.of(wrapsDir.dir("cuwrap"), buildDir.jarFile("hat-cuwrap-1.0.jar"),
-            extractedCudaJar
-    ).build();
+    //var cuWrap = MavenStyleProject.of(wrapsDir.dir("cuwrap"), buildDir.jarFile("hat-cuwrap-1.0.jar"),
+     //       extractedCudaJar
+    //).build();
 
 
     var backendsDir = dir.existingDir("backends");


### PR DESCRIPTION
This is just update from CUDA bld to allow it to use cmake to jextract cuda and opengl. 

Finally builds from `java @hat/bld` are consitant between mac and linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/398/head:pull/398` \
`$ git checkout pull/398`

Update a local copy of the PR: \
`$ git checkout pull/398` \
`$ git pull https://git.openjdk.org/babylon.git pull/398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 398`

View PR using the GUI difftool: \
`$ git pr show -t 398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/398.diff">https://git.openjdk.org/babylon/pull/398.diff</a>

</details>
