### PR TITLE
Rename TypeVarRef to TypeVariableType

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ClassType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ClassType.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 /**
  * A class type.
  */
-public final class ClassType implements TypeVarRef.Owner, JavaType {
+public final class ClassType implements TypeVariableType.Owner, JavaType {
     // Enclosing class type (might be null)
     private final ClassType enclosing;
     // Fully qualified name

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ConstructorRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ConstructorRef.java
@@ -39,7 +39,7 @@ import static jdk.incubator.code.type.FunctionType.functionType;
 /**
  * The symbolic reference to a Java constructor.
  */
-public sealed interface ConstructorRef extends JavaRef, TypeVarRef.Owner
+public sealed interface ConstructorRef extends JavaRef, TypeVariableType.Owner
         permits ConstructorRefImpl {
 
     FunctionType type();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/CoreTypeFactory.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/CoreTypeFactory.java
@@ -128,7 +128,7 @@ public final class CoreTypeFactory {
                     throw badType(tree, "type variable");
                 }
 
-                if (!(constructType(tree.arguments().get(0)) instanceof TypeVarRef.Owner owner)) {
+                if (!(constructType(tree.arguments().get(0)) instanceof TypeVariableType.Owner owner)) {
                     throw badType(tree, "type variable");
                 }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaType.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
  *     <li>{@linkplain ClassType class types}, e.g. {@code String}, {@code List<? extends Number>}</li>
  *     <li>{@linkplain ArrayType array types}, e.g. {@code Object[][]}, {@code List<Runnable>[]}</li>
  *     <li>{@linkplain WildcardType wildcard types}, e.g. {@code ? extends Number}, {@code ? super ArrayList<String>}</li>
- *     <li>{@linkplain TypeVarRef type-variables}, e.g. {@code T extends Runnable}</li>
+ *     <li>{@linkplain TypeVariableType type-variables}, e.g. {@code T extends Runnable}</li>
  * </ul>
  * Java types can be constructed from either {@linkplain ClassDesc nominal descriptors} or
  * {@linkplain Type reflective type mirrors}. Conversely, Java types can be
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * @sealedGraph
  */
 public sealed interface JavaType extends TypeElement permits ClassType, ArrayType,
-                                                             PrimitiveType, WildcardType, TypeVarRef {
+                                                             PrimitiveType, WildcardType, TypeVariableType {
 
     /** {@link JavaType} representing {@code void} */
     PrimitiveType VOID = new PrimitiveType(ConstantDescs.CD_void);
@@ -204,7 +204,7 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
         };
     }
 
-    private static TypeVarRef.Owner owner(GenericDeclaration genDecl) {
+    private static TypeVariableType.Owner owner(GenericDeclaration genDecl) {
         return switch (genDecl) {
             case Constructor<?> c -> ConstructorRef.constructor(c);
             case Method m -> MethodRef.method(m);
@@ -343,8 +343,8 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
      * @param owner the type-variable owner.
      * @return a type-variable reference.
      */
-    static TypeVarRef typeVarRef(String name, TypeVarRef.Owner owner, JavaType bound) {
-        return new TypeVarRef(name, owner, bound);
+    static TypeVariableType typeVarRef(String name, TypeVariableType.Owner owner, JavaType bound) {
+        return new TypeVariableType(name, owner, bound);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/MethodRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/MethodRef.java
@@ -32,18 +32,16 @@ import jdk.incubator.code.type.impl.MethodRefImpl;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import jdk.incubator.code.TypeElement;
 import java.util.List;
-import java.util.Optional;
 
 import static jdk.incubator.code.type.FunctionType.functionType;
 
 /**
  * The symbolic reference to a Java method.
  */
-public sealed interface MethodRef extends JavaRef, TypeVarRef.Owner
+public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
         permits MethodRefImpl {
 
     TypeElement refType();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
@@ -25,8 +25,6 @@
 
 package jdk.incubator.code.type;
 
-import jdk.incubator.code.TypeElement;
-
 import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Constructor;
@@ -38,13 +36,13 @@ import java.util.List;
 /**
  * A type-variable reference.
  */
-public final class TypeVarRef implements JavaType {
+public final class TypeVariableType implements JavaType {
 
     final String name;
     final Owner owner;
     final JavaType bound;
 
-    TypeVarRef(String name, Owner owner, JavaType bound) {
+    TypeVariableType(String name, Owner owner, JavaType bound) {
         this.name = name;
         this.owner = owner;
         this.bound = bound;
@@ -120,7 +118,7 @@ public final class TypeVarRef implements JavaType {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        return o instanceof TypeVarRef that &&
+        return o instanceof TypeVariableType that &&
                 name.equals(that.name) &&
                 bound.equals(that.bound);
     }

--- a/test/jdk/java/lang/reflect/code/type/TestErasure.java
+++ b/test/jdk/java/lang/reflect/code/type/TestErasure.java
@@ -37,7 +37,7 @@ import jdk.incubator.code.type.ArrayType;
 import jdk.incubator.code.type.ClassType;
 import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.type.PrimitiveType;
-import jdk.incubator.code.type.TypeVarRef;
+import jdk.incubator.code.type.TypeVariableType;
 import jdk.incubator.code.type.WildcardType.BoundKind;
 import java.util.ArrayList;
 import java.util.List;
@@ -152,8 +152,8 @@ public class TestErasure {
         return arrayTypes;
     }
 
-    static List<TypeAndErasure<TypeVarRef>> typeVars() {
-        List<TypeAndErasure<TypeVarRef>> typeVars = new ArrayList<>();
+    static List<TypeAndErasure<TypeVariableType>> typeVars() {
+        List<TypeAndErasure<TypeVariableType>> typeVars = new ArrayList<>();
         for (int dims = 1 ; dims <= 3 ; dims++) {
             for (TypeAndErasure<ClassType> t : references()) {
                 typeVars.add(new TypeAndErasure<>(JavaType.typeVarRef("X", JavaType.J_L_OBJECT, t.type), t.erasure));


### PR DESCRIPTION
Rename `TypeVarRef` to `TypeVariableType`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/417/head:pull/417` \
`$ git checkout pull/417`

Update a local copy of the PR: \
`$ git checkout pull/417` \
`$ git pull https://git.openjdk.org/babylon.git pull/417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 417`

View PR using the GUI difftool: \
`$ git pr show -t 417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/417.diff">https://git.openjdk.org/babylon/pull/417.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/417#issuecomment-2843104266)
</details>
