### PR TITLE
Method code model uniquness

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -230,16 +230,15 @@ public final class Method extends Executable {
 
     /* package */
     Optional<?> setCodeModelIfNeeded(Function<Method, Optional<?>> modelFactory) {
+        if (root != null) {
+            return root.setCodeModelIfNeeded(modelFactory);
+        }
         Optional<?> localRef = codeModel;
         if (localRef == null) {
             synchronized (this) {
                 localRef = codeModel;
                 if (localRef == null) {
-                    if (root != null) {
-                        localRef = root.setCodeModelIfNeeded(modelFactory);
-                    } else {
-                        localRef = modelFactory.apply(this);
-                    }
+                    localRef = modelFactory.apply(this);
                     codeModel = localRef;
                 }
             }

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -230,13 +230,17 @@ public final class Method extends Executable {
 
     /* package */
     Optional<?> setCodeModelIfNeeded(Function<Method, Optional<?>> modelFactory) {
-        Optional<?> localRef = root.codeModel;
+        Optional<?> localRef = codeModel;
         if (localRef == null) {
             synchronized (this) {
-                localRef = root.codeModel;
+                localRef = codeModel;
                 if (localRef == null) {
-                    Optional<?> op = modelFactory.apply(this);
-                    root.codeModel = localRef = op;
+                    if (root != null) {
+                        localRef = root.setCodeModelIfNeeded(modelFactory);
+                    } else {
+                        localRef = modelFactory.apply(this);
+                    }
+                    codeModel = localRef;
                 }
             }
         }

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -230,13 +230,13 @@ public final class Method extends Executable {
 
     /* package */
     Optional<?> setCodeModelIfNeeded(Function<Method, Optional<?>> modelFactory) {
-        Optional<?> localRef = codeModel;
+        Optional<?> localRef = root.codeModel;
         if (localRef == null) {
             synchronized (this) {
-                localRef = codeModel;
+                localRef = root.codeModel;
                 if (localRef == null) {
                     Optional<?> op = modelFactory.apply(this);
-                    codeModel = localRef = op;
+                    root.codeModel = localRef = op;
                 }
             }
         }

--- a/test/langtools/tools/javac/reflect/MethodModelTest.java
+++ b/test/langtools/tools/javac/reflect/MethodModelTest.java
@@ -17,16 +17,27 @@ public class MethodModelTest {
     @CodeReflection
     static void f() {
     }
-
-    @Test
-    void test() throws NoSuchMethodException {
-        Method f = this.getClass().getDeclaredMethod("f");
-        Method f2 = this.getClass().getDeclaredMethod("f");
-        CoreOp.FuncOp funcOp = Op.ofMethod(f).orElseThrow();
-        CoreOp.FuncOp funcOp2 = Op.ofMethod(f2).orElseThrow();
-        Assert.assertSame(funcOp, funcOp2);
+    @CodeReflection
+    static void g() {
     }
 
-    // different Method objects that rep the same java method, have different code models
-    // code model not unique accross multiple Method objects that rep the same thing
+    @Test
+    void testInstancesReflectSameMethodHaveSameModel() throws NoSuchMethodException {
+        Method f = this.getClass().getDeclaredMethod("f");
+        Method f2 = this.getClass().getDeclaredMethod("f");
+        CoreOp.FuncOp fm = Op.ofMethod(f).orElseThrow();
+        CoreOp.FuncOp fm2 = Op.ofMethod(f2).orElseThrow();
+        Assert.assertSame(fm, fm2);
+    }
+
+    @Test
+    void testInstancesReflectDiffMethodsHaveDiffModels() throws NoSuchMethodException {
+        Method f = this.getClass().getDeclaredMethod("f");
+        CoreOp.FuncOp fm = Op.ofMethod(f).orElseThrow();
+
+        Method g = this.getClass().getDeclaredMethod("g");
+        CoreOp.FuncOp gm = Op.ofMethod(g).orElseThrow();
+
+        Assert.assertNotSame(gm, fm);
+    }
 }

--- a/test/langtools/tools/javac/reflect/MethodModelTest.java
+++ b/test/langtools/tools/javac/reflect/MethodModelTest.java
@@ -1,0 +1,32 @@
+import jdk.incubator.code.CodeReflection;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.op.CoreOp;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+/*
+ * @test
+ * @modules jdk.incubator.code
+ * @run testng MethodModelTest
+ */
+
+public class MethodModelTest {
+
+    @CodeReflection
+    static void f() {
+    }
+
+    @Test
+    void test() throws NoSuchMethodException {
+        Method f = this.getClass().getDeclaredMethod("f");
+        Method f2 = this.getClass().getDeclaredMethod("f");
+        CoreOp.FuncOp funcOp = Op.ofMethod(f).orElseThrow();
+        CoreOp.FuncOp funcOp2 = Op.ofMethod(f2).orElseThrow();
+        Assert.assertSame(funcOp, funcOp2);
+    }
+
+    // different Method objects that rep the same java method, have different code models
+    // code model not unique accross multiple Method objects that rep the same thing
+}


### PR DESCRIPTION
Multiple `Method` objects that represent the same java method, have different code models. This is because every time we call `Class.getMethod` or `Class.getDeclaredMethod` we get a newly created instance. One possible solution is to attach the model to the root `Method` object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/415/head:pull/415` \
`$ git checkout pull/415`

Update a local copy of the PR: \
`$ git checkout pull/415` \
`$ git pull https://git.openjdk.org/babylon.git pull/415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 415`

View PR using the GUI difftool: \
`$ git pr show -t 415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/415.diff">https://git.openjdk.org/babylon/pull/415.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/415#issuecomment-2838321200)
</details>
