### PR TITLE
Reduce number of local variables when transforming code model builder to AST

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -134,7 +134,7 @@ public class CodeModelToAST {
         for (Value root : rootValues) {
             JCTree tree = opToTree(root);
             if (tree instanceof JCExpression e) {
-                var vs = new Symbol.VarSymbol(LocalVarFlags, names.fromString("_$" + localVarCount++), tree.type, ms);
+                var vs = new Symbol.VarSymbol(LocalVarFlags | SYNTHETIC, names.fromString("_$" + localVarCount++), tree.type, ms);
                 tree = treeMaker.VarDef(vs, e);
                 valueToTree.put(root, tree);
             }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -403,7 +403,7 @@ public class ReflectMethods extends TreeTranslator {
 
         public static CodeModelStorageOption parse(String s) {
             if (s == null) {
-                return CodeModelStorageOption.TEXT;
+                return CodeModelStorageOption.CODE_BUILDER;
             }
             return CodeModelStorageOption.valueOf(s);
         }


### PR DESCRIPTION
For CODE_BUILDER option, we transform code model builder to equivalent AST. We were introducing local variables for very expressions, as a result we were closer to the limit on local variables. In this PR, we add local variables where it's needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [f64ebf4f](https://git.openjdk.org/babylon/pull/410/files/f64ebf4fdd632af8eb6cfddf93325543aeb34b48)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/410/head:pull/410` \
`$ git checkout pull/410`

Update a local copy of the PR: \
`$ git checkout pull/410` \
`$ git pull https://git.openjdk.org/babylon.git pull/410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 410`

View PR using the GUI difftool: \
`$ git pr show -t 410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/410.diff">https://git.openjdk.org/babylon/pull/410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/410#issuecomment-2825755849)
</details>
