### PR TITLE
Automatically detect which event helper to exclude in glwrap

### DIFF
--- a/hat/hat/Script.java
+++ b/hat/hat/Script.java
@@ -30,8 +30,11 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -49,6 +52,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -539,6 +543,20 @@ public class Script {
         @Override
         public List<ClassPathEntry> classPathEntries() {
             return List.of(this);
+        }
+
+        public boolean contains(String entryName) {
+            java.util.jar.JarFile jarFile = null;
+            try {
+             //   println("looking for "+entryName);
+                jarFile = new java.util.jar.JarFile(path.toFile());
+
+                JarEntry entry = jarFile.getJarEntry(entryName);
+              //  println("entry = "+entry);
+                return entry != null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/hat/wrap/pom.xml
+++ b/hat/wrap/pom.xml
@@ -37,12 +37,12 @@ questions.
         <module>wrap</module>
     </modules>
   <profiles>
-        <profile>
+  <!--      <profile>
             <id>cuda</id>
             <modules>
                <module>cuwrap</module>
             </modules>
-        </profile>
+        </profile> -->
         <profile>
             <id>opencl</id>
             <modules>


### PR DESCRIPTION
Merged required cuda bld.java changes

Sadly extracted opengl is subtley different on mac and linux.  We need to exclude specific wrapper classes, depending on files in the jextracteOpenCL.jar. 

 This PR also has logic to detect this so we don't have to remember to comment in/out  'exclusion' patterns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/406/head:pull/406` \
`$ git checkout pull/406`

Update a local copy of the PR: \
`$ git checkout pull/406` \
`$ git pull https://git.openjdk.org/babylon.git pull/406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 406`

View PR using the GUI difftool: \
`$ git pr show -t 406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/406.diff">https://git.openjdk.org/babylon/pull/406.diff</a>

</details>
