### PR TITLE
Fixes required for maven/cmake on ubuntu - note cuda ptx working, cud…

### DIFF
--- a/hat/backends/ffi/cuda/CMakeLists.txt
+++ b/hat/backends/ffi/cuda/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CUDAToolkit_FOUND)
     endif()
 
     include_directories(
-            ${CUDAToolkit_INCLUDE_DIR}
+            ${CUDAToolkit_INCLUDE_DIRS} # was ${CUDAToolkit_INCLUDE_DIR}
 	        ${SHARED_BACKEND}/include
 	        ${CUDA_BACKEND}/include
     )

--- a/hat/backends/ffi/cuda/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend.cpp
@@ -74,7 +74,8 @@ PtxSource *PtxSource::nvcc(const char *cudaSource, size_t len) {
     int pid;
     cSource.write(cudaPath);
     if ((pid = fork()) == 0) {
-        const char *path = "/usr/local/cuda-12.2/bin/nvcc";
+        //const char *path = "/usr/local/cuda-12.2/bin/nvcc";
+        const char *path = "/usr/local/cuda/bin/nvcc";
         const char *argv[]{"nvcc", "-ptx", cudaPath.c_str(), "-o", ptxPath.c_str(), nullptr};
        // std::cerr << "child about to exec nvcc" << std::endl;
        // std::cerr << "path " << path<< " " << argv[1]<< " " << argv[2]<< " " << argv[3]<< " " << argv[4]<< std::endl;

--- a/hat/extractions/cuda/CMakeLists.txt
+++ b/hat/extractions/cuda/CMakeLists.txt
@@ -6,6 +6,10 @@ project(extract_cuda)
 set(JEXTRACT_PACKAGE cuda)
 set(JEXTRACT_SOURCE ${CMAKE_SOURCE_DIR}/${JEXTRACT_PACKAGE}/src/main/java)
 set(JEXTRACT_HEADER ${JEXTRACT_SOURCE}/${JEXTRACT_PACKAGE}/${JEXTRACT_PACKAGE}_h.java)
+#get_cmake_property(_variableNames VARIABLES)
+#foreach (_variableName ${_variableNames})
+#    message(STATUS "${_variableName}=${${_variableName}}")
+#endforeach()
 
 if (Apple)
 
@@ -17,13 +21,10 @@ add_custom_command(OUTPUT  ${JEXTRACT_HEADER}
        --output ${JEXTRACT_SOURCE}
        --library :${CUDA_cuda_driver_LIBRARY}
        --header-class-name ${JEXTRACT_PACKAGE}_h
-       ${CUDAToolkit_INCLUDE_DIR}/cuda.h
+       ${CUDAToolkit_INCLUDE_DIRS}/cuda.h   #  Note that iexpected  ${CUDAToolkit_INCLUDE_DIR}/cuda.h to work
        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
        VERBATIM
    )
-#CUDAToolkit_INCLUDE_DIR=/usr/local/cuda-12.2/include
-#CUDA_cuda_driver_LIBRARY =/usr/lib/aarch64-linux-gnu/libcuda.so
-
 endif()
 
 add_custom_target(extract_cuda DEPENDS  ${JEXTRACT_HEADER})

--- a/hat/wrap/glwrap/pom.xml
+++ b/hat/wrap/glwrap/pom.xml
@@ -58,7 +58,15 @@ questions.
       <artifactId>maven-compiler-plugin</artifactId>
       <configuration>
         <excludes>
-          <exclude>wrap/glwrap/GLCallbackEventHandler.java</exclude>
+          <!--
+              Annoyingly there seems to be two ways to handle callbacks in gl so we have two wrappers
+                 gl on mac needs  us to exclude
+                    wrap/glwrap/GLCallbackEventHandler.java 
+                 gl on ubuntu/jetson needs  us to exclude
+                   wrap/glwrap/GLCallbackEventHandler.java 
+          -->
+          <!-- uncomment for mac --> <!--<exclude>wrap/glwrap/GLCallbackEventHandler.java</exclude>-->
+          <!-- uncomment for ubuntu --> <exclude>wrap/glwrap/GLFuncEventHandler.java</exclude>
         </excludes>
       </configuration>
     </plugin>


### PR DESCRIPTION
Changes neeed to build opencl and cuda on ubuntu 

Mostly cmake realted.  CMake creates inconsistent vars for CUDA  include deps, this breaks ffi-backend build  and jextract 

Similarly pom.xml needs a conditional file exclusion for wrapping opengl.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/421/head:pull/421` \
`$ git checkout pull/421`

Update a local copy of the PR: \
`$ git checkout pull/421` \
`$ git pull https://git.openjdk.org/babylon.git pull/421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 421`

View PR using the GUI difftool: \
`$ git pr show -t 421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/421.diff">https://git.openjdk.org/babylon/pull/421.diff</a>

</details>
