### PR TITLE
JavaRef extends TypeElement

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/TypeElement.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/TypeElement.java
@@ -97,8 +97,8 @@ public non-sealed interface TypeElement extends CodeItem {
          * @param s the string
          * @return the externalized code type.
          */
-            public static ExternalizedTypeElement ofString(String s) {
-        return jdk.incubator.code.parser.impl.DescParser.parseExTypeElem(s);
+        public static ExternalizedTypeElement ofString(String s) {
+            return jdk.incubator.code.parser.impl.DescParser.parseExTypeElem(s);
         }
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/impl/DescParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/impl/DescParser.java
@@ -101,7 +101,7 @@ public final class DescParser {
 
     public static TypeElement.ExternalizedTypeElement parseExTypeElem(Lexer l) {
         StringBuilder identifier = new StringBuilder();
-        if (l.token().kind == TokenKind.HASH) {
+        if (l.token().kind == TokenKind.HASH || l.token().kind == TokenKind.AMP) {
             // Quoted identifier
             Token t = l.token();
             while (t.kind != TokenKind.LT) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ConstructorRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ConstructorRef.java
@@ -42,11 +42,11 @@ import static jdk.incubator.code.type.FunctionType.functionType;
 public sealed interface ConstructorRef extends JavaRef, TypeVarRef.Owner
         permits ConstructorRefImpl {
 
+    FunctionType type();
+
     default TypeElement refType() {
         return type().returnType();
     }
-
-    FunctionType type();
 
     // Resolutions to constructors and method handles
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaRef.java
@@ -17,7 +17,7 @@ public sealed interface JavaRef extends TypeElement
     //     - Uniform tree traversal and transformation independent of
     //       externalization.
     // @@@ Make RecordTypeRef.ComponentRef implement JavaRef?
-    //     - resolve to accessor method
+    //     - resolve to RecordComponent
     //     - (RecordTypeRef resolves to Type.)
     // @@@ AnnotatedElement is the common top type for resolved Java refs and types
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaRef.java
@@ -1,28 +1,23 @@
 package jdk.incubator.code.type;
 
+import jdk.incubator.code.TypeElement;
+
 /**
- * A symbolic reference to a Java class member or type, commonly containing
- * symbolic names together with {@link JavaType symbolic descriptions} of Java types.
+ * A symbolic reference to a Java class member or a Java type including members,
+ * commonly containing symbolic names together with {@link JavaType symbolic descriptions}
+ * of Java types.
  * <p>
  * A symbolic Java reference can be resolved to a corresponding instance of its
  * reflected representation, much like the symbolic description of a Java type
  * can be resolved to an instance of {@link java.lang.reflect.Type Type}.
  */
-public sealed interface JavaRef
+public sealed interface JavaRef extends TypeElement
     permits MethodRef, ConstructorRef, FieldRef, RecordTypeRef {
-    // @@@ Extend from TypeElement
-    //     - Uniform externalization of Java types and Java refs,
-    //       therefore we don't require specific string representations
-    //       and parser implementations. (Human readability of Java types
-    //       and refs is a separate issue.)
-    //       e.g., the description of a type-variable reference Java type
-    //       (TypeVarRef) contains an owner, a description of Java class
-    //       or a symbolic reference to a Java method or constructor.
     // @@@ Enhance TypeElement to traverse children
     //     - Uniform tree traversal and transformation independent of
     //       externalization.
-    // @@@ Make RecordTypeRef.ComponentRef implement JavaRef
+    // @@@ Make RecordTypeRef.ComponentRef implement JavaRef?
     //     - resolve to accessor method
-    //     - (RecordTypeRef resolves to Class.)
+    //     - (RecordTypeRef resolves to Type.)
     // @@@ AnnotatedElement is the common top type for resolved Java refs and types
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVarRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVarRef.java
@@ -25,6 +25,8 @@
 
 package jdk.incubator.code.type;
 
+import jdk.incubator.code.TypeElement;
+
 import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Constructor;
@@ -100,12 +102,30 @@ public final class TypeVarRef implements JavaType {
 
     @Override
     public ExternalizedTypeElement externalize() {
-        return new ExternalizedTypeElement(String.format("#%s::%s", owner, name),
-                List.of(bound.externalize()));
+        if (true) {
+            ExternalizedTypeElement eOwner = switch (owner) {
+                // @@@ Should be able to use TypeElement
+                case ClassType classType -> classType.externalize();
+                case ConstructorRef constructorRef -> constructorRef.externalize();
+                case MethodRef methodRef -> methodRef.externalize();
+            };
+            return new ExternalizedTypeElement("#" + name,
+                    List.of(eOwner, bound.externalize()));
+
+        } else {
+            String ownerString = switch (owner) {
+                case ClassType classType -> classType.externalize().toString();
+                case ConstructorRef constructorRef -> constructorRef.toString();
+                case MethodRef methodRef -> methodRef.toString();
+            };
+            return new ExternalizedTypeElement(String.format("#%s::%s", ownerString, name),
+                    List.of(bound.externalize()));
+        }
     }
 
     @Override
     public String toString() {
+        // @@@ required to pass TestJavaType.java
         return name;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVarRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVarRef.java
@@ -102,25 +102,13 @@ public final class TypeVarRef implements JavaType {
 
     @Override
     public ExternalizedTypeElement externalize() {
-        if (true) {
-            ExternalizedTypeElement eOwner = switch (owner) {
-                // @@@ Should be able to use TypeElement
-                case ClassType classType -> classType.externalize();
-                case ConstructorRef constructorRef -> constructorRef.externalize();
-                case MethodRef methodRef -> methodRef.externalize();
-            };
-            return new ExternalizedTypeElement("#" + name,
-                    List.of(eOwner, bound.externalize()));
-
-        } else {
-            String ownerString = switch (owner) {
-                case ClassType classType -> classType.externalize().toString();
-                case ConstructorRef constructorRef -> constructorRef.toString();
-                case MethodRef methodRef -> methodRef.toString();
-            };
-            return new ExternalizedTypeElement(String.format("#%s::%s", ownerString, name),
-                    List.of(bound.externalize()));
-        }
+        ExternalizedTypeElement eOwner = switch (owner) {
+            // @@@ Should be able to use single case matching TypeElement
+            case JavaRef ref -> ref.externalize();
+            case ClassType classType -> classType.externalize();
+        };
+        return new ExternalizedTypeElement("#" + name,
+                List.of(eOwner, bound.externalize()));
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
@@ -39,6 +39,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.joining;
 
@@ -46,7 +47,6 @@ public final class ConstructorRefImpl implements ConstructorRef {
     static final String NAME = "&c";
 
     final FunctionType type;
-    final TypeElement refType;
 
     static final MethodHandle MULTI_NEW_ARRAY_MH;
 
@@ -62,17 +62,11 @@ public final class ConstructorRefImpl implements ConstructorRef {
 
     public ConstructorRefImpl(FunctionType functionType) {
         this.type = functionType;
-        this.refType = functionType.returnType();
     }
 
     @Override
     public FunctionType type() {
         return type;
-    }
-
-    @Override
-    public TypeElement refType() {
-        return refType;
     }
 
     @Override
@@ -83,8 +77,8 @@ public final class ConstructorRefImpl implements ConstructorRef {
 
     @Override
     public MethodHandle resolveToHandle(MethodHandles.Lookup l) throws ReflectiveOperationException {
-        Class<?> refC = resolve(l, refType);
-        if (refType instanceof ArrayType at) {
+        Class<?> refC = resolve(l, type.returnType());
+        if (type.returnType() instanceof ArrayType at) {
             if (at.dimensions() == 1) {
                 return MethodHandles.arrayConstructor(refC);
             } else {
@@ -122,26 +116,19 @@ public final class ConstructorRefImpl implements ConstructorRef {
 
     @Override
     public String toString() {
-        return refType.externalize() + "::<new>" +
+        return type.returnType().externalize() + "::<new>" +
             type.parameterTypes().stream().map(t -> t.externalize().toString())
                     .collect(joining(", ", "(", ")"));
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ConstructorRefImpl that = (ConstructorRefImpl) o;
-
-        if (!refType.equals(that.refType)) return false;
-        return type.equals(that.type);
+        if (!(o instanceof ConstructorRefImpl that)) return false;
+        return Objects.equals(type, that.type);
     }
 
     @Override
     public int hashCode() {
-        int result = refType.hashCode();
-        result = 31 * result + type.hashCode();
-        return result;
+        return Objects.hashCode(type);
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
@@ -38,10 +38,13 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
+import java.util.List;
 
 import static java.util.stream.Collectors.joining;
 
 public final class ConstructorRefImpl implements ConstructorRef {
+    static final String NAME = "&c";
+
     final FunctionType type;
     final TypeElement refType;
 
@@ -63,13 +66,13 @@ public final class ConstructorRefImpl implements ConstructorRef {
     }
 
     @Override
-    public TypeElement refType() {
-        return refType;
+    public FunctionType type() {
+        return type;
     }
 
     @Override
-    public FunctionType type() {
-        return type;
+    public TypeElement refType() {
+        return refType;
     }
 
     @Override
@@ -109,6 +112,12 @@ public final class ConstructorRefImpl implements ConstructorRef {
             // @@@
             throw new ReflectiveOperationException();
         }
+    }
+
+    @Override
+    public ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(NAME,
+                List.of(type.externalize()));
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/FieldRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/FieldRefImpl.java
@@ -29,10 +29,14 @@ import jdk.incubator.code.type.FieldRef;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
+import java.util.List;
+
 import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.TypeElement;
 
 public final class FieldRefImpl implements FieldRef {
+    static final String NAME = "&f";
+
     final TypeElement refType;
     final String name;
     final TypeElement type;
@@ -109,6 +113,12 @@ public final class FieldRefImpl implements FieldRef {
             // @@@
             throw new ReflectiveOperationException();
         }
+    }
+
+    @Override
+    public ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(NAME,
+                List.of(refType.externalize(), ExternalizedTypeElement.ofString(name), type.externalize()));
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
@@ -41,6 +41,8 @@ import java.util.function.Function;
 import static java.util.stream.Collectors.joining;
 
 public final class MethodRefImpl implements MethodRef {
+    static final String NAME = "&m";
+
     final TypeElement refType;
     final String name;
     final FunctionType type;
@@ -135,6 +137,12 @@ public final class MethodRefImpl implements MethodRef {
             // @@@
             throw new ReflectiveOperationException();
         }
+    }
+
+    @Override
+    public ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(NAME,
+                List.of(refType.externalize(), new ExternalizedTypeElement(name, List.of()), type.externalize()));
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/RecordTypeRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/RecordTypeRefImpl.java
@@ -29,10 +29,14 @@ import jdk.incubator.code.type.MethodRef;
 import jdk.incubator.code.type.RecordTypeRef;
 import jdk.incubator.code.TypeElement;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 
 public final class RecordTypeRefImpl implements RecordTypeRef {
+    static final String NAME = "&r";
+
     final TypeElement recordType;
     final List<ComponentRef> components;
 
@@ -62,6 +66,16 @@ public final class RecordTypeRefImpl implements RecordTypeRef {
     }
 
     @Override
+    public ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(NAME,
+                Stream.concat(
+                        Stream.of(recordType.externalize()),
+                        components.stream().flatMap(cr ->
+                                Stream.of(cr.type().externalize(), new ExternalizedTypeElement(cr.name(), List.of())))
+                ).toList());
+    }
+
+    @Override
     public String toString() {
         return components.stream()
                 .map(c -> c.type().externalize() + " " + c.name())
@@ -69,4 +83,14 @@ public final class RecordTypeRefImpl implements RecordTypeRef {
                 recordType.externalize();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof RecordTypeRefImpl that)) return false;
+        return Objects.equals(recordType, that.recordType) && Objects.equals(components, that.components);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(recordType, components);
+    }
 }

--- a/test/jdk/java/lang/reflect/code/type/TestReferences.java
+++ b/test/jdk/java/lang/reflect/code/type/TestReferences.java
@@ -21,16 +21,14 @@
  * questions.
  */
 
-import jdk.incubator.code.type.ConstructorRef;
+import jdk.incubator.code.TypeElement;
+import jdk.incubator.code.type.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
 import jdk.incubator.code.op.CoreOp;
-import jdk.incubator.code.type.FieldRef;
-import jdk.incubator.code.type.MethodRef;
-import jdk.incubator.code.type.RecordTypeRef;
 import jdk.incubator.code.CodeReflection;
 import java.util.Optional;
 
@@ -51,7 +49,7 @@ public class TestReferences {
                 {"a::b(Func<String, Number>, Entry<List<String>, val>, int, long)void", "a", "b"},
                 {"java.io.PrintStream::println(java.lang.String)void", "java.io.PrintStream", "println"},
                 {"MethodReferenceTest$A::m(java.lang.Object)java.lang.Object", "MethodReferenceTest$A", "m"},
-                {"R<#R::T<java.lang.Number>>::n()#R::T<java.lang.Number>", "R<#R::T<java.lang.Number>>", "n"}
+                {"R<#T<R, java.lang.Number>>::n()#T<R, java.lang.Number>", "R<#T<R, java.lang.Number>>", "n"}
         };
     }
 
@@ -62,6 +60,30 @@ public class TestReferences {
         Assert.assertEquals(mr.refType().externalize().toString(), refType);
         Assert.assertEquals(mr.name(), name);
     }
+
+
+    @DataProvider
+    public Object[][] externalizedMethodRefs() {
+        return new Object[][]{
+                {"&m<a, b, func<void>>", "a", "b"},
+                {"&m<a.b, c, func<int, int>>", "a.b", "c"},
+                {"&m<a.b.c, d, func<int, int, int>>", "a.b.c", "d"},
+                {"&m<a, b, func<void, Func<String, Number>, Entry<List<String>, val>, int, long>>", "a", "b"},
+                {"&m<java.io.PrintStream, println, func<void, java.lang.String>>", "java.io.PrintStream", "println"},
+                {"&m<MethodReferenceTest$A, m, func<java.lang.Object, java.lang.Object>>", "MethodReferenceTest$A", "m"},
+                {"&m<R<#T<R, java.lang.Number>>, n, func<#T<R, java.lang.Number>>>", "R<#T<R, java.lang.Number>>", "n"}
+        };
+    }
+
+    @Test(dataProvider = "externalizedMethodRefs")
+    public void testExternalizedMethodRef(String mds, String refType, String name) {
+        TypeElement.ExternalizedTypeElement emr = TypeElement.ExternalizedTypeElement.ofString(mds);
+        MethodRef mr = (MethodRef) CoreTypeFactory.CORE_TYPE_FACTORY.constructType(emr);
+        Assert.assertEquals(mr.externalize().toString(), mds);
+        Assert.assertEquals(mr.refType().externalize().toString(), refType);
+        Assert.assertEquals(mr.name(), name);
+    }
+
 
     @DataProvider
     public Object[][] constructorRefs() {
@@ -79,12 +101,30 @@ public class TestReferences {
     }
 
     @DataProvider
+    public Object[][] externalizedConstructorRefs() {
+        return new Object[][]{
+                {"&c<func<MethodReferenceTest$X, int>>", "MethodReferenceTest$X"},
+                {"&c<func<MethodReferenceTest$A[], int>>", "MethodReferenceTest$A[]"},
+        };
+    }
+
+    @Test(dataProvider = "externalizedConstructorRefs")
+    public void testExternalizedConstructorRef(String crs, String refType) {
+        TypeElement.ExternalizedTypeElement ecr = TypeElement.ExternalizedTypeElement.ofString(crs);
+        ConstructorRef cr = (ConstructorRef) CoreTypeFactory.CORE_TYPE_FACTORY.constructType(ecr);
+
+        Assert.assertEquals(cr.externalize().toString(), crs);
+        Assert.assertEquals(cr.refType().externalize().toString(), refType);
+    }
+
+
+    @DataProvider
     public Object[][] fieldRefs() {
         return new Object[][]{
                 {"a.b::c()int", "a.b", "c", "int"},
                 {"a.b.c::d()int", "a.b.c", "d", "int"},
                 {"java.lang.System::out()java.io.PrintStream", "java.lang.System", "out", "java.io.PrintStream"},
-                {"R<#R::T<java.lang.Number>>::n()#R::T<java.lang.Number>", "R<#R::T<java.lang.Number>>", "n", "#R::T<java.lang.Number>"}
+                {"R<#T<R, java.lang.Number>>::n()#T<R, java.lang.Number>", "R<#T<R, java.lang.Number>>", "n", "#T<R, java.lang.Number>"}
         };
     }
 
@@ -92,6 +132,28 @@ public class TestReferences {
     public void testFieldRef(String fds, String refType, String name, String type) {
         FieldRef fr = FieldRef.ofString(fds);
         Assert.assertEquals(fr.toString(), fds);
+        Assert.assertEquals(fr.refType().externalize().toString(), refType);
+        Assert.assertEquals(fr.name(), name);
+        Assert.assertEquals(fr.type().externalize().toString(), type);
+    }
+
+    @DataProvider
+    public Object[][] externalizedFieldRefs() {
+        return new Object[][]{
+                {"&f<a.b, c, int>", "a.b", "c", "int"},
+                {"&f<a.b.c, d, int>", "a.b.c", "d", "int"},
+                {"&f<java.lang.System, out, java.io.PrintStream>", "java.lang.System", "out", "java.io.PrintStream"},
+                // @@@ Fails because of externalize().toString()
+                {"&f<R<#T<R, java.lang.Number>>, n, #T<R, java.lang.Number>>", "R<#T<R, java.lang.Number>>", "n", "#T<R, java.lang.Number>"}
+        };
+    }
+
+    @Test(dataProvider = "externalizedFieldRefs")
+    public void testExternalizedFieldRef(String frs, String refType, String name, String type) {
+        TypeElement.ExternalizedTypeElement efr = TypeElement.ExternalizedTypeElement.ofString(frs);
+        FieldRef fr = (FieldRef) CoreTypeFactory.CORE_TYPE_FACTORY.constructType(efr);
+
+        Assert.assertEquals(fr.externalize().toString(), frs);
         Assert.assertEquals(fr.refType().externalize().toString(), refType);
         Assert.assertEquals(fr.name(), name);
         Assert.assertEquals(fr.type().externalize().toString(), type);
@@ -105,7 +167,7 @@ public class TestReferences {
                 {"(B b)A"},
                 {"(B b, C c)A"},
                 {"(p.Func<String, Number> f, Entry<List<String>, val> e, int i, long l)p.A<R>"},
-                {"(#R::T<java.lang.Number> n)R<#R::T<java.lang.Number>>"}
+                {"(#T<R, java.lang.Number> n)R<#T<R, java.lang.Number>>"}
         };
     }
 
@@ -113,5 +175,24 @@ public class TestReferences {
     public void testRecordTypeRef(String rtds) {
         RecordTypeRef rtr = RecordTypeRef.ofString(rtds);
         Assert.assertEquals(rtr.toString(), rtds);
+    }
+
+    @DataProvider
+    public Object[][] externalizedRecordTypeRefs() {
+        return new Object[][]{
+                {"&r<A>"},
+                {"&r<A, B, b>"},
+                {"&r<A, B, b, C, c>"},
+                {"&r<p.A<R>, p.Func<String, Number>, f, Entry<List<String>, val>, e, int, i, long, l>"},
+                // @@@ Fails because of externalize().toString()
+                {"&r<R<#T<R, java.lang.Number>>, #T<R, java.lang.Number>, n>"}
+        };
+    }
+
+    @Test(dataProvider = "externalizedRecordTypeRefs")
+    public void testExternalizedRecordTypeRef(String rtds) {
+        TypeElement.ExternalizedTypeElement ertr = TypeElement.ExternalizedTypeElement.ofString(rtds);
+        RecordTypeRef rtr = (RecordTypeRef) CoreTypeFactory.CORE_TYPE_FACTORY.constructType(ertr);
+        Assert.assertEquals(rtr.externalize().toString(), rtds);
     }
 }

--- a/test/jdk/java/lang/reflect/code/type/TestReferences.java
+++ b/test/jdk/java/lang/reflect/code/type/TestReferences.java
@@ -143,7 +143,6 @@ public class TestReferences {
                 {"&f<a.b, c, int>", "a.b", "c", "int"},
                 {"&f<a.b.c, d, int>", "a.b.c", "d", "int"},
                 {"&f<java.lang.System, out, java.io.PrintStream>", "java.lang.System", "out", "java.io.PrintStream"},
-                // @@@ Fails because of externalize().toString()
                 {"&f<R<#T<R, java.lang.Number>>, n, #T<R, java.lang.Number>>", "R<#T<R, java.lang.Number>>", "n", "#T<R, java.lang.Number>"}
         };
     }

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -135,9 +135,9 @@ public class DenotableTypesTest {
     @CodeReflection
     @IR("""
             func @"test7" ()void -> {
-                  %0 : #DenotableTypesTest::test7()void::X<java.lang.Object> = constant @null;
-                  %1 : Var<#DenotableTypesTest::test7()void::X<java.lang.Object>> = var %0 @"x";
-                  %2 : #DenotableTypesTest::test7()void::X<java.lang.Object> = var.load %1;
+                  %0 : #X<&m<DenotableTypesTest, test7, func<void>>, java.lang.Object> = constant @null;
+                  %1 : Var<#X<&m<DenotableTypesTest, test7, func<void>>, java.lang.Object>> = var %0 @"x";
+                  %2 : #X<&m<DenotableTypesTest, test7, func<void>>, java.lang.Object> = var.load %1;
                   %3 : java.lang.Runnable = cast %2 @"java.lang.Runnable";
                   invoke %3 @"DenotableTypesTest::consume(java.lang.Runnable)void";
                   return;

--- a/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
+++ b/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
@@ -50,14 +50,14 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : #IntersectionTypeTest::test1(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>)void -> {
-                  %1 : Var<#IntersectionTypeTest::test1(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>> = var %0 @"x";
-                  %2 : #IntersectionTypeTest::test1(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+            func @"test1" (%0 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
+                  %1 : Var<#X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
+                  %2 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   invoke %2 @"IntersectionTypeTest$A::m_A()void";
-                  %3 : #IntersectionTypeTest::test1(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                  %3 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %4 : IntersectionTypeTest$B = cast %3 @"IntersectionTypeTest$B";
                   invoke %4 @"IntersectionTypeTest$B::m_B()void";
-                  %5 : #IntersectionTypeTest::test1(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                  %5 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %6 : IntersectionTypeTest$C = cast %5 @"IntersectionTypeTest$C";
                   invoke %6 @"IntersectionTypeTest$C::m_C()void";
                   return;
@@ -69,17 +69,19 @@ class IntersectionTypeTest {
         x.m_C();
     }
 
+    // #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>
+    // #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>, IntersectionTypeTest$A>
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : #IntersectionTypeTest::test2(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>)void -> {
-                  %1 : Var<#IntersectionTypeTest::test2(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>> = var %0 @"x";
-                  %2 : #IntersectionTypeTest::test2(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+            func @"test2" (%0 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
+                  %1 : Var<#X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
+                  %2 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %3 : java.lang.Object = field.load @"IntersectionTypeTest$A::f_A()java.lang.Object";
                   %4 : Var<java.lang.Object> = var %3 @"oA";
-                  %5 : #IntersectionTypeTest::test2(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                  %5 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %6 : java.lang.Object = field.load @"IntersectionTypeTest$B::f_B()java.lang.Object";
                   %7 : Var<java.lang.Object> = var %6 @"oB";
-                  %8 : #IntersectionTypeTest::test2(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                  %8 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %9 : java.lang.Object = field.load @"IntersectionTypeTest$C::f_C()java.lang.Object";
                   %10 : Var<java.lang.Object> = var %9 @"oC";
                   return;
@@ -93,9 +95,9 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : #IntersectionTypeTest::test3(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>)void -> {
-                  %1 : Var<#IntersectionTypeTest::test3(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>> = var %0 @"x";
-                  %2 : #IntersectionTypeTest::test3(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+            func @"test3" (%0 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
+                  %1 : Var<#X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
+                  %2 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %3 : Var<IntersectionTypeTest$A> = var %2 @"rec$";
                   %4 : java.lang.Runnable = lambda ()void -> {
                       %5 : IntersectionTypeTest$A = var.load %3;
@@ -103,7 +105,7 @@ class IntersectionTypeTest {
                       return;
                   };
                   %6 : Var<java.lang.Runnable> = var %4 @"rA";
-                  %7 : #IntersectionTypeTest::test3(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                  %7 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %8 : IntersectionTypeTest$B = cast %7 @"IntersectionTypeTest$B";
                   %9 : Var<IntersectionTypeTest$B> = var %8 @"rec$";
                   %10 : java.lang.Runnable = lambda ()void -> {
@@ -112,7 +114,7 @@ class IntersectionTypeTest {
                       return;
                   };
                   %12 : Var<java.lang.Runnable> = var %10 @"rB";
-                  %13 : #IntersectionTypeTest::test3(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                  %13 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                   %14 : IntersectionTypeTest$C = cast %13 @"IntersectionTypeTest$C";
                   %15 : Var<IntersectionTypeTest$C> = var %14 @"rec$";
                   %16 : java.lang.Runnable = lambda ()void -> {
@@ -136,14 +138,14 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : #IntersectionTypeTest::test4(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>)void -> {
-                %1 : Var<#IntersectionTypeTest::test4(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A>> = var %0 @"x";
-                %2 : #IntersectionTypeTest::test4(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+            func @"test4" (%0 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
+                %1 : Var<#X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
+                %2 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                 invoke %2 @"IntersectionTypeTest::g_A(IntersectionTypeTest$A)void";
-                %3 : #IntersectionTypeTest::test4(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                %3 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                 %4 : IntersectionTypeTest$B = cast %3 @"IntersectionTypeTest$B";
                 invoke %4 @"IntersectionTypeTest::g_B(IntersectionTypeTest$B)void";
-                %5 : #IntersectionTypeTest::test4(IntersectionTypeTest$A)void::X<IntersectionTypeTest$A> = var.load %1;
+                %5 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
                 %6 : IntersectionTypeTest$C = cast %5 @"IntersectionTypeTest$C";
                 invoke %6 @"IntersectionTypeTest::g_C(IntersectionTypeTest$C)void";
                 return;

--- a/test/langtools/tools/javac/reflect/PatternTest2.java
+++ b/test/langtools/tools/javac/reflect/PatternTest2.java
@@ -17,9 +17,9 @@ public class PatternTest2 {
                 %3 : java.lang.Integer = constant @null;
                 %4 : Var<java.lang.Integer> = var %3 @"i";
                 %5 : boolean = pattern.match %2
-                    ()jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<#PatternTest2$R::T<java.lang.Number>>> -> {
+                    ()jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<#T<PatternTest2$R, java.lang.Number>>> -> {
                         %6 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> = pattern.type @"i";
-                        %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<#PatternTest2$R::T<java.lang.Number>>> = pattern.record %6 @"(#PatternTest2$R::T<java.lang.Number> n)PatternTest2$R<#PatternTest2$R::T<java.lang.Number>>";
+                        %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<#T<PatternTest2$R, java.lang.Number>>> = pattern.record %6 @"(#T<PatternTest2$R, java.lang.Number> n)PatternTest2$R<#T<PatternTest2$R, java.lang.Number>>";
                         yield %7;
                     }
                     (%8 : java.lang.Integer)void -> {


### PR DESCRIPTION
Each implementation of `JavaRef` supports an external form, using the sigil prefix `&` to indicate a reference of some kind.

The externalized form of `TypeVarRef` is changed to be uniformly structured. This required update to the code model text of a few tests. Arguably we are taking a step back in terms of readability, but we can address that later - it was easier to update a few tests rather than preserve the existing encoding in a few places.

We still rely on the bespoke string form for java refs, which is used as the value of an externalized attribute. Ideally such attribute values are either instances of `JavaRef` or `ExternalizedTypeElement` to be transformed into the appropriate `JavaRef`. We can address that later to further separate out parsing.

I believe we have what we need to further enhance the code model builder to not rely on bespoke parsing logic of types and refs. We can either construct `ExternalizedTypeElement` tree instances explicitly or parse from a very simple grammar. If we are careful i believe we can share the results of nested type elements if reused e.g. as in `List<Double>` and `Set<Double>`.

More generally it now means we can generate a simple s-expression-like tree for the whole code model, e.g., a string where the `(` and `)` characters represent tree structure and say `L` represents a leaf node, and a list of leaf node values in topological order.

--

Below is the type grammar, which i believe is consistent with what we have implemented.

# Type element grammar

## General structure

```
identifier
  string

name
  identifier

sigil
  # | . | & | + | - | [

type
  sigil
  identifier
  sigil identifier
  identifier < types >
  sigil identifier < types >

types
   type
   type , types
```

## Core types

```
varType
  "var" < type >

tupleType
  "tuple"
  "tuple" < types >

funcType
  "func" < types >
```

# Java types

```
javaType
  primitiveType | classType | wildCardType | arrayType | typeVariableType

javaType-no-wildCardType
  primitiveType | classType | arrayType | typeVariableType

primitiveType
  boolean | byte | ... | void

classType
  name
  name < paramTypes >
  . < enclosingType , innerType >
paramTypes
  javaType
  javaType , javaTypes
enclosingType
  classType
innerType
  classType

wildcardType
  + < wildcardTypeBound >
  - < wildcardTypeBound >
wildcardTypeBound
  javaType-no-wildCardType

arrayType
  dims < javaType >
dims
 [
 [ dims

typeVariableType
  "#" name < typeVariableTypeOwner , typeVariableTypeBound >
typeVariableTypeOwner
  classType | methodRef | constructorRef
typeVariableTypeBound
  javaType-no-wildCardType
```

## Java refs

```
methodRef
  & "m" < type , name , funcType >

constructorRef
  & "c" < funcType >

fieldRef
  & "f" < type , name , type >

recordRef
  & "r" < type >
  & "r" < type , recordRefComponentTypes >
recordRefComponentTypes
  type , name
  type , name , recordRefComponentTypes
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [27da7be0](https://git.openjdk.org/babylon/pull/416/files/27da7be0e92b1bb20ef573d6a4ed33c7010fa09c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/416/head:pull/416` \
`$ git checkout pull/416`

Update a local copy of the PR: \
`$ git checkout pull/416` \
`$ git pull https://git.openjdk.org/babylon.git pull/416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 416`

View PR using the GUI difftool: \
`$ git pr show -t 416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/416.diff">https://git.openjdk.org/babylon/pull/416.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/416#issuecomment-2840380597)
</details>
