### PR TITLE
Build extern type element tree

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/TypeElement.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/TypeElement.java
@@ -3,6 +3,7 @@ package jdk.incubator.code;
 import jdk.incubator.code.type.TypeElementFactory;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A type, that defines a set of values.
@@ -85,6 +86,42 @@ public non-sealed interface TypeElement extends CodeItem {
         }
 
         // Factories
+
+        public static ExternalizedTypeElement of(String s) {
+            return new ExternalizedTypeElement(s, List.of());
+        }
+
+        public static ExternalizedTypeElement of(String s,
+                                                 ExternalizedTypeElement a) {
+            return new ExternalizedTypeElement(s, List.of(a));
+        }
+
+        public static ExternalizedTypeElement of(String s,
+                                                 ExternalizedTypeElement a1, ExternalizedTypeElement a2) {
+            return new ExternalizedTypeElement(s, List.of(a1, a2));
+        }
+
+        public static ExternalizedTypeElement of(String s,
+                                                 ExternalizedTypeElement a1, ExternalizedTypeElement a2,
+                                                 ExternalizedTypeElement a3) {
+            return new ExternalizedTypeElement(s, List.of(a1, a2, a3));
+        }
+
+        public static ExternalizedTypeElement of(String s,
+                                                 ExternalizedTypeElement a1, ExternalizedTypeElement a2,
+                                                 ExternalizedTypeElement a3, ExternalizedTypeElement a4) {
+            return new ExternalizedTypeElement(s, List.of(a1, a2, a3, a4));
+        }
+
+        public static ExternalizedTypeElement of(String s,
+                                                 ExternalizedTypeElement... arguments) {
+            return new ExternalizedTypeElement(s, List.of(arguments));
+        }
+
+        public static ExternalizedTypeElement of(String s,
+                                                 List<ExternalizedTypeElement> arguments) {
+            return new ExternalizedTypeElement(s, arguments);
+        }
 
         /**
          * Parses a string as an externalized type element.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/TypeElement.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/TypeElement.java
@@ -3,7 +3,6 @@ package jdk.incubator.code;
 import jdk.incubator.code.type.TypeElementFactory;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A type, that defines a set of values.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -198,8 +198,8 @@ public class CodeModelToAST {
             }
             case CoreOp.ArrayAccessOp.ArrayStoreOp arrayStoreOp -> {
                 var array = arrayStoreOp.operands().get(0);
-                var val = arrayStoreOp.operands().get(1);
-                var index = arrayStoreOp.operands().get(2);
+                var index = arrayStoreOp.operands().get(1);
+                var val = arrayStoreOp.operands().get(2);
                 var as = treeMaker.Assign(
                         treeMaker.Indexed(
                                 toExpr(opToTree(array)), toExpr(opToTree(index))), toExpr(opToTree(val))

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
@@ -52,9 +52,6 @@ public class OpBuilder {
     static final MethodRef TYPE_ELEMENT_FACTORY_CONSTRUCT = MethodRef.method(TypeElementFactory.class, "constructType",
             TypeElement.class, ExternalizedTypeElement.class);
 
-    static final MethodRef EX_TYPE_ELEMENT_OF_STRING = MethodRef.method(ExternalizedTypeElement.class, "ofString",
-            ExternalizedTypeElement.class, String.class);
-
     static final MethodRef BODY_BUILDER_OF = MethodRef.method(Body.Builder.class, "of",
             Body.Builder.class, Body.Builder.class, FunctionType.class);
 


### PR DESCRIPTION
The model that builds the model now explicitly builds the externalized type element tree rather than parsing it from the string form. Externalized type element instances are reused.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/419/head:pull/419` \
`$ git checkout pull/419`

Update a local copy of the PR: \
`$ git checkout pull/419` \
`$ git pull https://git.openjdk.org/babylon.git pull/419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 419`

View PR using the GUI difftool: \
`$ git pr show -t 419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/419.diff">https://git.openjdk.org/babylon/pull/419.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/419#issuecomment-2848115362)
</details>
