### PR TITLE
Build ref attributes from externalized type elems

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
@@ -78,18 +78,6 @@ public class OpBuilder {
     static final MethodRef FUNCTION_TYPE_FUNCTION_TYPE = MethodRef.method(FunctionType.class, "functionType",
             FunctionType.class, TypeElement.class, TypeElement[].class);
 
-    static final MethodRef METHOD_REF_OF_STRING = MethodRef.method(MethodRef.class, "ofString",
-            MethodRef.class, String.class);
-
-    static final MethodRef CONSTRUCTOR_REF_OF_STRING = MethodRef.method(ConstructorRef.class, "ofString",
-            ConstructorRef.class, String.class);
-
-    static final MethodRef FIELD_REF_OF_STRING = MethodRef.method(FieldRef.class, "ofString",
-            FieldRef.class, String.class);
-
-    static final MethodRef RECORD_TYPE_REF_OF_STRING = MethodRef.method(RecordTypeRef.class, "ofString",
-            RecordTypeRef.class, String.class);
-
 
     static final JavaType J_U_LIST = type(List.class);
 
@@ -313,22 +301,6 @@ public class OpBuilder {
             }
             case String s -> {
                 yield builder.op(constant(J_L_STRING, value));
-            }
-            case ConstructorRef r -> {
-                Value string = builder.op(constant(J_L_STRING, value.toString()));
-                yield builder.op(invoke(CONSTRUCTOR_REF_OF_STRING, string));
-            }
-            case MethodRef r -> {
-                Value string = builder.op(constant(J_L_STRING, value.toString()));
-                yield builder.op(invoke(METHOD_REF_OF_STRING, string));
-            }
-            case FieldRef r -> {
-                Value string = builder.op(constant(J_L_STRING, value.toString()));
-                yield builder.op(invoke(FIELD_REF_OF_STRING, string));
-            }
-            case RecordTypeRef r -> {
-                Value string = builder.op(constant(J_L_STRING, value.toString()));
-                yield builder.op(invoke(RECORD_TYPE_REF_OF_STRING, string));
             }
             case TypeElement f -> {
                 yield buildType(f);


### PR DESCRIPTION
This removes the dependence on specific parsing of refs. Now they are type elements we can use its string form.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/418/head:pull/418` \
`$ git checkout pull/418`

Update a local copy of the PR: \
`$ git checkout pull/418` \
`$ git pull https://git.openjdk.org/babylon.git pull/418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 418`

View PR using the GUI difftool: \
`$ git pr show -t 418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/418.diff">https://git.openjdk.org/babylon/pull/418.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/418#issuecomment-2847747816)
</details>
