### PR TITLE
Improve textual representation of code models

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/OpParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/OpParser.java
@@ -553,7 +553,7 @@ public final class OpParser {
 
         lexer.accept(Tokens.TokenKind.COLON);
 
-        TypeElement.ExternalizedTypeElement type = parseTypeElem();
+        TypeElement.ExternalizedTypeElement type = parseExTypeElem();
 
         return new ValueNode(valueName, type);
     }
@@ -602,10 +602,6 @@ public final class OpParser {
 
     TypeElement.ExternalizedTypeElement parseExTypeElem() {
         return DescParser.parseExTypeElem(lexer);
-    }
-
-    TypeElement.ExternalizedTypeElement parseTypeElem() {
-        return DescParser.parseTypeElem(lexer).externalize();
     }
 }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/OpParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/OpParser.java
@@ -553,7 +553,7 @@ public final class OpParser {
 
         lexer.accept(Tokens.TokenKind.COLON);
 
-        TypeElement.ExternalizedTypeElement type = parseExTypeElem();
+        TypeElement.ExternalizedTypeElement type = parseTypeElem();
 
         return new ValueNode(valueName, type);
     }
@@ -602,6 +602,10 @@ public final class OpParser {
 
     TypeElement.ExternalizedTypeElement parseExTypeElem() {
         return DescParser.parseExTypeElem(lexer);
+    }
+
+    TypeElement.ExternalizedTypeElement parseTypeElem() {
+        return DescParser.parseTypeElem(lexer).externalize();
     }
 }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/OpParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/OpParser.java
@@ -35,6 +35,7 @@ import jdk.incubator.code.parser.impl.Lexer;
 import jdk.incubator.code.parser.impl.Scanner;
 import jdk.incubator.code.parser.impl.Tokens;
 import jdk.incubator.code.type.CoreTypeFactory;
+import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.type.TypeElementFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -121,8 +122,7 @@ import java.util.Map;
  */
 public final class OpParser {
 
-    static final TypeElement.ExternalizedTypeElement VOID =
-            new TypeElement.ExternalizedTypeElement("void", List.of());
+    static final TypeElement.ExternalizedTypeElement VOID = JavaType.VOID.externalize();
 
     /**
      * Parse a code model from its serialized textual form obtained from an input stream.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/impl/DescParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/impl/DescParser.java
@@ -167,10 +167,10 @@ public final class DescParser {
             "void", JavaType.VOID);
 
     //    JavaType:
-    //        ClassType					            			    // class type
+    //        ClassType                                             // class type
     //        PrimitiveType                                         // primitive type
-    //        TypeVar				        	    			    // type variable
-    //        JavaType '['']'		    			    		    // array type
+    //        TypeVar                                               // type variable
+    //        JavaType '[' ']'                                      // array type
     //
     //    ClassType:
     //        ClassTypeNoPackage
@@ -181,9 +181,9 @@ public final class DescParser {
     //        Package '.' ident
     //
     //    ClassTypeNoPackage:
-    //        ident								                    // simple class type
-    //        ident '<' TypeArg* '>'		        		    	// parameterized class type
-    //        ClassType '$' ClassType             		    		// nested class type
+    //        ident                                                 // simple class type
+    //        ident '<' TypeArg* '>'                                // parameterized class type
+    //        ClassType '$' ClassType                               // nested class type
     //
     //    PrimitiveType:
     //        'boolean'
@@ -197,17 +197,17 @@ public final class DescParser {
     //        'void'
     //
     //    TypeVar:
-    //        '(' JavaRef ')' TypeVarRest			            		// method/constructor type variable
-    //        ClassType TypeVarRest			            			// class type variable
+    //        '(' JavaRef ')' TypeVarRest                           // method/constructor type variable
+    //        ClassType TypeVarRest                                 // class type variable
     //
     //    TypeVarRest:
     //        '::' '<' ident '>'
     //        '::' '<' ident 'extends' JavaType '>'
     //
     //    TypeArg:
-    //        '?' 							    	                // bivariant type argument
-    //        '?' 'extends' JavaType	    			        	// covariant type argument
-    //        '?' 'super' JavaType  					    	    // contravariant type argument
+    //        '?'                                                   // bivariant type argument
+    //        '?' 'extends' JavaType                                // covariant type argument
+    //        '?' 'super' JavaType                                  // contravariant type argument
     //        JavaType
     public static JavaType parseJavaType(Lexer l) {
         JavaType type = null;
@@ -315,9 +315,9 @@ public final class DescParser {
     }
 
     //    JavaRef:
-    //        JavaType `::` ident ':' JavaType			    		// field reference
+    //        JavaType `::` ident ':' JavaType                      // field reference
     //        JavaType `::` ident '(' JavaType* ')' ':' JavaType    // method reference
-    //        JavaType `::` '(' JavaType* ')'						// constructor reference
+    //        JavaType `::` '(' JavaType* ')'                       // constructor reference
     //        '(' RecordComponent* ')' JavaType                     // record reference
     //
     //    RecordComponent:

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/impl/DescParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/parser/impl/DescParser.java
@@ -155,6 +155,17 @@ public final class DescParser {
         return new TypeElement.ExternalizedTypeElement(identifier.toString(), args);
     }
 
+    static final Map<String, JavaType> PRIMITIVE_TYPES = Map.of(
+            "boolean", JavaType.BOOLEAN,
+            "char", JavaType.CHAR,
+            "byte", JavaType.BYTE,
+            "short", JavaType.SHORT,
+            "int", JavaType.INT,
+            "float", JavaType.FLOAT,
+            "long", JavaType.LONG,
+            "double", JavaType.DOUBLE,
+            "void", JavaType.VOID);
+
     //    JavaType:
     //        ClassType					            			    // class type
     //        PrimitiveType                                         // primitive type
@@ -186,7 +197,7 @@ public final class DescParser {
     //        'void'
     //
     //    TypeVar:
-    //        '(' Ref ')' TypeVarRest			            		// method/constructor type variable
+    //        '(' JavaRef ')' TypeVarRest			            		// method/constructor type variable
     //        ClassType TypeVarRest			            			// class type variable
     //
     //    TypeVarRest:
@@ -197,29 +208,7 @@ public final class DescParser {
     //        '?' 							    	                // bivariant type argument
     //        '?' 'extends' JavaType	    			        	// covariant type argument
     //        '?' 'super' JavaType  					    	    // contravariant type argument
-    //        JavaType	    						                // invariant type argument
-    //
-    //    Ref:
-    //        JavaType `::` ident ':' JavaType			    		// field reference
-    //        JavaType `::` ident '(' JavaType* ')' ':' JavaType    // method reference
-    //        JavaType `::` '(' JavaType* ')'						// constructor reference
-    //        '(' RecordComponent* ')' JavaType                     // record reference
-    //
-    //    RecordComponent:
-    //        JavaType ident
-
-
-    static final Map<String, JavaType> PRIMITIVE_TYPES = Map.of(
-            "boolean", JavaType.BOOLEAN,
-            "char", JavaType.CHAR,
-            "byte", JavaType.BYTE,
-            "short", JavaType.SHORT,
-            "int", JavaType.INT,
-            "float", JavaType.FLOAT,
-            "long", JavaType.LONG,
-            "double", JavaType.DOUBLE,
-            "void", JavaType.VOID);
-
+    //        JavaType
     public static JavaType parseJavaType(Lexer l) {
         JavaType type = null;
         if (l.token().kind == TokenKind.LPAREN) {
@@ -325,6 +314,14 @@ public final class DescParser {
         return ptypes;
     }
 
+    //    JavaRef:
+    //        JavaType `::` ident ':' JavaType			    		// field reference
+    //        JavaType `::` ident '(' JavaType* ')' ':' JavaType    // method reference
+    //        JavaType `::` '(' JavaType* ')'						// constructor reference
+    //        '(' RecordComponent* ')' JavaType                     // record reference
+    //
+    //    RecordComponent:
+    //        JavaType ident
     static JavaRef parseJavaRef(Lexer l) {
         if (l.token().kind == TokenKind.LPAREN) {
             // record type reference

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ArrayType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ArrayType.java
@@ -79,17 +79,6 @@ public final class ArrayType implements JavaType {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        int dims = 0;
-        TypeElement current = this;
-        while (current instanceof ArrayType at) {
-            dims++;
-            current = at.componentType();
-        }
-        return new ExternalizedTypeElement("[".repeat(dims), List.of(current.externalize()));
-    }
-
-    @Override
     public String toString() {
         return componentType.toString() + "[]";
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ClassType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ClassType.java
@@ -148,7 +148,9 @@ public final class ClassType implements TypeVariableType.Owner, JavaType {
      * type arguments}
      */
     public ClassType rawType() {
-        return new ClassType(type);
+        return enclosing == null ?
+                new ClassType(type) :
+                new ClassType(enclosing.rawType(), type);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ClassType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/ClassType.java
@@ -84,19 +84,6 @@ public final class ClassType implements TypeVariableType.Owner, JavaType {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        List<ExternalizedTypeElement> args = typeArguments.stream()
-                .map(TypeElement::externalize)
-                .toList();
-
-        ExternalizedTypeElement td = new ExternalizedTypeElement(toClassName(), args);
-        if (enclosing != null) {
-            td = new ExternalizedTypeElement(".", List.of(enclosing.externalize(), td));
-        }
-        return td;
-    }
-
-    @Override
     public String toString() {
         String prefix = enclosing != null ?
                 enclosing + "$":

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaRef.java
@@ -2,6 +2,8 @@ package jdk.incubator.code.type;
 
 import jdk.incubator.code.TypeElement;
 
+import java.util.List;
+
 /**
  * A symbolic reference to a Java class member or a Java type including members,
  * commonly containing symbolic names together with {@link JavaType symbolic descriptions}
@@ -20,4 +22,9 @@ public sealed interface JavaRef extends TypeElement
     //     - resolve to RecordComponent
     //     - (RecordTypeRef resolves to Type.)
     // @@@ AnnotatedElement is the common top type for resolved Java refs and types
+
+    @Override
+    default ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(String.format("java.ref:\"%s\"", this), List.of());
+    }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaType.java
@@ -168,6 +168,11 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
      */
     ClassDesc toNominalDescriptor();
 
+    @Override
+    default ExternalizedTypeElement externalize() {
+        return new ExternalizedTypeElement(String.format("java.type:\"%s\"", this), List.of());
+    }
+
     /**
      * Resolve this Java type to a reflective type mirror.
      * @param lookup the lookup used to create the reflective type mirror
@@ -354,6 +359,6 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
      * @return a Java type corresponding to the provided string representation
      */
     static JavaType ofString(String s) {
-        return (JavaType) DescParser.parseTypeElem(s);
+        return (JavaType) DescParser.parseJavaType(s);
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/JavaType.java
@@ -32,6 +32,7 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.*;
 
 import jdk.incubator.code.TypeElement;
+import jdk.incubator.code.parser.impl.DescParser;
 import jdk.incubator.code.type.WildcardType.BoundKind;
 import java.util.List;
 import java.util.Objects;
@@ -353,6 +354,6 @@ public sealed interface JavaType extends TypeElement permits ClassType, ArrayTyp
      * @return a Java type corresponding to the provided string representation
      */
     static JavaType ofString(String s) {
-        return (JavaType) CoreTypeFactory.JAVA_TYPE_FACTORY.constructType(jdk.incubator.code.parser.impl.DescParser.parseExTypeElem(s));
+        return (JavaType) DescParser.parseTypeElem(s);
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/PrimitiveType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/PrimitiveType.java
@@ -49,11 +49,6 @@ public final class PrimitiveType implements JavaType {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        return new ExternalizedTypeElement(type.displayName(), List.of());
-    }
-
-    @Override
     public String toString() {
         return type.displayName();
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
@@ -112,7 +112,7 @@ public final class TypeVariableType implements JavaType {
     @Override
     public String toString() {
         // @@@ required to pass TestJavaType.java
-        return name;
+        return String.format("%s::%s extends %s", owner, name, bound);
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
@@ -100,8 +100,12 @@ public final class TypeVariableType implements JavaType {
 
     @Override
     public String toString() {
-        // @@@ required to pass TestJavaType.java
-        return String.format("%s::%s extends %s", owner, name, bound);
+        String ownerString = (owner instanceof ClassType) ?
+                owner.toString() :
+                String.format("(%s)", owner);
+        return (bound.equals(JavaType.J_L_OBJECT)) ?
+                String.format("%s::<%s>", ownerString, name) :
+                String.format("%s::<%s extends %s>", ownerString, name, bound);
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/TypeVariableType.java
@@ -99,17 +99,6 @@ public final class TypeVariableType implements JavaType {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        ExternalizedTypeElement eOwner = switch (owner) {
-            // @@@ Should be able to use single case matching TypeElement
-            case JavaRef ref -> ref.externalize();
-            case ClassType classType -> classType.externalize();
-        };
-        return new ExternalizedTypeElement("#" + name,
-                List.of(eOwner, bound.externalize()));
-    }
-
-    @Override
     public String toString() {
         // @@@ required to pass TestJavaType.java
         return String.format("%s::%s extends %s", owner, name, bound);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/VarType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/VarType.java
@@ -30,7 +30,7 @@ public final class VarType implements TypeElement {
 
     @Override
     public String toString() {
-        return String.format("%s<%s>", NAME, valueType);
+        return externalize().toString();
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/VarType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/VarType.java
@@ -30,7 +30,7 @@ public final class VarType implements TypeElement {
 
     @Override
     public String toString() {
-        return externalize().toString();
+        return String.format("%s<%s>", NAME, valueType);
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/WildcardType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/WildcardType.java
@@ -72,12 +72,6 @@ public final class WildcardType implements JavaType {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        String prefix = kind == BoundKind.EXTENDS ? "+" : "-";
-        return new ExternalizedTypeElement(prefix, List.of(boundType.externalize()));
-    }
-
-    @Override
     public String toString() {
         return boundKind() == BoundKind.EXTENDS &&
                 boundType.equals(J_L_OBJECT) ?

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
@@ -44,7 +44,6 @@ import java.util.Objects;
 import static java.util.stream.Collectors.joining;
 
 public final class ConstructorRefImpl implements ConstructorRef {
-    static final String NAME = "&c";
 
     final FunctionType type;
 
@@ -109,14 +108,8 @@ public final class ConstructorRefImpl implements ConstructorRef {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        return new ExternalizedTypeElement(NAME,
-                List.of(type.externalize()));
-    }
-
-    @Override
     public String toString() {
-        return type.returnType() + "::<new>" +
+        return type.returnType() + "::" +
             type.parameterTypes().stream().map(Object::toString)
                     .collect(joining(", ", "(", ")"));
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/ConstructorRefImpl.java
@@ -116,8 +116,8 @@ public final class ConstructorRefImpl implements ConstructorRef {
 
     @Override
     public String toString() {
-        return type.returnType().externalize() + "::<new>" +
-            type.parameterTypes().stream().map(t -> t.externalize().toString())
+        return type.returnType() + "::<new>" +
+            type.parameterTypes().stream().map(Object::toString)
                     .collect(joining(", ", "(", ")"));
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/FieldRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/FieldRefImpl.java
@@ -123,7 +123,7 @@ public final class FieldRefImpl implements FieldRef {
 
     @Override
     public String toString() {
-        return refType.externalize() + "::" + name + "()" + type.externalize();
+        return refType + "::" + name + "()" + type;
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/FieldRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/FieldRefImpl.java
@@ -35,7 +35,6 @@ import jdk.incubator.code.type.JavaType;
 import jdk.incubator.code.TypeElement;
 
 public final class FieldRefImpl implements FieldRef {
-    static final String NAME = "&f";
 
     final TypeElement refType;
     final String name;
@@ -116,14 +115,8 @@ public final class FieldRefImpl implements FieldRef {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        return new ExternalizedTypeElement(NAME,
-                List.of(refType.externalize(), ExternalizedTypeElement.ofString(name), type.externalize()));
-    }
-
-    @Override
     public String toString() {
-        return refType + "::" + name + "()" + type;
+        return refType + "::" + name + ":" + type;
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
 import static java.util.stream.Collectors.joining;
 
 public final class MethodRefImpl implements MethodRef {
-    static final String NAME = "&m";
 
     final TypeElement refType;
     final String name;
@@ -140,14 +139,8 @@ public final class MethodRefImpl implements MethodRef {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        return new ExternalizedTypeElement(NAME,
-                List.of(refType.externalize(), new ExternalizedTypeElement(name, List.of()), type.externalize()));
-    }
-
-    @Override
     public String toString() {
-        return refType + "::" + name +
+        return refType + "::" + name + ":" +
             type.parameterTypes().stream().map(Object::toString)
                     .collect(joining(", ", "(", ")")) + type.returnType();
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
@@ -140,9 +140,9 @@ public final class MethodRefImpl implements MethodRef {
 
     @Override
     public String toString() {
-        return refType + "::" + name + ":" +
+        return refType + "::" + name +
             type.parameterTypes().stream().map(Object::toString)
-                    .collect(joining(", ", "(", ")")) + type.returnType();
+                    .collect(joining(", ", "(", ")")) + ":" + type.returnType();
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/MethodRefImpl.java
@@ -147,9 +147,9 @@ public final class MethodRefImpl implements MethodRef {
 
     @Override
     public String toString() {
-        return refType.externalize() + "::" + name +
-            type.parameterTypes().stream().map(t -> t.externalize().toString())
-                    .collect(joining(", ", "(", ")")) + type.returnType().externalize();
+        return refType + "::" + name +
+            type.parameterTypes().stream().map(Object::toString)
+                    .collect(joining(", ", "(", ")")) + type.returnType();
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/RecordTypeRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/RecordTypeRefImpl.java
@@ -66,21 +66,11 @@ public final class RecordTypeRefImpl implements RecordTypeRef {
     }
 
     @Override
-    public ExternalizedTypeElement externalize() {
-        return new ExternalizedTypeElement(NAME,
-                Stream.concat(
-                        Stream.of(recordType.externalize()),
-                        components.stream().flatMap(cr ->
-                                Stream.of(cr.type().externalize(), new ExternalizedTypeElement(cr.name(), List.of())))
-                ).toList());
-    }
-
-    @Override
     public String toString() {
         return components.stream()
-                .map(c -> c.type().externalize() + " " + c.name())
+                .map(c -> c.type() + " " + c.name())
                 .collect(joining(", ", "(", ")")) +
-                recordType.externalize();
+                recordType;
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/RecordTypeRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/type/impl/RecordTypeRefImpl.java
@@ -35,7 +35,6 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
 
 public final class RecordTypeRefImpl implements RecordTypeRef {
-    static final String NAME = "&r";
 
     final TypeElement recordType;
     final List<ComponentRef> components;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpWriter.java
@@ -557,7 +557,7 @@ public final class OpWriter {
     }
 
     void writeType(TypeElement te) {
-        write(te.toString());
+        write(te.externalize().toString());
     }
 
     void write(String s) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpWriter.java
@@ -557,7 +557,7 @@ public final class OpWriter {
     }
 
     void writeType(TypeElement te) {
-        write(te.externalize().toString());
+        write(te.toString());
     }
 
     void write(String s) {

--- a/test/jdk/java/lang/reflect/code/TestLiveness.java
+++ b/test/jdk/java/lang/reflect/code/TestLiveness.java
@@ -48,8 +48,8 @@ import java.util.stream.Collectors;
 public class TestLiveness {
 
     static final String F = """
-            func @"f" (%0 : int, %1 : int)int -> {
-                %2 : int = add %0 %1;
+            func @"f" (%0 : java.type:"int", %1 : java.type:"int")java.type:"int" -> {
+                %2 : java.type:"int" = add %0 %1;
                 return %2;
             };
             """;
@@ -65,23 +65,23 @@ public class TestLiveness {
     }
 
     static final String IF_ELSE = """
-            func @"ifelse" (%0 : int, %1 : int, %2 : int)int -> {
-                %3 : int = constant @"10";
+            func @"ifelse" (%0 : java.type:"int", %1 : java.type:"int", %2 : java.type:"int")java.type:"int" -> {
+                %3 : java.type:"int" = constant @"10";
                 %4 : boolean = lt %2 %3;
                 cbranch %4 ^block_0 ^block_1;
 
               ^block_0:
-                %5 : int = constant @"1";
-                %6 : int = add %0 %5;
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %0 %5;
                 branch ^block_2(%6, %1);
 
               ^block_1:
-                %7 : int = constant @"2";
-                %8 : int = add %1 %7;
+                %7 : java.type:"int" = constant @"2";
+                %8 : java.type:"int" = add %1 %7;
                 branch ^block_2(%0, %8);
 
-              ^block_2(%9 : int, %10 : int):
-                %11 : int = add %9 %10;
+              ^block_2(%9 : java.type:"int", %10 : java.type:"int"):
+                %11 : java.type:"int" = add %9 %10;
                 return %11;
             };
             """;
@@ -101,22 +101,22 @@ public class TestLiveness {
     }
 
     static final String LOOP = """
-            func @"loop" (%0 : int)int -> {
-                %1 : int = constant @"0";
-                %2 : int = constant @"0";
+            func @"loop" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : java.type:"int" = constant @"0";
                 branch ^block_0(%1, %2);
 
-              ^block_0(%3 : int, %4 : int):
+              ^block_0(%3 : java.type:"int", %4 : java.type:"int"):
                 %5 : boolean = lt %4 %0;
                 cbranch %5 ^block_1 ^block_2;
 
               ^block_1:
-                %6 : int = add %3 %4;
+                %6 : java.type:"int" = add %3 %4;
                 branch ^block_3;
 
               ^block_3:
-                %7 : int = constant @"1";
-                %8 : int = add %4 %7;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"int" = add %4 %7;
                 branch ^block_0(%6, %8);
 
               ^block_2:
@@ -140,55 +140,55 @@ public class TestLiveness {
     }
 
     static final String IF_ELSE_NESTED = """
-            func @"ifelseNested" (%0 : int, %1 : int, %2 : int, %3 : int, %4 : int)int -> {
-                %5 : int = constant @"20";
+            func @"ifelseNested" (%0 : java.type:"int", %1 : java.type:"int", %2 : java.type:"int", %3 : java.type:"int", %4 : java.type:"int")java.type:"int" -> {
+                %5 : java.type:"int" = constant @"20";
                 %6 : boolean = lt %4 %5;
                 cbranch %6 ^block_0 ^block_1;
 
               ^block_0:
-                %7 : int = constant @"10";
+                %7 : java.type:"int" = constant @"10";
                 %8 : boolean = lt %4 %7;
                 cbranch %8 ^block_2 ^block_3;
 
               ^block_2:
-                %9 : int = constant @"1";
-                %10 : int = add %0 %9;
+                %9 : java.type:"int" = constant @"1";
+                %10 : java.type:"int" = add %0 %9;
                 branch ^block_4(%10, %1);
 
               ^block_3:
-                %11 : int = constant @"2";
-                %12 : int = add %1 %11;
+                %11 : java.type:"int" = constant @"2";
+                %12 : java.type:"int" = add %1 %11;
                 branch ^block_4(%0, %12);
 
-              ^block_4(%13 : int, %14 : int):
-                %15 : int = constant @"3";
-                %16 : int = add %2 %15;
+              ^block_4(%13 : java.type:"int", %14 : java.type:"int"):
+                %15 : java.type:"int" = constant @"3";
+                %16 : java.type:"int" = add %2 %15;
                 branch ^block_5(%13, %14, %16, %3);
 
               ^block_1:
-                %17 : int = constant @"20";
+                %17 : java.type:"int" = constant @"20";
                 %18 : boolean = gt %4 %17;
                 cbranch %18 ^block_6 ^block_7;
 
               ^block_6:
-                %19 : int = constant @"4";
-                %20 : int = add %0 %19;
+                %19 : java.type:"int" = constant @"4";
+                %20 : java.type:"int" = add %0 %19;
                 branch ^block_8(%20, %1);
 
               ^block_7:
-                %21 : int = constant @"5";
-                %22 : int = add %1 %21;
+                %21 : java.type:"int" = constant @"5";
+                %22 : java.type:"int" = add %1 %21;
                 branch ^block_8(%0, %22);
 
-              ^block_8(%23 : int, %24 : int):
-                %25 : int = constant @"6";
-                %26 : int = add %3 %25;
+              ^block_8(%23 : java.type:"int", %24 : java.type:"int"):
+                %25 : java.type:"int" = constant @"6";
+                %26 : java.type:"int" = add %3 %25;
                 branch ^block_5(%23, %24, %2, %26);
 
-              ^block_5(%27 : int, %28 : int, %29 : int, %30 : int):
-                %31 : int = add %27 %28;
-                %32 : int = add %31 %29;
-                %33 : int = add %32 %30;
+              ^block_5(%27 : java.type:"int", %28 : java.type:"int", %29 : java.type:"int", %30 : java.type:"int"):
+                %31 : java.type:"int" = add %27 %28;
+                %32 : java.type:"int" = add %31 %29;
+                %33 : java.type:"int" = add %32 %30;
                 return %33;
             };
             """;
@@ -214,39 +214,39 @@ public class TestLiveness {
     }
 
     static final String LOOP_NESTED = """
-            func @"loopNested" (%0 : int)int -> {
-                %1 : int = constant @"0";
-                %2 : int = constant @"0";
+            func @"loopNested" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : java.type:"int" = constant @"0";
                 branch ^block_0(%1, %2);
 
-              ^block_0(%3 : int, %4 : int):
+              ^block_0(%3 : java.type:"int", %4 : java.type:"int"):
                 %5 : boolean = lt %4 %0;
                 cbranch %5 ^block_1 ^block_2;
 
               ^block_1:
-                %6 : int = constant @"0";
+                %6 : java.type:"int" = constant @"0";
                 branch ^block_3(%3, %6);
 
-              ^block_3(%7 : int, %8 : int):
+              ^block_3(%7 : java.type:"int", %8 : java.type:"int"):
                 %9 : boolean = lt %8 %0;
                 cbranch %9 ^block_4 ^block_5;
 
               ^block_4:
-                %10 : int = add %7 %4;
-                %11 : int = add %10 %8;
+                %10 : java.type:"int" = add %7 %4;
+                %11 : java.type:"int" = add %10 %8;
                 branch ^block_6;
 
               ^block_6:
-                %12 : int = constant @"1";
-                %13 : int = add %8 %12;
+                %12 : java.type:"int" = constant @"1";
+                %13 : java.type:"int" = add %8 %12;
                 branch ^block_3(%11, %13);
 
               ^block_5:
                 branch ^block_7;
 
               ^block_7:
-                %14 : int = constant @"1";
-                %15 : int = add %4 %14;
+                %14 : java.type:"int" = constant @"1";
+                %15 : java.type:"int" = add %4 %14;
                 branch ^block_0(%7, %15);
 
               ^block_2:

--- a/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
+++ b/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
@@ -39,20 +39,20 @@ import java.util.stream.Stream;
 
 public class TestNormalizeBlocksTransformer {
     static final String TEST1_INPUT = """
-            func @"f" (%0 : int)int -> {
-                %1 : int = invoke @"C::m()int";
+            func @"f" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = invoke @"C::m():int";
                 branch ^block_1;
 
               ^block_1:
-                %2 : int = invoke %1 @"C::m(int)int";
+                %2 : java.type:"int" = invoke %1 @"C::m(int):int";
                 branch ^block_2(%2);
 
-              ^block_2(%3: int):
-                %4 : int = invoke %2 %3 @"C::m(int, int)int";
+              ^block_2(%3: java.type:"int"):
+                %4 : java.type:"int" = invoke %2 %3 @"C::m(int, int):int";
                 branch ^block_3(%3);
 
-              ^block_3(%5: int):
-                %6 : int = invoke %4 %3 %5 @"C::m(int, int, int)int";
+              ^block_3(%5: java.type:"int"):
+                %6 : java.type:"int" = invoke %4 %3 %5 @"C::m(int, int, int):int";
                 branch ^block_4;
 
               ^block_4:
@@ -60,164 +60,164 @@ public class TestNormalizeBlocksTransformer {
             };
             """;
     static final String TEST1_EXPECTED = """
-            func @"f" (%0 : int)int -> {
-                %1 : int = invoke @"C::m()int";
-                %2 : int = invoke %1 @"C::m(int)int";
-                %3 : int = invoke %2 %2 @"C::m(int, int)int";
-                %4 : int = invoke %3 %2 %2 @"C::m(int, int, int)int";
+            func @"f" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = invoke @"C::m():int";
+                %2 : java.type:"int" = invoke %1 @"C::m(int):int";
+                %3 : java.type:"int" = invoke %2 %2 @"C::m(int, int):int";
+                %4 : java.type:"int" = invoke %3 %2 %2 @"C::m(int, int, int):int";
                 return %4;
             };
             """;
 
     static final String TEST2_INPUT = """
-            func @"f" (%0 : java.lang.Object)void -> {
-                %1 : Var<java.lang.Object> = var %0 @"o";
+            func @"f" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
                 exception.region.enter ^block_1 ^block_8 ^block_3;
 
               ^block_1:
-                %3 : int = invoke @"A::try_()int";
+                %3 : java.type:"int" = invoke @"A::try_():int";
                 branch ^block_2;
 
               ^block_2:
                 exception.region.exit ^block_6 ^block_3 ^block_8;
 
-              ^block_3(%4 : java.lang.RuntimeException):
+              ^block_3(%4 : java.type:"java.lang.RuntimeException"):
                 exception.region.enter ^block_4 ^block_8;
 
               ^block_4:
-                %6 : Var<java.lang.RuntimeException> = var %4 @"e";
+                %6 : Var<java.type:"java.lang.RuntimeException"> = var %4 @"e";
                 branch ^block_5;
 
               ^block_5:
                 exception.region.exit ^block_6 ^block_8;
 
               ^block_6:
-                %7 : int = invoke @"A::finally_()int";
+                %7 : java.type:"int" = invoke @"A::finally_():int";
                 branch ^block_7;
 
               ^block_7:
                 return;
 
-              ^block_8(%8 : java.lang.Throwable):
-                %9 : int = invoke @"A::finally_()int";
+              ^block_8(%8 : java.type:"java.lang.Throwable"):
+                %9 : java.type:"int" = invoke @"A::finally_():int";
                 throw %8;
             };
             """;
     static final String TEST2_EXPECTED = """
-            func @"f" (%0 : java.lang.Object)void -> {
-                %1 : Var<java.lang.Object> = var %0 @"o";
+            func @"f" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
                 exception.region.enter ^block_1 ^block_5 ^block_2;
 
               ^block_1:
-                %3 : int = invoke @"A::try_()int";
+                %3 : java.type:"int" = invoke @"A::try_():int";
                 exception.region.exit ^block_4 ^block_2 ^block_5;
 
-              ^block_2(%4 : java.lang.RuntimeException):
+              ^block_2(%4 : java.type:"java.lang.RuntimeException"):
                 exception.region.enter ^block_3 ^block_5;
 
               ^block_3:
-                %6 : Var<java.lang.RuntimeException> = var %4 @"e";
+                %6 : Var<java.type:"java.lang.RuntimeException"> = var %4 @"e";
                 exception.region.exit ^block_4 ^block_5;
 
               ^block_4:
-                %7 : int = invoke @"A::finally_()int";
+                %7 : java.type:"int" = invoke @"A::finally_():int";
                 return;
 
-              ^block_5(%8 : java.lang.Throwable):
-                %9 : int = invoke @"A::finally_()int";
+              ^block_5(%8 : java.type:"java.lang.Throwable"):
+                %9 : java.type:"int" = invoke @"A::finally_():int";
                 throw %8;
             };""";
 
     static final String TEST3_INPUT = """
-            func @"f" (%0 : int)int -> {
-                %1 : int = constant @"0";
+            func @"f" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
                 %2 : boolean = gt %0 %1;
                 cbranch %2 ^block_1 ^block_2;
 
               ^block_1:
-                %3 : int = constant @"1";
+                %3 : java.type:"int" = constant @"1";
                 branch ^block_1_1;
 
               ^block_1_1:
                 branch ^block_3(%3);
 
               ^block_2:
-                %4 : int = constant @"-1";
+                %4 : java.type:"int" = constant @"-1";
                 branch ^block_2_1;
 
               ^block_2_1:
                 branch ^block_3(%4);
 
-              ^block_3(%5 : int):
+              ^block_3(%5 : java.type:"int"):
                 return %5;
             };""";
     static final String TEST3_EXPECTED = """
-            func @"f" (%0 : int)int -> {
-                %1 : int = constant @"0";
+            func @"f" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
                 %2 : boolean = gt %0 %1;
                 cbranch %2 ^block_1 ^block_2;
 
               ^block_1:
-                %3 : int = constant @"1";
+                %3 : java.type:"int" = constant @"1";
                 branch ^block_3(%3);
 
               ^block_2:
-                %4 : int = constant @"-1";
+                %4 : java.type:"int" = constant @"-1";
                 branch ^block_3(%4);
 
-              ^block_3(%5 : int):
+              ^block_3(%5 : java.type:"int"):
                 return %5;
             };
             """;
 
     static final String TEST4_INPUT = """
-            func @"f" (%0 : int)int -> {
-                %1 : int = constant @"0";
+            func @"f" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
                 %2 : boolean = gt %0 %1;
                 cbranch %2 ^block_1 ^block_2;
 
               ^block_1:
-                %3 : int = constant @"1";
+                %3 : java.type:"int" = constant @"1";
                 branch ^block_1_1;
 
               ^block_1_1:
                 branch ^block_3(%0, %3, %1);
 
               ^block_2:
-                %4 : int = constant @"-1";
+                %4 : java.type:"int" = constant @"-1";
                 branch ^block_2_1;
 
               ^block_2_1:
                 branch ^block_3(%0, %4, %1);
 
-              ^block_3(%unused_1 : int, %5 : int, %unused_2 : int):
+              ^block_3(%unused_1 : java.type:"int", %5 : java.type:"int", %unused_2 : java.type:"int"):
                 return %5;
             };""";
     static final String TEST4_EXPECTED = """
-            func @"f" (%0 : int)int -> {
-                %1 : int = constant @"0";
+            func @"f" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
                 %2 : boolean = gt %0 %1;
                 cbranch %2 ^block_1 ^block_2;
 
               ^block_1:
-                %3 : int = constant @"1";
+                %3 : java.type:"int" = constant @"1";
                 branch ^block_3(%3);
 
               ^block_2:
-                %4 : int = constant @"-1";
+                %4 : java.type:"int" = constant @"-1";
                 branch ^block_3(%4);
 
-              ^block_3(%5 : int):
+              ^block_3(%5 : java.type:"int"):
                 return %5;
             };
             """;
 
     static final String TEST5_INPUT = """
-            func @"f" ()void -> {
+            func @"f" ()java.type:"void" -> {
                 exception.region.enter ^block_1 ^block_4;
 
               ^block_1:
-                invoke @"A::m()void";
+                invoke @"A::m():void";
                 branch ^block_2;
 
               ^block_2:
@@ -226,7 +226,7 @@ public class TestNormalizeBlocksTransformer {
               ^block_3:
                 branch ^block_5;
 
-              ^block_4(%1 : java.lang.Throwable):
+              ^block_4(%1 : java.type:"java.lang.Throwable"):
                 branch ^block_5;
 
               ^block_5:
@@ -234,17 +234,17 @@ public class TestNormalizeBlocksTransformer {
             };
             """;
     static final String TEST5_EXPECTED = """
-            func @"f" ()void -> {
+            func @"f" ()java.type:"void" -> {
                 exception.region.enter ^block_1 ^block_3;
 
               ^block_1:
-                invoke @"A::m()void";
+                invoke @"A::m():void";
                 exception.region.exit ^block_2 ^block_3;
 
               ^block_2:
                 branch ^block_4;
 
-              ^block_3(%1 : java.lang.Throwable):
+              ^block_3(%1 : java.type:"java.lang.Throwable"):
                 branch ^block_4;
 
               ^block_4:

--- a/test/jdk/java/lang/reflect/code/TestUsesDependsOn.java
+++ b/test/jdk/java/lang/reflect/code/TestUsesDependsOn.java
@@ -43,16 +43,16 @@ import java.util.function.Function;
 public class TestUsesDependsOn {
 
     static final String OP = """
-            func @"f" (%0 : int, %1 : int)int -> {
-                %2 : int = add %0 %1;
-                %3 : boolean = lt %0 %1;
-                %4 : void = cbranch %3 ^b1(%2, %2) ^b2(%0, %1);
+            func @"f" (%0 : java.type:"int", %1 : java.type:"int")java.type:"int" -> {
+                %2 : java.type:"int" = add %0 %1;
+                %3 : java.type:"boolean" = lt %0 %1;
+                %4 : java.type:"void" = cbranch %3 ^b1(%2, %2) ^b2(%0, %1);
 
-              ^b1(%5 : int, %6 : int):
-                %7 : void = return %5;
+              ^b1(%5 : java.type:"int", %6 : java.type:"int"):
+                %7 : java.type:"void" = return %5;
 
-              ^b2(%8 : int, %9 : int):
-                %10 : void = return %8;
+              ^b2(%8 : java.type:"int", %9 : java.type:"int"):
+                %10 : java.type:"void" = return %8;
             };
             """;
 

--- a/test/jdk/java/lang/reflect/code/lower/TestLoop.java
+++ b/test/jdk/java/lang/reflect/code/lower/TestLoop.java
@@ -35,39 +35,39 @@ import jdk.incubator.code.CodeReflection;
 public class TestLoop {
     @CodeReflection
     @LoweredModel(value = """
-            func @"testFor" (%0 : int[])int -> {
-                %1 : Var<int[]> = var %0 @"a";
-                %2 : int = constant @"0";
-                %3 : Var<int> = var %2 @"sum";
-                %4 : int = constant @"0";
-                %5 : Var<int> = var %4 @"i";
+            func @"testFor" (%0 : java.type:"int[]")java.type:"int" -> {
+                %1 : Var<java.type:"int[]"> = var %0 @"a";
+                %2 : java.type:"int" = constant @"0";
+                %3 : Var<java.type:"int"> = var %2 @"sum";
+                %4 : java.type:"int" = constant @"0";
+                %5 : Var<java.type:"int"> = var %4 @"i";
                 branch ^block_0;
 
               ^block_0:
-                %6 : int = var.load %5;
-                %7 : int[] = var.load %1;
-                %8 : int = array.length %7;
+                %6 : java.type:"int" = var.load %5;
+                %7 : java.type:"int[]" = var.load %1;
+                %8 : java.type:"int" = array.length %7;
                 %9 : boolean = lt %6 %8;
                 cbranch %9 ^block_1 ^block_2;
 
               ^block_1:
-                %10 : int = var.load %3;
-                %11 : int[] = var.load %1;
-                %12 : int = var.load %5;
-                %13 : int = array.load %11 %12;
-                %14 : int = add %10 %13;
+                %10 : java.type:"int" = var.load %3;
+                %11 : java.type:"int[]" = var.load %1;
+                %12 : java.type:"int" = var.load %5;
+                %13 : java.type:"int" = array.load %11 %12;
+                %14 : java.type:"int" = add %10 %13;
                 var.store %3 %14;
                 branch ^block_3;
 
               ^block_3:
-                %15 : int = var.load %5;
-                %16 : int = constant @"1";
-                %17 : int = add %15 %16;
+                %15 : java.type:"int" = var.load %5;
+                %16 : java.type:"int" = constant @"1";
+                %17 : java.type:"int" = add %15 %16;
                 var.store %5 %17;
                 branch ^block_0;
 
               ^block_2:
-                %18 : int = var.load %3;
+                %18 : java.type:"int" = var.load %3;
                 return %18;
             };
             """, ssa = false)
@@ -81,24 +81,24 @@ public class TestLoop {
 
     @CodeReflection
     @LoweredModel(value = """
-            func @"testForSSA" (%0 : int[])int -> {
-                %1 : int = constant @"0";
-                %2 : int = constant @"0";
+            func @"testForSSA" (%0 : java.type:"int[]")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : java.type:"int" = constant @"0";
                 branch ^block_1(%2, %1);
 
-              ^block_1(%3 : int, %4 : int):
-                %5 : int = array.length %0;
+              ^block_1(%3 : java.type:"int", %4 : java.type:"int"):
+                %5 : java.type:"int" = array.length %0;
                 %6 : boolean = lt %3 %5;
                 cbranch %6 ^block_2 ^block_4;
 
               ^block_2:
-                %7 : int = array.load %0 %3;
-                %8 : int = add %4 %7;
+                %7 : java.type:"int" = array.load %0 %3;
+                %8 : java.type:"int" = add %4 %7;
                 branch ^block_3;
 
               ^block_3:
-                %9 : int = constant @"1";
-                %10 : int = add %3 %9;
+                %9 : java.type:"int" = constant @"1";
+                %10 : java.type:"int" = add %3 %9;
                 branch ^block_1(%10, %8);
 
               ^block_4:

--- a/test/jdk/java/lang/reflect/code/lower/TestSynchronized.java
+++ b/test/jdk/java/lang/reflect/code/lower/TestSynchronized.java
@@ -36,29 +36,29 @@ public class TestSynchronized {
 
     @CodeReflection
     @LoweredModel(value = """
-            func @"test1" (%0 : java.lang.Object, %1 : int)int -> {
-                %2 : Var<java.lang.Object> = var %0 @"m";
-                %3 : Var<int> = var %1 @"i";
-                %4 : java.lang.Object = var.load %2;
+            func @"test1" (%0 : java.type:"java.lang.Object", %1 : java.type:"int")java.type:"int" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %0 @"m";
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : java.type:"java.lang.Object" = var.load %2;
                 branch ^block_1(%4);
 
-              ^block_1(%5 : java.lang.Object):
+              ^block_1(%5 : java.type:"java.lang.Object"):
                 monitor.enter %5;
                 exception.region.enter ^block_2 ^block_4;
 
               ^block_2:
-                %7 : int = var.load %3;
-                %8 : int = constant @"1";
-                %9 : int = add %7 %8;
+                %7 : java.type:"int" = var.load %3;
+                %8 : java.type:"int" = constant @"1";
+                %9 : java.type:"int" = add %7 %8;
                 var.store %3 %9;
                 monitor.exit %5;
                 exception.region.exit ^block_3 ^block_4;
 
               ^block_3:
-                %10 : int = var.load %3;
+                %10 : java.type:"int" = var.load %3;
                 return %10;
 
-              ^block_4(%11 : java.lang.Throwable):
+              ^block_4(%11 : java.type:"java.lang.Throwable"):
                 exception.region.enter ^block_5 ^block_4;
 
               ^block_5:
@@ -79,24 +79,24 @@ public class TestSynchronized {
 
     @CodeReflection
     @LoweredModel(value = """
-            func @"test2" (%0 : java.lang.Object, %1 : int)int -> {
-                %2 : Var<java.lang.Object> = var %0 @"m";
-                %3 : Var<int> = var %1 @"i";
-                %4 : java.lang.Object = var.load %2;
+            func @"test2" (%0 : java.type:"java.lang.Object", %1 : java.type:"int")java.type:"int" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %0 @"m";
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : java.type:"java.lang.Object" = var.load %2;
                 branch ^block_1(%4);
 
-              ^block_1(%5 : java.lang.Object):
+              ^block_1(%5 : java.type:"java.lang.Object"):
                 monitor.enter %5;
                 exception.region.enter ^block_2 ^block_8;
 
               ^block_2:
-                %7 : int = var.load %3;
-                %8 : int = constant @"0";
+                %7 : java.type:"int" = var.load %3;
+                %8 : java.type:"int" = constant @"0";
                 %9 : boolean = gt %7 %8;
                 cbranch %9 ^block_3 ^block_5;
 
               ^block_3:
-                %10 : int = constant @"-1";
+                %10 : java.type:"int" = constant @"-1";
                 monitor.exit %5;
                 exception.region.exit ^block_4 ^block_8;
 
@@ -107,18 +107,18 @@ public class TestSynchronized {
                 branch ^block_6;
 
               ^block_6:
-                %11 : int = var.load %3;
-                %12 : int = constant @"1";
-                %13 : int = add %11 %12;
+                %11 : java.type:"int" = var.load %3;
+                %12 : java.type:"int" = constant @"1";
+                %13 : java.type:"int" = add %11 %12;
                 var.store %3 %13;
                 monitor.exit %5;
                 exception.region.exit ^block_7 ^block_8;
 
               ^block_7:
-                %14 : int = var.load %3;
+                %14 : java.type:"int" = var.load %3;
                 return %14;
 
-              ^block_8(%15 : java.lang.Throwable):
+              ^block_8(%15 : java.type:"java.lang.Throwable"):
                 exception.region.enter ^block_9 ^block_8;
 
               ^block_9:

--- a/test/jdk/java/lang/reflect/code/parser/TestParse.java
+++ b/test/jdk/java/lang/reflect/code/parser/TestParse.java
@@ -85,12 +85,12 @@ public class TestParse {
 
 
     static final String NAMED_BODY = """
-            func @"test" ^body1(%0 : int, %1 : int)int -> {
-                %2 : int = constant @"5";
-                %3 : int = constant @"2";
+            func @"test" ^body1(%0 : java.type:"int", %1 : java.type:"int")java.type:"int" -> {
+                %2 : java.type:"int" = constant @"5";
+                %3 : java.type:"int" = constant @"2";
                 branch ^b1(%2, %3);
 
-              ^b1(%0 : int, %1 : int):
+              ^b1(%0 : java.type:"int", %1 : java.type:"int"):
                 return %0;
             };
             """;
@@ -103,8 +103,8 @@ public class TestParse {
 
 
     static final String ESCAPED_STRING = """
-            func @"test" ()String -> {
-                %0 : java.lang.String = constant @"\\b \\f \\n \\r \\t \\' \\" \\\\";
+            func @"test" ()java.type:"java.lang.String" -> {
+                %0 : java.type:"java.lang.String" = constant @"\\b \\f \\n \\r \\t \\' \\" \\\\";
                 return %0;
             };
             """;

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -177,11 +177,11 @@ public class TestJavaType {
         Assert.assertEquals(javaType, CoreTypeFactory.JAVA_TYPE_FACTORY.constructType(javaType.externalize()));
     }
 
-    @Test(dataProvider = "types")
-    public void testTypeString(Type type) throws ReflectiveOperationException {
-        JavaType javaType = JavaType.type(type);
-        Assert.assertEquals(type.getTypeName(), javaType.toString());
-    }
+//    @Test(dataProvider = "types")
+//    public void testTypeString(Type type) throws ReflectiveOperationException {
+//        JavaType javaType = JavaType.type(type);
+//        Assert.assertEquals(type.getTypeName(), javaType.toString());
+//    }
 
     @DataProvider
     public Object[][] types() throws ReflectiveOperationException {

--- a/test/jdk/java/lang/reflect/code/type/TestReferences.java
+++ b/test/jdk/java/lang/reflect/code/type/TestReferences.java
@@ -30,6 +30,9 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandles;
 import jdk.incubator.code.op.CoreOp;
 import jdk.incubator.code.CodeReflection;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /*
@@ -43,13 +46,13 @@ public class TestReferences {
     @DataProvider
     public Object[][] methodRefs() {
         return new Object[][]{
-                {"a::b()void", "a", "b"},
-                {"a.b::c(int)int", "a.b", "c"},
-                {"a.b.c::d(int, int)int", "a.b.c", "d"},
-                {"a::b(Func<String, Number>, Entry<List<String>, val>, int, long)void", "a", "b"},
-                {"java.io.PrintStream::println(java.lang.String)void", "java.io.PrintStream", "println"},
-                {"MethodReferenceTest$A::m(java.lang.Object)java.lang.Object", "MethodReferenceTest$A", "m"},
-                {"R<#T<R, java.lang.Number>>::n()#T<R, java.lang.Number>", "R<#T<R, java.lang.Number>>", "n"}
+                {"a::b():void", "a", "b"},
+                {"a.b::c(int):int", "a.b", "c"},
+                {"a.b.c::d(int, int):int", "a.b.c", "d"},
+                {"a::b(Func<String, Number>, Entry<List<String>, val>, int, long):void", "a", "b"},
+                {"java.io.PrintStream::println(java.lang.String):void", "java.io.PrintStream", "println"},
+                {"MethodReferenceTest$A::m(java.lang.Object):java.lang.Object", "MethodReferenceTest$A", "m"},
+                {"R<R::<T extends java.lang.Number>>::n():R::<T extends java.lang.Number>", "R<R::<T extends java.lang.Number>>", "n"}
         };
     }
 
@@ -57,7 +60,7 @@ public class TestReferences {
     public void testMethodRef(String mds, String refType, String name) {
         MethodRef mr = MethodRef.ofString(mds);
         Assert.assertEquals(mr.toString(), mds);
-        Assert.assertEquals(mr.refType().externalize().toString(), refType);
+        Assert.assertEquals(mr.refType().toString(), refType);
         Assert.assertEquals(mr.name(), name);
     }
 
@@ -65,13 +68,13 @@ public class TestReferences {
     @DataProvider
     public Object[][] externalizedMethodRefs() {
         return new Object[][]{
-                {"&m<a, b, func<void>>", "a", "b"},
-                {"&m<a.b, c, func<int, int>>", "a.b", "c"},
-                {"&m<a.b.c, d, func<int, int, int>>", "a.b.c", "d"},
-                {"&m<a, b, func<void, Func<String, Number>, Entry<List<String>, val>, int, long>>", "a", "b"},
-                {"&m<java.io.PrintStream, println, func<void, java.lang.String>>", "java.io.PrintStream", "println"},
-                {"&m<MethodReferenceTest$A, m, func<java.lang.Object, java.lang.Object>>", "MethodReferenceTest$A", "m"},
-                {"&m<R<#T<R, java.lang.Number>>, n, func<#T<R, java.lang.Number>>>", "R<#T<R, java.lang.Number>>", "n"}
+                {"java.ref:\"a::b():void\"", "a", "b"},
+                {"java.ref:\"a.b::c(int):int\"", "a.b", "c"},
+                {"java.ref:\"a.b.c::d(int, int):int\"", "a.b.c", "d"},
+                {"java.ref:\"a::b(Func<String, Number>, Entry<List<String>, val>, int, long):void\"", "a", "b"},
+                {"java.ref:\"java.io.PrintStream::println(java.lang.String):void\"", "java.io.PrintStream", "println"},
+                {"java.ref:\"MethodReferenceTest$A::m(java.lang.Object):java.lang.Object\"", "MethodReferenceTest$A", "m"},
+                {"java.ref:\"R<R::<T extends java.lang.Number>>::n():R::<T extends java.lang.Number>\"", "R<R::<T extends java.lang.Number>>", "n"}
         };
     }
 
@@ -80,7 +83,7 @@ public class TestReferences {
         TypeElement.ExternalizedTypeElement emr = TypeElement.ExternalizedTypeElement.ofString(mds);
         MethodRef mr = (MethodRef) CoreTypeFactory.CORE_TYPE_FACTORY.constructType(emr);
         Assert.assertEquals(mr.externalize().toString(), mds);
-        Assert.assertEquals(mr.refType().externalize().toString(), refType);
+        Assert.assertEquals(mr.refType().toString(), refType);
         Assert.assertEquals(mr.name(), name);
     }
 
@@ -88,8 +91,8 @@ public class TestReferences {
     @DataProvider
     public Object[][] constructorRefs() {
         return new Object[][]{
-                {"MethodReferenceTest$X::<new>(int)", "MethodReferenceTest$X"},
-                {"MethodReferenceTest$A[]::<new>(int)", "MethodReferenceTest$A[]"},
+                {"MethodReferenceTest$X::(int)", "MethodReferenceTest$X"},
+                {"MethodReferenceTest$A[]::(int)", "MethodReferenceTest$A[]"},
         };
     }
 
@@ -97,14 +100,14 @@ public class TestReferences {
     public void testConstructorRef(String cds, String refType) {
         ConstructorRef cr = ConstructorRef.ofString(cds);
         Assert.assertEquals(cr.toString(), cds);
-        Assert.assertEquals(cr.refType().externalize().toString(), refType);
+        Assert.assertEquals(cr.refType().toString(), refType);
     }
 
     @DataProvider
     public Object[][] externalizedConstructorRefs() {
         return new Object[][]{
-                {"&c<func<MethodReferenceTest$X, int>>", "MethodReferenceTest$X"},
-                {"&c<func<MethodReferenceTest$A[], int>>", "MethodReferenceTest$A[]"},
+                {"java.ref:\"MethodReferenceTest$X::(int)\"", "MethodReferenceTest$X"},
+                {"java.ref:\"MethodReferenceTest$A[]::(int)\"", "MethodReferenceTest$A[]"},
         };
     }
 
@@ -114,17 +117,17 @@ public class TestReferences {
         ConstructorRef cr = (ConstructorRef) CoreTypeFactory.CORE_TYPE_FACTORY.constructType(ecr);
 
         Assert.assertEquals(cr.externalize().toString(), crs);
-        Assert.assertEquals(cr.refType().externalize().toString(), refType);
+        Assert.assertEquals(cr.refType().toString(), refType);
     }
 
 
     @DataProvider
     public Object[][] fieldRefs() {
         return new Object[][]{
-                {"a.b::c()int", "a.b", "c", "int"},
-                {"a.b.c::d()int", "a.b.c", "d", "int"},
-                {"java.lang.System::out()java.io.PrintStream", "java.lang.System", "out", "java.io.PrintStream"},
-                {"R<#T<R, java.lang.Number>>::n()#T<R, java.lang.Number>", "R<#T<R, java.lang.Number>>", "n", "#T<R, java.lang.Number>"}
+                {"a.b::c:int", "a.b", "c", "int"},
+                {"a.b.c::d:int", "a.b.c", "d", "int"},
+                {"java.lang.System::out:java.io.PrintStream", "java.lang.System", "out", "java.io.PrintStream"},
+                {"R<R::<T extends java.lang.Number>>::n:R::<T extends java.lang.Number>", "R<R::<T extends java.lang.Number>>", "n", "R::<T extends java.lang.Number>"}
         };
     }
 
@@ -132,18 +135,18 @@ public class TestReferences {
     public void testFieldRef(String fds, String refType, String name, String type) {
         FieldRef fr = FieldRef.ofString(fds);
         Assert.assertEquals(fr.toString(), fds);
-        Assert.assertEquals(fr.refType().externalize().toString(), refType);
+        Assert.assertEquals(fr.refType().toString(), refType);
         Assert.assertEquals(fr.name(), name);
-        Assert.assertEquals(fr.type().externalize().toString(), type);
+        Assert.assertEquals(fr.type().toString(), type);
     }
 
     @DataProvider
     public Object[][] externalizedFieldRefs() {
         return new Object[][]{
-                {"&f<a.b, c, int>", "a.b", "c", "int"},
-                {"&f<a.b.c, d, int>", "a.b.c", "d", "int"},
-                {"&f<java.lang.System, out, java.io.PrintStream>", "java.lang.System", "out", "java.io.PrintStream"},
-                {"&f<R<#T<R, java.lang.Number>>, n, #T<R, java.lang.Number>>", "R<#T<R, java.lang.Number>>", "n", "#T<R, java.lang.Number>"}
+                {"java.ref:\"a.b::c:int\"", "a.b", "c", "int"},
+                {"java.ref:\"a.b.c::d:int\"", "a.b.c", "d", "int"},
+                {"java.ref:\"java.lang.System::out:java.io.PrintStream\"", "java.lang.System", "out", "java.io.PrintStream"},
+                {"java.ref:\"R<R::<T extends java.lang.Number>>::n:R::<T extends java.lang.Number>\"", "R<R::<T extends java.lang.Number>>", "n", "R::<T extends java.lang.Number>"}
         };
     }
 
@@ -153,9 +156,9 @@ public class TestReferences {
         FieldRef fr = (FieldRef) CoreTypeFactory.CORE_TYPE_FACTORY.constructType(efr);
 
         Assert.assertEquals(fr.externalize().toString(), frs);
-        Assert.assertEquals(fr.refType().externalize().toString(), refType);
+        Assert.assertEquals(fr.refType().toString(), refType);
         Assert.assertEquals(fr.name(), name);
-        Assert.assertEquals(fr.type().externalize().toString(), type);
+        Assert.assertEquals(fr.type().toString(), type);
     }
 
 
@@ -166,7 +169,7 @@ public class TestReferences {
                 {"(B b)A"},
                 {"(B b, C c)A"},
                 {"(p.Func<String, Number> f, Entry<List<String>, val> e, int i, long l)p.A<R>"},
-                {"(#T<R, java.lang.Number> n)R<#T<R, java.lang.Number>>"}
+                {"(R::<T extends java.lang.Number> n)R<R::<T extends java.lang.Number>>"}
         };
     }
 
@@ -179,12 +182,12 @@ public class TestReferences {
     @DataProvider
     public Object[][] externalizedRecordTypeRefs() {
         return new Object[][]{
-                {"&r<A>"},
-                {"&r<A, B, b>"},
-                {"&r<A, B, b, C, c>"},
-                {"&r<p.A<R>, p.Func<String, Number>, f, Entry<List<String>, val>, e, int, i, long, l>"},
+                {"java.ref:\"()A\""},
+                {"java.ref:\"(B b)A\""},
+                {"java.ref:\"(B b, C c)A\""},
+                {"java.ref:\"(p.Func<String, Number> f, Entry<List<String>, val> e, int i, long l)p.A<R>\""},
                 // @@@ Fails because of externalize().toString()
-                {"&r<R<#T<R, java.lang.Number>>, #T<R, java.lang.Number>, n>"}
+                {"java.ref:\"(R::<T extends java.lang.Number> n)R<R::<T extends java.lang.Number>>\""}
         };
     }
 

--- a/test/langtools/tools/javac/reflect/ArrayAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ArrayAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,11 @@ import jdk.incubator.code.CodeReflection;
 public class ArrayAccessTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : ArrayAccessTest, %1 : int[])int -> {
-                %2 : Var<int[]> = var %1 @"ia";
-                %3 : int[] = var.load %2;
-                %4 : int = constant @"0";
-                %5 : int = array.load %3 %4;
+            func @"test1" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]")java.type:"int" -> {
+                %2 : Var<java.type:"int[]"> = var %1 @"ia";
+                %3 : java.type:"int[]" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"int" = array.load %3 %4;
                 return %5;
             };
             """)
@@ -49,14 +49,14 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : ArrayAccessTest, %1 : int[], %2 : int)int -> {
-                %3 : Var<int[]> = var %1 @"ia";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int[] = var.load %3;
-                %6 : int = var.load %4;
-                %7 : int = constant @"1";
-                %8 : int = add %6 %7;
-                %9 : int = array.load %5 %8;
+            func @"test2" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]", %2 : java.type:"int")java.type:"int" -> {
+                %3 : Var<java.type:"int[]"> = var %1 @"ia";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int[]" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"int" = add %6 %7;
+                %9 : java.type:"int" = array.load %5 %8;
                 return %9;
             };
             """)
@@ -66,11 +66,11 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : ArrayAccessTest, %1 : int[])void -> {
-                %2 : Var<int[]> = var %1 @"ia";
-                %3 : int[] = var.load %2;
-                %4 : int = constant @"0";
-                %5 : int = constant @"1";
+            func @"test3" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %1 @"ia";
+                %3 : java.type:"int[]" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"int" = constant @"1";
                 array.store %3 %4 %5;
                 return;
             };
@@ -81,14 +81,14 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : ArrayAccessTest, %1 : int[], %2 : int)void -> {
-                %3 : Var<int[]> = var %1 @"ia";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int[] = var.load %3;
-                %6 : int = var.load %4;
-                %7 : int = constant @"1";
-                %8 : int = add %6 %7;
-                %9 : int = constant @"1";
+            func @"test4" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int[]"> = var %1 @"ia";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int[]" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"int" = add %6 %7;
+                %9 : java.type:"int" = constant @"1";
                 array.store %5 %8 %9;
                 return;
             };
@@ -99,18 +99,18 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : ArrayAccessTest, %1 : int[][], %2 : int)int -> {
-                %3 : Var<int[][]> = var %1 @"ia";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int[][] = var.load %3;
-                %6 : int = var.load %4;
-                %7 : int = constant @"1";
-                %8 : int = add %6 %7;
-                %9 : int[] = array.load %5 %8;
-                %10 : int = var.load %4;
-                %11 : int = constant @"2";
-                %12 : int = add %10 %11;
-                %13 : int = array.load %9 %12;
+            func @"test5" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[][]", %2 : java.type:"int")java.type:"int" -> {
+                %3 : Var<java.type:"int[][]"> = var %1 @"ia";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int[][]" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"int" = add %6 %7;
+                %9 : java.type:"int[]" = array.load %5 %8;
+                %10 : java.type:"int" = var.load %4;
+                %11 : java.type:"int" = constant @"2";
+                %12 : java.type:"int" = add %10 %11;
+                %13 : java.type:"int" = array.load %9 %12;
                 return %13;
             };
             """)
@@ -120,18 +120,18 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : ArrayAccessTest, %1 : int[][], %2 : int)void -> {
-                %3 : Var<int[][]> = var %1 @"ia";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int[][] = var.load %3;
-                %6 : int = var.load %4;
-                %7 : int = constant @"1";
-                %8 : int = add %6 %7;
-                %9 : int[] = array.load %5 %8;
-                %10 : int = var.load %4;
-                %11 : int = constant @"2";
-                %12 : int = add %10 %11;
-                %13 : int = constant @"1";
+            func @"test6" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[][]", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int[][]"> = var %1 @"ia";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int[][]" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"int" = add %6 %7;
+                %9 : java.type:"int[]" = array.load %5 %8;
+                %10 : java.type:"int" = var.load %4;
+                %11 : java.type:"int" = constant @"2";
+                %12 : java.type:"int" = add %10 %11;
+                %13 : java.type:"int" = constant @"1";
                 array.store %9 %12 %13;
                 return;
             };
@@ -144,10 +144,10 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : ArrayAccessTest)int -> {
-                %1 : int[] = field.load %0 @"ArrayAccessTest::ia()int[]";
-                %2 : int = constant @"0";
-                %3 : int = array.load %1 %2;
+            func @"test7" (%0 : java.type:"ArrayAccessTest")java.type:"int" -> {
+                %1 : java.type:"int[]" = field.load %0 @"ArrayAccessTest::ia:int[]";
+                %2 : java.type:"int" = constant @"0";
+                %3 : java.type:"int" = array.load %1 %2;
                 return %3;
             };
             """)
@@ -157,10 +157,10 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : ArrayAccessTest)int -> {
-                %1 : int[] = field.load %0 @"ArrayAccessTest::ia()int[]";
-                %2 : int = constant @"0";
-                %3 : int = array.load %1 %2;
+            func @"test8" (%0 : java.type:"ArrayAccessTest")java.type:"int" -> {
+                %1 : java.type:"int[]" = field.load %0 @"ArrayAccessTest::ia:int[]";
+                %2 : java.type:"int" = constant @"0";
+                %3 : java.type:"int" = array.load %1 %2;
                 return %3;
             };
             """)
@@ -174,12 +174,12 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : ArrayAccessTest, %1 : ArrayAccessTest$A[])int -> {
-                %2 : Var<ArrayAccessTest$A[]> = var %1 @"aa";
-                %3 : ArrayAccessTest$A[] = var.load %2;
-                %4 : int = constant @"0";
-                %5 : ArrayAccessTest$A = array.load %3 %4;
-                %6 : int = field.load %5 @"ArrayAccessTest$A::i()int";
+            func @"test9" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"ArrayAccessTest$A[]")java.type:"int" -> {
+                %2 : Var<java.type:"ArrayAccessTest$A[]"> = var %1 @"aa";
+                %3 : java.type:"ArrayAccessTest$A[]" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"ArrayAccessTest$A" = array.load %3 %4;
+                %6 : java.type:"int" = field.load %5 @"ArrayAccessTest$A::i:int";
                 return %6;
             };
             """)
@@ -189,13 +189,13 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0 : ArrayAccessTest, %1 : ArrayAccessTest$A[])void -> {
-                %2 : Var<ArrayAccessTest$A[]> = var %1 @"aa";
-                %3 : ArrayAccessTest$A[] = var.load %2;
-                %4 : int = constant @"0";
-                %5 : ArrayAccessTest$A = array.load %3 %4;
-                %6 : int = constant @"1";
-                field.store %5 %6 @"ArrayAccessTest$A::i()int";
+            func @"test10" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"ArrayAccessTest$A[]")java.type:"void" -> {
+                %2 : Var<java.type:"ArrayAccessTest$A[]"> = var %1 @"aa";
+                %3 : java.type:"ArrayAccessTest$A[]" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"ArrayAccessTest$A" = array.load %3 %4;
+                %6 : java.type:"int" = constant @"1";
+                field.store %5 %6 @"ArrayAccessTest$A::i:int";
                 return;
             };
             """)
@@ -205,13 +205,13 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test11" (%0 : ArrayAccessTest, %1 : int[])void -> {
-                %2 : Var<int[]> = var %1 @"ia";
-                %3 : int[] = var.load %2;
-                %4 : int = constant @"0";
-                %5 : int = array.load %3 %4;
-                %6 : int = constant @"1";
-                %7 : int = add %5 %6;
+            func @"test11" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %1 @"ia";
+                %3 : java.type:"int[]" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"int" = array.load %3 %4;
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = add %5 %6;
                 array.store %3 %4 %7;
                 return;
             };
@@ -222,18 +222,18 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test12" (%0 : ArrayAccessTest, %1 : int[], %2 : int)void -> {
-                %3 : Var<int[]> = var %1 @"ia";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int[] = var.load %3;
-                %6 : int = constant @"1";
-                %7 : int[] = var.load %3;
-                %8 : int = var.load %4;
-                %9 : int = constant @"2";
-                %10 : int = add %8 %9;
-                %11 : int = array.load %7 %10;
-                %12 : int = constant @"1";
-                %13 : int = add %11 %12;
+            func @"test12" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int[]"> = var %1 @"ia";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int[]" = var.load %3;
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int[]" = var.load %3;
+                %8 : java.type:"int" = var.load %4;
+                %9 : java.type:"int" = constant @"2";
+                %10 : java.type:"int" = add %8 %9;
+                %11 : java.type:"int" = array.load %7 %10;
+                %12 : java.type:"int" = constant @"1";
+                %13 : java.type:"int" = add %11 %12;
                 array.store %7 %10 %13;
                 array.store %5 %6 %13;
                 return;
@@ -245,21 +245,21 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test13" (%0 : ArrayAccessTest, %1 : int[], %2 : int)void -> {
-                %3 : Var<int[]> = var %1 @"ia";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int[] = var.load %3;
-                %6 : int = constant @"1";
-                %7 : int = array.load %5 %6;
-                %8 : int[] = var.load %3;
-                %9 : int = var.load %4;
-                %10 : int = constant @"2";
-                %11 : int = add %9 %10;
-                %12 : int = array.load %8 %11;
-                %13 : int = constant @"1";
-                %14 : int = add %12 %13;
+            func @"test13" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int[]"> = var %1 @"ia";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int[]" = var.load %3;
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = array.load %5 %6;
+                %8 : java.type:"int[]" = var.load %3;
+                %9 : java.type:"int" = var.load %4;
+                %10 : java.type:"int" = constant @"2";
+                %11 : java.type:"int" = add %9 %10;
+                %12 : java.type:"int" = array.load %8 %11;
+                %13 : java.type:"int" = constant @"1";
+                %14 : java.type:"int" = add %12 %13;
                 array.store %8 %11 %14;
-                %15 : int = add %7 %14;
+                %15 : java.type:"int" = add %7 %14;
                 array.store %5 %6 %15;
                 return;
             };
@@ -271,22 +271,22 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test14" (%0 : ArrayAccessTest, %1 : int[])void -> {
-                %2 : Var<int[]> = var %1 @"ia";
-                %3 : int[] = var.load %2;
-                %4 : int = constant @"0";
-                %5 : int = array.load %3 %4;
-                %6 : int = constant @"1";
-                %7 : int = add %5 %6;
+            func @"test14" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %1 @"ia";
+                %3 : java.type:"int[]" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"int" = array.load %3 %4;
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = add %5 %6;
                 array.store %3 %4 %7;
-                %8 : Var<int> = var %5 @"x";
-                %9 : int[] = var.load %2;
-                %10 : int = constant @"0";
-                %11 : int = array.load %9 %10;
-                %12 : int = constant @"1";
-                %13 : int = sub %11 %12;
+                %8 : Var<java.type:"int"> = var %5 @"x";
+                %9 : java.type:"int[]" = var.load %2;
+                %10 : java.type:"int" = constant @"0";
+                %11 : java.type:"int" = array.load %9 %10;
+                %12 : java.type:"int" = constant @"1";
+                %13 : java.type:"int" = sub %11 %12;
                 array.store %9 %10 %13;
-                %14 : Var<int> = var %11 @"y";
+                %14 : Var<java.type:"int"> = var %11 @"y";
                 return;
             };
             """)
@@ -297,22 +297,22 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test15" (%0 : ArrayAccessTest, %1 : int[])void -> {
-                %2 : Var<int[]> = var %1 @"ia";
-                %3 : int[] = var.load %2;
-                %4 : int = constant @"0";
-                %5 : int = array.load %3 %4;
-                %6 : int = constant @"1";
-                %7 : int = add %5 %6;
+            func @"test15" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %1 @"ia";
+                %3 : java.type:"int[]" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"int" = array.load %3 %4;
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = add %5 %6;
                 array.store %3 %4 %7;
-                %8 : Var<int> = var %7 @"x";
-                %9 : int[] = var.load %2;
-                %10 : int = constant @"0";
-                %11 : int = array.load %9 %10;
-                %12 : int = constant @"1";
-                %13 : int = sub %11 %12;
+                %8 : Var<java.type:"int"> = var %7 @"x";
+                %9 : java.type:"int[]" = var.load %2;
+                %10 : java.type:"int" = constant @"0";
+                %11 : java.type:"int" = array.load %9 %10;
+                %12 : java.type:"int" = constant @"1";
+                %13 : java.type:"int" = sub %11 %12;
                 array.store %9 %10 %13;
-                %14 : Var<int> = var %13 @"y";
+                %14 : Var<java.type:"int"> = var %13 @"y";
                 return;
             };
             """)
@@ -323,13 +323,13 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test16" (%0 : ArrayAccessTest, %1 : int[])int -> {
-                %2 : Var<int[]> = var %1 @"ia";
-                %3 : int[] = var.load %2;
-                %4 : int = array.length %3;
-                %5 : int[] = var.load %2;
-                %6 : int = invoke %5 @"java.lang.Object::hashCode()int";
-                %7 : int = add %4 %6;
+            func @"test16" (%0 : java.type:"ArrayAccessTest", %1 : java.type:"int[]")java.type:"int" -> {
+                %2 : Var<java.type:"int[]"> = var %1 @"ia";
+                %3 : java.type:"int[]" = var.load %2;
+                %4 : java.type:"int" = array.length %3;
+                %5 : java.type:"int[]" = var.load %2;
+                %6 : java.type:"int" = invoke %5 @"java.lang.Object::hashCode():int";
+                %7 : java.type:"int" = add %4 %6;
                 return %7;
             };
             """)
@@ -339,12 +339,12 @@ public class ArrayAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test17" (%0 : java.lang.Object[])java.lang.Object -> {
-                %1 : Var<java.lang.Object[]> = var %0 @"a";
-                %2 : java.lang.Object[] = var.load %1;
-                %3 : char = constant @"c";
-                %4 : int = conv %3;
-                %5 : java.lang.Object = array.load %2 %4;
+            func @"test17" (%0 : java.type:"java.lang.Object[]")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.Object[]"> = var %0 @"a";
+                %2 : java.type:"java.lang.Object[]" = var.load %1;
+                %3 : java.type:"char" = constant @"c";
+                %4 : java.type:"int" = conv %3;
+                %5 : java.type:"java.lang.Object" = array.load %2 %4;
                 return %5;
             };
             """)

--- a/test/langtools/tools/javac/reflect/AssertTest.java
+++ b/test/langtools/tools/javac/reflect/AssertTest.java
@@ -35,21 +35,21 @@ public class AssertTest {
 
     @CodeReflection
     @IR("""
-              func @"assertTest" (%0 : int)void -> {
-                  %1 : Var<int> = var %0 @"i";
-                  assert
-                      ()boolean -> {
-                          %2 : int = var.load %1;
-                          %3 : int = constant @"1";
-                          %4 : boolean = eq %2 %3;
-                          yield %4;
-                      }
-                      ()java.lang.String -> {
-                          %5 : java.lang.String = constant @"i does not equal 1";
-                          yield %5;
-                      };
-                  return;
-              };
+            func @"assertTest" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                assert
+                    ()java.type:"boolean" -> {
+                        %2 : java.type:"int" = var.load %1;
+                        %3 : java.type:"int" = constant @"1";
+                        %4 : java.type:"boolean" = eq %2 %3;
+                        yield %4;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %5 : java.type:"java.lang.String" = constant @"i does not equal 1";
+                        yield %5;
+                    };
+                return;
+            };
             """)
     public static void assertTest(int i) {
         assert (i == 1) : "i does not equal 1";
@@ -57,16 +57,16 @@ public class AssertTest {
 
     @CodeReflection
     @IR("""
-            func @"assertTest2" (%0 : int)void -> {
-                  %1 : Var<int> = var %0 @"i";
-                  assert ()boolean -> {
-                      %2 : int = var.load %1;
-                      %3 : int = constant @"1";
-                      %4 : boolean = eq %2 %3;
-                      yield %4;
-                  };
-                  return;
-              };
+            func @"assertTest2" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                assert ()java.type:"boolean" -> {
+                    %2 : java.type:"int" = var.load %1;
+                    %3 : java.type:"int" = constant @"1";
+                    %4 : java.type:"boolean" = eq %2 %3;
+                    yield %4;
+                };
+                return;
+            };
             """)
     public static void assertTest2(int i) {
         assert (i == 1);

--- a/test/langtools/tools/javac/reflect/BinopTest.java
+++ b/test/langtools/tools/javac/reflect/BinopTest.java
@@ -36,14 +36,14 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test" (%0 : BinopTest)int -> {
-                %1 : int = constant @"5";
-                %2 : int = constant @"2";
-                %3 : int = constant @"4";
-                %4 : int = mul %2 %3;
-                %5 : int = add %1 %4;
-                %6 : int = constant @"3";
-                %7 : int = sub %5 %6;
+            func @"test" (%0 : java.type:"BinopTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"5";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"int" = constant @"4";
+                %4 : java.type:"int" = mul %2 %3;
+                %5 : java.type:"int" = add %1 %4;
+                %6 : java.type:"int" = constant @"3";
+                %7 : java.type:"int" = sub %5 %6;
                 return %7;
             };
             """)
@@ -53,14 +53,14 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : BinopTest)int -> {
-                %1 : int = constant @"1";
-                %2 : int = constant @"2";
-                %3 : int = constant @"3";
-                %4 : int = constant @"4";
-                %5 : int = add %3 %4;
-                %6 : int = add %2 %5;
-                %7 : int = add %1 %6;
+            func @"test2" (%0 : java.type:"BinopTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"int" = constant @"3";
+                %4 : java.type:"int" = constant @"4";
+                %5 : java.type:"int" = add %3 %4;
+                %6 : java.type:"int" = add %2 %5;
+                %7 : java.type:"int" = add %1 %6;
                 return %7;
             };
             """)
@@ -70,14 +70,14 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : BinopTest)int -> {
-                %1 : int = constant @"1";
-                %2 : int = constant @"2";
-                %3 : int = add %1 %2;
-                %4 : int = constant @"3";
-                %5 : int = add %3 %4;
-                %6 : int = constant @"4";
-                %7 : int = add %5 %6;
+            func @"test3" (%0 : java.type:"BinopTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"int" = add %1 %2;
+                %4 : java.type:"int" = constant @"3";
+                %5 : java.type:"int" = add %3 %4;
+                %6 : java.type:"int" = constant @"4";
+                %7 : java.type:"int" = add %5 %6;
                 return %7;
             };
             """)
@@ -87,32 +87,32 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : BinopTest, %1 : int)int -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = constant @"1";
-                %5 : int = add %3 %4;
+            func @"test4" (%0 : java.type:"BinopTest", %1 : java.type:"int")java.type:"int" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"int" = add %3 %4;
                 var.store %2 %5;
-                %6 : int = var.load %2;
-                %7 : int = constant @"1";
-                %8 : int = mul %6 %7;
+                %6 : java.type:"int" = var.load %2;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"int" = mul %6 %7;
                 var.store %2 %8;
-                %9 : int = add %5 %8;
-                %10 : int = var.load %2;
-                %11 : int = constant @"1";
-                %12 : int = div %10 %11;
+                %9 : java.type:"int" = add %5 %8;
+                %10 : java.type:"int" = var.load %2;
+                %11 : java.type:"int" = constant @"1";
+                %12 : java.type:"int" = div %10 %11;
                 var.store %2 %12;
-                %13 : int = add %9 %12;
-                %14 : int = var.load %2;
-                %15 : int = constant @"1";
-                %16 : int = sub %14 %15;
+                %13 : java.type:"int" = add %9 %12;
+                %14 : java.type:"int" = var.load %2;
+                %15 : java.type:"int" = constant @"1";
+                %16 : java.type:"int" = sub %14 %15;
                 var.store %2 %16;
-                %17 : int = add %13 %16;
-                %18 : int = var.load %2;
-                %19 : int = constant @"1";
-                %20 : int = mod %18 %19;
+                %17 : java.type:"int" = add %13 %16;
+                %18 : java.type:"int" = var.load %2;
+                %19 : java.type:"int" = constant @"1";
+                %20 : java.type:"int" = mod %18 %19;
                 var.store %2 %20;
-                %21 : int = add %17 %20;
+                %21 : java.type:"int" = add %17 %20;
                 return %21;
             };
             """)
@@ -122,12 +122,12 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : BinopTest, %1 : int)boolean -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = constant @"0";
-                %5 : boolean = eq %3 %4;
-                %6 : boolean = not %5;
+            func @"test5" (%0 : java.type:"BinopTest", %1 : java.type:"int")java.type:"boolean" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"boolean" = eq %3 %4;
+                %6 : java.type:"boolean" = not %5;
                 return %6;
             };
             """)
@@ -137,10 +137,10 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : BinopTest)int -> {
-                %1 : int = constant @"5";
-                %2 : int = constant @"2";
-                %3 : int = mod %1 %2;
+            func @"test6" (%0 : java.type:"BinopTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"5";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"int" = mod %1 %2;
                 return %3;
             };
             """)
@@ -150,60 +150,60 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : BinopTest, %1 : double)void -> {
-                %2 : Var<double> = var %1 @"d";
-                %3 : double = var.load %2;
-                %4 : int = constant @"1";
-                %5 : double = conv %4;
-                %6 : double = add %3 %5;
+            func @"test7" (%0 : java.type:"BinopTest", %1 : java.type:"double")java.type:"void" -> {
+                %2 : Var<java.type:"double"> = var %1 @"d";
+                %3 : java.type:"double" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"double" = conv %4;
+                %6 : java.type:"double" = add %3 %5;
                 var.store %2 %6;
-                %7 : long = constant @"1";
-                %8 : double = conv %7;
-                %9 : double = var.load %2;
-                %10 : double = add %8 %9;
+                %7 : java.type:"long" = constant @"1";
+                %8 : java.type:"double" = conv %7;
+                %9 : java.type:"double" = var.load %2;
+                %10 : java.type:"double" = add %8 %9;
                 var.store %2 %10;
-                %11 : double = var.load %2;
-                %12 : long = constant @"1";
-                %13 : double = conv %12;
-                %14 : double = sub %11 %13;
+                %11 : java.type:"double" = var.load %2;
+                %12 : java.type:"long" = constant @"1";
+                %13 : java.type:"double" = conv %12;
+                %14 : java.type:"double" = sub %11 %13;
                 var.store %2 %14;
-                %15 : int = constant @"1";
-                %16 : double = conv %15;
-                %17 : double = var.load %2;
-                %18 : double = sub %16 %17;
+                %15 : java.type:"int" = constant @"1";
+                %16 : java.type:"double" = conv %15;
+                %17 : java.type:"double" = var.load %2;
+                %18 : java.type:"double" = sub %16 %17;
                 var.store %2 %18;
-                %19 : double = var.load %2;
-                %20 : int = constant @"1";
-                %21 : double = conv %20;
-                %22 : double = mul %19 %21;
+                %19 : java.type:"double" = var.load %2;
+                %20 : java.type:"int" = constant @"1";
+                %21 : java.type:"double" = conv %20;
+                %22 : java.type:"double" = mul %19 %21;
                 var.store %2 %22;
-                %23 : long = constant @"1";
-                %24 : double = conv %23;
-                %25 : double = var.load %2;
-                %26 : double = mul %24 %25;
+                %23 : java.type:"long" = constant @"1";
+                %24 : java.type:"double" = conv %23;
+                %25 : java.type:"double" = var.load %2;
+                %26 : java.type:"double" = mul %24 %25;
                 var.store %2 %26;
-                %27 : double = var.load %2;
-                %28 : long = constant @"1";
-                %29 : double = conv %28;
-                %30 : double = div %27 %29;
+                %27 : java.type:"double" = var.load %2;
+                %28 : java.type:"long" = constant @"1";
+                %29 : java.type:"double" = conv %28;
+                %30 : java.type:"double" = div %27 %29;
                 var.store %2 %30;
-                %31 : int = constant @"1";
-                %32 : double = conv %31;
-                %33 : double = var.load %2;
-                %34 : double = div %32 %33;
+                %31 : java.type:"int" = constant @"1";
+                %32 : java.type:"double" = conv %31;
+                %33 : java.type:"double" = var.load %2;
+                %34 : java.type:"double" = div %32 %33;
                 var.store %2 %34;
-                %35 : double = var.load %2;
-                %36 : int = constant @"1";
-                %37 : double = conv %36;
-                %38 : double = mod %35 %37;
+                %35 : java.type:"double" = var.load %2;
+                %36 : java.type:"int" = constant @"1";
+                %37 : java.type:"double" = conv %36;
+                %38 : java.type:"double" = mod %35 %37;
                 var.store %2 %38;
-                %39 : long = constant @"1";
-                %40 : double = conv %39;
-                %41 : double = var.load %2;
-                %42 : double = mod %40 %41;
+                %39 : java.type:"long" = constant @"1";
+                %40 : java.type:"double" = conv %39;
+                %41 : java.type:"double" = var.load %2;
+                %42 : java.type:"double" = mod %40 %41;
                 var.store %2 %42;
-                %43 : int = constant @"-1";
-                %44 : double = conv %43;
+                %43 : java.type:"int" = constant @"-1";
+                %44 : java.type:"double" = conv %43;
                 var.store %2 %44;
                 return;
             };
@@ -229,32 +229,32 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : BinopTest, %1 : double)void -> {
-                %2 : Var<double> = var %1 @"d";
-                %3 : double = var.load %2;
-                %4 : int = constant @"1";
-                %5 : double = conv %4;
-                %6 : double = add %3 %5;
+            func @"test8" (%0 : java.type:"BinopTest", %1 : java.type:"double")java.type:"void" -> {
+                %2 : Var<java.type:"double"> = var %1 @"d";
+                %3 : java.type:"double" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"double" = conv %4;
+                %6 : java.type:"double" = add %3 %5;
                 var.store %2 %6;
-                %7 : double = var.load %2;
-                %8 : long = constant @"1";
-                %9 : double = conv %8;
-                %10 : double = sub %7 %9;
+                %7 : java.type:"double" = var.load %2;
+                %8 : java.type:"long" = constant @"1";
+                %9 : java.type:"double" = conv %8;
+                %10 : java.type:"double" = sub %7 %9;
                 var.store %2 %10;
-                %11 : double = var.load %2;
-                %12 : int = constant @"1";
-                %13 : double = conv %12;
-                %14 : double = mul %11 %13;
+                %11 : java.type:"double" = var.load %2;
+                %12 : java.type:"int" = constant @"1";
+                %13 : java.type:"double" = conv %12;
+                %14 : java.type:"double" = mul %11 %13;
                 var.store %2 %14;
-                %15 : double = var.load %2;
-                %16 : long = constant @"1";
-                %17 : double = conv %16;
-                %18 : double = div %15 %17;
+                %15 : java.type:"double" = var.load %2;
+                %16 : java.type:"long" = constant @"1";
+                %17 : java.type:"double" = conv %16;
+                %18 : java.type:"double" = div %15 %17;
                 var.store %2 %18;
-                %19 : double = var.load %2;
-                %20 : int = constant @"1";
-                %21 : double = conv %20;
-                %22 : double = mod %19 %21;
+                %19 : java.type:"double" = var.load %2;
+                %20 : java.type:"int" = constant @"1";
+                %21 : java.type:"double" = conv %20;
+                %22 : java.type:"double" = mod %19 %21;
                 var.store %2 %22;
                 return;
             };
@@ -273,37 +273,37 @@ public class BinopTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : BinopTest, %1 : byte, %2 : byte, %3 : short)void -> {
-                %4 : Var<byte> = var %1 @"a";
-                %5 : Var<byte> = var %2 @"b";
-                %6 : Var<short> = var %3 @"s";
-                %7 : byte = var.load %4;
-                %8 : byte = var.load %5;
-                %9 : byte = add %7 %8;
+            func @"test9" (%0 : java.type:"BinopTest", %1 : java.type:"byte", %2 : java.type:"byte", %3 : java.type:"short")java.type:"void" -> {
+                %4 : Var<java.type:"byte"> = var %1 @"a";
+                %5 : Var<java.type:"byte"> = var %2 @"b";
+                %6 : Var<java.type:"short"> = var %3 @"s";
+                %7 : java.type:"byte" = var.load %4;
+                %8 : java.type:"byte" = var.load %5;
+                %9 : java.type:"byte" = add %7 %8;
                 var.store %4 %9;
-                %10 : byte = var.load %4;
-                %11 : short = var.load %6;
-                %12 : byte = conv %11;
-                %13 : byte = div %10 %12;
+                %10 : java.type:"byte" = var.load %4;
+                %11 : java.type:"short" = var.load %6;
+                %12 : java.type:"byte" = conv %11;
+                %13 : java.type:"byte" = div %10 %12;
                 var.store %4 %13;
-                %14 : byte = var.load %4;
-                %15 : double = constant @"3.5";
-                %16 : byte = conv %15;
-                %17 : byte = mul %14 %16;
+                %14 : java.type:"byte" = var.load %4;
+                %15 : java.type:"double" = constant @"3.5";
+                %16 : java.type:"byte" = conv %15;
+                %17 : java.type:"byte" = mul %14 %16;
                 var.store %4 %17;
-                %18 : byte = var.load %4;
-                %19 : byte = var.load %5;
-                %20 : byte = lshl %18 %19;
+                %18 : java.type:"byte" = var.load %4;
+                %19 : java.type:"byte" = var.load %5;
+                %20 : java.type:"byte" = lshl %18 %19;
                 var.store %4 %20;
-                %21 : byte = var.load %4;
-                %22 : int = constant @"1";
-                %23 : byte = conv %22;
-                %24 : byte = ashr %21 %23;
+                %21 : java.type:"byte" = var.load %4;
+                %22 : java.type:"int" = constant @"1";
+                %23 : java.type:"byte" = conv %22;
+                %24 : java.type:"byte" = ashr %21 %23;
                 var.store %4 %24;
-                %25 : byte = var.load %4;
-                %26 : long = constant @"1";
-                %27 : byte = conv %26;
-                %28 : byte = ashr %25 %27;
+                %25 : java.type:"byte" = var.load %4;
+                %26 : java.type:"long" = constant @"1";
+                %27 : java.type:"byte" = conv %26;
+                %28 : java.type:"byte" = ashr %25 %27;
                 var.store %4 %28;
                 return;
             };

--- a/test/langtools/tools/javac/reflect/BlockTest.java
+++ b/test/langtools/tools/javac/reflect/BlockTest.java
@@ -37,18 +37,18 @@ import java.util.function.Consumer;
 public class BlockTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : BlockTest)void -> {
-                java.block ()void -> {
-                    %1 : int = constant @"0";
-                    %2 : Var<int> = var %1 @"i";
+            func @"test1" (%0 : java.type:"BlockTest")java.type:"void" -> {
+                java.block ()java.type:"void" -> {
+                    %1 : java.type:"int" = constant @"0";
+                    %2 : Var<java.type:"int"> = var %1 @"i";
                     yield;
                 };
-                java.block ()void -> {
-                    %3 : int = constant @"1";
-                    %4 : Var<int> = var %3 @"i";
-                    java.block ()void -> {
-                        %5 : int = constant @"2";
-                        %6 : Var<int> = var %5 @"j";
+                java.block ()java.type:"void" -> {
+                    %3 : java.type:"int" = constant @"1";
+                    %4 : Var<java.type:"int"> = var %3 @"i";
+                    java.block ()java.type:"void" -> {
+                        %5 : java.type:"int" = constant @"2";
+                        %6 : Var<java.type:"int"> = var %5 @"j";
                         yield;
                     };
                     yield;
@@ -72,46 +72,46 @@ public class BlockTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : BlockTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test2" (%0 : java.type:"BlockTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        java.block ()void -> {
-                            %6 : int = var.load %2;
-                            %7 : int = constant @"1";
-                            %8 : int = add %6 %7;
+                    ()java.type:"void" -> {
+                        java.block ()java.type:"void" -> {
+                            %6 : java.type:"int" = var.load %2;
+                            %7 : java.type:"int" = constant @"1";
+                            %8 : java.type:"int" = add %6 %7;
                             var.store %2 %8;
                             yield;
                         };
                         yield;
                     }
-                    ^else_if()boolean -> {
-                        %9 : int = var.load %2;
-                        %10 : int = constant @"2";
-                        %11 : boolean = lt %9 %10;
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"int" = var.load %2;
+                        %10 : java.type:"int" = constant @"2";
+                        %11 : java.type:"boolean" = lt %9 %10;
                         yield %11;
                     }
-                    ^then()void -> {
-                        java.block ()void -> {
-                            %12 : int = var.load %2;
-                            %13 : int = constant @"2";
-                            %14 : int = add %12 %13;
+                    ()java.type:"void" -> {
+                        java.block ()java.type:"void" -> {
+                            %12 : java.type:"int" = var.load %2;
+                            %13 : java.type:"int" = constant @"2";
+                            %14 : java.type:"int" = add %12 %13;
                             var.store %2 %14;
                             yield;
                         };
                         yield;
                     }
-                    ^else()void -> {
-                        java.block ()void -> {
-                            %15 : int = var.load %2;
-                            %16 : int = constant @"3";
-                            %17 : int = add %15 %16;
+                    ()java.type:"void" -> {
+                        java.block ()java.type:"void" -> {
+                            %15 : java.type:"int" = var.load %2;
+                            %16 : java.type:"int" = constant @"3";
+                            %17 : java.type:"int" = add %15 %16;
                             var.store %2 %17;
                             yield;
                         };
@@ -138,22 +138,22 @@ public class BlockTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : BlockTest)void -> {
+            func @"test3" (%0 : java.type:"BlockTest")java.type:"void" -> {
                 java.for
-                    ^init()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     }
-                    ^cond()boolean -> {
-                        %1 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %1 : java.type:"boolean" = constant @"true";
                         yield %1;
                     }
-                    ^update()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     }
-                    ^body()void -> {
-                        java.block ()void -> {
-                            %2 : int = constant @"0";
-                            %3 : Var<int> = var %2 @"i";
+                    ()java.type:"void" -> {
+                        java.block ()java.type:"void" -> {
+                            %2 : java.type:"int" = constant @"0";
+                            %3 : Var<java.type:"int"> = var %2 @"i";
                             yield;
                         };
                         java.continue;
@@ -171,22 +171,22 @@ public class BlockTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : BlockTest, %1 : int[])void -> {
-                %2 : Var<int[]> = var %1 @"ia";
+            func @"test4" (%0 : java.type:"BlockTest", %1 : java.type:"int[]")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %1 @"ia";
                 java.enhancedFor
-                    ^expr()int[] -> {
-                        %3 : int[] = var.load %2;
+                    ()java.type:"int[]" -> {
+                        %3 : java.type:"int[]" = var.load %2;
                         yield %3;
                     }
-                    ^def(%4 : int)Var<int> -> {
-                        %5 : Var<int> = var %4 @"i";
+                    (%4 : java.type:"int")Var<java.type:"int"> -> {
+                        %5 : Var<java.type:"int"> = var %4 @"i";
                         yield %5;
                     }
-                    ^body(%6 : Var<int>)void -> {
-                        java.block ()void -> {
-                            %7 : int = var.load %6;
-                            %8 : int = constant @"1";
-                            %9 : int = add %7 %8;
+                    (%6 : Var<java.type:"int">)java.type:"void" -> {
+                        java.block ()java.type:"void" -> {
+                            %7 : java.type:"int" = var.load %6;
+                            %8 : java.type:"int" = constant @"1";
+                            %9 : java.type:"int" = add %7 %8;
                             var.store %6 %9;
                             yield;
                         };
@@ -205,18 +205,18 @@ public class BlockTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : BlockTest)void -> {
-                %1 : java.util.function.Consumer<java.lang.String> = lambda (%2 : java.lang.String)void -> {
-                    %3 : Var<java.lang.String> = var %2 @"s";
-                    java.block ()void -> {
-                        %4 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %5 : java.lang.String = var.load %3;
-                        invoke %4 %5 @"java.io.PrintStream::println(java.lang.String)void";
+            func @"test5" (%0 : java.type:"BlockTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Consumer<java.lang.String>" = lambda (%2 : java.type:"java.lang.String")java.type:"void" -> {
+                    %3 : Var<java.type:"java.lang.String"> = var %2 @"s";
+                    java.block ()java.type:"void" -> {
+                        %4 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %5 : java.type:"java.lang.String" = var.load %3;
+                        invoke %4 %5 @"java.io.PrintStream::println(java.lang.String):void";
                         yield;
                     };
                     return;
                 };
-                %6 : Var<java.util.function.Consumer<java.lang.String>> = var %1 @"c";
+                %6 : Var<java.type:"java.util.function.Consumer<java.lang.String>"> = var %1 @"c";
                 return;
             };
             """)
@@ -231,39 +231,39 @@ public class BlockTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : BlockTest)void -> {
-                 java.if
-                     ()boolean -> {
-                         %1 : boolean = constant @"true";
-                         yield %1;
-                     }
-                     ^then()void -> {
-                         java.block ()void -> {
-                             return;
-                         };
-                         yield;
-                     }
-                     ^else()void -> {
-                         yield;
-                     };
-                 java.if
-                     ()boolean -> {
-                         %2 : boolean = constant @"true";
-                         yield %2;
-                     }
-                     ^then()void -> {
-                         java.block ()void -> {
-                             %3 : java.lang.RuntimeException = new @"java.lang.RuntimeException::<new>()";
-                             throw %3;
-                         };
-                         yield;
-                     }
-                     ^else()void -> {
-                         yield;
-                     };
-                 return;
-             };
-             """)
+            func @"test6" (%0 : java.type:"BlockTest")java.type:"void" -> {
+                java.if
+                    ()java.type:"boolean" -> {
+                        %1 : java.type:"boolean" = constant @"true";
+                        yield %1;
+                    }
+                    ()java.type:"void" -> {
+                        java.block ()java.type:"void" -> {
+                            return;
+                        };
+                        yield;
+                    }
+                    ()java.type:"void" -> {
+                        yield;
+                    };
+                java.if
+                    ()java.type:"boolean" -> {
+                        %2 : java.type:"boolean" = constant @"true";
+                        yield %2;
+                    }
+                    ()java.type:"void" -> {
+                        java.block ()java.type:"void" -> {
+                            %3 : java.type:"java.lang.RuntimeException" = new @"java.lang.RuntimeException::()";
+                            throw %3;
+                        };
+                        yield;
+                    }
+                    ()java.type:"void" -> {
+                        yield;
+                    };
+                return;
+            };
+            """)
     void test6() {
         if (true) {
             {

--- a/test/langtools/tools/javac/reflect/BoxingConversionTest.java
+++ b/test/langtools/tools/javac/reflect/BoxingConversionTest.java
@@ -36,11 +36,11 @@ import java.util.function.Supplier;
 public class BoxingConversionTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : BoxingConversionTest)void -> {
-                  %1 : long = constant @"1";
-                  %2 : java.lang.Long = invoke %1 @"java.lang.Long::valueOf(long)java.lang.Long";
-                  %3 : Var<java.lang.Long> = var %2 @"x";
-                  return;
+            func @"test1" (%0 : java.type:"BoxingConversionTest")java.type:"void" -> {
+                %1 : java.type:"long" = constant @"1";
+                %2 : java.type:"java.lang.Long" = invoke %1 @"java.lang.Long::valueOf(long):java.lang.Long";
+                %3 : Var<java.type:"java.lang.Long"> = var %2 @"x";
+                return;
             };
             """)
     void test1() {
@@ -49,11 +49,11 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : BoxingConversionTest, %1 : java.lang.Long)void -> {
-                %2 : Var<java.lang.Long> = var %1 @"L";
-                %3 : java.lang.Long = var.load %2;
-                %4 : long = invoke %3 @"java.lang.Long::longValue()long";
-                %5 : Var<long> = var %4 @"l";
+            func @"test2" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"java.lang.Long")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Long"> = var %1 @"L";
+                %3 : java.type:"java.lang.Long" = var.load %2;
+                %4 : java.type:"long" = invoke %3 @"java.lang.Long::longValue():long";
+                %5 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -63,10 +63,10 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : BoxingConversionTest)void -> {
-                %1 : long = constant @"0";
-                %2 : java.lang.Long = invoke %1 @"java.lang.Long::valueOf(long)java.lang.Long";
-                %3 : Var<java.lang.Object> = var %2 @"o";
+            func @"test3" (%0 : java.type:"BoxingConversionTest")java.type:"void" -> {
+                %1 : java.type:"long" = constant @"0";
+                %2 : java.type:"java.lang.Long" = invoke %1 @"java.lang.Long::valueOf(long):java.lang.Long";
+                %3 : Var<java.type:"java.lang.Object"> = var %2 @"o";
                 return;
             };
             """)
@@ -76,12 +76,12 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : BoxingConversionTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.Object = var.load %2;
-                %4 : java.lang.Long = cast %3 @"java.lang.Long";
-                %5 : long = invoke %4 @"java.lang.Long::longValue()long";
-                %6 : Var<long> = var %5 @"l";
+            func @"test4" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"java.lang.Long" = cast %3 @"java.lang.Long";
+                %5 : java.type:"long" = invoke %4 @"java.lang.Long::longValue():long";
+                %6 : Var<java.type:"long"> = var %5 @"l";
                 return;
             };
             """)
@@ -91,13 +91,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : BoxingConversionTest, %1 : java.lang.Integer)void -> {
-                %2 : Var<java.lang.Integer> = var %1 @"i2";
-                %3 : java.lang.Integer = var.load %2;
-                %4 : int = constant @"1";
-                %5 : int = invoke %3 @"java.lang.Integer::intValue()int";
-                %6 : int = add %5 %4;
-                %7 : java.lang.Integer = invoke %6 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+            func @"test5" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Integer"> = var %1 @"i2";
+                %3 : java.type:"java.lang.Integer" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"int" = invoke %3 @"java.lang.Integer::intValue():int";
+                %6 : java.type:"int" = add %5 %4;
+                %7 : java.type:"java.lang.Integer" = invoke %6 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                 var.store %2 %7;
                 return;
             };
@@ -108,13 +108,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : BoxingConversionTest, %1 : java.lang.Integer)void -> {
-                %2 : Var<java.lang.Integer> = var %1 @"i2";
-                %3 : java.lang.Integer = var.load %2;
-                %4 : int = constant @"3";
-                %5 : int = invoke %3 @"java.lang.Integer::intValue()int";
-                %6 : int = add %5 %4;
-                %7 : java.lang.Integer = invoke %6 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+            func @"test6" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Integer"> = var %1 @"i2";
+                %3 : java.type:"java.lang.Integer" = var.load %2;
+                %4 : java.type:"int" = constant @"3";
+                %5 : java.type:"int" = invoke %3 @"java.lang.Integer::intValue():int";
+                %6 : java.type:"int" = add %5 %4;
+                %7 : java.type:"java.lang.Integer" = invoke %6 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                 var.store %2 %7;
                 return;
             };
@@ -129,14 +129,14 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : BoxingConversionTest)void -> {
-                %1 : BoxingConversionTest$Box = new @"BoxingConversionTest$Box::<new>()";
-                %2 : java.lang.Integer = field.load %1 @"BoxingConversionTest$Box::i()java.lang.Integer";
-                %3 : int = constant @"1";
-                %4 : int = invoke %2 @"java.lang.Integer::intValue()int";
-                %5 : int = add %4 %3;
-                %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                field.store %1 %6 @"BoxingConversionTest$Box::i()java.lang.Integer";
+            func @"test7" (%0 : java.type:"BoxingConversionTest")java.type:"void" -> {
+                %1 : java.type:"BoxingConversionTest$Box" = new @"BoxingConversionTest$Box::()";
+                %2 : java.type:"java.lang.Integer" = field.load %1 @"BoxingConversionTest$Box::i:java.lang.Integer";
+                %3 : java.type:"int" = constant @"1";
+                %4 : java.type:"int" = invoke %2 @"java.lang.Integer::intValue():int";
+                %5 : java.type:"int" = add %4 %3;
+                %6 : java.type:"java.lang.Integer" = invoke %5 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                field.store %1 %6 @"BoxingConversionTest$Box::i:java.lang.Integer";
                 return;
             };
             """)
@@ -146,14 +146,14 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : BoxingConversionTest)void -> {
-                %1 : BoxingConversionTest$Box = new @"BoxingConversionTest$Box::<new>()";
-                %2 : java.lang.Integer = field.load %1 @"BoxingConversionTest$Box::i()java.lang.Integer";
-                %3 : int = constant @"3";
-                %4 : int = invoke %2 @"java.lang.Integer::intValue()int";
-                %5 : int = add %4 %3;
-                %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                field.store %1 %6 @"BoxingConversionTest$Box::i()java.lang.Integer";
+            func @"test8" (%0 : java.type:"BoxingConversionTest")java.type:"void" -> {
+                %1 : java.type:"BoxingConversionTest$Box" = new @"BoxingConversionTest$Box::()";
+                %2 : java.type:"java.lang.Integer" = field.load %1 @"BoxingConversionTest$Box::i:java.lang.Integer";
+                %3 : java.type:"int" = constant @"3";
+                %4 : java.type:"int" = invoke %2 @"java.lang.Integer::intValue():int";
+                %5 : java.type:"int" = add %4 %3;
+                %6 : java.type:"java.lang.Integer" = invoke %5 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                field.store %1 %6 @"BoxingConversionTest$Box::i:java.lang.Integer";
                 return;
             };
             """)
@@ -163,15 +163,15 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : BoxingConversionTest, %1 : int[], %2 : java.lang.Integer)void -> {
-                %3 : Var<int[]> = var %1 @"ia";
-                %4 : Var<java.lang.Integer> = var %2 @"i";
-                %5 : int[] = var.load %3;
-                %6 : int = constant @"0";
-                %7 : int = array.load %5 %6;
-                %8 : java.lang.Integer = var.load %4;
-                %9 : int = invoke %8 @"java.lang.Integer::intValue()int";
-                %10 : int = add %7 %9;
+            func @"test9" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int[]", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"int[]"> = var %1 @"ia";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"i";
+                %5 : java.type:"int[]" = var.load %3;
+                %6 : java.type:"int" = constant @"0";
+                %7 : java.type:"int" = array.load %5 %6;
+                %8 : java.type:"java.lang.Integer" = var.load %4;
+                %9 : java.type:"int" = invoke %8 @"java.lang.Integer::intValue():int";
+                %10 : java.type:"int" = add %7 %9;
                 array.store %5 %6 %10;
                 return;
             };
@@ -182,24 +182,24 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0 : BoxingConversionTest, %1 : boolean, %2 : java.lang.Integer)void -> {
-                %3 : Var<boolean> = var %1 @"cond";
-                %4 : Var<java.lang.Integer> = var %2 @"I";
-                %5 : int = java.cexpression
-                    ^cond()boolean -> {
-                        %6 : boolean = var.load %3;
+            func @"test10" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"boolean", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"boolean"> = var %1 @"cond";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"I";
+                %5 : java.type:"int" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %6 : java.type:"boolean" = var.load %3;
                         yield %6;
                     }
-                    ^truepart()int -> {
-                        %7 : java.lang.Integer = var.load %4;
-                        %8 : int = invoke %7 @"java.lang.Integer::intValue()int";
+                    ()java.type:"int" -> {
+                        %7 : java.type:"java.lang.Integer" = var.load %4;
+                        %8 : java.type:"int" = invoke %7 @"java.lang.Integer::intValue():int";
                         yield %8;
                     }
-                    ^falsepart()int -> {
-                        %9 : int = constant @"2";
+                    ()java.type:"int" -> {
+                        %9 : java.type:"int" = constant @"2";
                         yield %9;
                     };
-                %10 : Var<int> = var %5 @"res";
+                %10 : Var<java.type:"int"> = var %5 @"res";
                 return;
             };
             """)
@@ -209,24 +209,24 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test11" (%0 : BoxingConversionTest, %1 : boolean, %2 : java.lang.Integer)void -> {
-                %3 : Var<boolean> = var %1 @"cond";
-                %4 : Var<java.lang.Integer> = var %2 @"I";
-                %5 : int = java.cexpression
-                    ^cond()boolean -> {
-                        %6 : boolean = var.load %3;
+            func @"test11" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"boolean", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"boolean"> = var %1 @"cond";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"I";
+                %5 : java.type:"int" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %6 : java.type:"boolean" = var.load %3;
                         yield %6;
                     }
-                    ^truepart()int -> {
-                        %7 : int = constant @"2";
+                    ()java.type:"int" -> {
+                        %7 : java.type:"int" = constant @"2";
                         yield %7;
                     }
-                    ^falsepart()int -> {
-                        %8 : java.lang.Integer = var.load %4;
-                        %9 : int = invoke %8 @"java.lang.Integer::intValue()int";
+                    ()java.type:"int" -> {
+                        %8 : java.type:"java.lang.Integer" = var.load %4;
+                        %9 : java.type:"int" = invoke %8 @"java.lang.Integer::intValue():int";
                         yield %9;
                     };
-                %10 : Var<int> = var %5 @"res";
+                %10 : Var<java.type:"int"> = var %5 @"res";
                 return;
             };
             """)
@@ -236,39 +236,39 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test12" (%0 : BoxingConversionTest, %1 : boolean)void -> {
-                 %2 : Var<boolean> = var %1 @"cond";
-                 %3 : int = java.cexpression
-                     ^cond()boolean -> {
-                         %4 : boolean = var.load %2;
-                         yield %4;
-                     }
-                     ^truepart()int -> {
-                         %5 : int = constant @"1";
-                         yield %5;
-                     }
-                     ^falsepart()int -> {
-                         %6 : int = constant @"2";
-                         yield %6;
-                     };
-                 %7 : java.lang.Integer = invoke %3 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                 %8 : Var<java.lang.Integer> = var %7 @"x";
-                 return;
-             };
-             """)
+            func @"test12" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : java.type:"int" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = var.load %2;
+                        yield %4;
+                    }
+                    ()java.type:"int" -> {
+                        %5 : java.type:"int" = constant @"1";
+                        yield %5;
+                    }
+                    ()java.type:"int" -> {
+                        %6 : java.type:"int" = constant @"2";
+                        yield %6;
+                    };
+                %7 : java.type:"java.lang.Integer" = invoke %3 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %8 : Var<java.type:"java.lang.Integer"> = var %7 @"x";
+                return;
+            };
+            """)
     void test12(boolean cond) {
         Integer x = cond ? 1 : 2;
     }
 
     @CodeReflection
     @IR("""
-            func @"test13" (%0 : BoxingConversionTest)void -> {
-                %1 : java.util.function.Supplier<java.lang.Integer> = lambda ()java.lang.Integer -> {
-                    %2 : int = constant @"1";
-                    %3 : java.lang.Integer = invoke %2 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+            func @"test13" (%0 : java.type:"BoxingConversionTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.Integer>" = lambda ()java.type:"java.lang.Integer" -> {
+                    %2 : java.type:"int" = constant @"1";
+                    %3 : java.type:"java.lang.Integer" = invoke %2 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                     return %3;
                 };
-                %4 : Var<java.util.function.Supplier<java.lang.Integer>> = var %1 @"s";
+                %4 : Var<java.type:"java.util.function.Supplier<java.lang.Integer>"> = var %1 @"s";
                 return;
             };
             """)
@@ -278,13 +278,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test14" (%0 : BoxingConversionTest)void -> {
-                %1 : java.util.function.Supplier<java.lang.Integer> = lambda ()java.lang.Integer -> {
-                    %2 : int = constant @"1";
-                    %3 : java.lang.Integer = invoke %2 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+            func @"test14" (%0 : java.type:"BoxingConversionTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.Integer>" = lambda ()java.type:"java.lang.Integer" -> {
+                    %2 : java.type:"int" = constant @"1";
+                    %3 : java.type:"java.lang.Integer" = invoke %2 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                     return %3;
                 };
-                %4 : Var<java.util.function.Supplier<java.lang.Integer>> = var %1 @"s";
+                %4 : Var<java.type:"java.util.function.Supplier<java.lang.Integer>"> = var %1 @"s";
                 return;
             };
             """)
@@ -294,30 +294,30 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test15" (%0 : BoxingConversionTest, %1 : int, %2 : java.lang.Integer)void -> {
-                %3 : Var<int> = var %1 @"i";
-                %4 : Var<java.lang.Integer> = var %2 @"I";
-                %5 : int = var.load %3;
-                %6 : int = java.switch.expression %5
-                    ^constantCaseLabel(%7 : int)boolean -> {
-                        %8 : int = constant @"1";
-                        %9 : boolean = eq %7 %8;
+            func @"test15" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"I";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = java.switch.expression %5
+                    (%7 : java.type:"int")java.type:"boolean" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"boolean" = eq %7 %8;
                         yield %9;
                     }
-                    ()int -> {
-                        %10 : java.lang.Integer = var.load %4;
-                        %11 : int = invoke %10 @"java.lang.Integer::intValue()int";
+                    ()java.type:"int" -> {
+                        %10 : java.type:"java.lang.Integer" = var.load %4;
+                        %11 : java.type:"int" = invoke %10 @"java.lang.Integer::intValue():int";
                         yield %11;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
-                    }
-                    ()int -> {
-                        %12 : int = constant @"0";
+                    ()java.type:"boolean" -> {
+                        %12 : java.type:"boolean" = constant @"true";
                         yield %12;
+                    }
+                    ()java.type:"int" -> {
+                        %13 : java.type:"int" = constant @"0";
+                        yield %13;
                     };
-                %13 : Var<int> = var %6 @"x";
+                %14 : Var<java.type:"int"> = var %6 @"x";
                 return;
             };
             """)
@@ -330,30 +330,30 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test16" (%0 : BoxingConversionTest, %1 : int, %2 : java.lang.Integer)void -> {
-                %3 : Var<int> = var %1 @"i";
-                %4 : Var<java.lang.Integer> = var %2 @"I";
-                %5 : int = var.load %3;
-                %6 : int = java.switch.expression %5
-                    ^constantCaseLabel(%7 : int)boolean -> {
-                        %8 : int = constant @"1";
-                        %9 : boolean = eq %7 %8;
+            func @"test16" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"I";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = java.switch.expression %5
+                    (%7 : java.type:"int")java.type:"boolean" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"boolean" = eq %7 %8;
                         yield %9;
                     }
-                    ()int -> {
-                        %10 : int = constant @"1";
+                    ()java.type:"int" -> {
+                        %10 : java.type:"int" = constant @"1";
                         yield %10;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %11 : java.type:"boolean" = constant @"true";
+                        yield %11;
                     }
-                    ()int -> {
-                        %11 : java.lang.Integer = var.load %4;
-                        %12 : int = invoke %11 @"java.lang.Integer::intValue()int";
-                        yield %12;
+                    ()java.type:"int" -> {
+                        %12 : java.type:"java.lang.Integer" = var.load %4;
+                        %13 : java.type:"int" = invoke %12 @"java.lang.Integer::intValue():int";
+                        yield %13;
                     };
-                %13 : Var<int> = var %6 @"x";
+                %14 : Var<java.type:"int"> = var %6 @"x";
                 return;
             };
             """)
@@ -366,30 +366,30 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test17" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : java.lang.Integer = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test17" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.Integer" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.Integer -> {
-                        %8 : int = constant @"1";
-                        %9 : java.lang.Integer = invoke %8 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+                    ()java.type:"java.lang.Integer" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"java.lang.Integer" = invoke %8 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                         yield %9;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = constant @"true";
+                        yield %10;
                     }
-                    ()java.lang.Integer -> {
-                        %10 : int = constant @"0";
-                        %11 : java.lang.Integer = invoke %10 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                        yield %11;
+                    ()java.type:"java.lang.Integer" -> {
+                        %11 : java.type:"int" = constant @"0";
+                        %12 : java.type:"java.lang.Integer" = invoke %11 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        yield %12;
                     };
-                %12 : Var<java.lang.Integer> = var %4 @"x";
+                %13 : Var<java.type:"java.lang.Integer"> = var %4 @"x";
                 return;
             };
             """)
@@ -402,30 +402,30 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test18" (%0 : BoxingConversionTest, %1 : int, %2 : java.lang.Integer)void -> {
-                %3 : Var<int> = var %1 @"i";
-                %4 : Var<java.lang.Integer> = var %2 @"I";
-                %5 : int = var.load %3;
-                %6 : int = java.switch.expression %5
-                    ^constantCaseLabel(%7 : int)boolean -> {
-                        %8 : int = constant @"1";
-                        %9 : boolean = eq %7 %8;
+            func @"test18" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"I";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = java.switch.expression %5
+                    (%7 : java.type:"int")java.type:"boolean" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"boolean" = eq %7 %8;
                         yield %9;
                     }
-                    ()int -> {
-                        %10 : java.lang.Integer = var.load %4;
-                        %11 : int = invoke %10 @"java.lang.Integer::intValue()int";
+                    ()java.type:"int" -> {
+                        %10 : java.type:"java.lang.Integer" = var.load %4;
+                        %11 : java.type:"int" = invoke %10 @"java.lang.Integer::intValue():int";
                         java.yield %11;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %12 : java.type:"boolean" = constant @"true";
+                        yield %12;
                     }
-                    ()int -> {
-                        %12 : int = constant @"0";
-                        java.yield %12;
+                    ()java.type:"int" -> {
+                        %13 : java.type:"int" = constant @"0";
+                        java.yield %13;
                     };
-                %13 : Var<int> = var %6 @"x";
+                %14 : Var<java.type:"int"> = var %6 @"x";
                 return;
             };
             """)
@@ -438,30 +438,30 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test19" (%0 : BoxingConversionTest, %1 : int, %2 : java.lang.Integer)void -> {
-                %3 : Var<int> = var %1 @"i";
-                %4 : Var<java.lang.Integer> = var %2 @"I";
-                %5 : int = var.load %3;
-                %6 : int = java.switch.expression %5
-                    ^constantCaseLabel(%7 : int)boolean -> {
-                        %8 : int = constant @"1";
-                        %9 : boolean = eq %7 %8;
+            func @"test19" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"I";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = java.switch.expression %5
+                    (%7 : java.type:"int")java.type:"boolean" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"boolean" = eq %7 %8;
                         yield %9;
                     }
-                    ()int -> {
-                        %10 : int = constant @"1";
+                    ()java.type:"int" -> {
+                        %10 : java.type:"int" = constant @"1";
                         java.yield %10;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %11 : java.type:"boolean" = constant @"true";
+                        yield %11;
                     }
-                    ()int -> {
-                        %11 : java.lang.Integer = var.load %4;
-                        %12 : int = invoke %11 @"java.lang.Integer::intValue()int";
-                        java.yield %12;
+                    ()java.type:"int" -> {
+                        %12 : java.type:"java.lang.Integer" = var.load %4;
+                        %13 : java.type:"int" = invoke %12 @"java.lang.Integer::intValue():int";
+                        java.yield %13;
                     };
-                %13 : Var<int> = var %6 @"x";
+                %14 : Var<java.type:"int"> = var %6 @"x";
                 return;
             };
             """)
@@ -474,30 +474,30 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test20" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : java.lang.Integer = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test20" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.Integer" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.Integer -> {
-                        %8 : int = constant @"1";
-                        %9 : java.lang.Integer = invoke %8 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+                    ()java.type:"java.lang.Integer" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"java.lang.Integer" = invoke %8 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                         java.yield %9;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = constant @"true";
+                        yield %10;
                     }
-                    ()java.lang.Integer -> {
-                        %10 : int = constant @"0";
-                        %11 : java.lang.Integer = invoke %10 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                        java.yield %11;
+                    ()java.type:"java.lang.Integer" -> {
+                        %11 : java.type:"int" = constant @"0";
+                        %12 : java.type:"java.lang.Integer" = invoke %11 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        java.yield %12;
                     };
-                %12 : Var<java.lang.Integer> = var %4 @"x";
+                %13 : Var<java.type:"java.lang.Integer"> = var %4 @"x";
                 return;
             };
             """)
@@ -510,14 +510,14 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test21" (%0 : BoxingConversionTest, %1 : int, %2 : java.lang.Integer)void -> {
-                %3 : Var<int> = var %1 @"i";
-                %4 : Var<java.lang.Integer> = var %2 @"I";
-                %5 : int = var.load %3;
-                %6 : java.lang.Integer = var.load %4;
-                %7 : int = invoke %6 @"java.lang.Integer::intValue()int";
-                %8 : int = add %5 %7;
-                %9 : Var<int> = var %8 @"l";
+            func @"test21" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int", %2 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : Var<java.type:"java.lang.Integer"> = var %2 @"I";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"java.lang.Integer" = var.load %4;
+                %7 : java.type:"int" = invoke %6 @"java.lang.Integer::intValue():int";
+                %8 : java.type:"int" = add %5 %7;
+                %9 : Var<java.type:"int"> = var %8 @"l";
                 return;
             };
             """)
@@ -529,11 +529,11 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test22" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : java.lang.Integer = invoke %3 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                invoke %0 %4 @"BoxingConversionTest::m(java.lang.Integer)void";
+            func @"test22" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.Integer" = invoke %3 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                invoke %0 %4 @"BoxingConversionTest::m(java.lang.Integer):void";
                 return;
             };
             """)
@@ -545,11 +545,11 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test23" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                invoke %0 %3 %4 @invoke.kind="INSTANCE" @invoke.varargs="true" @"BoxingConversionTest::m(int, int, java.lang.Integer[])void";
+            func @"test23" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                invoke %0 %3 %4 @"BoxingConversionTest::m(int, int, java.lang.Integer[]):void" @invoke.kind="INSTANCE" @invoke.varargs="true";
                 return;
             };
             """)
@@ -559,13 +559,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test24" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = var.load %2;
-                %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                invoke %0 %3 %4 %6 @invoke.kind="INSTANCE" @invoke.varargs="true" @"BoxingConversionTest::m(int, int, java.lang.Integer[])void";
+            func @"test24" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"java.lang.Integer" = invoke %5 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                invoke %0 %3 %4 %6 @"BoxingConversionTest::m(int, int, java.lang.Integer[]):void" @invoke.kind="INSTANCE" @invoke.varargs="true";
                 return;
             };
             """)
@@ -575,15 +575,15 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test25" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = var.load %2;
-                %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                %7 : int = var.load %2;
-                %8 : java.lang.Integer = invoke %7 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                invoke %0 %3 %4 %6 %8 @invoke.kind="INSTANCE" @invoke.varargs="true" @"BoxingConversionTest::m(int, int, java.lang.Integer[])void";
+            func @"test25" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"java.lang.Integer" = invoke %5 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %7 : java.type:"int" = var.load %2;
+                %8 : java.type:"java.lang.Integer" = invoke %7 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                invoke %0 %3 %4 %6 %8 @"BoxingConversionTest::m(int, int, java.lang.Integer[]):void" @invoke.kind="INSTANCE" @invoke.varargs="true";
                 return;
             };
             """)
@@ -598,11 +598,11 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test26" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : java.lang.Integer = invoke %3 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                %5 : BoxingConversionTest$Box2 = new %4 @"BoxingConversionTest$Box2::<new>(java.lang.Integer)";
+            func @"test26" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.Integer" = invoke %3 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %5 : java.type:"BoxingConversionTest$Box2" = new %4 @"BoxingConversionTest$Box2::(java.lang.Integer)";
                 return;
             };
             """)
@@ -612,11 +612,11 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test27" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : BoxingConversionTest$Box2 = new %3 %4 @new.varargs="true" @"BoxingConversionTest$Box2::<new>(int,int,java.lang.Integer[])";
+            func @"test27" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"BoxingConversionTest$Box2" = new %3 %4 @"BoxingConversionTest$Box2::(int, int, java.lang.Integer[])" @new.varargs="true";
                 return;
             };
             """)
@@ -626,13 +626,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test28" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = var.load %2;
-                %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                %7 : BoxingConversionTest$Box2 = new %3 %4 %6 @new.varargs="true" @"BoxingConversionTest$Box2::<new>(int,int,java.lang.Integer[])";
+            func @"test28" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"java.lang.Integer" = invoke %5 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %7 : java.type:"BoxingConversionTest$Box2" = new %3 %4 %6 @"BoxingConversionTest$Box2::(int, int, java.lang.Integer[])" @new.varargs="true";
                 return;
             };
             """)
@@ -642,15 +642,15 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test29" (%0 : BoxingConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = var.load %2;
-                %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                %7 : int = var.load %2;
-                %8 : java.lang.Integer = invoke %7 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                %9 : BoxingConversionTest$Box2 = new %3 %4 %6 %8 @new.varargs="true" @"BoxingConversionTest$Box2::<new>(int,int,java.lang.Integer[])";
+            func @"test29" (%0 : java.type:"BoxingConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"java.lang.Integer" = invoke %5 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %7 : java.type:"int" = var.load %2;
+                %8 : java.type:"java.lang.Integer" = invoke %7 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %9 : java.type:"BoxingConversionTest$Box2" = new %3 %4 %6 %8 @"BoxingConversionTest$Box2::(int, int, java.lang.Integer[])" @new.varargs="true";
                 return;
             };
             """)
@@ -660,13 +660,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test30" (%0 : java.lang.Integer)void -> {
-                  %1 : Var<java.lang.Integer> = var %0 @"i";
-                  %2 : java.lang.Integer = var.load %1;
-                  %3 : int = invoke %2 @"java.lang.Integer::intValue()int";
-                  %4 : int = neg %3;
-                  %5 : Var<int> = var %4 @"j";
-                  return;
+            func @"test30" (%0 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Integer"> = var %0 @"i";
+                %2 : java.type:"java.lang.Integer" = var.load %1;
+                %3 : java.type:"int" = invoke %2 @"java.lang.Integer::intValue():int";
+                %4 : java.type:"int" = neg %3;
+                %5 : Var<java.type:"int"> = var %4 @"j";
+                return;
             };
             """)
     static void test30(Integer i) {
@@ -675,13 +675,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test31" (%0 : int)void -> {
-                  %1 : Var<int> = var %0 @"i";
-                  %2 : int = var.load %1;
-                  %3 : int = neg %2;
-                  %4 : java.lang.Integer = invoke %3 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                  %5 : Var<java.lang.Integer> = var %4 @"j";
-                  return;
+            func @"test31" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = neg %2;
+                %4 : java.type:"java.lang.Integer" = invoke %3 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %5 : Var<java.type:"java.lang.Integer"> = var %4 @"j";
+                return;
             };
             """)
     static void test31(int i) {
@@ -690,13 +690,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test32" (%0 : boolean)void -> {
-                  %1 : Var<boolean> = var %0 @"i";
-                  %2 : boolean = var.load %1;
-                  %3 : boolean = not %2;
-                  %4 : java.lang.Boolean = invoke %3 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
-                  %5 : Var<java.lang.Boolean> = var %4 @"j";
-                  return;
+            func @"test32" (%0 : java.type:"boolean")java.type:"void" -> {
+                %1 : Var<java.type:"boolean"> = var %0 @"i";
+                %2 : java.type:"boolean" = var.load %1;
+                %3 : java.type:"boolean" = not %2;
+                %4 : java.type:"java.lang.Boolean" = invoke %3 @"java.lang.Boolean::valueOf(boolean):java.lang.Boolean";
+                %5 : Var<java.type:"java.lang.Boolean"> = var %4 @"j";
+                return;
             };
             """)
     static void test32(boolean i) {
@@ -705,13 +705,13 @@ public class BoxingConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test33" (%0 : java.lang.Boolean)void -> {
-                  %1 : Var<java.lang.Boolean> = var %0 @"i";
-                  %2 : java.lang.Boolean = var.load %1;
-                  %3 : boolean = invoke %2 @"java.lang.Boolean::booleanValue()boolean";
-                  %4 : boolean = not %3;
-                  %5 : Var<boolean> = var %4 @"j";
-                  return;
+            func @"test33" (%0 : java.type:"java.lang.Boolean")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Boolean"> = var %0 @"i";
+                %2 : java.type:"java.lang.Boolean" = var.load %1;
+                %3 : java.type:"boolean" = invoke %2 @"java.lang.Boolean::booleanValue():boolean";
+                %4 : java.type:"boolean" = not %3;
+                %5 : Var<java.type:"boolean"> = var %4 @"j";
+                return;
             };
             """)
     static void test33(Boolean i) {

--- a/test/langtools/tools/javac/reflect/BreakContinueTest.java
+++ b/test/langtools/tools/javac/reflect/BreakContinueTest.java
@@ -37,89 +37,89 @@ import java.util.List;
 public class BreakContinueTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : BreakContinueTest)void -> {
+            func @"test1" (%0 : java.type:"BreakContinueTest")java.type:"void" -> {
                 java.for
-                    ^init()Var<int> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
                         yield %2;
                     }
-                    ^cond(%3 : Var<int>)boolean -> {
-                        %4 : int = var.load %3;
-                        %5 : int = constant @"10";
-                        %6 : boolean = lt %4 %5;
+                    (%3 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %4 : java.type:"int" = var.load %3;
+                        %5 : java.type:"int" = constant @"10";
+                        %6 : java.type:"boolean" = lt %4 %5;
                         yield %6;
                     }
-                    ^update(%7 : Var<int>)void -> {
-                        %8 : int = var.load %7;
-                        %9 : int = constant @"1";
-                        %10 : int = add %8 %9;
+                    (%7 : Var<java.type:"int">)java.type:"void" -> {
+                        %8 : java.type:"int" = var.load %7;
+                        %9 : java.type:"int" = constant @"1";
+                        %10 : java.type:"int" = add %8 %9;
                         var.store %7 %10;
                         yield;
                     }
-                    ^body(%11 : Var<int>)void -> {
+                    (%11 : Var<java.type:"int">)java.type:"void" -> {
                         java.if
-                            ()boolean -> {
-                                %12 : boolean = constant @"true";
+                            ()java.type:"boolean" -> {
+                                %12 : java.type:"boolean" = constant @"true";
                                 yield %12;
                             }
-                            ^then()void -> {
+                            ()java.type:"void" -> {
                                 java.continue;
                             }
-                            ^else()void -> {
+                            ()java.type:"void" -> {
                                 yield;
                             };
                         java.if
-                            ()boolean -> {
-                                %13 : boolean = constant @"true";
+                            ()java.type:"boolean" -> {
+                                %13 : java.type:"boolean" = constant @"true";
                                 yield %13;
                             }
-                            ^then()void -> {
+                            ()java.type:"void" -> {
                                 java.break;
                             }
-                            ^else()void -> {
+                            ()java.type:"void" -> {
                                 yield;
                             };
                         java.for
-                            ^init()Var<int> -> {
-                                %14 : int = constant @"0";
-                                %15 : Var<int> = var %14 @"j";
+                            ()Var<java.type:"int"> -> {
+                                %14 : java.type:"int" = constant @"0";
+                                %15 : Var<java.type:"int"> = var %14 @"j";
                                 yield %15;
                             }
-                            ^cond(%16 : Var<int>)boolean -> {
-                                %17 : int = var.load %16;
-                                %18 : int = constant @"10";
-                                %19 : boolean = lt %17 %18;
+                            (%16 : Var<java.type:"int">)java.type:"boolean" -> {
+                                %17 : java.type:"int" = var.load %16;
+                                %18 : java.type:"int" = constant @"10";
+                                %19 : java.type:"boolean" = lt %17 %18;
                                 yield %19;
                             }
-                            ^update(%20 : Var<int>)void -> {
-                                %21 : int = var.load %20;
-                                %22 : int = constant @"1";
-                                %23 : int = add %21 %22;
+                            (%20 : Var<java.type:"int">)java.type:"void" -> {
+                                %21 : java.type:"int" = var.load %20;
+                                %22 : java.type:"int" = constant @"1";
+                                %23 : java.type:"int" = add %21 %22;
                                 var.store %20 %23;
                                 yield;
                             }
-                            ^body(%24 : Var<int>)void -> {
+                            (%24 : Var<java.type:"int">)java.type:"void" -> {
                                 java.if
-                                    ()boolean -> {
-                                        %25 : boolean = constant @"true";
+                                    ()java.type:"boolean" -> {
+                                        %25 : java.type:"boolean" = constant @"true";
                                         yield %25;
                                     }
-                                    ^then()void -> {
+                                    ()java.type:"void" -> {
                                         java.continue;
                                     }
-                                    ^else()void -> {
+                                    ()java.type:"void" -> {
                                         yield;
                                     };
                                 java.if
-                                    ()boolean -> {
-                                        %26 : boolean = constant @"true";
+                                    ()java.type:"boolean" -> {
+                                        %26 : java.type:"boolean" = constant @"true";
                                         yield %26;
                                     }
-                                    ^then()void -> {
+                                    ()java.type:"void" -> {
                                         java.break;
                                     }
-                                    ^else()void -> {
+                                    ()java.type:"void" -> {
                                         yield;
                                     };
                                 java.continue;
@@ -150,115 +150,115 @@ public class BreakContinueTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : BreakContinueTest)void -> {
-                java.labeled ()void -> {
-                    %1 : java.lang.String = constant @"outer";
+            func @"test2" (%0 : java.type:"BreakContinueTest")java.type:"void" -> {
+                java.labeled ()java.type:"void" -> {
+                    %1 : java.type:"java.lang.String" = constant @"outer";
                     java.for
-                        ^init()Var<int> -> {
-                            %2 : int = constant @"0";
-                            %3 : Var<int> = var %2 @"i";
+                        ()Var<java.type:"int"> -> {
+                            %2 : java.type:"int" = constant @"0";
+                            %3 : Var<java.type:"int"> = var %2 @"i";
                             yield %3;
                         }
-                        ^cond(%4 : Var<int>)boolean -> {
-                            %5 : int = var.load %4;
-                            %6 : int = constant @"10";
-                            %7 : boolean = lt %5 %6;
+                        (%4 : Var<java.type:"int">)java.type:"boolean" -> {
+                            %5 : java.type:"int" = var.load %4;
+                            %6 : java.type:"int" = constant @"10";
+                            %7 : java.type:"boolean" = lt %5 %6;
                             yield %7;
                         }
-                        ^update(%8 : Var<int>)void -> {
-                            %9 : int = var.load %8;
-                            %10 : int = constant @"1";
-                            %11 : int = add %9 %10;
+                        (%8 : Var<java.type:"int">)java.type:"void" -> {
+                            %9 : java.type:"int" = var.load %8;
+                            %10 : java.type:"int" = constant @"1";
+                            %11 : java.type:"int" = add %9 %10;
                             var.store %8 %11;
                             yield;
                         }
-                        ^body(%12 : Var<int>)void -> {
+                        (%12 : Var<java.type:"int">)java.type:"void" -> {
                             java.if
-                                ()boolean -> {
-                                    %13 : boolean = constant @"true";
+                                ()java.type:"boolean" -> {
+                                    %13 : java.type:"boolean" = constant @"true";
                                     yield %13;
                                 }
-                                ^then()void -> {
+                                ()java.type:"void" -> {
                                     java.continue %1;
                                 }
-                                ^else()void -> {
+                                ()java.type:"void" -> {
                                     yield;
                                 };
                             java.if
-                                ()boolean -> {
-                                    %14 : boolean = constant @"true";
+                                ()java.type:"boolean" -> {
+                                    %14 : java.type:"boolean" = constant @"true";
                                     yield %14;
                                 }
-                                ^then()void -> {
+                                ()java.type:"void" -> {
                                     java.break %1;
                                 }
-                                ^else()void -> {
+                                ()java.type:"void" -> {
                                     yield;
                                 };
-                            java.labeled ()void -> {
-                                %15 : java.lang.String = constant @"inner";
+                            java.labeled ()java.type:"void" -> {
+                                %15 : java.type:"java.lang.String" = constant @"inner";
                                 java.for
-                                    ^init()Var<int> -> {
-                                        %16 : int = constant @"0";
-                                        %17 : Var<int> = var %16 @"j";
+                                    ()Var<java.type:"int"> -> {
+                                        %16 : java.type:"int" = constant @"0";
+                                        %17 : Var<java.type:"int"> = var %16 @"j";
                                         yield %17;
                                     }
-                                    ^cond(%18 : Var<int>)boolean -> {
-                                        %19 : int = var.load %18;
-                                        %20 : int = constant @"10";
-                                        %21 : boolean = lt %19 %20;
+                                    (%18 : Var<java.type:"int">)java.type:"boolean" -> {
+                                        %19 : java.type:"int" = var.load %18;
+                                        %20 : java.type:"int" = constant @"10";
+                                        %21 : java.type:"boolean" = lt %19 %20;
                                         yield %21;
                                     }
-                                    ^update(%22 : Var<int>)void -> {
-                                        %23 : int = var.load %22;
-                                        %24 : int = constant @"1";
-                                        %25 : int = add %23 %24;
+                                    (%22 : Var<java.type:"int">)java.type:"void" -> {
+                                        %23 : java.type:"int" = var.load %22;
+                                        %24 : java.type:"int" = constant @"1";
+                                        %25 : java.type:"int" = add %23 %24;
                                         var.store %22 %25;
                                         yield;
                                     }
-                                    ^body(%26 : Var<int>)void -> {
+                                    (%26 : Var<java.type:"int">)java.type:"void" -> {
                                         java.if
-                                            ()boolean -> {
-                                                %27 : boolean = constant @"true";
+                                            ()java.type:"boolean" -> {
+                                                %27 : java.type:"boolean" = constant @"true";
                                                 yield %27;
                                             }
-                                            ^then()void -> {
+                                            ()java.type:"void" -> {
                                                 java.continue;
                                             }
-                                            ^else()void -> {
+                                            ()java.type:"void" -> {
                                                 yield;
                                             };
                                         java.if
-                                            ()boolean -> {
-                                                %28 : boolean = constant @"true";
+                                            ()java.type:"boolean" -> {
+                                                %28 : java.type:"boolean" = constant @"true";
                                                 yield %28;
                                             }
-                                            ^then()void -> {
+                                            ()java.type:"void" -> {
                                                 java.break;
                                             }
-                                            ^else()void -> {
+                                            ()java.type:"void" -> {
                                                 yield;
                                             };
                                         java.if
-                                            ()boolean -> {
-                                                %29 : boolean = constant @"true";
+                                            ()java.type:"boolean" -> {
+                                                %29 : java.type:"boolean" = constant @"true";
                                                 yield %29;
                                             }
-                                            ^then()void -> {
+                                            ()java.type:"void" -> {
                                                 java.continue %1;
                                             }
-                                            ^else()void -> {
+                                            ()java.type:"void" -> {
                                                 yield;
                                             };
                                         java.if
-                                            ()boolean -> {
-                                                %30 : boolean = constant @"true";
+                                            ()java.type:"boolean" -> {
+                                                %30 : java.type:"boolean" = constant @"true";
                                                 yield %30;
                                             }
-                                            ^then()void -> {
+                                            ()java.type:"void" -> {
                                                 java.break %1;
                                             }
-                                            ^else()void -> {
+                                            ()java.type:"void" -> {
                                                 yield;
                                             };
                                         java.continue;
@@ -301,33 +301,33 @@ public class BreakContinueTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : BreakContinueTest)void -> {
-                java.labeled ()void -> {
-                    %1 : java.lang.String = constant @"b1";
-                    java.block ()void -> {
-                        java.labeled ()void -> {
-                            %2 : java.lang.String = constant @"b2";
-                            java.block ()void -> {
+            func @"test3" (%0 : java.type:"BreakContinueTest")java.type:"void" -> {
+                java.labeled ()java.type:"void" -> {
+                    %1 : java.type:"java.lang.String" = constant @"b1";
+                    java.block ()java.type:"void" -> {
+                        java.labeled ()java.type:"void" -> {
+                            %2 : java.type:"java.lang.String" = constant @"b2";
+                            java.block ()java.type:"void" -> {
                                 java.if
-                                    ()boolean -> {
-                                        %3 : boolean = constant @"true";
+                                    ()java.type:"boolean" -> {
+                                        %3 : java.type:"boolean" = constant @"true";
                                         yield %3;
                                     }
-                                    ^then()void -> {
+                                    ()java.type:"void" -> {
                                         java.break %1;
                                     }
-                                    ^else()void -> {
+                                    ()java.type:"void" -> {
                                         yield;
                                     };
                                 java.if
-                                    ()boolean -> {
-                                        %4 : boolean = constant @"true";
+                                    ()java.type:"boolean" -> {
+                                        %4 : java.type:"boolean" = constant @"true";
                                         yield %4;
                                     }
-                                    ^then()void -> {
+                                    ()java.type:"void" -> {
                                         java.break %2;
                                     }
-                                    ^else()void -> {
+                                    ()java.type:"void" -> {
                                         yield;
                                     };
                                 yield;
@@ -358,26 +358,26 @@ public class BreakContinueTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : BreakContinueTest)void -> {
-                java.labeled ()void -> {
-                    %1 : java.lang.String = constant @"b";
+            func @"test4" (%0 : java.type:"BreakContinueTest")java.type:"void" -> {
+                java.labeled ()java.type:"void" -> {
+                    %1 : java.type:"java.lang.String" = constant @"b";
                     java.break %1;
                 };
-                %2 : int = constant @"0";
-                %3 : Var<int> = var %2 @"i";
-                java.labeled ()void -> {
-                    %4 : java.lang.String = constant @"b";
-                    %5 : int = var.load %3;
-                    %6 : int = constant @"1";
-                    %7 : int = add %5 %6;
+                %2 : java.type:"int" = constant @"0";
+                %3 : Var<java.type:"int"> = var %2 @"i";
+                java.labeled ()java.type:"void" -> {
+                    %4 : java.type:"java.lang.String" = constant @"b";
+                    %5 : java.type:"int" = var.load %3;
+                    %6 : java.type:"int" = constant @"1";
+                    %7 : java.type:"int" = add %5 %6;
                     var.store %3 %7;
                     yield;
                 };
-                java.labeled ()void -> {
-                    %8 : java.lang.String = constant @"a";
-                    java.labeled ()void -> {
-                        %9 : java.lang.String = constant @"b";
-                        java.block ()void -> {
+                java.labeled ()java.type:"void" -> {
+                    %8 : java.type:"java.lang.String" = constant @"a";
+                    java.labeled ()java.type:"void" -> {
+                        %9 : java.type:"java.lang.String" = constant @"b";
+                        java.block ()java.type:"void" -> {
                             yield;
                         };
                         yield;

--- a/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
+++ b/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
@@ -38,13 +38,13 @@ public class CastInstanceOfTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : CastInstanceOfTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.Object = var.load %2;
-                %4 : java.lang.String = cast %3 @"java.lang.String";
-                %5 : Var<java.lang.String> = var %4 @"s";
-                %6 : java.lang.String = var.load %5;
-                %7 : Var<java.lang.String> = var %6 @"ss";
+            func @"test1" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"java.lang.String" = cast %3 @"java.lang.String";
+                %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
+                %6 : java.type:"java.lang.String" = var.load %5;
+                %7 : Var<java.type:"java.lang.String"> = var %6 @"ss";
                 return;
             };
             """)
@@ -55,15 +55,15 @@ public class CastInstanceOfTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : CastInstanceOfTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.Object = var.load %2;
-                %4 : java.util.List<java.lang.String> = cast %3 @"java.util.List";
-                %5 : Var<java.util.List<java.lang.String>> = var %4 @"l";
-                %6 : java.util.List<java.lang.String> = var.load %5;
-                %7 : Var<java.util.Collection<java.lang.String>> = var %6 @"c1";
-                %8 : java.util.List<java.lang.String> = var.load %5;
-                %9 : Var<java.util.Collection<java.lang.String>> = var %8 @"c2";
+            func @"test2" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"java.util.List<java.lang.String>" = cast %3 @"java.util.List";
+                %5 : Var<java.type:"java.util.List<java.lang.String>"> = var %4 @"l";
+                %6 : java.type:"java.util.List<java.lang.String>" = var.load %5;
+                %7 : Var<java.type:"java.util.Collection<java.lang.String>"> = var %6 @"c1";
+                %8 : java.type:"java.util.List<java.lang.String>" = var.load %5;
+                %9 : Var<java.type:"java.util.Collection<java.lang.String>"> = var %8 @"c2";
                 return;
             };
             """)
@@ -75,12 +75,12 @@ public class CastInstanceOfTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : CastInstanceOfTest, %1 : java.util.List<java.lang.String>)void -> {
-                %2 : Var<java.util.List<java.lang.String>> = var %1 @"l";
-                %3 : java.util.List<java.lang.String> = var.load %2;
-                %4 : Var<java.util.List> = var %3 @"raw";
-                %5 : java.util.List = var.load %4;
-                %6 : Var<java.util.List<java.lang.Number>> = var %5 @"ln";
+            func @"test3" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.util.List<java.lang.String>")java.type:"void" -> {
+                %2 : Var<java.type:"java.util.List<java.lang.String>"> = var %1 @"l";
+                %3 : java.type:"java.util.List<java.lang.String>" = var.load %2;
+                %4 : Var<java.type:"java.util.List"> = var %3 @"raw";
+                %5 : java.type:"java.util.List" = var.load %4;
+                %6 : Var<java.type:"java.util.List<java.lang.Number>"> = var %5 @"ln";
                 return;
             };
             """)
@@ -91,11 +91,11 @@ public class CastInstanceOfTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : CastInstanceOfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = conv %3;
-                %5 : Var<long> = var %4 @"l";
+            func @"test4" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = conv %3;
+                %5 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -105,11 +105,11 @@ public class CastInstanceOfTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : CastInstanceOfTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.Object = var.load %2;
-                %4 : boolean = instanceof %3 @"java.lang.String";
-                %5 : Var<boolean> = var %4 @"b";
+            func @"test5" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"boolean" = instanceof %3 @"java.lang.String";
+                %5 : Var<java.type:"boolean"> = var %4 @"b";
                 return;
             };
             """)
@@ -119,13 +119,13 @@ public class CastInstanceOfTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : CastInstanceOfTest, %1 : java.util.List<java.lang.Object>)void -> {
-                %2 : Var<java.util.List<java.lang.Object>> = var %1 @"l";
-                %3 : java.util.List<java.lang.Object> = var.load %2;
-                %4 : int = constant @"0";
-                %5 : java.lang.Object = invoke %3 %4 @"java.util.List::get(int)java.lang.Object";
-                %6 : boolean = instanceof %5 @"java.lang.String";
-                %7 : Var<boolean> = var %6 @"b";
+            func @"test6" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.util.List<java.lang.Object>")java.type:"void" -> {
+                %2 : Var<java.type:"java.util.List<java.lang.Object>"> = var %1 @"l";
+                %3 : java.type:"java.util.List<java.lang.Object>" = var.load %2;
+                %4 : java.type:"int" = constant @"0";
+                %5 : java.type:"java.lang.Object" = invoke %3 %4 @"java.util.List::get(int):java.lang.Object";
+                %6 : java.type:"boolean" = instanceof %5 @"java.lang.String";
+                %7 : Var<java.type:"boolean"> = var %6 @"b";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/ConditionalAndOrTest.java
+++ b/test/langtools/tools/javac/reflect/ConditionalAndOrTest.java
@@ -36,22 +36,22 @@ public class ConditionalAndOrTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : ConditionalAndOrTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : boolean = java.cand
-                    ()boolean -> {
-                        %4 : int = var.load %2;
-                        %5 : int = constant @"1";
-                        %6 : boolean = gt %4 %5;
+            func @"test1" (%0 : java.type:"ConditionalAndOrTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"boolean" = java.cand
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"int" = var.load %2;
+                        %5 : java.type:"int" = constant @"1";
+                        %6 : java.type:"boolean" = gt %4 %5;
                         yield %6;
                     }
-                    ()boolean -> {
-                        %7 : int = var.load %2;
-                        %8 : int = constant @"10";
-                        %9 : boolean = lt %7 %8;
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"int" = var.load %2;
+                        %8 : java.type:"int" = constant @"10";
+                        %9 : java.type:"boolean" = lt %7 %8;
                         yield %9;
                     };
-                %10 : Var<boolean> = var %3 @"b";
+                %10 : Var<java.type:"boolean"> = var %3 @"b";
                 return;
             };
             """)
@@ -61,22 +61,22 @@ public class ConditionalAndOrTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : ConditionalAndOrTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : boolean = java.cor
-                    ()boolean -> {
-                        %4 : int = var.load %2;
-                        %5 : int = constant @"1";
-                        %6 : boolean = gt %4 %5;
+            func @"test2" (%0 : java.type:"ConditionalAndOrTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"boolean" = java.cor
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"int" = var.load %2;
+                        %5 : java.type:"int" = constant @"1";
+                        %6 : java.type:"boolean" = gt %4 %5;
                         yield %6;
                     }
-                    ()boolean -> {
-                        %7 : int = var.load %2;
-                        %8 : int = constant @"10";
-                        %9 : boolean = lt %7 %8;
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"int" = var.load %2;
+                        %8 : java.type:"int" = constant @"10";
+                        %9 : java.type:"boolean" = lt %7 %8;
                         yield %9;
                     };
-                %10 : Var<boolean> = var %3 @"b";
+                %10 : Var<java.type:"boolean"> = var %3 @"b";
                 return;
             };
             """)
@@ -86,32 +86,32 @@ public class ConditionalAndOrTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : ConditionalAndOrTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : boolean = java.cor
-                    ()boolean -> {
-                        %4 : boolean = java.cand
-                            ()boolean -> {
-                                %5 : int = var.load %2;
-                                %6 : int = constant @"1";
-                                %7 : boolean = gt %5 %6;
+            func @"test3" (%0 : java.type:"ConditionalAndOrTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"boolean" = java.cor
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %5 : java.type:"int" = var.load %2;
+                                %6 : java.type:"int" = constant @"1";
+                                %7 : java.type:"boolean" = gt %5 %6;
                                 yield %7;
                             }
-                            ()boolean -> {
-                                %8 : int = var.load %2;
-                                %9 : int = constant @"10";
-                                %10 : boolean = lt %8 %9;
+                            ()java.type:"boolean" -> {
+                                %8 : java.type:"int" = var.load %2;
+                                %9 : java.type:"int" = constant @"10";
+                                %10 : java.type:"boolean" = lt %8 %9;
                                 yield %10;
                             };
                         yield %4;
                     }
-                    ()boolean -> {
-                        %11 : int = var.load %2;
-                        %12 : int = constant @"100";
-                        %13 : boolean = eq %11 %12;
+                    ()java.type:"boolean" -> {
+                        %11 : java.type:"int" = var.load %2;
+                        %12 : java.type:"int" = constant @"100";
+                        %13 : java.type:"boolean" = eq %11 %12;
                         yield %13;
                     };
-                %14 : Var<boolean> = var %3 @"b";
+                %14 : Var<java.type:"boolean"> = var %3 @"b";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/ConditionalExpressionTest.java
+++ b/test/langtools/tools/javac/reflect/ConditionalExpressionTest.java
@@ -37,24 +37,24 @@ import java.util.function.Supplier;
 public class ConditionalExpressionTest {
 
     @IR("""
-            func @"test1" (%0 : ConditionalExpressionTest, %1 : boolean, %2 : int, %3 : int)void -> {
-                %4 : Var<boolean> = var %1 @"b";
-                %5 : Var<int> = var %2 @"x";
-                %6 : Var<int> = var %3 @"y";
-                %7 : int = java.cexpression
-                    ^cond()boolean -> {
-                        %8 : boolean = var.load %4;
+            func @"test1" (%0 : java.type:"ConditionalExpressionTest", %1 : java.type:"boolean", %2 : java.type:"int", %3 : java.type:"int")java.type:"void" -> {
+                %4 : Var<java.type:"boolean"> = var %1 @"b";
+                %5 : Var<java.type:"int"> = var %2 @"x";
+                %6 : Var<java.type:"int"> = var %3 @"y";
+                %7 : java.type:"int" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = var.load %4;
                         yield %8;
                     }
-                    ^truepart()int -> {
-                        %9 : int = var.load %5;
+                    ()java.type:"int" -> {
+                        %9 : java.type:"int" = var.load %5;
                         yield %9;
                     }
-                    ^falsepart()int -> {
-                        %10 : int = var.load %6;
+                    ()java.type:"int" -> {
+                        %10 : java.type:"int" = var.load %6;
                         yield %10;
                     };
-                %11 : Var<int> = var %7 @"z";
+                %11 : Var<java.type:"int"> = var %7 @"z";
                 return;
             };
             """)
@@ -64,26 +64,26 @@ public class ConditionalExpressionTest {
     }
 
     @IR("""
-            func @"test2" (%0 : ConditionalExpressionTest, %1 : boolean, %2 : int, %3 : double)void -> {
-                %4 : Var<boolean> = var %1 @"b";
-                %5 : Var<int> = var %2 @"x";
-                %6 : Var<double> = var %3 @"y";
-                %7 : double = java.cexpression
-                    ^cond()boolean -> {
-                        %8 : boolean = var.load %4;
-                        %9 : boolean = not %8;
+            func @"test2" (%0 : java.type:"ConditionalExpressionTest", %1 : java.type:"boolean", %2 : java.type:"int", %3 : java.type:"double")java.type:"void" -> {
+                %4 : Var<java.type:"boolean"> = var %1 @"b";
+                %5 : Var<java.type:"int"> = var %2 @"x";
+                %6 : Var<java.type:"double"> = var %3 @"y";
+                %7 : java.type:"double" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = var.load %4;
+                        %9 : java.type:"boolean" = not %8;
                         yield %9;
                     }
-                    ^truepart()double -> {
-                        %10 : int = var.load %5;
-                        %11 : double = conv %10;
+                    ()java.type:"double" -> {
+                        %10 : java.type:"int" = var.load %5;
+                        %11 : java.type:"double" = conv %10;
                         yield %11;
                     }
-                    ^falsepart()double -> {
-                        %12 : double = var.load %6;
+                    ()java.type:"double" -> {
+                        %12 : java.type:"double" = var.load %6;
                         yield %12;
                     };
-                %13 : Var<double> = var %7 @"z";
+                %13 : Var<java.type:"double"> = var %7 @"z";
                 return;
             };
             """)
@@ -93,33 +93,33 @@ public class ConditionalExpressionTest {
     }
 
     @IR("""
-            func @"test3" (%0 : ConditionalExpressionTest, %1 : boolean, %2 : int, %3 : double)void -> {
-                %4 : Var<boolean> = var %1 @"b";
-                %5 : Var<int> = var %2 @"x";
-                %6 : Var<double> = var %3 @"y";
-                %7 : java.util.function.Supplier<java.lang.Double> = java.cexpression
-                    ^cond()boolean -> {
-                        %8 : boolean = var.load %4;
+            func @"test3" (%0 : java.type:"ConditionalExpressionTest", %1 : java.type:"boolean", %2 : java.type:"int", %3 : java.type:"double")java.type:"void" -> {
+                %4 : Var<java.type:"boolean"> = var %1 @"b";
+                %5 : Var<java.type:"int"> = var %2 @"x";
+                %6 : Var<java.type:"double"> = var %3 @"y";
+                %7 : java.type:"java.util.function.Supplier<java.lang.Double>" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = var.load %4;
                         yield %8;
                     }
-                    ^truepart()java.util.function.Supplier<java.lang.Double> -> {
-                        %9 : java.util.function.Supplier<java.lang.Double> = lambda ()java.lang.Double -> {
-                            %10 : int = var.load %5;
-                            %11 : double = conv %10;
-                            %12 : java.lang.Double = invoke %11 @"java.lang.Double::valueOf(double)java.lang.Double";
+                    ()java.type:"java.util.function.Supplier<java.lang.Double>" -> {
+                        %9 : java.type:"java.util.function.Supplier<java.lang.Double>" = lambda ()java.type:"java.lang.Double" -> {
+                            %10 : java.type:"int" = var.load %5;
+                            %11 : java.type:"double" = conv %10;
+                            %12 : java.type:"java.lang.Double" = invoke %11 @"java.lang.Double::valueOf(double):java.lang.Double";
                             return %12;
                         };
                         yield %9;
                     }
-                    ^falsepart()java.util.function.Supplier<java.lang.Double> -> {
-                        %13 : java.util.function.Supplier<java.lang.Double> = lambda ()java.lang.Double -> {
-                            %14 : double = var.load %6;
-                            %15 : java.lang.Double = invoke %14 @"java.lang.Double::valueOf(double)java.lang.Double";
+                    ()java.type:"java.util.function.Supplier<java.lang.Double>" -> {
+                        %13 : java.type:"java.util.function.Supplier<java.lang.Double>" = lambda ()java.type:"java.lang.Double" -> {
+                            %14 : java.type:"double" = var.load %6;
+                            %15 : java.type:"java.lang.Double" = invoke %14 @"java.lang.Double::valueOf(double):java.lang.Double";
                             return %15;
                         };
                         yield %13;
                     };
-                %16 : Var<java.util.function.Supplier<java.lang.Double>> = var %7 @"z";
+                %16 : Var<java.type:"java.util.function.Supplier<java.lang.Double>"> = var %7 @"z";
                 return;
             };
             """)
@@ -129,39 +129,39 @@ public class ConditionalExpressionTest {
     }
 
     @IR("""
-            func @"test4" (%0 : ConditionalExpressionTest, %1 : boolean, %2 : boolean, %3 : int, %4 : double, %5 : double)void -> {
-                %6 : Var<boolean> = var %1 @"b1";
-                %7 : Var<boolean> = var %2 @"b2";
-                %8 : Var<int> = var %3 @"x";
-                %9 : Var<double> = var %4 @"y";
-                %10 : Var<double> = var %5 @"z";
-                %11 : double = java.cexpression
-                    ^cond()boolean -> {
-                        %12 : boolean = var.load %6;
+            func @"test4" (%0 : java.type:"ConditionalExpressionTest", %1 : java.type:"boolean", %2 : java.type:"boolean", %3 : java.type:"int", %4 : java.type:"double", %5 : java.type:"double")java.type:"void" -> {
+                %6 : Var<java.type:"boolean"> = var %1 @"b1";
+                %7 : Var<java.type:"boolean"> = var %2 @"b2";
+                %8 : Var<java.type:"int"> = var %3 @"x";
+                %9 : Var<java.type:"double"> = var %4 @"y";
+                %10 : Var<java.type:"double"> = var %5 @"z";
+                %11 : java.type:"double" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %12 : java.type:"boolean" = var.load %6;
                         yield %12;
                     }
-                    ^truepart()double -> {
-                        %13 : double = java.cexpression
-                            ^cond()boolean -> {
-                                %14 : boolean = var.load %7;
+                    ()java.type:"double" -> {
+                        %13 : java.type:"double" = java.cexpression
+                            ()java.type:"boolean" -> {
+                                %14 : java.type:"boolean" = var.load %7;
                                 yield %14;
                             }
-                            ^truepart()double -> {
-                                %15 : int = var.load %8;
-                                %16 : double = conv %15;
+                            ()java.type:"double" -> {
+                                %15 : java.type:"int" = var.load %8;
+                                %16 : java.type:"double" = conv %15;
                                 yield %16;
                             }
-                            ^falsepart()double -> {
-                                %17 : double = var.load %9;
+                            ()java.type:"double" -> {
+                                %17 : java.type:"double" = var.load %9;
                                 yield %17;
                             };
                         yield %13;
                     }
-                    ^falsepart()double -> {
-                        %18 : double = var.load %10;
+                    ()java.type:"double" -> {
+                        %18 : java.type:"double" = var.load %10;
                         yield %18;
                     };
-                %19 : Var<double> = var %11 @"r";
+                %19 : Var<java.type:"double"> = var %11 @"r";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/ConstantsTest.java
+++ b/test/langtools/tools/javac/reflect/ConstantsTest.java
@@ -36,9 +36,9 @@ import java.util.function.Function;
 public class ConstantsTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.String = constant @"";
-                %2 : Var<java.lang.String> = var %1 @"s";
+            func @"test1" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @"";
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
                 return;
             };
             """)
@@ -48,9 +48,9 @@ public class ConstantsTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.String = constant @"Hello World";
-                %2 : Var<java.lang.String> = var %1 @"s";
+            func @"test2" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @"Hello World";
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
                 return;
             };
             """)
@@ -60,9 +60,9 @@ public class ConstantsTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.String = constant @null;
-                %2 : Var<java.lang.String> = var %1 @"s";
+            func @"test3" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
                 return;
             };
             """)
@@ -71,9 +71,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test4" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.Class = constant @"java.util.function.Function";
-                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
+            func @"test4" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @"java.util.function.Function";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"s";
                 return;
             };
             """)
@@ -83,12 +83,12 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test5" (%0 : ConstantsTest)void -> {
-                %1 : int = constant @"42";
-                %2 : byte = conv %1;
-                %3 : Var<byte> = var %2 @"v";
-                %4 : int = constant @"-42";
-                %5 : byte = conv %4;
+            func @"test5" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"42";
+                %2 : java.type:"byte" = conv %1;
+                %3 : Var<java.type:"byte"> = var %2 @"v";
+                %4 : java.type:"int" = constant @"-42";
+                %5 : java.type:"byte" = conv %4;
                 var.store %3 %5;
                 return;
             };
@@ -100,12 +100,12 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test6" (%0 : ConstantsTest)void -> {
-                %1 : int = constant @"42";
-                %2 : short = conv %1;
-                %3 : Var<short> = var %2 @"v";
-                %4 : int = constant @"-42";
-                %5 : short = conv %4;
+            func @"test6" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"42";
+                %2 : java.type:"short" = conv %1;
+                %3 : Var<java.type:"short"> = var %2 @"v";
+                %4 : java.type:"int" = constant @"-42";
+                %5 : java.type:"short" = conv %4;
                 var.store %3 %5;
                 return;
             };
@@ -117,10 +117,10 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test7" (%0 : ConstantsTest)void -> {
-                %1 : int = constant @"42";
-                %2 : Var<int> = var %1 @"v";
-                %3 : int = constant @"-42";
+            func @"test7" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"42";
+                %2 : Var<java.type:"int"> = var %1 @"v";
+                %3 : java.type:"int" = constant @"-42";
                 var.store %2 %3;
                 return;
             };
@@ -132,10 +132,10 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test8" (%0 : ConstantsTest)void -> {
-                %1 : long = constant @"42";
-                %2 : Var<long> = var %1 @"v";
-                %3 : long = constant @"-42";
+            func @"test8" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"long" = constant @"42";
+                %2 : Var<java.type:"long"> = var %1 @"v";
+                %3 : java.type:"long" = constant @"-42";
                 var.store %2 %3;
                 return;
             };
@@ -147,11 +147,11 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test9" (%0 : ConstantsTest)void -> {
-                %1 : float = constant @"42.0";
-                %2 : Var<float> = var %1 @"v";
-                %3 : float = constant @"42.0";
-                %4 : float = neg %3;
+            func @"test9" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"float" = constant @"42.0";
+                %2 : Var<java.type:"float"> = var %1 @"v";
+                %3 : java.type:"float" = constant @"42.0";
+                %4 : java.type:"float" = neg %3;
                 var.store %2 %4;
                 return;
             };
@@ -163,11 +163,11 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test10" (%0 : ConstantsTest)void -> {
-                %1 : double = constant @"42.0";
-                %2 : Var<double> = var %1 @"v";
-                %3 : double = constant @"42.0";
-                %4 : double = neg %3;
+            func @"test10" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"double" = constant @"42.0";
+                %2 : Var<java.type:"double"> = var %1 @"v";
+                %3 : java.type:"double" = constant @"42.0";
+                %4 : java.type:"double" = neg %3;
                 var.store %2 %4;
                 return;
             };
@@ -179,9 +179,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test11" (%0 : ConstantsTest)void -> {
-                %1 : char = constant @"a";
-                %2 : Var<char> = var %1 @"v";
+            func @"test11" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"char" = constant @"a";
+                %2 : Var<java.type:"char"> = var %1 @"v";
                 return;
             };
             """)
@@ -191,10 +191,10 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test12" (%0 : ConstantsTest)void -> {
-                %1 : boolean = constant @"true";
-                %2 : Var<boolean> = var %1 @"b";
-                %3 : boolean = constant @"false";
+            func @"test12" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"boolean" = constant @"true";
+                %2 : Var<java.type:"boolean"> = var %1 @"b";
+                %3 : java.type:"boolean" = constant @"false";
                 var.store %2 %3;
                 return;
             };
@@ -206,9 +206,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test13" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.Class = constant @"float";
-                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
+            func @"test13" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @"float";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"s";
                 return;
             };
             """)
@@ -218,9 +218,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test14" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.Class = constant @"java.lang.String[]";
-                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
+            func @"test14" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @"java.lang.String[]";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"s";
                 return;
             };
             """)
@@ -230,9 +230,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test15" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.Class = constant @"java.lang.String[][]";
-                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
+            func @"test15" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @"java.lang.String[][]";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"s";
                 return;
             };
             """)
@@ -242,9 +242,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test16" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.Class = constant @"java.lang.String[][][]";
-                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
+            func @"test16" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @"java.lang.String[][][]";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"s";
                 return;
             };
             """)
@@ -254,9 +254,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test17" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.Class = constant @"boolean[]";
-                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
+            func @"test17" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @"boolean[]";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"s";
                 return;
             };
             """)
@@ -266,9 +266,9 @@ public class ConstantsTest {
     }
 
     @IR("""
-            func @"test18" (%0 : ConstantsTest)void -> {
-                %1 : java.lang.Class = constant @"boolean[][][]";
-                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
+            func @"test18" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @"boolean[][][]";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"s";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/ConstantsTest.java
+++ b/test/langtools/tools/javac/reflect/ConstantsTest.java
@@ -73,7 +73,7 @@ public class ConstantsTest {
     @IR("""
             func @"test4" (%0 : ConstantsTest)void -> {
                 %1 : java.lang.Class = constant @"java.util.function.Function";
-                %2 : Var<java.lang.Class<+<java.lang.Object>>> = var %1 @"s";
+                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
                 return;
             };
             """)
@@ -208,7 +208,7 @@ public class ConstantsTest {
     @IR("""
             func @"test13" (%0 : ConstantsTest)void -> {
                 %1 : java.lang.Class = constant @"float";
-                %2 : Var<java.lang.Class<+<java.lang.Object>>> = var %1 @"s";
+                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
                 return;
             };
             """)
@@ -220,7 +220,7 @@ public class ConstantsTest {
     @IR("""
             func @"test14" (%0 : ConstantsTest)void -> {
                 %1 : java.lang.Class = constant @"java.lang.String[]";
-                %2 : Var<java.lang.Class<+<java.lang.Object>>> = var %1 @"s";
+                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
                 return;
             };
             """)
@@ -232,7 +232,7 @@ public class ConstantsTest {
     @IR("""
             func @"test15" (%0 : ConstantsTest)void -> {
                 %1 : java.lang.Class = constant @"java.lang.String[][]";
-                %2 : Var<java.lang.Class<+<java.lang.Object>>> = var %1 @"s";
+                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
                 return;
             };
             """)
@@ -244,7 +244,7 @@ public class ConstantsTest {
     @IR("""
             func @"test16" (%0 : ConstantsTest)void -> {
                 %1 : java.lang.Class = constant @"java.lang.String[][][]";
-                %2 : Var<java.lang.Class<+<java.lang.Object>>> = var %1 @"s";
+                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
                 return;
             };
             """)
@@ -256,7 +256,7 @@ public class ConstantsTest {
     @IR("""
             func @"test17" (%0 : ConstantsTest)void -> {
                 %1 : java.lang.Class = constant @"boolean[]";
-                %2 : Var<java.lang.Class<+<java.lang.Object>>> = var %1 @"s";
+                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
                 return;
             };
             """)
@@ -268,7 +268,7 @@ public class ConstantsTest {
     @IR("""
             func @"test18" (%0 : ConstantsTest)void -> {
                 %1 : java.lang.Class = constant @"boolean[][][]";
-                %2 : Var<java.lang.Class<+<java.lang.Object>>> = var %1 @"s";
+                %2 : Var<java.lang.Class<? extends java.lang.Object>> = var %1 @"s";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -37,10 +37,10 @@ public class DenotableTypesTest {
     static <X extends Number & Runnable> X m1(X x) { return null; }
     @CodeReflection
     @IR("""
-            func @"test1" ()void -> {
-                  %0 : java.lang.Number = constant @null;
-                  %1 : java.lang.Number = invoke %0 @"DenotableTypesTest::m1(java.lang.Number)java.lang.Number";
-                  return;
+            func @"test1" ()java.type:"void" -> {
+                %0 : java.type:"java.lang.Number" = constant @null;
+                %1 : java.type:"java.lang.Number" = invoke %0 @"DenotableTypesTest::m1(java.lang.Number):java.lang.Number";
+                return;
             };
             """)
     static void test1() {
@@ -49,13 +49,13 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" ()void -> {
-                  %0 : int = constant @"1";
-                  %1 : java.lang.Integer = invoke %0 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                  %2 : double = constant @"3.0";
-                  %3 : java.lang.Double = invoke %2 @"java.lang.Double::valueOf(double)java.lang.Double";
-                  %4 : java.util.List<+<java.lang.Number>> = invoke %1 %3 @"java.util.List::of(java.lang.Object, java.lang.Object)java.util.List";
-                  return;
+            func @"test2" ()java.type:"void" -> {
+                %0 : java.type:"int" = constant @"1";
+                %1 : java.type:"java.lang.Integer" = invoke %0 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %2 : java.type:"double" = constant @"3.0";
+                %3 : java.type:"java.lang.Double" = invoke %2 @"java.lang.Double::valueOf(double):java.lang.Double";
+                %4 : java.type:"java.util.List<? extends java.lang.Number>" = invoke %1 %3 @"java.util.List::of(java.lang.Object, java.lang.Object):java.util.List";
+                return;
             };
             """)
     static void test2() {
@@ -66,9 +66,9 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" ()void -> {
-                %0 : java.lang.RuntimeException = constant @null;
-                %1 : java.lang.RuntimeException = invoke %0 @"DenotableTypesTest::m2(java.lang.Throwable)java.lang.Throwable";
+            func @"test3" ()java.type:"void" -> {
+                %0 : java.type:"java.lang.RuntimeException" = constant @null;
+                %1 : java.type:"java.lang.RuntimeException" = invoke %0 @"DenotableTypesTest::m2(java.lang.Throwable):java.lang.Throwable";
                 return;
             };
             """)
@@ -85,13 +85,13 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" ()void -> {
-                  %0 : java.lang.Object = constant @null;
-                  %1 : DenotableTypesTest$C = cast %0 @"DenotableTypesTest$C";
-                  %2 : java.lang.Object = constant @null;
-                  %3 : DenotableTypesTest$D = cast %2 @"DenotableTypesTest$D";
-                  %4 : DenotableTypesTest$A = invoke %1 %3 @"DenotableTypesTest::pick(java.lang.Object, java.lang.Object)java.lang.Object";
-                  return;
+            func @"test4" ()java.type:"void" -> {
+                %0 : java.type:"java.lang.Object" = constant @null;
+                %1 : java.type:"DenotableTypesTest$C" = cast %0 @"DenotableTypesTest$C";
+                %2 : java.type:"java.lang.Object" = constant @null;
+                %3 : java.type:"DenotableTypesTest$D" = cast %2 @"DenotableTypesTest$D";
+                %4 : java.type:"DenotableTypesTest$A" = invoke %1 %3 @"DenotableTypesTest::pick(java.lang.Object, java.lang.Object):java.lang.Object";
+                return;
             };
             """)
     static void test4() { // @@@ cast?
@@ -100,13 +100,13 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" ()void -> {
-                  %0 : java.util.List<+<java.lang.Number>> = constant @null;
-                  %1 : Var<java.util.List<+<java.lang.Number>>> = var %0 @"l";
-                  %2 : java.util.List<+<java.lang.Number>> = var.load %1;
-                  %3 : int = constant @"0";
-                  %4 : java.lang.Number = invoke %2 %3 @"java.util.List::get(int)java.lang.Object";
-                  return;
+            func @"test5" ()java.type:"void" -> {
+                %0 : java.type:"java.util.List<? extends java.lang.Number>" = constant @null;
+                %1 : Var<java.type:"java.util.List<? extends java.lang.Number>"> = var %0 @"l";
+                %2 : java.type:"java.util.List<? extends java.lang.Number>" = var.load %1;
+                %3 : java.type:"int" = constant @"0";
+                %4 : java.type:"java.lang.Number" = invoke %2 %3 @"java.util.List::get(int):java.lang.Object";
+                return;
             };
             """)
     static void test5() { // @@@ cast?
@@ -116,13 +116,13 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" ()void -> {
-                  %0 : java.util.List<-<java.lang.Number>> = constant @null;
-                  %1 : Var<java.util.List<-<java.lang.Number>>> = var %0 @"l";
-                  %2 : java.util.List<-<java.lang.Number>> = var.load %1;
-                  %3 : int = constant @"0";
-                  %4 : java.lang.Object = invoke %2 %3 @"java.util.List::get(int)java.lang.Object";
-                  return;
+            func @"test6" ()java.type:"void" -> {
+                %0 : java.type:"java.util.List<? super java.lang.Number>" = constant @null;
+                %1 : Var<java.type:"java.util.List<? super java.lang.Number>"> = var %0 @"l";
+                %2 : java.type:"java.util.List<? super java.lang.Number>" = var.load %1;
+                %3 : java.type:"int" = constant @"0";
+                %4 : java.type:"java.lang.Object" = invoke %2 %3 @"java.util.List::get(int):java.lang.Object";
+                return;
             };
             """)
     static void test6() {
@@ -134,13 +134,13 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" ()void -> {
-                  %0 : #X<&m<DenotableTypesTest, test7, func<void>>, java.lang.Object> = constant @null;
-                  %1 : Var<#X<&m<DenotableTypesTest, test7, func<void>>, java.lang.Object>> = var %0 @"x";
-                  %2 : #X<&m<DenotableTypesTest, test7, func<void>>, java.lang.Object> = var.load %1;
-                  %3 : java.lang.Runnable = cast %2 @"java.lang.Runnable";
-                  invoke %3 @"DenotableTypesTest::consume(java.lang.Runnable)void";
-                  return;
+            func @"test7" ()java.type:"void" -> {
+                %0 : java.type:"(DenotableTypesTest::test7():void)::<X>" = constant @null;
+                %1 : Var<java.type:"(DenotableTypesTest::test7():void)::<X>"> = var %0 @"x";
+                %2 : java.type:"(DenotableTypesTest::test7():void)::<X>" = var.load %1;
+                %3 : java.type:"java.lang.Runnable" = cast %2 @"java.lang.Runnable";
+                invoke %3 @"DenotableTypesTest::consume(java.lang.Runnable):void";
+                return;
             };
             """)
     static <X extends Object & Runnable> void test7() {
@@ -154,16 +154,16 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : java.util.List<+<DenotableTypesTest$Adder<java.lang.Integer>>>)void -> {
-                  %1 : Var<java.util.List<+<DenotableTypesTest$Adder<java.lang.Integer>>>> = var %0 @"list";
-                  %2 : java.util.List<+<DenotableTypesTest$Adder<java.lang.Integer>>> = var.load %1;
-                  %3 : int = constant @"0";
-                  %4 : DenotableTypesTest$Adder<java.lang.Integer> = invoke %2 %3 @"java.util.List::get(int)java.lang.Object";
-                  %5 : java.util.List<+<DenotableTypesTest$Adder<java.lang.Integer>>> = var.load %1;
-                  %6 : int = constant @"1";
-                  %7 : DenotableTypesTest$Adder<java.lang.Integer> = invoke %5 %6 @"java.util.List::get(int)java.lang.Object";
-                  invoke %4 %7 @"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder)void";
-                  return;
+            func @"test8" (%0 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>")java.type:"void" -> {
+                %1 : Var<java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>"> = var %0 @"list";
+                %2 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
+                %3 : java.type:"int" = constant @"0";
+                %4 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %2 %3 @"java.util.List::get(int):java.lang.Object";
+                %5 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %5 %6 @"java.util.List::get(int):java.lang.Object";
+                invoke %4 %7 @"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder):void";
+                return;
             };
             """)
     static void test8(List<? extends Adder<Integer>> list) {
@@ -176,14 +176,14 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : java.util.List<+<DenotableTypesTest$Box<java.lang.Integer>>>)void -> {
-                  %1 : Var<java.util.List<+<DenotableTypesTest$Box<java.lang.Integer>>>> = var %0 @"list";
-                  %2 : java.util.List<+<DenotableTypesTest$Box<java.lang.Integer>>> = var.load %1;
-                  %3 : int = constant @"0";
-                  %4 : DenotableTypesTest$Box<java.lang.Integer> = invoke %2 %3 @"java.util.List::get(int)java.lang.Object";
-                  %5 : java.lang.Integer = field.load %4 @"DenotableTypesTest$Box::x()java.lang.Object";
-                  %6 : Var<java.lang.Integer> = var %5 @"i";
-                  return;
+            func @"test9" (%0 : java.type:"java.util.List<? extends DenotableTypesTest$Box<java.lang.Integer>>")java.type:"void" -> {
+                %1 : Var<java.type:"java.util.List<? extends DenotableTypesTest$Box<java.lang.Integer>>"> = var %0 @"list";
+                %2 : java.type:"java.util.List<? extends DenotableTypesTest$Box<java.lang.Integer>>" = var.load %1;
+                %3 : java.type:"int" = constant @"0";
+                %4 : java.type:"DenotableTypesTest$Box<java.lang.Integer>" = invoke %2 %3 @"java.util.List::get(int):java.lang.Object";
+                %5 : java.type:"java.lang.Integer" = field.load %4 @"DenotableTypesTest$Box::x:java.lang.Object";
+                %6 : Var<java.type:"java.lang.Integer"> = var %5 @"i";
+                return;
             };
             """)
     static void test9(List<? extends Box<Integer>> list) {
@@ -206,20 +206,20 @@ public class DenotableTypesTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" ()void -> {
-                  java.try
-                      ()void -> {
-                          invoke @"DenotableTypesTest::g()void";
-                          yield;
-                      }
-                      (%0 : java.lang.Exception)void -> {
-                          %1 : Var<java.lang.Exception> = var %0 @"x";
-                          %2 : java.lang.Exception = var.load %1;
-                          %3 : DenotableTypesTest$E = cast %2 @"DenotableTypesTest$E";
-                          invoke %3 @"DenotableTypesTest$E::m()void";
-                          yield;
-                      };
-                  return;
+            func @"test10" ()java.type:"void" -> {
+                java.try
+                    ()java.type:"void" -> {
+                        invoke @"DenotableTypesTest::g():void";
+                        yield;
+                    }
+                    (%0 : java.type:"java.lang.Exception")java.type:"void" -> {
+                        %1 : Var<java.type:"java.lang.Exception"> = var %0 @"x";
+                        %2 : java.type:"java.lang.Exception" = var.load %1;
+                        %3 : java.type:"DenotableTypesTest$E" = cast %2 @"DenotableTypesTest$E";
+                        invoke %3 @"DenotableTypesTest$E::m():void";
+                        yield;
+                    };
+                return;
             };
             """)
     static void test10() {

--- a/test/langtools/tools/javac/reflect/EnumAccessTest.java
+++ b/test/langtools/tools/javac/reflect/EnumAccessTest.java
@@ -39,8 +39,8 @@ import static java.lang.constant.DirectMethodHandleDesc.Kind.VIRTUAL;
 public class EnumAccessTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : EnumAccessTest)java.lang.constant.DirectMethodHandleDesc$Kind -> {
-                %1 : java.lang.constant.DirectMethodHandleDesc$Kind = field.load @"java.lang.constant.DirectMethodHandleDesc$Kind::VIRTUAL()java.lang.constant.DirectMethodHandleDesc$Kind";
+            func @"test1" (%0 : java.type:"EnumAccessTest")java.type:"java.lang.constant.DirectMethodHandleDesc$Kind" -> {
+                %1 : java.type:"java.lang.constant.DirectMethodHandleDesc$Kind" = field.load @"java.lang.constant.DirectMethodHandleDesc$Kind::VIRTUAL:java.lang.constant.DirectMethodHandleDesc$Kind";
                 return %1;
             };
             """)
@@ -50,8 +50,8 @@ public class EnumAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : EnumAccessTest)java.lang.constant.DirectMethodHandleDesc$Kind -> {
-                %1 : java.lang.constant.DirectMethodHandleDesc$Kind = field.load @"java.lang.constant.DirectMethodHandleDesc$Kind::VIRTUAL()java.lang.constant.DirectMethodHandleDesc$Kind";
+            func @"test2" (%0 : java.type:"EnumAccessTest")java.type:"java.lang.constant.DirectMethodHandleDesc$Kind" -> {
+                %1 : java.type:"java.lang.constant.DirectMethodHandleDesc$Kind" = field.load @"java.lang.constant.DirectMethodHandleDesc$Kind::VIRTUAL:java.lang.constant.DirectMethodHandleDesc$Kind";
                 return %1;
             };
             """)
@@ -61,8 +61,8 @@ public class EnumAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : EnumAccessTest)java.lang.constant.DirectMethodHandleDesc$Kind -> {
-                %1 : java.lang.constant.DirectMethodHandleDesc$Kind = field.load @"java.lang.constant.DirectMethodHandleDesc$Kind::VIRTUAL()java.lang.constant.DirectMethodHandleDesc$Kind";
+            func @"test3" (%0 : java.type:"EnumAccessTest")java.type:"java.lang.constant.DirectMethodHandleDesc$Kind" -> {
+                %1 : java.type:"java.lang.constant.DirectMethodHandleDesc$Kind" = field.load @"java.lang.constant.DirectMethodHandleDesc$Kind::VIRTUAL:java.lang.constant.DirectMethodHandleDesc$Kind";
                 return %1;
             };
             """)

--- a/test/langtools/tools/javac/reflect/FieldAccessTest.java
+++ b/test/langtools/tools/javac/reflect/FieldAccessTest.java
@@ -44,11 +44,11 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : FieldAccessTest)void -> {
-                %1 : int = constant @"1";
-                field.store %1 @"FieldAccessTest::s_f()int";
-                %2 : int = constant @"1";
-                field.store %0 %2 @"FieldAccessTest::f()int";
+            func @"test1" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                field.store %1 @"FieldAccessTest::s_f:int";
+                %2 : java.type:"int" = constant @"1";
+                field.store %0 %2 @"FieldAccessTest::f:int";
                 return;
             };
             """)
@@ -59,15 +59,15 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test1_1" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                %4 : int = field.load @"FieldAccessTest::s_f()int";
-                %5 : int = constant @"1";
-                %6 : int = add %4 %5;
-                field.store %6 @"FieldAccessTest::s_f()int";
+            func @"test1_1" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                %4 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %4 %5;
+                field.store %6 @"FieldAccessTest::s_f:int";
                 return;
             };
             """)
@@ -78,10 +78,10 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : FieldAccessTest)void -> {
-                %1 : int = constant @"1";
-                field.store %0 %1 @"FieldAccessTest::f()int";
-                field.store %1 @"FieldAccessTest::s_f()int";
+            func @"test2" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                field.store %0 %1 @"FieldAccessTest::f:int";
+                field.store %1 @"FieldAccessTest::s_f:int";
                 return;
             };
             """)
@@ -91,9 +91,9 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test2_1" (%0 : FieldAccessTest)void -> {
-                %1 : int = constant @"1";
-                field.store %0 %1 @"FieldAccessTest::f()int";
+            func @"test2_1" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                field.store %0 %1 @"FieldAccessTest::f:int";
                 return;
             };
             """)
@@ -103,8 +103,8 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test2_2" (%0 : FieldAccessTest)int -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
+            func @"test2_2" (%0 : java.type:"FieldAccessTest")java.type:"int" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
                 return %1;
             };
             """)
@@ -114,9 +114,9 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test2_3" (%0 : FieldAccessTest)void -> {
-                %1 : int = constant @"1";
-                field.store %0 %1 @"FieldAccessTest::f()int";
+            func @"test2_3" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                field.store %0 %1 @"FieldAccessTest::f:int";
                 return;
             };
             """)
@@ -126,8 +126,8 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test2_4" (%0 : FieldAccessTest)int -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
+            func @"test2_4" (%0 : java.type:"FieldAccessTest")java.type:"int" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
                 return %1;
             };
             """)
@@ -137,10 +137,10 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : FieldAccessTest)int -> {
-                %1 : int = field.load @"FieldAccessTest::s_f()int";
-                %2 : int = field.load %0 @"FieldAccessTest::f()int";
-                %3 : int = add %1 %2;
+            func @"test3" (%0 : java.type:"FieldAccessTest")java.type:"int" -> {
+                %1 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %2 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %3 : java.type:"int" = add %1 %2;
                 return %3;
             };
             """)
@@ -162,13 +162,13 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : FieldAccessTest, %1 : FieldAccessTest$A)void -> {
-                %2 : Var<FieldAccessTest$A> = var %1 @"a";
-                %3 : FieldAccessTest$A = var.load %2;
-                %4 : FieldAccessTest$B = field.load %3 @"FieldAccessTest$A::b()FieldAccessTest$B";
-                %5 : FieldAccessTest$C = field.load %4 @"FieldAccessTest$B::c()FieldAccessTest$C";
-                %6 : int = constant @"1";
-                field.store %5 %6 @"FieldAccessTest$C::f()int";
+            func @"test4" (%0 : java.type:"FieldAccessTest", %1 : java.type:"FieldAccessTest$A")java.type:"void" -> {
+                %2 : Var<java.type:"FieldAccessTest$A"> = var %1 @"a";
+                %3 : java.type:"FieldAccessTest$A" = var.load %2;
+                %4 : java.type:"FieldAccessTest$B" = field.load %3 @"FieldAccessTest$A::b:FieldAccessTest$B";
+                %5 : java.type:"FieldAccessTest$C" = field.load %4 @"FieldAccessTest$B::c:FieldAccessTest$C";
+                %6 : java.type:"int" = constant @"1";
+                field.store %5 %6 @"FieldAccessTest$C::f:int";
                 return;
             };
             """)
@@ -183,8 +183,8 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : FieldAccessTest)int -> {
-                %1 : int = field.load @"FieldAccessTest$X::s_f()int";
+            func @"test5" (%0 : java.type:"FieldAccessTest")java.type:"int" -> {
+                %1 : java.type:"int" = field.load @"FieldAccessTest$X::s_f:int";
                 return %1;
             };
             """)
@@ -194,9 +194,9 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : FieldAccessTest)void -> {
-                %1 : int = constant @"1";
-                field.store %1 @"FieldAccessTest$X::s_f()int";
+            func @"test6" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                field.store %1 @"FieldAccessTest$X::s_f:int";
                 return;
             };
             """)
@@ -207,15 +207,15 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                %4 : int = field.load @"FieldAccessTest::s_f()int";
-                %5 : int = constant @"1";
-                %6 : int = add %4 %5;
-                field.store %6 @"FieldAccessTest::s_f()int";
+            func @"test7" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                %4 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %4 %5;
+                field.store %6 @"FieldAccessTest::s_f:int";
                 return;
             };
             """)
@@ -226,15 +226,15 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                %4 : int = field.load @"FieldAccessTest::s_f()int";
-                %5 : int = constant @"1";
-                %6 : int = add %4 %5;
-                field.store %6 @"FieldAccessTest::s_f()int";
+            func @"test8" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                %4 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %4 %5;
+                field.store %6 @"FieldAccessTest::s_f:int";
                 return;
             };
             """)
@@ -245,11 +245,11 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load @"FieldAccessTest$X::s_f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %3 @"FieldAccessTest$X::s_f()int";
+            func @"test9" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load @"FieldAccessTest$X::s_f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %3 @"FieldAccessTest$X::s_f:int";
                 return;
             };
             """)
@@ -259,12 +259,12 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                field.store %3 @"FieldAccessTest::s_f()int";
+            func @"test10" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                field.store %3 @"FieldAccessTest::s_f:int";
                 return;
             };
             """)
@@ -274,15 +274,15 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test11" (%0 : FieldAccessTest, %1 : FieldAccessTest$A)void -> {
-                %2 : Var<FieldAccessTest$A> = var %1 @"a";
-                %3 : FieldAccessTest$A = var.load %2;
-                %4 : FieldAccessTest$B = field.load %3 @"FieldAccessTest$A::b()FieldAccessTest$B";
-                %5 : FieldAccessTest$C = field.load %4 @"FieldAccessTest$B::c()FieldAccessTest$C";
-                %6 : int = field.load %5 @"FieldAccessTest$C::f()int";
-                %7 : int = constant @"1";
-                %8 : int = add %6 %7;
-                field.store %5 %8 @"FieldAccessTest$C::f()int";
+            func @"test11" (%0 : java.type:"FieldAccessTest", %1 : java.type:"FieldAccessTest$A")java.type:"void" -> {
+                %2 : Var<java.type:"FieldAccessTest$A"> = var %1 @"a";
+                %3 : java.type:"FieldAccessTest$A" = var.load %2;
+                %4 : java.type:"FieldAccessTest$B" = field.load %3 @"FieldAccessTest$A::b:FieldAccessTest$B";
+                %5 : java.type:"FieldAccessTest$C" = field.load %4 @"FieldAccessTest$B::c:FieldAccessTest$C";
+                %6 : java.type:"int" = field.load %5 @"FieldAccessTest$C::f:int";
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"int" = add %6 %7;
+                field.store %5 %8 @"FieldAccessTest$C::f:int";
                 return;
             };
             """)
@@ -292,17 +292,17 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test12" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                %4 : Var<int> = var %1 @"x";
-                %5 : int = field.load %0 @"FieldAccessTest::f()int";
-                %6 : int = constant @"1";
-                %7 : int = sub %5 %6;
-                field.store %0 %7 @"FieldAccessTest::f()int";
-                %8 : Var<int> = var %5 @"y";
+            func @"test12" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                %4 : Var<java.type:"int"> = var %1 @"x";
+                %5 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = sub %5 %6;
+                field.store %0 %7 @"FieldAccessTest::f:int";
+                %8 : Var<java.type:"int"> = var %5 @"y";
                 return;
             };
             """)
@@ -313,17 +313,17 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test13" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                %4 : Var<int> = var %1 @"x";
-                %5 : int = field.load %0 @"FieldAccessTest::f()int";
-                %6 : int = constant @"1";
-                %7 : int = sub %5 %6;
-                field.store %0 %7 @"FieldAccessTest::f()int";
-                %8 : Var<int> = var %5 @"y";
+            func @"test13" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                %4 : Var<java.type:"int"> = var %1 @"x";
+                %5 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = sub %5 %6;
+                field.store %0 %7 @"FieldAccessTest::f:int";
+                %8 : Var<java.type:"int"> = var %5 @"y";
                 return;
             };
             """)
@@ -334,17 +334,17 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test14" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load @"FieldAccessTest::s_f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %3 @"FieldAccessTest::s_f()int";
-                %4 : Var<int> = var %1 @"x";
-                %5 : int = field.load @"FieldAccessTest::s_f()int";
-                %6 : int = constant @"1";
-                %7 : int = sub %5 %6;
-                field.store %7 @"FieldAccessTest::s_f()int";
-                %8 : Var<int> = var %5 @"y";
+            func @"test14" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %3 @"FieldAccessTest::s_f:int";
+                %4 : Var<java.type:"int"> = var %1 @"x";
+                %5 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = sub %5 %6;
+                field.store %7 @"FieldAccessTest::s_f:int";
+                %8 : Var<java.type:"int"> = var %5 @"y";
                 return;
             };
             """)
@@ -355,20 +355,20 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test15" (%0 : FieldAccessTest, %1 : FieldAccessTest$X)void -> {
-                %2 : Var<FieldAccessTest$X> = var %1 @"h";
-                %3 : FieldAccessTest$X = var.load %2;
-                %4 : int = field.load %3 @"FieldAccessTest$X::f()int";
-                %5 : int = constant @"1";
-                %6 : int = add %4 %5;
-                field.store %3 %6 @"FieldAccessTest$X::f()int";
-                %7 : Var<int> = var %4 @"x";
-                %8 : FieldAccessTest$X = var.load %2;
-                %9 : int = field.load %8 @"FieldAccessTest$X::f()int";
-                %10 : int = constant @"1";
-                %11 : int = sub %9 %10;
-                field.store %8 %11 @"FieldAccessTest$X::f()int";
-                %12 : Var<int> = var %9 @"y";
+            func @"test15" (%0 : java.type:"FieldAccessTest", %1 : java.type:"FieldAccessTest$X")java.type:"void" -> {
+                %2 : Var<java.type:"FieldAccessTest$X"> = var %1 @"h";
+                %3 : java.type:"FieldAccessTest$X" = var.load %2;
+                %4 : java.type:"int" = field.load %3 @"FieldAccessTest$X::f:int";
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %4 %5;
+                field.store %3 %6 @"FieldAccessTest$X::f:int";
+                %7 : Var<java.type:"int"> = var %4 @"x";
+                %8 : java.type:"FieldAccessTest$X" = var.load %2;
+                %9 : java.type:"int" = field.load %8 @"FieldAccessTest$X::f:int";
+                %10 : java.type:"int" = constant @"1";
+                %11 : java.type:"int" = sub %9 %10;
+                field.store %8 %11 @"FieldAccessTest$X::f:int";
+                %12 : Var<java.type:"int"> = var %9 @"y";
                 return;
             };
             """)
@@ -382,17 +382,17 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test16" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                %4 : Var<int> = var %3 @"x";
-                %5 : int = field.load %0 @"FieldAccessTest::f()int";
-                %6 : int = constant @"1";
-                %7 : int = sub %5 %6;
-                field.store %0 %7 @"FieldAccessTest::f()int";
-                %8 : Var<int> = var %7 @"y";
+            func @"test16" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                %4 : Var<java.type:"int"> = var %3 @"x";
+                %5 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = sub %5 %6;
+                field.store %0 %7 @"FieldAccessTest::f:int";
+                %8 : Var<java.type:"int"> = var %7 @"y";
                 return;
             };
             """)
@@ -403,17 +403,17 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test17" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load %0 @"FieldAccessTest::f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %0 %3 @"FieldAccessTest::f()int";
-                %4 : Var<int> = var %3 @"x";
-                %5 : int = field.load %0 @"FieldAccessTest::f()int";
-                %6 : int = constant @"1";
-                %7 : int = sub %5 %6;
-                field.store %0 %7 @"FieldAccessTest::f()int";
-                %8 : Var<int> = var %7 @"y";
+            func @"test17" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %0 %3 @"FieldAccessTest::f:int";
+                %4 : Var<java.type:"int"> = var %3 @"x";
+                %5 : java.type:"int" = field.load %0 @"FieldAccessTest::f:int";
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = sub %5 %6;
+                field.store %0 %7 @"FieldAccessTest::f:int";
+                %8 : Var<java.type:"int"> = var %7 @"y";
                 return;
             };
             """)
@@ -424,17 +424,17 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test18" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load @"FieldAccessTest::s_f()int";
-                %2 : int = constant @"1";
-                %3 : int = add %1 %2;
-                field.store %3 @"FieldAccessTest::s_f()int";
-                %4 : Var<int> = var %3 @"x";
-                %5 : int = field.load @"FieldAccessTest::s_f()int";
-                %6 : int = constant @"1";
-                %7 : int = sub %5 %6;
-                field.store %7 @"FieldAccessTest::s_f()int";
-                %8 : Var<int> = var %7 @"y";
+            func @"test18" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"int" = add %1 %2;
+                field.store %3 @"FieldAccessTest::s_f:int";
+                %4 : Var<java.type:"int"> = var %3 @"x";
+                %5 : java.type:"int" = field.load @"FieldAccessTest::s_f:int";
+                %6 : java.type:"int" = constant @"1";
+                %7 : java.type:"int" = sub %5 %6;
+                field.store %7 @"FieldAccessTest::s_f:int";
+                %8 : Var<java.type:"int"> = var %7 @"y";
                 return;
             };
             """)
@@ -445,20 +445,20 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test19" (%0 : FieldAccessTest, %1 : FieldAccessTest$X)void -> {
-                %2 : Var<FieldAccessTest$X> = var %1 @"h";
-                %3 : FieldAccessTest$X = var.load %2;
-                %4 : int = field.load %3 @"FieldAccessTest$X::f()int";
-                %5 : int = constant @"1";
-                %6 : int = add %4 %5;
-                field.store %3 %6 @"FieldAccessTest$X::f()int";
-                %7 : Var<int> = var %6 @"x";
-                %8 : FieldAccessTest$X = var.load %2;
-                %9 : int = field.load %8 @"FieldAccessTest$X::f()int";
-                %10 : int = constant @"1";
-                %11 : int = sub %9 %10;
-                field.store %8 %11 @"FieldAccessTest$X::f()int";
-                %12 : Var<int> = var %11 @"y";
+            func @"test19" (%0 : java.type:"FieldAccessTest", %1 : java.type:"FieldAccessTest$X")java.type:"void" -> {
+                %2 : Var<java.type:"FieldAccessTest$X"> = var %1 @"h";
+                %3 : java.type:"FieldAccessTest$X" = var.load %2;
+                %4 : java.type:"int" = field.load %3 @"FieldAccessTest$X::f:int";
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %4 %5;
+                field.store %3 %6 @"FieldAccessTest$X::f:int";
+                %7 : Var<java.type:"int"> = var %6 @"x";
+                %8 : java.type:"FieldAccessTest$X" = var.load %2;
+                %9 : java.type:"int" = field.load %8 @"FieldAccessTest$X::f:int";
+                %10 : java.type:"int" = constant @"1";
+                %11 : java.type:"int" = sub %9 %10;
+                field.store %8 %11 @"FieldAccessTest$X::f:int";
+                %12 : Var<java.type:"int"> = var %11 @"y";
                 return;
             };
             """)
@@ -473,10 +473,10 @@ public class FieldAccessTest {
 
         @CodeReflection
         @IR("""
-                func @"test" (%0 : FieldAccessTest$Y)void -> {
-                    %1 : int = field.load %0 @"FieldAccessTest$Y::f()int";
-                    %2 : Var<int> = var %1 @"x";
-                    %3 : int = field.load @"FieldAccessTest$Y::s_f()int";
+                func @"test" (%0 : java.type:"FieldAccessTest$Y")java.type:"void" -> {
+                    %1 : java.type:"int" = field.load %0 @"FieldAccessTest$Y::f:int";
+                    %2 : Var<java.type:"int"> = var %1 @"x";
+                    %3 : java.type:"int" = field.load @"FieldAccessTest$Y::s_f:int";
                     var.store %2 %3;
                     return;
                 };
@@ -488,11 +488,11 @@ public class FieldAccessTest {
 
         @CodeReflection
         @IR("""
-                func @"test2" (%0 : FieldAccessTest$Y)void -> {
-                    %1 : int = constant @"1";
-                    field.store %0 %1 @"FieldAccessTest$Y::f()int";
-                    %2 : int = constant @"1";
-                    field.store %2 @"FieldAccessTest$Y::s_f()int";
+                func @"test2" (%0 : java.type:"FieldAccessTest$Y")java.type:"void" -> {
+                    %1 : java.type:"int" = constant @"1";
+                    field.store %0 %1 @"FieldAccessTest$Y::f:int";
+                    %2 : java.type:"int" = constant @"1";
+                    field.store %2 @"FieldAccessTest$Y::s_f:int";
                     return;
                 };
                 """)
@@ -503,15 +503,15 @@ public class FieldAccessTest {
 
         @CodeReflection
         @IR("""
-                func @"test3" (%0 : FieldAccessTest$Y)void -> {
-                    %1 : int = field.load %0 @"FieldAccessTest$Y::f()int";
-                    %2 : int = constant @"1";
-                    %3 : int = add %1 %2;
-                    field.store %0 %3 @"FieldAccessTest$Y::f()int";
-                    %4 : int = field.load @"FieldAccessTest$Y::s_f()int";
-                    %5 : int = constant @"1";
-                    %6 : int = add %4 %5;
-                    field.store %6 @"FieldAccessTest$Y::s_f()int";
+                func @"test3" (%0 : java.type:"FieldAccessTest$Y")java.type:"void" -> {
+                    %1 : java.type:"int" = field.load %0 @"FieldAccessTest$Y::f:int";
+                    %2 : java.type:"int" = constant @"1";
+                    %3 : java.type:"int" = add %1 %2;
+                    field.store %0 %3 @"FieldAccessTest$Y::f:int";
+                    %4 : java.type:"int" = field.load @"FieldAccessTest$Y::s_f:int";
+                    %5 : java.type:"int" = constant @"1";
+                    %6 : java.type:"int" = add %4 %5;
+                    field.store %6 @"FieldAccessTest$Y::s_f:int";
                     return;
                 };
                 """)
@@ -523,23 +523,23 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test20" (%0 : FieldAccessTest, %1 : FieldAccessTest$Y)void -> {
-                %2 : Var<FieldAccessTest$Y> = var %1 @"y";
-                %3 : FieldAccessTest$Y = var.load %2;
-                %4 : int = field.load %3 @"FieldAccessTest$Y::f()int";
-                %5 : Var<int> = var %4 @"x";
-                %6 : FieldAccessTest$Y = var.load %2;
-                %7 : int = field.load %6 @"FieldAccessTest$Y::yf()int";
+            func @"test20" (%0 : java.type:"FieldAccessTest", %1 : java.type:"FieldAccessTest$Y")java.type:"void" -> {
+                %2 : Var<java.type:"FieldAccessTest$Y"> = var %1 @"y";
+                %3 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %4 : java.type:"int" = field.load %3 @"FieldAccessTest$Y::f:int";
+                %5 : Var<java.type:"int"> = var %4 @"x";
+                %6 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %7 : java.type:"int" = field.load %6 @"FieldAccessTest$Y::yf:int";
                 var.store %5 %7;
-                %8 : FieldAccessTest$Y = var.load %2;
-                %9 : int = field.load @"FieldAccessTest$Y::s_yf()int";
+                %8 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %9 : java.type:"int" = field.load @"FieldAccessTest$Y::s_yf:int";
                 var.store %5 %9;
-                %10 : int = field.load @"FieldAccessTest$Y::s_yf()int";
+                %10 : java.type:"int" = field.load @"FieldAccessTest$Y::s_yf:int";
                 var.store %5 %10;
-                %11 : FieldAccessTest$Y = var.load %2;
-                %12 : int = field.load @"FieldAccessTest$Y::s_f()int";
+                %11 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %12 : java.type:"int" = field.load @"FieldAccessTest$Y::s_f:int";
                 var.store %5 %12;
-                %13 : int = field.load @"FieldAccessTest$Y::s_f()int";
+                %13 : java.type:"int" = field.load @"FieldAccessTest$Y::s_f:int";
                 var.store %5 %13;
                 return;
             };
@@ -555,24 +555,24 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test21" (%0 : FieldAccessTest, %1 : FieldAccessTest$Y)void -> {
-                %2 : Var<FieldAccessTest$Y> = var %1 @"y";
-                %3 : FieldAccessTest$Y = var.load %2;
-                %4 : int = constant @"1";
-                field.store %3 %4 @"FieldAccessTest$Y::f()int";
-                %5 : FieldAccessTest$Y = var.load %2;
-                %6 : int = constant @"1";
-                field.store %5 %6 @"FieldAccessTest$Y::yf()int";
-                %7 : FieldAccessTest$Y = var.load %2;
-                %8 : int = constant @"1";
-                field.store %8 @"FieldAccessTest$Y::s_yf()int";
-                %9 : int = constant @"1";
-                field.store %9 @"FieldAccessTest$Y::s_yf()int";
-                %10 : FieldAccessTest$Y = var.load %2;
-                %11 : int = constant @"1";
-                field.store %11 @"FieldAccessTest$Y::s_f()int";
-                %12 : int = constant @"1";
-                field.store %12 @"FieldAccessTest$Y::s_f()int";
+            func @"test21" (%0 : java.type:"FieldAccessTest", %1 : java.type:"FieldAccessTest$Y")java.type:"void" -> {
+                %2 : Var<java.type:"FieldAccessTest$Y"> = var %1 @"y";
+                %3 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                field.store %3 %4 @"FieldAccessTest$Y::f:int";
+                %5 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %6 : java.type:"int" = constant @"1";
+                field.store %5 %6 @"FieldAccessTest$Y::yf:int";
+                %7 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %8 : java.type:"int" = constant @"1";
+                field.store %8 @"FieldAccessTest$Y::s_yf:int";
+                %9 : java.type:"int" = constant @"1";
+                field.store %9 @"FieldAccessTest$Y::s_yf:int";
+                %10 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %11 : java.type:"int" = constant @"1";
+                field.store %11 @"FieldAccessTest$Y::s_f:int";
+                %12 : java.type:"int" = constant @"1";
+                field.store %12 @"FieldAccessTest$Y::s_f:int";
                 return;
             };
             """)
@@ -587,36 +587,36 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-          func @"test22" (%0 : FieldAccessTest, %1 : FieldAccessTest$Y)void -> {
-                %2 : Var<FieldAccessTest$Y> = var %1 @"y";
-                %3 : FieldAccessTest$Y = var.load %2;
-                %4 : int = field.load %3 @"FieldAccessTest$Y::f()int";
-                %5 : int = constant @"1";
-                %6 : int = add %4 %5;
-                field.store %3 %6 @"FieldAccessTest$Y::f()int";
-                %7 : FieldAccessTest$Y = var.load %2;
-                %8 : int = field.load %7 @"FieldAccessTest$Y::yf()int";
-                %9 : int = constant @"1";
-                %10 : int = add %8 %9;
-                field.store %7 %10 @"FieldAccessTest$Y::yf()int";
-                %11 : FieldAccessTest$Y = var.load %2;
-                %12 : int = field.load @"FieldAccessTest$Y::s_yf()int";
-                %13 : int = constant @"1";
-                %14 : int = add %12 %13;
-                field.store %14 @"FieldAccessTest$Y::s_yf()int";
-                %15 : int = field.load @"FieldAccessTest$Y::s_yf()int";
-                %16 : int = constant @"1";
-                %17 : int = add %15 %16;
-                field.store %17 @"FieldAccessTest$Y::s_yf()int";
-                %18 : FieldAccessTest$Y = var.load %2;
-                %19 : int = field.load @"FieldAccessTest$Y::s_f()int";
-                %20 : int = constant @"1";
-                %21 : int = add %19 %20;
-                field.store %21 @"FieldAccessTest$Y::s_f()int";
-                %22 : int = field.load @"FieldAccessTest$Y::s_f()int";
-                %23 : int = constant @"1";
-                %24 : int = add %22 %23;
-                field.store %24 @"FieldAccessTest$Y::s_f()int";
+            func @"test22" (%0 : java.type:"FieldAccessTest", %1 : java.type:"FieldAccessTest$Y")java.type:"void" -> {
+                %2 : Var<java.type:"FieldAccessTest$Y"> = var %1 @"y";
+                %3 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %4 : java.type:"int" = field.load %3 @"FieldAccessTest$Y::f:int";
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %4 %5;
+                field.store %3 %6 @"FieldAccessTest$Y::f:int";
+                %7 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %8 : java.type:"int" = field.load %7 @"FieldAccessTest$Y::yf:int";
+                %9 : java.type:"int" = constant @"1";
+                %10 : java.type:"int" = add %8 %9;
+                field.store %7 %10 @"FieldAccessTest$Y::yf:int";
+                %11 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %12 : java.type:"int" = field.load @"FieldAccessTest$Y::s_yf:int";
+                %13 : java.type:"int" = constant @"1";
+                %14 : java.type:"int" = add %12 %13;
+                field.store %14 @"FieldAccessTest$Y::s_yf:int";
+                %15 : java.type:"int" = field.load @"FieldAccessTest$Y::s_yf:int";
+                %16 : java.type:"int" = constant @"1";
+                %17 : java.type:"int" = add %15 %16;
+                field.store %17 @"FieldAccessTest$Y::s_yf:int";
+                %18 : java.type:"FieldAccessTest$Y" = var.load %2;
+                %19 : java.type:"int" = field.load @"FieldAccessTest$Y::s_f:int";
+                %20 : java.type:"int" = constant @"1";
+                %21 : java.type:"int" = add %19 %20;
+                field.store %21 @"FieldAccessTest$Y::s_f:int";
+                %22 : java.type:"int" = field.load @"FieldAccessTest$Y::s_f:int";
+                %23 : java.type:"int" = constant @"1";
+                %24 : java.type:"int" = add %22 %23;
+                field.store %24 @"FieldAccessTest$Y::s_f:int";
                 return;
             };
             """)
@@ -632,12 +632,12 @@ public class FieldAccessTest {
     // @@@ Should propagate as constant value?
     @CodeReflection
     @IR("""
-            func @"test23" (%0 : FieldAccessTest)void -> {
-                %1 : int = field.load @"java.util.Spliterator$OfInt::CONCURRENT()int";
-                %2 : Var<int> = var %1 @"x";
-                %3 : int = field.load @"java.util.Spliterator$OfInt::CONCURRENT()int";
+            func @"test23" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load @"java.util.Spliterator$OfInt::CONCURRENT:int";
+                %2 : Var<java.type:"int"> = var %1 @"x";
+                %3 : java.type:"int" = field.load @"java.util.Spliterator$OfInt::CONCURRENT:int";
                 var.store %2 %3;
-                %4 : int = field.load @"java.util.Spliterator$OfInt::CONCURRENT()int";
+                %4 : java.type:"int" = field.load @"java.util.Spliterator$OfInt::CONCURRENT:int";
                 var.store %2 %4;
                 return;
             };
@@ -650,9 +650,9 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test24" (%0 : FieldAccessTest)void -> {
-                %1 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                %2 : Var<java.io.PrintStream> = var %1 @"ps";
+            func @"test24" (%0 : java.type:"FieldAccessTest")java.type:"void" -> {
+                %1 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                %2 : Var<java.type:"java.io.PrintStream"> = var %1 @"ps";
                 return;
             };
             """)
@@ -670,14 +670,14 @@ public class FieldAccessTest {
 
     @CodeReflection
     @IR("""
-            func @"test25" ()void -> {
-                    %0 : java.lang.String = constant @"abc";
-                    %1 : FieldAccessTest$Box<java.lang.String> = new %0 @"FieldAccessTest$Box::<new>(java.lang.Object)";
-                    %2 : Var<FieldAccessTest$Box<java.lang.String>> = var %1 @"b";
-                    %3 : FieldAccessTest$Box<java.lang.String> = var.load %2;
-                    %4 : java.lang.String = field.load %3 @"FieldAccessTest$Box::v()java.lang.Object";
-                    %5 : Var<java.lang.String> = var %4 @"s";
-                    return;
+            func @"test25" ()java.type:"void" -> {
+                %0 : java.type:"java.lang.String" = constant @"abc";
+                %1 : java.type:"FieldAccessTest$Box<java.lang.String>" = new %0 @"FieldAccessTest$Box::(java.lang.Object)";
+                %2 : Var<java.type:"FieldAccessTest$Box<java.lang.String>"> = var %1 @"b";
+                %3 : java.type:"FieldAccessTest$Box<java.lang.String>" = var.load %2;
+                %4 : java.type:"java.lang.String" = field.load %3 @"FieldAccessTest$Box::v:java.lang.Object";
+                %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
+                return;
             };
             """)
     static void test25() {

--- a/test/langtools/tools/javac/reflect/ForLoopTest.java
+++ b/test/langtools/tools/javac/reflect/ForLoopTest.java
@@ -36,36 +36,36 @@ import java.util.List;
 public class ForLoopTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : ForLoopTest, %1 : java.util.List<java.util.List<java.lang.String>>)void -> {
-              %2 : Var<java.util.List<java.util.List<java.lang.String>>> = var %1 @"ll";
-              java.enhancedFor
-                  ^expr()java.util.List<java.util.List<java.lang.String>> -> {
-                      %3 : java.util.List<java.util.List<java.lang.String>> = var.load %2;
-                      yield %3;
-                  }
-                  ^def(%4 : java.util.List<java.lang.String>)Var<java.util.List<java.lang.String>> -> {
-                      %5 : Var<java.util.List<java.lang.String>> = var %4 @"l";
-                      yield %5;
-                  }
-                  ^body(%6 : Var<java.util.List<java.lang.String>>)void -> {
-                      java.enhancedFor
-                          ^expr()java.util.List<java.lang.String> -> {
-                              %7 : java.util.List<java.lang.String> = var.load %6;
-                              yield %7;
-                          }
-                          ^def(%8 : java.lang.String)Var<java.lang.String> -> {
-                              %9 : Var<java.lang.String> = var %8 @"s";
-                              yield %9;
-                          }
-                          ^body(%10 : Var<java.lang.String>)void -> {
-                              %11 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                              %12 : java.lang.String = var.load %10;
-                              invoke %11 %12 @"java.io.PrintStream::println(java.lang.String)void";
-                              java.continue;
-                          };
-                      java.continue;
-                  };
-              return;
+            func @"test1" (%0 : java.type:"ForLoopTest", %1 : java.type:"java.util.List<java.util.List<java.lang.String>>")java.type:"void" -> {
+                %2 : Var<java.type:"java.util.List<java.util.List<java.lang.String>>"> = var %1 @"ll";
+                java.enhancedFor
+                    ()java.type:"java.util.List<java.util.List<java.lang.String>>" -> {
+                        %3 : java.type:"java.util.List<java.util.List<java.lang.String>>" = var.load %2;
+                        yield %3;
+                    }
+                    (%4 : java.type:"java.util.List<java.lang.String>")Var<java.type:"java.util.List<java.lang.String>"> -> {
+                        %5 : Var<java.type:"java.util.List<java.lang.String>"> = var %4 @"l";
+                        yield %5;
+                    }
+                    (%6 : Var<java.type:"java.util.List<java.lang.String>">)java.type:"void" -> {
+                        java.enhancedFor
+                            ()java.type:"java.util.List<java.lang.String>" -> {
+                                %7 : java.type:"java.util.List<java.lang.String>" = var.load %6;
+                                yield %7;
+                            }
+                            (%8 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
+                                %9 : Var<java.type:"java.lang.String"> = var %8 @"s";
+                                yield %9;
+                            }
+                            (%10 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                                %11 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                                %12 : java.type:"java.lang.String" = var.load %10;
+                                invoke %11 %12 @"java.io.PrintStream::println(java.lang.String):void";
+                                java.continue;
+                            };
+                        java.continue;
+                    };
+                return;
             };
             """)
     void test1(List<List<String>> ll) {
@@ -78,32 +78,32 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : ForLoopTest, %1 : java.util.List<java.lang.String>)void -> {
-                %2 : Var<java.util.List<java.lang.String>> = var %1 @"l";
+            func @"test2" (%0 : java.type:"ForLoopTest", %1 : java.type:"java.util.List<java.lang.String>")java.type:"void" -> {
+                %2 : Var<java.type:"java.util.List<java.lang.String>"> = var %1 @"l";
                 java.enhancedFor
-                    ^expr()java.util.List<java.lang.String> -> {
-                        %3 : java.util.List<java.lang.String> = var.load %2;
-                        %4 : java.util.stream.Stream<java.lang.String> = invoke %3 @"java.util.List::stream()java.util.stream.Stream";
-                        %5 : java.util.function.Predicate<java.lang.String> = lambda (%6 : java.lang.String)boolean -> {
-                            %7 : Var<java.lang.String> = var %6 @"s";
-                            %8 : java.lang.String = var.load %7;
-                            %9 : int = invoke %8 @"java.lang.String::length()int";
-                            %10 : int = constant @"10";
-                            %11 : boolean = lt %9 %10;
+                    ()java.type:"java.util.List<java.lang.String>" -> {
+                        %3 : java.type:"java.util.List<java.lang.String>" = var.load %2;
+                        %4 : java.type:"java.util.stream.Stream<java.lang.String>" = invoke %3 @"java.util.List::stream():java.util.stream.Stream";
+                        %5 : java.type:"java.util.function.Predicate<java.lang.String>" = lambda (%6 : java.type:"java.lang.String")java.type:"boolean" -> {
+                            %7 : Var<java.type:"java.lang.String"> = var %6 @"s";
+                            %8 : java.type:"java.lang.String" = var.load %7;
+                            %9 : java.type:"int" = invoke %8 @"java.lang.String::length():int";
+                            %10 : java.type:"int" = constant @"10";
+                            %11 : java.type:"boolean" = lt %9 %10;
                             return %11;
                         };
-                        %12 : java.util.stream.Stream<java.lang.String> = invoke %4 %5 @"java.util.stream.Stream::filter(java.util.function.Predicate)java.util.stream.Stream";
-                        %13 : java.util.List<java.lang.String> = invoke %12 @"java.util.stream.Stream::toList()java.util.List";
+                        %12 : java.type:"java.util.stream.Stream<java.lang.String>" = invoke %4 %5 @"java.util.stream.Stream::filter(java.util.function.Predicate):java.util.stream.Stream";
+                        %13 : java.type:"java.util.List<java.lang.String>" = invoke %12 @"java.util.stream.Stream::toList():java.util.List";
                         yield %13;
                     }
-                    ^def(%14 : java.lang.String)Var<java.lang.String> -> {
-                        %15 : Var<java.lang.String> = var %14 @"s";
+                    (%14 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
+                        %15 : Var<java.type:"java.lang.String"> = var %14 @"s";
                         yield %15;
                     }
-                    ^body(%16 : Var<java.lang.String>)void -> {
-                        %17 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %18 : java.lang.String = var.load %16;
-                        invoke %17 %18 @"java.io.PrintStream::println(java.lang.String)void";
+                    (%16 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                        %17 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %18 : java.type:"java.lang.String" = var.load %16;
+                        invoke %17 %18 @"java.io.PrintStream::println(java.lang.String):void";
                         java.continue;
                     };
                 return;
@@ -117,21 +117,21 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test2_1" (%0 : ForLoopTest, %1 : java.util.List<java.lang.String>)void -> {
-              %2 : Var<java.util.List<java.lang.String>> = var %1 @"l";
-              java.enhancedFor
-                  ^expr()java.util.List<java.lang.String> -> {
-                      %3 : java.util.List<java.lang.String> = var.load %2;
-                      yield %3;
-                  }
-                  ^def(%4 : java.lang.String)Var<java.lang.String> -> {
-                      %5 : Var<java.lang.String> = var %4 @"s";
-                      yield %5;
-                  }
-                  ^body(%6 : Var<java.lang.String>)void -> {
-                      java.continue;
-                  };
-              return;
+            func @"test2_1" (%0 : java.type:"ForLoopTest", %1 : java.type:"java.util.List<java.lang.String>")java.type:"void" -> {
+                %2 : Var<java.type:"java.util.List<java.lang.String>"> = var %1 @"l";
+                java.enhancedFor
+                    ()java.type:"java.util.List<java.lang.String>" -> {
+                        %3 : java.type:"java.util.List<java.lang.String>" = var.load %2;
+                        yield %3;
+                    }
+                    (%4 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
+                        %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
+                        yield %5;
+                    }
+                    (%6 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                        java.continue;
+                    };
+                return;
             };
             """)
     void test2_1(List<String> l) {
@@ -140,23 +140,23 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test2_2" (%0 : ForLoopTest, %1 : java.util.List<java.lang.String>)java.lang.String -> {
-              %2 : Var<java.util.List<java.lang.String>> = var %1 @"l";
-              java.enhancedFor
-                  ^expr()java.util.List<java.lang.String> -> {
-                      %3 : java.util.List<java.lang.String> = var.load %2;
-                      yield %3;
-                  }
-                  ^def(%4 : java.lang.String)Var<java.lang.String> -> {
-                      %5 : Var<java.lang.String> = var %4 @"s";
-                      yield %5;
-                  }
-                  ^body(%6 : Var<java.lang.String>)void -> {
-                      %7 : java.lang.String = var.load %6;
-                      return %7;
-                  };
-              %8 : java.lang.String = constant @"";
-              return %8;
+            func @"test2_2" (%0 : java.type:"ForLoopTest", %1 : java.type:"java.util.List<java.lang.String>")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.util.List<java.lang.String>"> = var %1 @"l";
+                java.enhancedFor
+                    ()java.type:"java.util.List<java.lang.String>" -> {
+                        %3 : java.type:"java.util.List<java.lang.String>" = var.load %2;
+                        yield %3;
+                    }
+                    (%4 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
+                        %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
+                        yield %5;
+                    }
+                    (%6 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                        %7 : java.type:"java.lang.String" = var.load %6;
+                        return %7;
+                    };
+                %8 : java.type:"java.lang.String" = constant @"";
+                return %8;
             };
             """)
     String test2_2(List<String> l) {
@@ -168,30 +168,30 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : ForLoopTest)void -> {
+            func @"test3" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
                 java.for
-                    ^init()Var<int> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
                         yield %2;
                     }
-                    ^cond(%3 : Var<int>)boolean -> {
-                        %4 : int = var.load %3;
-                        %5 : int = constant @"10";
-                        %6 : boolean = lt %4 %5;
+                    (%3 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %4 : java.type:"int" = var.load %3;
+                        %5 : java.type:"int" = constant @"10";
+                        %6 : java.type:"boolean" = lt %4 %5;
                         yield %6;
                     }
-                    ^update(%7 : Var<int>)void -> {
-                        %8 : int = var.load %7;
-                        %9 : int = constant @"1";
-                        %10 : int = add %8 %9;
+                    (%7 : Var<java.type:"int">)java.type:"void" -> {
+                        %8 : java.type:"int" = var.load %7;
+                        %9 : java.type:"int" = constant @"1";
+                        %10 : java.type:"int" = add %8 %9;
                         var.store %7 %10;
                         yield;
                     }
-                    ^body(%11 : Var<int>)void -> {
-                        %12 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %13 : int = var.load %11;
-                        invoke %12 %13 @"java.io.PrintStream::println(int)void";
+                    (%11 : Var<java.type:"int">)java.type:"void" -> {
+                        %12 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %13 : java.type:"int" = var.load %11;
+                        invoke %12 %13 @"java.io.PrintStream::println(int):void";
                         java.continue;
                     };
                 return;
@@ -205,31 +205,31 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test3_1" (%0 : ForLoopTest)int -> {
+            func @"test3_1" (%0 : java.type:"ForLoopTest")java.type:"int" -> {
                 java.for
-                    ^init()Var<int> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
                         yield %2;
                     }
-                    ^cond(%3 : Var<int>)boolean -> {
-                        %4 : int = var.load %3;
-                        %5 : int = constant @"10";
-                        %6 : boolean = lt %4 %5;
+                    (%3 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %4 : java.type:"int" = var.load %3;
+                        %5 : java.type:"int" = constant @"10";
+                        %6 : java.type:"boolean" = lt %4 %5;
                         yield %6;
                     }
-                    ^update(%7 : Var<int>)void -> {
-                        %8 : int = var.load %7;
-                        %9 : int = constant @"1";
-                        %10 : int = add %8 %9;
+                    (%7 : Var<java.type:"int">)java.type:"void" -> {
+                        %8 : java.type:"int" = var.load %7;
+                        %9 : java.type:"int" = constant @"1";
+                        %10 : java.type:"int" = add %8 %9;
                         var.store %7 %10;
                         yield;
                     }
-                    ^body(%11 : Var<int>)void -> {
-                        %12 : int = var.load %11;
+                    (%11 : Var<java.type:"int">)java.type:"void" -> {
+                        %12 : java.type:"int" = var.load %11;
                         return %12;
                     };
-                %13 : int = constant @"-1";
+                %13 : java.type:"int" = constant @"-1";
                 return %13;
             };
             """)
@@ -242,30 +242,30 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : ForLoopTest)void -> {
+            func @"test4" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
                 java.for
-                    ^init()Var<int> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
                         yield %2;
                     }
-                    ^cond(%3 : Var<int>)boolean -> {
-                        %4 : int = var.load %3;
-                        %5 : int = constant @"10";
-                        %6 : boolean = lt %4 %5;
+                    (%3 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %4 : java.type:"int" = var.load %3;
+                        %5 : java.type:"int" = constant @"10";
+                        %6 : java.type:"boolean" = lt %4 %5;
                         yield %6;
                     }
-                    ^update(%7 : Var<int>)void -> {
-                        %8 : int = var.load %7;
-                        %9 : int = constant @"1";
-                        %10 : int = add %8 %9;
+                    (%7 : Var<java.type:"int">)java.type:"void" -> {
+                        %8 : java.type:"int" = var.load %7;
+                        %9 : java.type:"int" = constant @"1";
+                        %10 : java.type:"int" = add %8 %9;
                         var.store %7 %10;
                         yield;
                     }
-                    ^body(%11 : Var<int>)void -> {
-                        %12 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %13 : int = var.load %11;
-                        invoke %12 %13 @"java.io.PrintStream::println(int)void";
+                    (%11 : Var<java.type:"int">)java.type:"void" -> {
+                        %12 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %13 : java.type:"int" = var.load %11;
+                        invoke %12 %13 @"java.io.PrintStream::println(int):void";
                         java.continue;
                     };
                 return;
@@ -278,27 +278,27 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : ForLoopTest)void -> {
+            func @"test5" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
                 java.for
-                    ^init()Var<int> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
                         yield %2;
                     }
-                    ^cond(%3 : Var<int>)boolean -> {
-                        %4 : int = var.load %3;
-                        %5 : int = constant @"10";
-                        %6 : boolean = lt %4 %5;
+                    (%3 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %4 : java.type:"int" = var.load %3;
+                        %5 : java.type:"int" = constant @"10";
+                        %6 : java.type:"boolean" = lt %4 %5;
                         yield %6;
                     }
-                    ^update(%7 : Var<int>)void -> {
-                        %8 : int = var.load %7;
-                        %9 : int = constant @"1";
-                        %10 : int = add %8 %9;
+                    (%7 : Var<java.type:"int">)java.type:"void" -> {
+                        %8 : java.type:"int" = var.load %7;
+                        %9 : java.type:"int" = constant @"1";
+                        %10 : java.type:"int" = add %8 %9;
                         var.store %7 %10;
                         yield;
                     }
-                    ^body(%11 : Var<int>)void -> {
+                    (%11 : Var<java.type:"int">)java.type:"void" -> {
                         java.continue;
                     };
                 return;
@@ -310,30 +310,30 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : ForLoopTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test6" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.for
-                    ^init()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     }
-                    ^cond()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"10";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"10";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^update()void -> {
-                        %6 : int = var.load %2;
-                        %7 : int = constant @"1";
-                        %8 : int = add %6 %7;
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = var.load %2;
+                        %7 : java.type:"int" = constant @"1";
+                        %8 : java.type:"int" = add %6 %7;
                         var.store %2 %8;
                         yield;
                     }
-                    ^body()void -> {
-                        %9 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %10 : int = var.load %2;
-                        invoke %9 %10 @"java.io.PrintStream::println(int)void";
+                    ()java.type:"void" -> {
+                        %9 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %10 : java.type:"int" = var.load %2;
+                        invoke %9 %10 @"java.io.PrintStream::println(int):void";
                         java.continue;
                     };
                 return;
@@ -348,34 +348,34 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : ForLoopTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test7" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.for
-                    ^init()void -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : int = add %3 %4;
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"int" = add %3 %4;
                         var.store %2 %5;
                         yield;
                     }
-                    ^cond()boolean -> {
-                        %6 : int = var.load %2;
-                        %7 : int = constant @"10";
-                        %8 : boolean = lt %6 %7;
+                    ()java.type:"boolean" -> {
+                        %6 : java.type:"int" = var.load %2;
+                        %7 : java.type:"int" = constant @"10";
+                        %8 : java.type:"boolean" = lt %6 %7;
                         yield %8;
                     }
-                    ^update()void -> {
-                        %9 : int = var.load %2;
-                        %10 : int = constant @"1";
-                        %11 : int = add %9 %10;
+                    ()java.type:"void" -> {
+                        %9 : java.type:"int" = var.load %2;
+                        %10 : java.type:"int" = constant @"1";
+                        %11 : java.type:"int" = add %9 %10;
                         var.store %2 %11;
                         yield;
                     }
-                    ^body()void -> {
-                        %12 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %13 : int = var.load %2;
-                        invoke %12 %13 @"java.io.PrintStream::println(int)void";
+                    ()java.type:"void" -> {
+                        %12 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %13 : java.type:"int" = var.load %2;
+                        invoke %12 %13 @"java.io.PrintStream::println(int):void";
                         java.continue;
                     };
                 return;
@@ -390,28 +390,28 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : ForLoopTest)void -> {
+            func @"test8" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
                 java.for
-                    ^init()Var<int> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
                         yield %2;
                     }
-                    ^cond(%3 : Var<int>)boolean -> {
-                        %4 : boolean = constant @"true";
+                    (%3 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = constant @"true";
                         yield %4;
                     }
-                    ^update(%5 : Var<int>)void -> {
-                        %6 : int = var.load %5;
-                        %7 : int = constant @"1";
-                        %8 : int = add %6 %7;
+                    (%5 : Var<java.type:"int">)java.type:"void" -> {
+                        %6 : java.type:"int" = var.load %5;
+                        %7 : java.type:"int" = constant @"1";
+                        %8 : java.type:"int" = add %6 %7;
                         var.store %5 %8;
                         yield;
                     }
-                    ^body(%9 : Var<int>)void -> {
-                        %10 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %11 : int = var.load %9;
-                        invoke %10 %11 @"java.io.PrintStream::println(int)void";
+                    (%9 : Var<java.type:"int">)java.type:"void" -> {
+                        %10 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %11 : java.type:"int" = var.load %9;
+                        invoke %10 %11 @"java.io.PrintStream::println(int):void";
                         java.continue;
                     };
                 unreachable;
@@ -425,24 +425,24 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : ForLoopTest)void -> {
+            func @"test9" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
                 java.for
-                    ^init()Var<int> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
                         yield %2;
                     }
-                    ^cond(%3 : Var<int>)boolean -> {
-                        %4 : boolean = constant @"true";
+                    (%3 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = constant @"true";
                         yield %4;
                     }
-                    ^update(%5 : Var<int>)void -> {
+                    (%5 : Var<java.type:"int">)java.type:"void" -> {
                         yield;
                     }
-                    ^body(%6 : Var<int>)void -> {
-                        %7 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %8 : int = var.load %6;
-                        invoke %7 %8 @"java.io.PrintStream::println(int)void";
+                    (%6 : Var<java.type:"int">)java.type:"void" -> {
+                        %7 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %8 : java.type:"int" = var.load %6;
+                        invoke %7 %8 @"java.io.PrintStream::println(int):void";
                         java.continue;
                     };
                 unreachable;
@@ -456,19 +456,19 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0 : ForLoopTest)void -> {
+            func @"test10" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
                 java.for
-                    ^init()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     }
-                    ^cond()boolean -> {
-                        %1 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %1 : java.type:"boolean" = constant @"true";
                         yield %1;
                     }
-                    ^update()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     }
-                    ^body()void -> {
+                    ()java.type:"void" -> {
                         java.continue;
                     };
                 unreachable;
@@ -481,50 +481,50 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test11" (%0 : ForLoopTest)void -> {
+            func @"test11" (%0 : java.type:"ForLoopTest")java.type:"void" -> {
                 java.for
-                    ^init()Tuple<Var<int>, Var<int>> -> {
-                        %1 : int = constant @"0";
-                        %2 : Var<int> = var %1 @"i";
-                        %3 : int = constant @"0";
-                        %4 : Var<int> = var %3 @"j";
-                        %5 : Tuple<Var<int>, Var<int>> = tuple %2 %4;
+                    ()Tuple<Var<java.type:"int">, Var<java.type:"int">> -> {
+                        %1 : java.type:"int" = constant @"0";
+                        %2 : Var<java.type:"int"> = var %1 @"i";
+                        %3 : java.type:"int" = constant @"0";
+                        %4 : Var<java.type:"int"> = var %3 @"j";
+                        %5 : Tuple<Var<java.type:"int">, Var<java.type:"int">> = tuple %2 %4;
                         yield %5;
                     }
-                    ^cond(%6 : Var<int>, %7 : Var<int>)boolean -> {
-                        %8 : boolean = java.cand
-                            ()boolean -> {
-                                %9 : int = var.load %6;
-                                %10 : int = constant @"10";
-                                %11 : boolean = lt %9 %10;
+                    (%6 : Var<java.type:"int">, %7 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %9 : java.type:"int" = var.load %6;
+                                %10 : java.type:"int" = constant @"10";
+                                %11 : java.type:"boolean" = lt %9 %10;
                                 yield %11;
                             }
-                            ()boolean -> {
-                                %12 : int = var.load %7;
-                                %13 : int = constant @"20";
-                                %14 : boolean = lt %12 %13;
+                            ()java.type:"boolean" -> {
+                                %12 : java.type:"int" = var.load %7;
+                                %13 : java.type:"int" = constant @"20";
+                                %14 : java.type:"boolean" = lt %12 %13;
                                 yield %14;
                             };
                         yield %8;
                     }
-                    ^update(%15 : Var<int>, %16 : Var<int>)void -> {
-                        %17 : int = var.load %15;
-                        %18 : int = constant @"1";
-                        %19 : int = add %17 %18;
+                    (%15 : Var<java.type:"int">, %16 : Var<java.type:"int">)java.type:"void" -> {
+                        %17 : java.type:"int" = var.load %15;
+                        %18 : java.type:"int" = constant @"1";
+                        %19 : java.type:"int" = add %17 %18;
                         var.store %15 %19;
-                        %20 : int = var.load %16;
-                        %21 : int = constant @"2";
-                        %22 : int = add %20 %21;
+                        %20 : java.type:"int" = var.load %16;
+                        %21 : java.type:"int" = constant @"2";
+                        %22 : java.type:"int" = add %20 %21;
                         var.store %16 %22;
                         yield;
                     }
-                    ^body(%23 : Var<int>, %24 : Var<int>)void -> {
-                        %25 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %26 : int = var.load %23;
-                        invoke %25 %26 @"java.io.PrintStream::println(int)void";
-                        %27 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %28 : int = var.load %24;
-                        invoke %27 %28 @"java.io.PrintStream::println(int)void";
+                    (%23 : Var<java.type:"int">, %24 : Var<java.type:"int">)java.type:"void" -> {
+                        %25 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %26 : java.type:"int" = var.load %23;
+                        invoke %25 %26 @"java.io.PrintStream::println(int):void";
+                        %27 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %28 : java.type:"int" = var.load %24;
+                        invoke %27 %28 @"java.io.PrintStream::println(int):void";
                         java.continue;
                     };
                 return;
@@ -539,48 +539,48 @@ public class ForLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test12" (%0 : ForLoopTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"r";
+            func @"test12" (%0 : java.type:"ForLoopTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"r";
                 java.for
-                    ^init()Var<int> -> {
-                        %3 : int = constant @"0";
-                        %4 : Var<int> = var %3 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %3 : java.type:"int" = constant @"0";
+                        %4 : Var<java.type:"int"> = var %3 @"i";
                         yield %4;
                     }
-                    ^cond(%5 : Var<int>)boolean -> {
-                        %6 : int = var.load %5;
-                        %7 : int = constant @"10";
-                        %8 : boolean = lt %6 %7;
+                    (%5 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %6 : java.type:"int" = var.load %5;
+                        %7 : java.type:"int" = constant @"10";
+                        %8 : java.type:"boolean" = lt %6 %7;
                         yield %8;
                     }
-                    ^update(%9 : Var<int>)void -> {
-                        %10 : int = var.load %9;
-                        %11 : int = constant @"1";
-                        %12 : int = add %10 %11;
+                    (%9 : Var<java.type:"int">)java.type:"void" -> {
+                        %10 : java.type:"int" = var.load %9;
+                        %11 : java.type:"int" = constant @"1";
+                        %12 : java.type:"int" = add %10 %11;
                         var.store %9 %12;
                         yield;
                     }
-                    ^body(%13 : Var<int>)void -> {
+                    (%13 : Var<java.type:"int">)java.type:"void" -> {
                         java.if
-                            ()boolean -> {
-                                %14 : int = var.load %2;
-                                %15 : int = constant @"0";
-                                %16 : boolean = eq %14 %15;
+                            ()java.type:"boolean" -> {
+                                %14 : java.type:"int" = var.load %2;
+                                %15 : java.type:"int" = constant @"0";
+                                %16 : java.type:"boolean" = eq %14 %15;
                                 yield %16;
                             }
-                            ^then()void -> {
+                            ()java.type:"void" -> {
                                 java.break;
                             }
-                            ^else_if()boolean -> {
-                                %17 : int = var.load %2;
-                                %18 : int = constant @"1";
-                                %19 : boolean = eq %17 %18;
+                            ()java.type:"boolean" -> {
+                                %17 : java.type:"int" = var.load %2;
+                                %18 : java.type:"int" = constant @"1";
+                                %19 : java.type:"boolean" = eq %17 %18;
                                 yield %19;
                             }
-                            ^then()void -> {
+                            ()java.type:"void" -> {
                                 java.continue;
                             }
-                            ^else()void -> {
+                            ()java.type:"void" -> {
                                 yield;
                             };
                         java.continue;

--- a/test/langtools/tools/javac/reflect/IfTest.java
+++ b/test/langtools/tools/javac/reflect/IfTest.java
@@ -35,21 +35,21 @@ import jdk.incubator.code.CodeReflection;
 public class IfTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : IfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test1" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        %6 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
                         var.store %2 %6;
                         yield;
                     }
-                    ^else()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     };
                 return;
@@ -63,22 +63,22 @@ public class IfTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : IfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test2" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        %6 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
                         var.store %2 %6;
                         yield;
                     }
-                    ^else()void -> {
-                        %7 : int = constant @"2";
+                    ()java.type:"void" -> {
+                        %7 : java.type:"int" = constant @"2";
                         var.store %2 %7;
                         yield;
                     };
@@ -95,32 +95,32 @@ public class IfTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : IfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test3" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        %6 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
                         var.store %2 %6;
                         yield;
                     }
-                    ^else_if()boolean -> {
-                        %7 : int = var.load %2;
-                        %8 : int = constant @"2";
-                        %9 : boolean = lt %7 %8;
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"int" = var.load %2;
+                        %8 : java.type:"int" = constant @"2";
+                        %9 : java.type:"boolean" = lt %7 %8;
                         yield %9;
                     }
-                    ^then()void -> {
-                        %10 : int = constant @"2";
+                    ()java.type:"void" -> {
+                        %10 : java.type:"int" = constant @"2";
                         var.store %2 %10;
                         yield;
                     }
-                    ^else()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     };
                 return;
@@ -136,33 +136,33 @@ public class IfTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : IfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test4" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        %6 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
                         var.store %2 %6;
                         yield;
                     }
-                    ^else_if()boolean -> {
-                        %7 : int = var.load %2;
-                        %8 : int = constant @"2";
-                        %9 : boolean = lt %7 %8;
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"int" = var.load %2;
+                        %8 : java.type:"int" = constant @"2";
+                        %9 : java.type:"boolean" = lt %7 %8;
                         yield %9;
                     }
-                    ^then()void -> {
-                        %10 : int = constant @"2";
+                    ()java.type:"void" -> {
+                        %10 : java.type:"int" = constant @"2";
                         var.store %2 %10;
                         yield;
                     }
-                    ^else()void -> {
-                        %11 : int = constant @"3";
+                    ()java.type:"void" -> {
+                        %11 : java.type:"int" = constant @"3";
                         var.store %2 %11;
                         yield;
                     };
@@ -180,34 +180,34 @@ public class IfTest {
     }
 
     @IR("""
-            func @"test5" (%0 : IfTest, %1 : int)int -> {
-              %2 : Var<int> = var %1 @"i";
-              java.if
-                  ()boolean -> {
-                      %3 : int = var.load %2;
-                      %4 : int = constant @"1";
-                      %5 : boolean = lt %3 %4;
-                      yield %5;
-                  }
-                  ^then()void -> {
-                      %6 : int = constant @"1";
-                      return %6;
-                  }
-                  ^else_if()boolean -> {
-                      %7 : int = var.load %2;
-                      %8 : int = constant @"2";
-                      %9 : boolean = lt %7 %8;
-                      yield %9;
-                  }
-                  ^then()void -> {
-                      %10 : int = constant @"2";
-                      return %10;
-                  }
-                  ^else()void -> {
-                      %11 : int = constant @"3";
-                      return %11;
-                  };
-              unreachable;
+            func @"test5" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"int" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                java.if
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
+                        yield %5;
+                    }
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        return %6;
+                    }
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"int" = var.load %2;
+                        %8 : java.type:"int" = constant @"2";
+                        %9 : java.type:"boolean" = lt %7 %8;
+                        yield %9;
+                    }
+                    ()java.type:"void" -> {
+                        %10 : java.type:"int" = constant @"2";
+                        return %10;
+                    }
+                    ()java.type:"void" -> {
+                        %11 : java.type:"int" = constant @"3";
+                        return %11;
+                    };
+                unreachable;
             };
             """)
     @CodeReflection
@@ -223,21 +223,21 @@ public class IfTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : IfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test6" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        %6 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
                         var.store %2 %6;
                         yield;
                     }
-                    ^else()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     };
                 return;
@@ -250,22 +250,22 @@ public class IfTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : IfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test7" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        %6 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
                         var.store %2 %6;
                         yield;
                     }
-                    ^else()void -> {
-                        %7 : int = constant @"2";
+                    ()java.type:"void" -> {
+                        %7 : java.type:"int" = constant @"2";
                         var.store %2 %7;
                         yield;
                     };
@@ -281,33 +281,33 @@ public class IfTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : IfTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test8" (%0 : java.type:"IfTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.if
-                    ()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^then()void -> {
-                        %6 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"1";
                         var.store %2 %6;
                         yield;
                     }
-                    ^else_if()boolean -> {
-                        %7 : int = var.load %2;
-                        %8 : int = constant @"2";
-                        %9 : boolean = lt %7 %8;
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"int" = var.load %2;
+                        %8 : java.type:"int" = constant @"2";
+                        %9 : java.type:"boolean" = lt %7 %8;
                         yield %9;
                     }
-                    ^then()void -> {
-                        %10 : int = constant @"2";
+                    ()java.type:"void" -> {
+                        %10 : java.type:"int" = constant @"2";
                         var.store %2 %10;
                         yield;
                     }
-                    ^else()void -> {
-                        %11 : int = constant @"3";
+                    ()java.type:"void" -> {
+                        %11 : java.type:"int" = constant @"3";
                         var.store %2 %11;
                         yield;
                     };
@@ -324,23 +324,23 @@ public class IfTest {
     }
 
     @IR("""
-            func @"test9" (%0 : java.lang.Boolean)void -> {
-                %1 : Var<java.lang.Boolean> = var %0 @"b";
-                %3 : Var<int> = var @"i";
+            func @"test9" (%0 : java.type:"java.lang.Boolean")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Boolean"> = var %0 @"b";
+                %2 : Var<java.type:"int"> = var @"i";
                 java.if
-                    ()boolean -> {
-                        %4 : java.lang.Boolean = var.load %1;
-                        %5 : boolean = invoke %4 @"java.lang.Boolean::booleanValue()boolean";
-                        yield %5;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"java.lang.Boolean" = var.load %1;
+                        %4 : java.type:"boolean" = invoke %3 @"java.lang.Boolean::booleanValue():boolean";
+                        yield %4;
                     }
-                    ()void -> {
-                        %6 : int = constant @"1";
-                        var.store %3 %6;
+                    ()java.type:"void" -> {
+                        %5 : java.type:"int" = constant @"1";
+                        var.store %2 %5;
                         yield;
                     }
-                    ()void -> {
-                        %7 : int = constant @"2";
-                        var.store %3 %7;
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = constant @"2";
+                        var.store %2 %6;
                         yield;
                     };
                 return;

--- a/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
+++ b/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
@@ -38,10 +38,10 @@ import java.util.function.LongSupplier;
 public class ImplicitConversionTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0: ImplicitConversionTest)void -> {
-                %1 : int = constant @"1";
-                %2 : long = conv %1;
-                %3 : Var<long> = var %2 @"x";
+            func @"test1" (%0 : java.type:"ImplicitConversionTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : java.type:"long" = conv %1;
+                %3 : Var<java.type:"long"> = var %2 @"x";
                 return;
             };
             """)
@@ -51,11 +51,11 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0: ImplicitConversionTest)void -> {
-                %2 : Var<long> = var @"x";
-                %3 : int = constant @"1";
-                %4 : long = conv %3;
-                var.store %2 %4;
+            func @"test2" (%0 : java.type:"ImplicitConversionTest")java.type:"void" -> {
+                %1 : Var<java.type:"long"> = var @"x";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"long" = conv %2;
+                var.store %1 %3;
                 return;
             };
             """)
@@ -66,13 +66,13 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0: ImplicitConversionTest)void -> {
-                %1 : long = constant @"0";
-                %2 : Var<long> = var %1 @"x";
-                %3 : long = var.load %2;
-                %4 : int = constant @"1";
-                %5 : long = conv %4;
-                %6 : long = add %3 %5;
+            func @"test3" (%0 : java.type:"ImplicitConversionTest")java.type:"void" -> {
+                %1 : java.type:"long" = constant @"0";
+                %2 : Var<java.type:"long"> = var %1 @"x";
+                %3 : java.type:"long" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"long" = conv %4;
+                %6 : java.type:"long" = add %3 %5;
                 var.store %2 %6;
                 return;
             };
@@ -84,24 +84,24 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0: ImplicitConversionTest, %1 : boolean)void -> {
-                %2 : Var<boolean> = var %1 @"cond";
-                %4 : Var<long> = var @"x";
-                %5 : long = java.cexpression
-                    ^cond()boolean -> {
-                        %6 : boolean = var.load %2;
+            func @"test4" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : Var<java.type:"long"> = var @"x";
+                %4 : java.type:"long" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"long" -> {
+                        %6 : java.type:"long" = constant @"1";
                         yield %6;
                     }
-                    ^truepart()long -> {
-                        %7 : long = constant @"1";
-                        yield %7;
-                    }
-                    ^falsepart()long -> {
-                        %8 : int = constant @"2";
-                        %9 : long = conv %8;
-                        yield %9;
+                    ()java.type:"long" -> {
+                        %7 : java.type:"int" = constant @"2";
+                        %8 : java.type:"long" = conv %7;
+                        yield %8;
                     };
-                var.store %4 %5;
+                var.store %3 %4;
                 return;
             };
             """)
@@ -112,26 +112,26 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-           func @"test5" (%0: ImplicitConversionTest, %1 : boolean)void -> {
-               %2 : Var<boolean> = var %1 @"cond";
-               %4 : Var<long> = var @"x";
-               %5 : long = java.cexpression
-                   ^cond()boolean -> {
-                       %6 : boolean = var.load %2;
-                       yield %6;
-                   }
-                   ^truepart()long -> {
-                       %7 : int = constant @"1";
-                       %8 : long = conv %7;
-                       yield %8;
-                   }
-                   ^falsepart()long -> {
-                       %9 : long = constant @"2";
-                       yield %9;
-                   };
-               var.store %4 %5;
-               return;
-           };
+            func @"test5" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : Var<java.type:"long"> = var @"x";
+                %4 : java.type:"long" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"long" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"long" = conv %6;
+                        yield %7;
+                    }
+                    ()java.type:"long" -> {
+                        %8 : java.type:"long" = constant @"2";
+                        yield %8;
+                    };
+                var.store %3 %4;
+                return;
+            };
            """)
     void test5(boolean cond) {
         long x;
@@ -140,26 +140,26 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-           func @"test6" (%0: ImplicitConversionTest, %1 : boolean)void -> {
-               %2 : Var<boolean> = var %1 @"cond";
-               %4 : Var<long> = var @"x";
-               %5 : int = java.cexpression
-                   ^cond()boolean -> {
-                       %6 : boolean = var.load %2;
-                       yield %6;
-                   }
-                   ^truepart()int -> {
-                       %7 : int = constant @"1";
-                       yield %7;
-                   }
-                   ^falsepart()int -> {
-                       %8 : int = constant @"2";
-                       yield %8;
-                   };
-               %9 : long = conv %5;
-               var.store %4 %9;
-               return;
-           };
+            func @"test6" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : Var<java.type:"long"> = var @"x";
+                %4 : java.type:"int" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"int" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        yield %6;
+                    }
+                    ()java.type:"int" -> {
+                        %7 : java.type:"int" = constant @"2";
+                        yield %7;
+                    };
+                %8 : java.type:"long" = conv %4;
+                var.store %3 %8;
+                return;
+            };
            """)
     void test6(boolean cond) {
         long x;
@@ -168,9 +168,9 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0: ImplicitConversionTest)long -> {
-                %1 : int = constant @"1";
-                %2 : long = conv %1;
+            func @"test7" (%0 : java.type:"ImplicitConversionTest")java.type:"long" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : java.type:"long" = conv %1;
                 return %2;
             };
             """)
@@ -180,13 +180,13 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0: ImplicitConversionTest)void -> {
-                %1 : java.util.function.LongSupplier = lambda ()long -> {
-                    %2 : int = constant @"1";
-                    %3 : long = conv %2;
+            func @"test8" (%0 : java.type:"ImplicitConversionTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.LongSupplier" = lambda ()java.type:"long" -> {
+                    %2 : java.type:"int" = constant @"1";
+                    %3 : java.type:"long" = conv %2;
                     return %3;
                 };
-                %4 : Var<java.util.function.LongSupplier> = var %1 @"s";
+                %4 : Var<java.type:"java.util.function.LongSupplier"> = var %1 @"s";
                 return;
             };
             """)
@@ -196,13 +196,13 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0: ImplicitConversionTest)void -> {
-                %1 : java.util.function.LongSupplier = lambda ()long -> {
-                    %2 : int = constant @"1";
-                    %3 : long = conv %2;
+            func @"test9" (%0 : java.type:"ImplicitConversionTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.LongSupplier" = lambda ()java.type:"long" -> {
+                    %2 : java.type:"int" = constant @"1";
+                    %3 : java.type:"long" = conv %2;
                     return %3;
                 };
-                %4 : Var<java.util.function.LongSupplier> = var %1 @"s";
+                %4 : Var<java.type:"java.util.function.LongSupplier"> = var %1 @"s";
                 return;
             };
             """)
@@ -212,29 +212,29 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test10" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()long -> {
-                        %8 : long = constant @"1";
+                    ()java.type:"long" -> {
+                        %8 : java.type:"long" = constant @"1";
                         yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
+                        yield %9;
                     }
-                    ()long -> {
-                        %9 : int = constant @"0";
-                        %10 : long = conv %9;
-                        yield %10;
+                    ()java.type:"long" -> {
+                        %10 : java.type:"int" = constant @"0";
+                        %11 : java.type:"long" = conv %10;
+                        yield %11;
                     };
-                %11 : Var<long> = var %4 @"l";
+                %12 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -247,29 +247,29 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test11" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test11" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()long -> {
-                        %8 : int = constant @"1";
-                        %9 : long = conv %8;
+                    ()java.type:"long" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"long" = conv %8;
                         yield %9;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
-                    }
-                    ()long -> {
-                        %10 : long = constant @"0";
+                    ()java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = constant @"true";
                         yield %10;
+                    }
+                    ()java.type:"long" -> {
+                        %11 : java.type:"long" = constant @"0";
+                        yield %11;
                     };
-                %11 : Var<long> = var %4 @"l";
+                %12 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -282,30 +282,30 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test12" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test12" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()long -> {
-                        %8 : int = constant @"1";
-                        %9 : long = conv %8;
+                    ()java.type:"long" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"long" = conv %8;
                         yield %9;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = constant @"true";
+                        yield %10;
                     }
-                    ()long -> {
-                        %10 : int = constant @"0";
-                        %11 : long = conv %10;
-                        yield %11;
+                    ()java.type:"long" -> {
+                        %11 : java.type:"int" = constant @"0";
+                        %12 : java.type:"long" = conv %11;
+                        yield %12;
                     };
-                %12 : Var<long> = var %4 @"l";
+                %13 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -318,29 +318,29 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test13" (%0 : ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test13" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()long -> {
-                        %8 : long = constant @"1";
+                    ()java.type:"long" -> {
+                        %8 : java.type:"long" = constant @"1";
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
+                        yield %9;
                     }
-                    ()long -> {
-                        %9 : int = constant @"0";
-                        %10 : long = conv %9;
-                        java.yield %10;
+                    ()java.type:"long" -> {
+                        %10 : java.type:"int" = constant @"0";
+                        %11 : java.type:"long" = conv %10;
+                        java.yield %11;
                     };
-                %11 : Var<long> = var %4 @"l";
+                %12 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -353,29 +353,29 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test14" (%0 : ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test14" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()long -> {
-                        %8 : int = constant @"1";
-                        %9 : long = conv %8;
+                    ()java.type:"long" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"long" = conv %8;
                         java.yield %9;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = constant @"true";
+                        yield %10;
                     }
-                    ()long -> {
-                        %10 : long = constant @"0";
-                        java.yield %10;
+                    ()java.type:"long" -> {
+                        %11 : java.type:"long" = constant @"0";
+                        java.yield %11;
                     };
-                %11 : Var<long> = var %4 @"l";
+                %12 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -388,30 +388,30 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test15" (%0 : ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test15" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()long -> {
-                        %8 : int = constant @"1";
-                        %9 : long = conv %8;
+                    ()java.type:"long" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"long" = conv %8;
                         java.yield %9;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = constant @"true";
+                        yield %10;
                     }
-                    ()long -> {
-                        %10 : int = constant @"0";
-                        %11 : long = conv %10;
-                        java.yield %11;
+                    ()java.type:"long" -> {
+                        %11 : java.type:"int" = constant @"0";
+                        %12 : java.type:"long" = conv %11;
+                        java.yield %12;
                     };
-                %12 : Var<long> = var %4 @"l";
+                %13 : Var<java.type:"long"> = var %4 @"l";
                 return;
             };
             """)
@@ -424,13 +424,13 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test16" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = conv %3;
-                %5 : long = constant @"2";
-                %6 : long = add %4 %5;
-                %7 : Var<long> = var %6 @"l";
+            func @"test16" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = conv %3;
+                %5 : java.type:"long" = constant @"2";
+                %6 : java.type:"long" = add %4 %5;
+                %7 : Var<java.type:"long"> = var %6 @"l";
                 return;
             };
             """)
@@ -442,11 +442,11 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test17" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = conv %3;
-                invoke %0 %4 @"ImplicitConversionTest::m(long)void";
+            func @"test17" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = conv %3;
+                invoke %0 %4 @"ImplicitConversionTest::m(long):void";
                 return;
             };
             """)
@@ -458,11 +458,11 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test18" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                invoke %0 %3 %4 @invoke.kind="INSTANCE" @invoke.varargs="true" @"ImplicitConversionTest::m(int, int, long[])void";
+            func @"test18" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                invoke %0 %3 %4 @"ImplicitConversionTest::m(int, int, long[]):void" @invoke.kind="INSTANCE" @invoke.varargs="true";
                 return;
             };
             """)
@@ -472,15 +472,15 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-           func @"test19" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = var.load %2;
-                %6 : long = conv %5;
-                invoke %0 %3 %4 %6 @invoke.kind="INSTANCE" @invoke.varargs="true" @"ImplicitConversionTest::m(int, int, long[])void";
+            func @"test19" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"long" = conv %5;
+                invoke %0 %3 %4 %6 @"ImplicitConversionTest::m(int, int, long[]):void" @invoke.kind="INSTANCE" @invoke.varargs="true";
                 return;
-           };
+            };
            """)
     void test19(int i) {
         m(i, i, i);
@@ -488,15 +488,15 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test20" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = var.load %2;
-                %6 : long = conv %5;
-                %7 : int = var.load %2;
-                %8 : long = conv %7;
-                invoke %0 %3 %4 %6 %8 @invoke.kind="INSTANCE" @invoke.varargs="true" @"ImplicitConversionTest::m(int, int, long[])void";
+            func @"test20" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"long" = conv %5;
+                %7 : java.type:"int" = var.load %2;
+                %8 : java.type:"long" = conv %7;
+                invoke %0 %3 %4 %6 %8 @"ImplicitConversionTest::m(int, int, long[]):void" @invoke.kind="INSTANCE" @invoke.varargs="true";
                 return;
             };
             """)
@@ -511,11 +511,11 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test21" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : long = conv %3;
-                %5 : ImplicitConversionTest$Box = new %4 @"ImplicitConversionTest$Box::<new>(long)";
+            func @"test21" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"long" = conv %3;
+                %5 : java.type:"ImplicitConversionTest$Box" = new %4 @"ImplicitConversionTest$Box::(long)";
                 return;
             };
             """)
@@ -525,11 +525,11 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test22" (%0: ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : ImplicitConversionTest$Box = new %3 %4 @new.varargs="true" @"ImplicitConversionTest$Box::<new>(int, int, long[])";
+            func @"test22" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"ImplicitConversionTest$Box" = new %3 %4 @"ImplicitConversionTest$Box::(int, int, long[])" @new.varargs="true";
                 return;
             };
             """)
@@ -539,15 +539,15 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-           func @"test23" (%0 : ImplicitConversionTest, %1 : int)void -> {
-               %2 : Var<int> = var %1 @"i";
-               %3 : int = var.load %2;
-               %4 : int = var.load %2;
-               %5 : int = var.load %2;
-               %6 : long = conv %5;
-               %7 : ImplicitConversionTest$Box = new %3 %4 %6 @new.varargs="true" @"ImplicitConversionTest$Box::<new>(int, int, long[])";
-               return;
-           };
+            func @"test23" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"long" = conv %5;
+                %7 : java.type:"ImplicitConversionTest$Box" = new %3 %4 %6 @"ImplicitConversionTest$Box::(int, int, long[])" @new.varargs="true";
+                return;
+            };
            """)
     void test23(int i) {
         new Box(i, i, i);
@@ -555,15 +555,15 @@ public class ImplicitConversionTest {
 
     @CodeReflection
     @IR("""
-            func @"test24" (%0 : ImplicitConversionTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = var.load %2;
-                %6 : long = conv %5;
-                %7 : int = var.load %2;
-                %8 : long = conv %7;
-                %9 : ImplicitConversionTest$Box = new %3 %4 %6 %8 @new.varargs="true" @"ImplicitConversionTest$Box::<new>(int, int, long[])";
+            func @"test24" (%0 : java.type:"ImplicitConversionTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"long" = conv %5;
+                %7 : java.type:"int" = var.load %2;
+                %8 : java.type:"long" = conv %7;
+                %9 : java.type:"ImplicitConversionTest$Box" = new %3 %4 %6 %8 @"ImplicitConversionTest$Box::(int, int, long[])" @new.varargs="true";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
+++ b/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
@@ -50,17 +50,17 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
-                  %1 : Var<#X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
-                  %2 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  invoke %2 @"IntersectionTypeTest$A::m_A()void";
-                  %3 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %4 : IntersectionTypeTest$B = cast %3 @"IntersectionTypeTest$B";
-                  invoke %4 @"IntersectionTypeTest$B::m_B()void";
-                  %5 : #X<&m<IntersectionTypeTest, test1, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %6 : IntersectionTypeTest$C = cast %5 @"IntersectionTypeTest$C";
-                  invoke %6 @"IntersectionTypeTest$C::m_C()void";
-                  return;
+            func @"test1" (%0 : java.type:"(IntersectionTypeTest::test1(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)")java.type:"void" -> {
+                %1 : Var<java.type:"(IntersectionTypeTest::test1(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)"> = var %0 @"x";
+                %2 : java.type:"(IntersectionTypeTest::test1(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                invoke %2 @"IntersectionTypeTest$A::m_A():void";
+                %3 : java.type:"(IntersectionTypeTest::test1(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %4 : java.type:"IntersectionTypeTest$B" = cast %3 @"IntersectionTypeTest$B";
+                invoke %4 @"IntersectionTypeTest$B::m_B():void";
+                %5 : java.type:"(IntersectionTypeTest::test1(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %6 : java.type:"IntersectionTypeTest$C" = cast %5 @"IntersectionTypeTest$C";
+                invoke %6 @"IntersectionTypeTest$C::m_C():void";
+                return;
             };
             """)
     static <X extends A & B & C> void test1(X x) {
@@ -73,18 +73,18 @@ class IntersectionTypeTest {
     // #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>, IntersectionTypeTest$A>
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
-                  %1 : Var<#X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
-                  %2 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %3 : java.lang.Object = field.load @"IntersectionTypeTest$A::f_A()java.lang.Object";
-                  %4 : Var<java.lang.Object> = var %3 @"oA";
-                  %5 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %6 : java.lang.Object = field.load @"IntersectionTypeTest$B::f_B()java.lang.Object";
-                  %7 : Var<java.lang.Object> = var %6 @"oB";
-                  %8 : #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %9 : java.lang.Object = field.load @"IntersectionTypeTest$C::f_C()java.lang.Object";
-                  %10 : Var<java.lang.Object> = var %9 @"oC";
-                  return;
+            func @"test2" (%0 : java.type:"(IntersectionTypeTest::test2(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)")java.type:"void" -> {
+                %1 : Var<java.type:"(IntersectionTypeTest::test2(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)"> = var %0 @"x";
+                %2 : java.type:"(IntersectionTypeTest::test2(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %3 : java.type:"java.lang.Object" = field.load @"IntersectionTypeTest$A::f_A:java.lang.Object";
+                %4 : Var<java.type:"java.lang.Object"> = var %3 @"oA";
+                %5 : java.type:"(IntersectionTypeTest::test2(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %6 : java.type:"java.lang.Object" = field.load @"IntersectionTypeTest$B::f_B:java.lang.Object";
+                %7 : Var<java.type:"java.lang.Object"> = var %6 @"oB";
+                %8 : java.type:"(IntersectionTypeTest::test2(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %9 : java.type:"java.lang.Object" = field.load @"IntersectionTypeTest$C::f_C:java.lang.Object";
+                %10 : Var<java.type:"java.lang.Object"> = var %9 @"oC";
+                return;
             };
             """)
     static <X extends A & B & C> void test2(X x) {
@@ -95,35 +95,35 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
-                  %1 : Var<#X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
-                  %2 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %3 : Var<IntersectionTypeTest$A> = var %2 @"rec$";
-                  %4 : java.lang.Runnable = lambda ()void -> {
-                      %5 : IntersectionTypeTest$A = var.load %3;
-                      invoke %5 @"IntersectionTypeTest$A::m_A()void";
-                      return;
-                  };
-                  %6 : Var<java.lang.Runnable> = var %4 @"rA";
-                  %7 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %8 : IntersectionTypeTest$B = cast %7 @"IntersectionTypeTest$B";
-                  %9 : Var<IntersectionTypeTest$B> = var %8 @"rec$";
-                  %10 : java.lang.Runnable = lambda ()void -> {
-                      %11 : IntersectionTypeTest$B = var.load %9;
-                      invoke %11 @"IntersectionTypeTest$B::m_B()void";
-                      return;
-                  };
-                  %12 : Var<java.lang.Runnable> = var %10 @"rB";
-                  %13 : #X<&m<IntersectionTypeTest, test3, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                  %14 : IntersectionTypeTest$C = cast %13 @"IntersectionTypeTest$C";
-                  %15 : Var<IntersectionTypeTest$C> = var %14 @"rec$";
-                  %16 : java.lang.Runnable = lambda ()void -> {
-                      %17 : IntersectionTypeTest$C = var.load %15;
-                      invoke %17 @"IntersectionTypeTest$C::m_C()void";
-                      return;
-                  };
-                  %18 : Var<java.lang.Runnable> = var %16 @"rC";
-                  return;
+            func @"test3" (%0 : java.type:"(IntersectionTypeTest::test3(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)")java.type:"void" -> {
+                %1 : Var<java.type:"(IntersectionTypeTest::test3(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)"> = var %0 @"x";
+                %2 : java.type:"(IntersectionTypeTest::test3(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %3 : Var<java.type:"IntersectionTypeTest$A"> = var %2 @"rec$";
+                %4 : java.type:"java.lang.Runnable" = lambda ()java.type:"void" -> {
+                    %5 : java.type:"IntersectionTypeTest$A" = var.load %3;
+                    invoke %5 @"IntersectionTypeTest$A::m_A():void";
+                    return;
+                };
+                %6 : Var<java.type:"java.lang.Runnable"> = var %4 @"rA";
+                %7 : java.type:"(IntersectionTypeTest::test3(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %8 : java.type:"IntersectionTypeTest$B" = cast %7 @"IntersectionTypeTest$B";
+                %9 : Var<java.type:"IntersectionTypeTest$B"> = var %8 @"rec$";
+                %10 : java.type:"java.lang.Runnable" = lambda ()java.type:"void" -> {
+                    %11 : java.type:"IntersectionTypeTest$B" = var.load %9;
+                    invoke %11 @"IntersectionTypeTest$B::m_B():void";
+                    return;
+                };
+                %12 : Var<java.type:"java.lang.Runnable"> = var %10 @"rB";
+                %13 : java.type:"(IntersectionTypeTest::test3(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %14 : java.type:"IntersectionTypeTest$C" = cast %13 @"IntersectionTypeTest$C";
+                %15 : Var<java.type:"IntersectionTypeTest$C"> = var %14 @"rec$";
+                %16 : java.type:"java.lang.Runnable" = lambda ()java.type:"void" -> {
+                    %17 : java.type:"IntersectionTypeTest$C" = var.load %15;
+                    invoke %17 @"IntersectionTypeTest$C::m_C():void";
+                    return;
+                };
+                %18 : Var<java.type:"java.lang.Runnable"> = var %16 @"rC";
+                return;
             };
             """)
     static <X extends A & B & C> void test3(X x) {
@@ -138,16 +138,16 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>)void -> {
-                %1 : Var<#X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A>> = var %0 @"x";
-                %2 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                invoke %2 @"IntersectionTypeTest::g_A(IntersectionTypeTest$A)void";
-                %3 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                %4 : IntersectionTypeTest$B = cast %3 @"IntersectionTypeTest$B";
-                invoke %4 @"IntersectionTypeTest::g_B(IntersectionTypeTest$B)void";
-                %5 : #X<&m<IntersectionTypeTest, test4, func<void, IntersectionTypeTest$A>>, IntersectionTypeTest$A> = var.load %1;
-                %6 : IntersectionTypeTest$C = cast %5 @"IntersectionTypeTest$C";
-                invoke %6 @"IntersectionTypeTest::g_C(IntersectionTypeTest$C)void";
+            func @"test4" (%0 : java.type:"(IntersectionTypeTest::test4(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)")java.type:"void" -> {
+                %1 : Var<java.type:"(IntersectionTypeTest::test4(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)"> = var %0 @"x";
+                %2 : java.type:"(IntersectionTypeTest::test4(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                invoke %2 @"IntersectionTypeTest::g_A(IntersectionTypeTest$A):void";
+                %3 : java.type:"(IntersectionTypeTest::test4(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %4 : java.type:"IntersectionTypeTest$B" = cast %3 @"IntersectionTypeTest$B";
+                invoke %4 @"IntersectionTypeTest::g_B(IntersectionTypeTest$B):void";
+                %5 : java.type:"(IntersectionTypeTest::test4(IntersectionTypeTest$A):void)::<X extends IntersectionTypeTest$A>)" = var.load %1;
+                %6 : java.type:"IntersectionTypeTest$C" = cast %5 @"IntersectionTypeTest$C";
+                invoke %6 @"IntersectionTypeTest::g_C(IntersectionTypeTest$C):void";
                 return;
             };
             """)
@@ -181,21 +181,21 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : IntersectionTypeTest$E1, %1 : IntersectionTypeTest$E2)void -> {
-                %2 : Var<IntersectionTypeTest$E1> = var %0 @"e1";
-                %3 : Var<IntersectionTypeTest$E2> = var %1 @"e2";
-                %4 : IntersectionTypeTest$E1 = var.load %2;
-                %5 : IntersectionTypeTest$E2 = var.load %3;
-                %6 : IntersectionTypeTest$A = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A)IntersectionTypeTest$A";
-                %7 : Var<IntersectionTypeTest$A> = var %6 @"x";
-                %8 : IntersectionTypeTest$A = var.load %7;
-                invoke %8 @"IntersectionTypeTest$A::m_A()void";
-                %9 : IntersectionTypeTest$A = var.load %7;
-                %10 : IntersectionTypeTest$B = cast %9 @"IntersectionTypeTest$B";
-                invoke %10 @"IntersectionTypeTest$B::m_B()void";
-                %11 : IntersectionTypeTest$A = var.load %7;
-                %12 : IntersectionTypeTest$C = cast %11 @"IntersectionTypeTest$C";
-                invoke %12 @"IntersectionTypeTest$C::m_C()void";
+            func @"test5" (%0 : java.type:"IntersectionTypeTest$E1", %1 : java.type:"IntersectionTypeTest$E2")java.type:"void" -> {
+                %2 : Var<java.type:"IntersectionTypeTest$E1"> = var %0 @"e1";
+                %3 : Var<java.type:"IntersectionTypeTest$E2"> = var %1 @"e2";
+                %4 : java.type:"IntersectionTypeTest$E1" = var.load %2;
+                %5 : java.type:"IntersectionTypeTest$E2" = var.load %3;
+                %6 : java.type:"IntersectionTypeTest$A" = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A):IntersectionTypeTest$A";
+                %7 : Var<java.type:"IntersectionTypeTest$A"> = var %6 @"x";
+                %8 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                invoke %8 @"IntersectionTypeTest$A::m_A():void";
+                %9 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %10 : java.type:"IntersectionTypeTest$B" = cast %9 @"IntersectionTypeTest$B";
+                invoke %10 @"IntersectionTypeTest$B::m_B():void";
+                %11 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %12 : java.type:"IntersectionTypeTest$C" = cast %11 @"IntersectionTypeTest$C";
+                invoke %12 @"IntersectionTypeTest$C::m_C():void";
                 return;
             };
             """)
@@ -208,22 +208,22 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : IntersectionTypeTest$E1, %1 : IntersectionTypeTest$E2)void -> {
-                %2 : Var<IntersectionTypeTest$E1> = var %0 @"e1";
-                %3 : Var<IntersectionTypeTest$E2> = var %1 @"e2";
-                %4 : IntersectionTypeTest$E1 = var.load %2;
-                %5 : IntersectionTypeTest$E2 = var.load %3;
-                %6 : IntersectionTypeTest$A = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A)IntersectionTypeTest$A";
-                %7 : Var<IntersectionTypeTest$A> = var %6 @"x";
-                %8 : IntersectionTypeTest$A = var.load %7;
-                %9 : java.lang.Object = field.load @"IntersectionTypeTest$A::f_A()java.lang.Object";
-                %10 : Var<java.lang.Object> = var %9 @"oA";
-                %11 : IntersectionTypeTest$A = var.load %7;
-                %12 : java.lang.Object = field.load @"IntersectionTypeTest$B::f_B()java.lang.Object";
-                %13 : Var<java.lang.Object> = var %12 @"oB";
-                %14 : IntersectionTypeTest$A = var.load %7;
-                %15 : java.lang.Object = field.load @"IntersectionTypeTest$C::f_C()java.lang.Object";
-                %16 : Var<java.lang.Object> = var %15 @"oC";
+            func @"test6" (%0 : java.type:"IntersectionTypeTest$E1", %1 : java.type:"IntersectionTypeTest$E2")java.type:"void" -> {
+                %2 : Var<java.type:"IntersectionTypeTest$E1"> = var %0 @"e1";
+                %3 : Var<java.type:"IntersectionTypeTest$E2"> = var %1 @"e2";
+                %4 : java.type:"IntersectionTypeTest$E1" = var.load %2;
+                %5 : java.type:"IntersectionTypeTest$E2" = var.load %3;
+                %6 : java.type:"IntersectionTypeTest$A" = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A):IntersectionTypeTest$A";
+                %7 : Var<java.type:"IntersectionTypeTest$A"> = var %6 @"x";
+                %8 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %9 : java.type:"java.lang.Object" = field.load @"IntersectionTypeTest$A::f_A:java.lang.Object";
+                %10 : Var<java.type:"java.lang.Object"> = var %9 @"oA";
+                %11 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %12 : java.type:"java.lang.Object" = field.load @"IntersectionTypeTest$B::f_B:java.lang.Object";
+                %13 : Var<java.type:"java.lang.Object"> = var %12 @"oB";
+                %14 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %15 : java.type:"java.lang.Object" = field.load @"IntersectionTypeTest$C::f_C:java.lang.Object";
+                %16 : Var<java.type:"java.lang.Object"> = var %15 @"oC";
                 return;
             };
             """)
@@ -236,39 +236,39 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : IntersectionTypeTest$E1, %1 : IntersectionTypeTest$E2)void -> {
-                %2 : Var<IntersectionTypeTest$E1> = var %0 @"e1";
-                %3 : Var<IntersectionTypeTest$E2> = var %1 @"e2";
-                %4 : IntersectionTypeTest$E1 = var.load %2;
-                %5 : IntersectionTypeTest$E2 = var.load %3;
-                %6 : IntersectionTypeTest$A = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A)IntersectionTypeTest$A";
-                %7 : Var<IntersectionTypeTest$A> = var %6 @"x";
-                %8 : IntersectionTypeTest$A = var.load %7;
-                %9 : Var<IntersectionTypeTest$A> = var %8 @"rec$";
-                %10 : java.lang.Runnable = lambda ()void -> {
-                    %11 : IntersectionTypeTest$A = var.load %9;
-                    invoke %11 @"IntersectionTypeTest$A::m_A()void";
+            func @"test7" (%0 : java.type:"IntersectionTypeTest$E1", %1 : java.type:"IntersectionTypeTest$E2")java.type:"void" -> {
+                %2 : Var<java.type:"IntersectionTypeTest$E1"> = var %0 @"e1";
+                %3 : Var<java.type:"IntersectionTypeTest$E2"> = var %1 @"e2";
+                %4 : java.type:"IntersectionTypeTest$E1" = var.load %2;
+                %5 : java.type:"IntersectionTypeTest$E2" = var.load %3;
+                %6 : java.type:"IntersectionTypeTest$A" = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A):IntersectionTypeTest$A";
+                %7 : Var<java.type:"IntersectionTypeTest$A"> = var %6 @"x";
+                %8 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %9 : Var<java.type:"IntersectionTypeTest$A"> = var %8 @"rec$";
+                %10 : java.type:"java.lang.Runnable" = lambda ()java.type:"void" -> {
+                    %11 : java.type:"IntersectionTypeTest$A" = var.load %9;
+                    invoke %11 @"IntersectionTypeTest$A::m_A():void";
                     return;
                 };
-                %12 : Var<java.lang.Runnable> = var %10 @"rA";
-                %13 : IntersectionTypeTest$A = var.load %7;
-                %14 : IntersectionTypeTest$B = cast %13 @"IntersectionTypeTest$B";
-                %15 : Var<IntersectionTypeTest$B> = var %14 @"rec$";
-                %16 : java.lang.Runnable = lambda ()void -> {
-                    %17 : IntersectionTypeTest$B = var.load %15;
-                    invoke %17 @"IntersectionTypeTest$B::m_B()void";
+                %12 : Var<java.type:"java.lang.Runnable"> = var %10 @"rA";
+                %13 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %14 : java.type:"IntersectionTypeTest$B" = cast %13 @"IntersectionTypeTest$B";
+                %15 : Var<java.type:"IntersectionTypeTest$B"> = var %14 @"rec$";
+                %16 : java.type:"java.lang.Runnable" = lambda ()java.type:"void" -> {
+                    %17 : java.type:"IntersectionTypeTest$B" = var.load %15;
+                    invoke %17 @"IntersectionTypeTest$B::m_B():void";
                     return;
                 };
-                %18 : Var<java.lang.Runnable> = var %16 @"rB";
-                %19 : IntersectionTypeTest$A = var.load %7;
-                %20 : IntersectionTypeTest$C = cast %19 @"IntersectionTypeTest$C";
-                %21 : Var<IntersectionTypeTest$C> = var %20 @"rec$";
-                %22 : java.lang.Runnable = lambda ()void -> {
-                    %23 : IntersectionTypeTest$C = var.load %21;
-                    invoke %23 @"IntersectionTypeTest$C::m_C()void";
+                %18 : Var<java.type:"java.lang.Runnable"> = var %16 @"rB";
+                %19 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %20 : java.type:"IntersectionTypeTest$C" = cast %19 @"IntersectionTypeTest$C";
+                %21 : Var<java.type:"IntersectionTypeTest$C"> = var %20 @"rec$";
+                %22 : java.type:"java.lang.Runnable" = lambda ()java.type:"void" -> {
+                    %23 : java.type:"IntersectionTypeTest$C" = var.load %21;
+                    invoke %23 @"IntersectionTypeTest$C::m_C():void";
                     return;
                 };
-                %24 : Var<java.lang.Runnable> = var %22 @"rC";
+                %24 : Var<java.type:"java.lang.Runnable"> = var %22 @"rC";
                 return;
             };
             """)
@@ -281,21 +281,21 @@ class IntersectionTypeTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : IntersectionTypeTest$E1, %1 : IntersectionTypeTest$E2)void -> {
-                %2 : Var<IntersectionTypeTest$E1> = var %0 @"e1";
-                %3 : Var<IntersectionTypeTest$E2> = var %1 @"e2";
-                %4 : IntersectionTypeTest$E1 = var.load %2;
-                %5 : IntersectionTypeTest$E2 = var.load %3;
-                %6 : IntersectionTypeTest$A = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A)IntersectionTypeTest$A";
-                %7 : Var<IntersectionTypeTest$A> = var %6 @"x";
-                %8 : IntersectionTypeTest$A = var.load %7;
-                invoke %8 @"IntersectionTypeTest::g_A(IntersectionTypeTest$A)void";
-                %9 : IntersectionTypeTest$A = var.load %7;
-                %10 : IntersectionTypeTest$B = cast %9 @"IntersectionTypeTest$B";
-                invoke %10 @"IntersectionTypeTest::g_B(IntersectionTypeTest$B)void";
-                %11 : IntersectionTypeTest$A = var.load %7;
-                %12 : IntersectionTypeTest$C = cast %11 @"IntersectionTypeTest$C";
-                invoke %12 @"IntersectionTypeTest::g_C(IntersectionTypeTest$C)void";
+            func @"test8" (%0 : java.type:"IntersectionTypeTest$E1", %1 : java.type:"IntersectionTypeTest$E2")java.type:"void" -> {
+                %2 : Var<java.type:"IntersectionTypeTest$E1"> = var %0 @"e1";
+                %3 : Var<java.type:"IntersectionTypeTest$E2"> = var %1 @"e2";
+                %4 : java.type:"IntersectionTypeTest$E1" = var.load %2;
+                %5 : java.type:"IntersectionTypeTest$E2" = var.load %3;
+                %6 : java.type:"IntersectionTypeTest$A" = invoke %4 %5 @"IntersectionTypeTest::makeIntersection(IntersectionTypeTest$A, IntersectionTypeTest$A):IntersectionTypeTest$A";
+                %7 : Var<java.type:"IntersectionTypeTest$A"> = var %6 @"x";
+                %8 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                invoke %8 @"IntersectionTypeTest::g_A(IntersectionTypeTest$A):void";
+                %9 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %10 : java.type:"IntersectionTypeTest$B" = cast %9 @"IntersectionTypeTest$B";
+                invoke %10 @"IntersectionTypeTest::g_B(IntersectionTypeTest$B):void";
+                %11 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %12 : java.type:"IntersectionTypeTest$C" = cast %11 @"IntersectionTypeTest$C";
+                invoke %12 @"IntersectionTypeTest::g_C(IntersectionTypeTest$C):void";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/LambdaTest.java
+++ b/test/langtools/tools/javac/reflect/LambdaTest.java
@@ -38,18 +38,18 @@ public class LambdaTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : LambdaTest)void -> {
-                %1 : java.util.function.Consumer<java.lang.String> = lambda (%2 : java.lang.String)void -> {
-                    %3 : Var<java.lang.String> = var %2 @"s";
-                    %4 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                    %5 : java.lang.String = var.load %3;
-                    invoke %4 %5 @"java.io.PrintStream::println(java.lang.String)void";
+            func @"test1" (%0 : java.type:"LambdaTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Consumer<java.lang.String>" = lambda (%2 : java.type:"java.lang.String")java.type:"void" -> {
+                    %3 : Var<java.type:"java.lang.String"> = var %2 @"s";
+                    %4 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                    %5 : java.type:"java.lang.String" = var.load %3;
+                    invoke %4 %5 @"java.io.PrintStream::println(java.lang.String):void";
                     return;
                 };
-                %6 : Var<java.util.function.Consumer<java.lang.String>> = var %1 @"c";
-                %7 : java.util.function.Consumer<java.lang.String> = var.load %6;
-                %8 : java.lang.String = constant @"Hello World";
-                invoke %7 %8 @"java.util.function.Consumer::accept(java.lang.Object)void";
+                %6 : Var<java.type:"java.util.function.Consumer<java.lang.String>"> = var %1 @"c";
+                %7 : java.type:"java.util.function.Consumer<java.lang.String>" = var.load %6;
+                %8 : java.type:"java.lang.String" = constant @"Hello World";
+                invoke %7 %8 @"java.util.function.Consumer::accept(java.lang.Object):void";
                 return;
             };
             """)
@@ -62,15 +62,15 @@ public class LambdaTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : LambdaTest)void -> {
-                %1 : java.util.function.Supplier<java.lang.String> = lambda ()java.lang.String -> {
-                    %2 : java.lang.String = constant @"Hello World";
+            func @"test2" (%0 : java.type:"LambdaTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.String>" = lambda ()java.type:"java.lang.String" -> {
+                    %2 : java.type:"java.lang.String" = constant @"Hello World";
                     return %2;
                 };
-                %3 : Var<java.util.function.Supplier<java.lang.String>> = var %1 @"c";
-                %4 : java.util.function.Supplier<java.lang.String> = var.load %3;
-                %5 : java.lang.String = invoke %4 @"java.util.function.Supplier::get()java.lang.Object";
-                %6 : Var<java.lang.String> = var %5 @"s";
+                %3 : Var<java.type:"java.util.function.Supplier<java.lang.String>"> = var %1 @"c";
+                %4 : java.type:"java.util.function.Supplier<java.lang.String>" = var.load %3;
+                %5 : java.type:"java.lang.String" = invoke %4 @"java.util.function.Supplier::get():java.lang.Object";
+                %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
                 return;
             };
             """)
@@ -83,12 +83,12 @@ public class LambdaTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : LambdaTest)void -> {
-                %1 : java.util.function.Supplier<java.lang.String> = lambda ()java.lang.String -> {
-                    %2 : java.lang.String = constant @"Hello World";
+            func @"test3" (%0 : java.type:"LambdaTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.String>" = lambda ()java.type:"java.lang.String" -> {
+                    %2 : java.type:"java.lang.String" = constant @"Hello World";
                     return %2;
                 };
-                %3 : Var<java.util.function.Supplier<java.lang.String>> = var %1 @"c";
+                %3 : Var<java.type:"java.util.function.Supplier<java.lang.String>"> = var %1 @"c";
                 return;
             };
             """)
@@ -100,12 +100,12 @@ public class LambdaTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : LambdaTest)void -> {
-                %1 : java.util.function.Supplier<java.lang.String> = lambda ()java.lang.String -> {
-                    %2 : java.lang.String = field.load %0 @"LambdaTest::s_f()java.lang.String";
+            func @"test4" (%0 : java.type:"LambdaTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.String>" = lambda ()java.type:"java.lang.String" -> {
+                    %2 : java.type:"java.lang.String" = field.load %0 @"LambdaTest::s_f:java.lang.String";
                     return %2;
                 };
-                %3 : Var<java.util.function.Supplier<java.lang.String>> = var %1 @"c";
+                %3 : Var<java.type:"java.util.function.Supplier<java.lang.String>"> = var %1 @"c";
                 return;
             };
             """)
@@ -117,37 +117,37 @@ public class LambdaTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : LambdaTest, %1 : int, %2 : int)void -> {
-                %3 : Var<int> = var %1 @"i";
-                %4 : Var<int> = var %2 @"j";
-                %5 : int = constant @"3";
-                %6 : Var<int> = var %5 @"k";
-                %7 : java.util.function.Supplier<java.lang.Integer> = lambda ()java.lang.Integer -> {
-                    %8 : int = constant @"4";
-                    %9 : Var<int> = var %8 @"l";
-                    %10 : java.util.function.Supplier<java.lang.Integer> = lambda ()java.lang.Integer -> {
-                        %11 : int = var.load %4;
-                        %12 : int = var.load %6;
-                        %13 : int = add %11 %12;
-                        %14 : int = var.load %9;
-                        %15 : int = add %13 %14;
-                        %16 : Var<int> = var %15 @"r";
-                        %17 : int = var.load %16;
-                        %18 : java.lang.Integer = invoke %17 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+            func @"test5" (%0 : java.type:"LambdaTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"i";
+                %4 : Var<java.type:"int"> = var %2 @"j";
+                %5 : java.type:"int" = constant @"3";
+                %6 : Var<java.type:"int"> = var %5 @"k";
+                %7 : java.type:"java.util.function.Supplier<java.lang.Integer>" = lambda ()java.type:"java.lang.Integer" -> {
+                    %8 : java.type:"int" = constant @"4";
+                    %9 : Var<java.type:"int"> = var %8 @"l";
+                    %10 : java.type:"java.util.function.Supplier<java.lang.Integer>" = lambda ()java.type:"java.lang.Integer" -> {
+                        %11 : java.type:"int" = var.load %4;
+                        %12 : java.type:"int" = var.load %6;
+                        %13 : java.type:"int" = add %11 %12;
+                        %14 : java.type:"int" = var.load %9;
+                        %15 : java.type:"int" = add %13 %14;
+                        %16 : Var<java.type:"int"> = var %15 @"r";
+                        %17 : java.type:"int" = var.load %16;
+                        %18 : java.type:"java.lang.Integer" = invoke %17 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                         return %18;
                     };
-                    %19 : Var<java.util.function.Supplier<java.lang.Integer>> = var %10 @"sInner";
-                    %20 : int = var.load %3;
-                    %21 : java.util.function.Supplier<java.lang.Integer> = var.load %19;
-                    %22 : java.lang.Integer = invoke %21 @"java.util.function.Supplier::get()java.lang.Object";
-                    %23 : int = invoke %22 @"java.lang.Integer::intValue()int";
-                    %24 : int = add %20 %23;
-                    %25 : Var<int> = var %24 @"r";
-                    %26 : int = var.load %25;
-                    %27 : java.lang.Integer = invoke %26 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+                    %19 : Var<java.type:"java.util.function.Supplier<java.lang.Integer>"> = var %10 @"sInner";
+                    %20 : java.type:"int" = var.load %3;
+                    %21 : java.type:"java.util.function.Supplier<java.lang.Integer>" = var.load %19;
+                    %22 : java.type:"java.lang.Integer" = invoke %21 @"java.util.function.Supplier::get():java.lang.Object";
+                    %23 : java.type:"int" = invoke %22 @"java.lang.Integer::intValue():int";
+                    %24 : java.type:"int" = add %20 %23;
+                    %25 : Var<java.type:"int"> = var %24 @"r";
+                    %26 : java.type:"int" = var.load %25;
+                    %27 : java.type:"java.lang.Integer" = invoke %26 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                     return %27;
                 };
-                %28 : Var<java.util.function.Supplier<java.lang.Integer>> = var %7 @"sOuter";
+                %28 : Var<java.type:"java.util.function.Supplier<java.lang.Integer>"> = var %7 @"sOuter";
                 return;
             };
             """)
@@ -169,13 +169,13 @@ public class LambdaTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : LambdaTest)void -> {
-                %1 : java.util.function.Supplier<java.lang.Integer> = lambda ()java.lang.Integer -> {
-                    %2 : int = field.load %0 @"LambdaTest::f()int";
-                    %3 : java.lang.Integer = invoke %2 @"java.lang.Integer::valueOf(int)java.lang.Integer";
+            func @"test6" (%0 : java.type:"LambdaTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.Integer>" = lambda ()java.type:"java.lang.Integer" -> {
+                    %2 : java.type:"int" = field.load %0 @"LambdaTest::f:int";
+                    %3 : java.type:"java.lang.Integer" = invoke %2 @"java.lang.Integer::valueOf(int):java.lang.Integer";
                     return %3;
                 };
-                %4 : Var<java.util.function.Supplier<java.lang.Integer>> = var %1 @"s";
+                %4 : Var<java.type:"java.util.function.Supplier<java.lang.Integer>"> = var %1 @"s";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/LocalClassTest.java
+++ b/test/langtools/tools/javac/reflect/LocalClassTest.java
@@ -41,9 +41,9 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testLocalNoCapture" (%0 : LocalClassTest)void -> {
-                %1 : LocalClassTest$1Foo = new %0 @"LocalClassTest$1Foo::<new>(LocalClassTest)";
-                invoke %1 @"LocalClassTest$1Foo::m()void";
+            func @"testLocalNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+                %1 : java.type:"LocalClassTest$1Foo" = new %0 @"LocalClassTest$1Foo::(LocalClassTest)";
+                invoke %1 @"LocalClassTest$1Foo::m():void";
                 return;
             };
             """)
@@ -56,9 +56,9 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testAnonNoCapture" (%0 : LocalClassTest)void -> {
-                %1 : LocalClassTest$1 = new %0 @"LocalClassTest$1::<new>(LocalClassTest)";
-                invoke %1 @"LocalClassTest$1::m()void";
+            func @"testAnonNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+                %1 : java.type:"LocalClassTest$1" = new %0 @"LocalClassTest$1::(LocalClassTest)";
+                invoke %1 @"LocalClassTest$1::m():void";
                 return;
             };
             """)
@@ -70,11 +70,11 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testLocalCaptureParam" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
-                %2 : Var<java.lang.String> = var %1 @"s";
-                %3 : java.lang.String = var.load %2;
-                %4 : LocalClassTest$2Foo = new %0 %3 @"LocalClassTest$2Foo::<new>(LocalClassTest, java.lang.String)";
-                %5 : java.lang.String = invoke %4 @"LocalClassTest$2Foo::m()java.lang.String";
+            func @"testLocalCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = var.load %2;
+                %4 : java.type:"LocalClassTest$2Foo" = new %0 %3 @"LocalClassTest$2Foo::(LocalClassTest, java.lang.String)";
+                %5 : java.type:"java.lang.String" = invoke %4 @"LocalClassTest$2Foo::m():java.lang.String";
                 return %5;
             };
             """)
@@ -87,11 +87,11 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testAnonCaptureParam" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
-                %2 : Var<java.lang.String> = var %1 @"s";
-                %3 : java.lang.String = var.load %2;
-                %4 : LocalClassTest$2 = new %0 %3 @"LocalClassTest$2::<new>(LocalClassTest, java.lang.String)";
-                %5 : java.lang.String = invoke %4 @"LocalClassTest$2::m()java.lang.String";
+            func @"testAnonCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = var.load %2;
+                %4 : java.type:"LocalClassTest$2" = new %0 %3 @"LocalClassTest$2::(LocalClassTest, java.lang.String)";
+                %5 : java.type:"java.lang.String" = invoke %4 @"LocalClassTest$2::m():java.lang.String";
                 return %5;
             };
             """)
@@ -103,13 +103,13 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testLocalCaptureParamAndField" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
-                %2 : Var<java.lang.String> = var %1 @"s";
-                %3 : java.lang.String = constant @"Hello!";
-                %4 : Var<java.lang.String> = var %3 @"localConst";
-                %5 : java.lang.String = var.load %2;
-                %6 : LocalClassTest$3Foo = new %0 %5 @"LocalClassTest$3Foo::<new>(LocalClassTest, java.lang.String)";
-                %7 : java.lang.String = invoke %6 @"LocalClassTest$3Foo::m()java.lang.String";
+            func @"testLocalCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = constant @"Hello!";
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
+                %5 : java.type:"java.lang.String" = var.load %2;
+                %6 : java.type:"LocalClassTest$3Foo" = new %0 %5 @"LocalClassTest$3Foo::(LocalClassTest, java.lang.String)";
+                %7 : java.type:"java.lang.String" = invoke %6 @"LocalClassTest$3Foo::m():java.lang.String";
                 return %7;
             };
             """)
@@ -123,13 +123,13 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testAnonCaptureParamAndField" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
-                %2 : Var<java.lang.String> = var %1 @"s";
-                %3 : java.lang.String = constant @"Hello!";
-                %4 : Var<java.lang.String> = var %3 @"localConst";
-                %5 : java.lang.String = var.load %2;
-                %6 : LocalClassTest$3 = new %0 %5 @"LocalClassTest$3::<new>(LocalClassTest, java.lang.String)";
-                %7 : java.lang.String = invoke %6 @"LocalClassTest$3::m()java.lang.String";
+            func @"testAnonCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = constant @"Hello!";
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
+                %5 : java.type:"java.lang.String" = var.load %2;
+                %6 : java.type:"LocalClassTest$3" = new %0 %5 @"LocalClassTest$3::(LocalClassTest, java.lang.String)";
+                %7 : java.type:"java.lang.String" = invoke %6 @"LocalClassTest$3::m():java.lang.String";
                 return %7;
             };
             """)
@@ -142,12 +142,12 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testLocalDependency" (%0 : LocalClassTest, %1 : int, %2 : int)void -> {
-                %3 : Var<int> = var %1 @"s";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int = var.load %3;
-                %6 : int = var.load %4;
-                %7 : LocalClassTest$1Bar = new %0 %5 %6 @"LocalClassTest$1Bar::<new>(LocalClassTest, int, int)";
+            func @"testLocalDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"s";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"LocalClassTest$1Bar" = new %0 %5 %6 @"LocalClassTest$1Bar::(LocalClassTest, int, int)";
                 return;
             };
             """)
@@ -164,12 +164,12 @@ public class LocalClassTest {
 
     @CodeReflection
     @IR("""
-            func @"testAnonDependency" (%0 : LocalClassTest, %1 : int, %2 : int)void -> {
-                %3 : Var<int> = var %1 @"s";
-                %4 : Var<int> = var %2 @"i";
-                %5 : int = var.load %3;
-                %6 : int = var.load %4;
-                %7 : LocalClassTest$4 = new %0 %5 %6 @"LocalClassTest$4::<new>(LocalClassTest, int, int)";
+            func @"testAnonDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"s";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"LocalClassTest$4" = new %0 %5 %6 @"LocalClassTest$4::(LocalClassTest, int, int)";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/LocalClassTest.java
+++ b/test/langtools/tools/javac/reflect/LocalClassTest.java
@@ -42,8 +42,8 @@ public class LocalClassTest {
     @CodeReflection
     @IR("""
             func @"testLocalNoCapture" (%0 : LocalClassTest)void -> {
-                %1 : .<LocalClassTest, LocalClassTest$1Foo> = new %0 @".<LocalClassTest, LocalClassTest$1Foo>::<new>(LocalClassTest)";
-                invoke %1 @".<LocalClassTest, LocalClassTest$1Foo>::m()void";
+                %1 : LocalClassTest$1Foo = new %0 @"LocalClassTest$1Foo::<new>(LocalClassTest)";
+                invoke %1 @"LocalClassTest$1Foo::m()void";
                 return;
             };
             """)
@@ -57,8 +57,8 @@ public class LocalClassTest {
     @CodeReflection
     @IR("""
             func @"testAnonNoCapture" (%0 : LocalClassTest)void -> {
-                %1 : .<LocalClassTest, LocalClassTest$1> = new %0 @".<LocalClassTest, LocalClassTest$1>::<new>(LocalClassTest)";
-                invoke %1 @".<LocalClassTest, LocalClassTest$1>::m()void";
+                %1 : LocalClassTest$1 = new %0 @"LocalClassTest$1::<new>(LocalClassTest)";
+                invoke %1 @"LocalClassTest$1::m()void";
                 return;
             };
             """)
@@ -73,8 +73,8 @@ public class LocalClassTest {
             func @"testLocalCaptureParam" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
                 %2 : Var<java.lang.String> = var %1 @"s";
                 %3 : java.lang.String = var.load %2;
-                %4 : .<LocalClassTest, LocalClassTest$2Foo> = new %0 %3 @".<LocalClassTest, LocalClassTest$2Foo>::<new>(LocalClassTest, java.lang.String)";
-                %5 : java.lang.String = invoke %4 @".<LocalClassTest, LocalClassTest$2Foo>::m()java.lang.String";
+                %4 : LocalClassTest$2Foo = new %0 %3 @"LocalClassTest$2Foo::<new>(LocalClassTest, java.lang.String)";
+                %5 : java.lang.String = invoke %4 @"LocalClassTest$2Foo::m()java.lang.String";
                 return %5;
             };
             """)
@@ -90,8 +90,8 @@ public class LocalClassTest {
             func @"testAnonCaptureParam" (%0 : LocalClassTest, %1 : java.lang.String)java.lang.String -> {
                 %2 : Var<java.lang.String> = var %1 @"s";
                 %3 : java.lang.String = var.load %2;
-                %4 : .<LocalClassTest, LocalClassTest$2> = new %0 %3 @".<LocalClassTest, LocalClassTest$2>::<new>(LocalClassTest, java.lang.String)";
-                %5 : java.lang.String = invoke %4 @".<LocalClassTest, LocalClassTest$2>::m()java.lang.String";
+                %4 : LocalClassTest$2 = new %0 %3 @"LocalClassTest$2::<new>(LocalClassTest, java.lang.String)";
+                %5 : java.lang.String = invoke %4 @"LocalClassTest$2::m()java.lang.String";
                 return %5;
             };
             """)
@@ -108,8 +108,8 @@ public class LocalClassTest {
                 %3 : java.lang.String = constant @"Hello!";
                 %4 : Var<java.lang.String> = var %3 @"localConst";
                 %5 : java.lang.String = var.load %2;
-                %6 : .<LocalClassTest, LocalClassTest$3Foo> = new %0 %5 @".<LocalClassTest, LocalClassTest$3Foo>::<new>(LocalClassTest, java.lang.String)";
-                %7 : java.lang.String = invoke %6 @".<LocalClassTest, LocalClassTest$3Foo>::m()java.lang.String";
+                %6 : LocalClassTest$3Foo = new %0 %5 @"LocalClassTest$3Foo::<new>(LocalClassTest, java.lang.String)";
+                %7 : java.lang.String = invoke %6 @"LocalClassTest$3Foo::m()java.lang.String";
                 return %7;
             };
             """)
@@ -128,8 +128,8 @@ public class LocalClassTest {
                 %3 : java.lang.String = constant @"Hello!";
                 %4 : Var<java.lang.String> = var %3 @"localConst";
                 %5 : java.lang.String = var.load %2;
-                %6 : .<LocalClassTest, LocalClassTest$3> = new %0 %5 @".<LocalClassTest, LocalClassTest$3>::<new>(LocalClassTest, java.lang.String)";
-                %7 : java.lang.String = invoke %6 @".<LocalClassTest, LocalClassTest$3>::m()java.lang.String";
+                %6 : LocalClassTest$3 = new %0 %5 @"LocalClassTest$3::<new>(LocalClassTest, java.lang.String)";
+                %7 : java.lang.String = invoke %6 @"LocalClassTest$3::m()java.lang.String";
                 return %7;
             };
             """)
@@ -147,7 +147,7 @@ public class LocalClassTest {
                 %4 : Var<int> = var %2 @"i";
                 %5 : int = var.load %3;
                 %6 : int = var.load %4;
-                %7 : .<LocalClassTest, LocalClassTest$1Bar> = new %0 %5 %6 @".<LocalClassTest, LocalClassTest$1Bar>::<new>(LocalClassTest, int, int)";
+                %7 : LocalClassTest$1Bar = new %0 %5 %6 @"LocalClassTest$1Bar::<new>(LocalClassTest, int, int)";
                 return;
             };
             """)
@@ -169,7 +169,7 @@ public class LocalClassTest {
                 %4 : Var<int> = var %2 @"i";
                 %5 : int = var.load %3;
                 %6 : int = var.load %4;
-                %7 : .<LocalClassTest, LocalClassTest$4> = new %0 %5 %6 @".<LocalClassTest, LocalClassTest$4>::<new>(LocalClassTest, int, int)";
+                %7 : LocalClassTest$4 = new %0 %5 %6 @"LocalClassTest$4::<new>(LocalClassTest, int, int)";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/LocalVarTest.java
+++ b/test/langtools/tools/javac/reflect/LocalVarTest.java
@@ -36,14 +36,14 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : LocalVarTest)int -> {
-                %1 : int = constant @"1";
-                %2 : Var<int> = var %1 @"x";
-                %3 : int = constant @"2";
-                %4 : Var<int> = var %3 @"y";
-                %5 : int = var.load %2;
-                %6 : int = var.load %4;
-                %7 : int = add %5 %6;
+            func @"test1" (%0 : java.type:"LocalVarTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : Var<java.type:"int"> = var %1 @"x";
+                %3 : java.type:"int" = constant @"2";
+                %4 : Var<java.type:"int"> = var %3 @"y";
+                %5 : java.type:"int" = var.load %2;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"int" = add %5 %6;
                 return %7;
             };
             """)
@@ -55,12 +55,12 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : LocalVarTest, %1 : int, %2 : int)int -> {
-                %3 : Var<int> = var %1 @"x";
-                %4 : Var<int> = var %2 @"y";
-                %5 : int = var.load %3;
-                %6 : int = var.load %4;
-                %7 : int = add %5 %6;
+            func @"test2" (%0 : java.type:"LocalVarTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"int" -> {
+                %3 : Var<java.type:"int"> = var %1 @"x";
+                %4 : Var<java.type:"int"> = var %2 @"y";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"int" = add %5 %6;
                 return %7;
             };
             """)
@@ -70,17 +70,17 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : LocalVarTest)int -> {
-                %2 : Var<int> = var @"x";
-                %4 : Var<int> = var @"y";
-                %5 : int = constant @"1";
-                var.store %2 %5;
-                %6 : int = constant @"2";
-                var.store %4 %6;
-                %7 : int = var.load %2;
-                %8 : int = var.load %4;
-                %9 : int = add %7 %8;
-                return %9;
+            func @"test3" (%0 : java.type:"LocalVarTest")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var @"x";
+                %2 : Var<java.type:"int"> = var @"y";
+                %3 : java.type:"int" = constant @"1";
+                var.store %1 %3;
+                %4 : java.type:"int" = constant @"2";
+                var.store %2 %4;
+                %5 : java.type:"int" = var.load %1;
+                %6 : java.type:"int" = var.load %2;
+                %7 : java.type:"int" = add %5 %6;
+                return %7;
             };
             """)
     int test3() {
@@ -93,14 +93,14 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : LocalVarTest)int -> {
-                %1 : int = constant @"1";
-                %2 : Var<int> = var %1 @"x";
-                %3 : int = var.load %2;
-                %4 : int = constant @"1";
-                %5 : int = add %3 %4;
-                %6 : Var<int> = var %5 @"y";
-                %7 : int = var.load %6;
+            func @"test4" (%0 : java.type:"LocalVarTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : Var<java.type:"int"> = var %1 @"x";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"int" = add %3 %4;
+                %6 : Var<java.type:"int"> = var %5 @"y";
+                %7 : java.type:"int" = var.load %6;
                 return %7;
             };
             """)
@@ -112,12 +112,12 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : LocalVarTest)int -> {
-                %1 : int = constant @"1";
-                %2 : Var<int> = var %1 @"x";
-                %3 : int = var.load %2;
-                %4 : Var<int> = var %3 @"y";
-                %5 : int = var.load %4;
+            func @"test5" (%0 : java.type:"LocalVarTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : Var<java.type:"int"> = var %1 @"x";
+                %3 : java.type:"int" = var.load %2;
+                %4 : Var<java.type:"int"> = var %3 @"y";
+                %5 : java.type:"int" = var.load %4;
                 return %5;
             };
             """)
@@ -129,17 +129,17 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : LocalVarTest)int -> {
-                %1 : int = constant @"1";
-                %2 : Var<int> = var %1 @"x";
-                %3 : int = constant @"1";
-                %4 : Var<int> = var %3 @"y";
-                %5 : int = constant @"1";
-                %6 : Var<int> = var %5 @"z";
-                %7 : int = var.load %2;
+            func @"test6" (%0 : java.type:"LocalVarTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : Var<java.type:"int"> = var %1 @"x";
+                %3 : java.type:"int" = constant @"1";
+                %4 : Var<java.type:"int"> = var %3 @"y";
+                %5 : java.type:"int" = constant @"1";
+                %6 : Var<java.type:"int"> = var %5 @"z";
+                %7 : java.type:"int" = var.load %2;
                 var.store %4 %7;
                 var.store %6 %7;
-                %8 : int = var.load %6;
+                %8 : java.type:"int" = var.load %6;
                 return %8;
             };
             """)
@@ -153,23 +153,23 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : LocalVarTest)int -> {
-                %1 : int = constant @"1";
-                %2 : Var<int> = var %1 @"x";
-                %3 : int = var.load %2;
-                %4 : int = constant @"2";
-                %5 : int = add %3 %4;
+            func @"test7" (%0 : java.type:"LocalVarTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : Var<java.type:"int"> = var %1 @"x";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = constant @"2";
+                %5 : java.type:"int" = add %3 %4;
                 var.store %2 %5;
-                %6 : Var<int> = var %5 @"y";
-                %7 : int = var.load %6;
-                %8 : int = constant @"3";
-                %9 : int = add %7 %8;
+                %6 : Var<java.type:"int"> = var %5 @"y";
+                %7 : java.type:"int" = var.load %6;
+                %8 : java.type:"int" = constant @"3";
+                %9 : java.type:"int" = add %7 %8;
                 var.store %6 %9;
-                %10 : int = var.load %2;
-                %11 : int = constant @"4";
-                %12 : int = add %10 %11;
+                %10 : java.type:"int" = var.load %2;
+                %11 : java.type:"int" = constant @"4";
+                %12 : java.type:"int" = add %10 %11;
                 var.store %2 %12;
-                %13 : int = add %9 %12;
+                %13 : java.type:"int" = add %9 %12;
                 return %13;
             };
             """)
@@ -181,18 +181,18 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : LocalVarTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = constant @"1";
-                %5 : int = add %3 %4;
+            func @"test8" (%0 : java.type:"LocalVarTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"int" = add %3 %4;
                 var.store %2 %5;
-                %6 : Var<int> = var %3 @"x";
-                %7 : int = var.load %2;
-                %8 : int = constant @"1";
-                %9 : int = sub %7 %8;
+                %6 : Var<java.type:"int"> = var %3 @"x";
+                %7 : java.type:"int" = var.load %2;
+                %8 : java.type:"int" = constant @"1";
+                %9 : java.type:"int" = sub %7 %8;
                 var.store %2 %9;
-                %10 : Var<int> = var %7 @"y";
+                %10 : Var<java.type:"int"> = var %7 @"y";
                 return;
             };
             """)
@@ -203,18 +203,18 @@ public class LocalVarTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : LocalVarTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = constant @"1";
-                %5 : int = add %3 %4;
+            func @"test9" (%0 : java.type:"LocalVarTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = constant @"1";
+                %5 : java.type:"int" = add %3 %4;
                 var.store %2 %5;
-                %6 : Var<int> = var %5 @"x";
-                %7 : int = var.load %2;
-                %8 : int = constant @"1";
-                %9 : int = sub %7 %8;
+                %6 : Var<java.type:"int"> = var %5 @"x";
+                %7 : java.type:"int" = var.load %2;
+                %8 : java.type:"int" = constant @"1";
+                %9 : java.type:"int" = sub %7 %8;
                 var.store %2 %9;
-                %10 : Var<int> = var %9 @"y";
+                %10 : Var<java.type:"int"> = var %9 @"y";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -45,8 +45,8 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : MethodCallTest)void -> {
-                invoke %0 @"MethodCallTest::m()void";
+            func @"test1" (%0 : java.type:"MethodCallTest")java.type:"void" -> {
+                invoke %0 @"MethodCallTest::m():void";
                 return;
             };
             """)
@@ -56,8 +56,8 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : MethodCallTest)void -> {
-                invoke %0 @"MethodCallTest::m()void";
+            func @"test2" (%0 : java.type:"MethodCallTest")java.type:"void" -> {
+                invoke %0 @"MethodCallTest::m():void";
                 return;
             };
             """)
@@ -67,8 +67,8 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test2_1" (%0 : MethodCallTest)void -> {
-                invoke %0 @"MethodCallTest::m()void";
+            func @"test2_1" (%0 : java.type:"MethodCallTest")java.type:"void" -> {
+                invoke %0 @"MethodCallTest::m():void";
                 return;
             };
             """)
@@ -78,8 +78,8 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : MethodCallTest)int -> {
-                %1 : int = invoke %0 @"MethodCallTest::m_int()int";
+            func @"test3" (%0 : java.type:"MethodCallTest")java.type:"int" -> {
+                %1 : java.type:"int" = invoke %0 @"MethodCallTest::m_int():int";
                 return %1;
             };
             """)
@@ -93,8 +93,8 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : MethodCallTest)void -> {
-                invoke @"MethodCallTest::ms()void";
+            func @"test4" (%0 : java.type:"MethodCallTest")java.type:"void" -> {
+                invoke @"MethodCallTest::ms():void";
                 return;
             };
             """)
@@ -104,8 +104,8 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test4_1" (%0 : MethodCallTest)void -> {
-                invoke @"MethodCallTest::ms()void";
+            func @"test4_1" (%0 : java.type:"MethodCallTest")java.type:"void" -> {
+                invoke @"MethodCallTest::ms():void";
                 return;
             };
             """)
@@ -115,8 +115,8 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test4_2" (%0 : MethodCallTest)java.util.List<java.lang.String> -> {
-                %1 : java.util.List<java.lang.String> = invoke @"java.util.List::of()java.util.List";
+            func @"test4_2" (%0 : java.type:"MethodCallTest")java.type:"java.util.List<java.lang.String>" -> {
+                %1 : java.type:"java.util.List<java.lang.String>" = invoke @"java.util.List::of():java.util.List";
                 return %1;
             };
             """)
@@ -130,13 +130,13 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : MethodCallTest, %1 : java.util.List<java.lang.Number>)void -> {
-                %2 : Var<java.util.List<java.lang.Number>> = var %1 @"l";
-                %3 : int = constant @"1";
-                %4 : java.lang.String = constant @"1";
-                %5 : java.util.List<java.lang.Number> = var.load %2;
-                %6 : java.lang.String = invoke %0 %3 %4 %5 @"MethodCallTest::m(int, java.lang.String, java.util.List)java.lang.String";
-                %7 : Var<java.lang.String> = var %6 @"s";
+            func @"test5" (%0 : java.type:"MethodCallTest", %1 : java.type:"java.util.List<java.lang.Number>")java.type:"void" -> {
+                %2 : Var<java.type:"java.util.List<java.lang.Number>"> = var %1 @"l";
+                %3 : java.type:"int" = constant @"1";
+                %4 : java.type:"java.lang.String" = constant @"1";
+                %5 : java.type:"java.util.List<java.lang.Number>" = var.load %2;
+                %6 : java.type:"java.lang.String" = invoke %0 %3 %4 %5 @"MethodCallTest::m(int, java.lang.String, java.util.List):java.lang.String";
+                %7 : Var<java.type:"java.lang.String"> = var %6 @"s";
                 return;
             };
             """)
@@ -167,12 +167,12 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : MethodCallTest, %1 : MethodCallTest$A)void -> {
-                %2 : Var<MethodCallTest$A> = var %1 @"a";
-                %3 : MethodCallTest$A = var.load %2;
-                %4 : MethodCallTest$B = invoke %3 @"MethodCallTest$A::m()MethodCallTest$B";
-                %5 : MethodCallTest$C = invoke %4 @"MethodCallTest$B::m()MethodCallTest$C";
-                %6 : int = invoke %5 @"MethodCallTest$C::m()int";
+            func @"test6" (%0 : java.type:"MethodCallTest", %1 : java.type:"MethodCallTest$A")java.type:"void" -> {
+                %2 : Var<java.type:"MethodCallTest$A"> = var %1 @"a";
+                %3 : java.type:"MethodCallTest$A" = var.load %2;
+                %4 : java.type:"MethodCallTest$B" = invoke %3 @"MethodCallTest$A::m():MethodCallTest$B";
+                %5 : java.type:"MethodCallTest$C" = invoke %4 @"MethodCallTest$B::m():MethodCallTest$C";
+                %6 : java.type:"int" = invoke %5 @"MethodCallTest$C::m():int";
                 return;
             };
             """)
@@ -182,11 +182,11 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : MethodCallTest, %1 : MethodCallTest$A)void -> {
-                %2 : Var<MethodCallTest$A> = var %1 @"a";
-                %3 : MethodCallTest$A = var.load %2;
-                %4 : MethodCallTest$B = field.load %3 @"MethodCallTest$A::b()MethodCallTest$B";
-                %5 : MethodCallTest$C = invoke %4 @"MethodCallTest$B::m()MethodCallTest$C";
+            func @"test7" (%0 : java.type:"MethodCallTest", %1 : java.type:"MethodCallTest$A")java.type:"void" -> {
+                %2 : Var<java.type:"MethodCallTest$A"> = var %1 @"a";
+                %3 : java.type:"MethodCallTest$A" = var.load %2;
+                %4 : java.type:"MethodCallTest$B" = field.load %3 @"MethodCallTest$A::b:MethodCallTest$B";
+                %5 : java.type:"MethodCallTest$C" = invoke %4 @"MethodCallTest$B::m():MethodCallTest$C";
                 return;
             };
             """)
@@ -196,11 +196,11 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : MethodCallTest, %1 : java.lang.String)void -> {
-                %2 : Var<java.lang.String> = var %1 @"s";
-                %3 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                %4 : java.lang.String = var.load %2;
-                invoke %3 %4 @"java.io.PrintStream::println(java.lang.String)void";
+            func @"test8" (%0 : java.type:"MethodCallTest", %1 : java.type:"java.lang.String")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                %4 : java.type:"java.lang.String" = var.load %2;
+                invoke %3 %4 @"java.io.PrintStream::println(java.lang.String):void";
                 return;
             };
             """)
@@ -221,13 +221,13 @@ public class MethodCallTest {
 
         @CodeReflection
         @IR("""
-                func @"test" (%0 : MethodCallTest$Y)void -> {
-                    invoke %0 @"MethodCallTest$Y::x()void";
-                    invoke %0 @"MethodCallTest$Y::y()void";
-                    invoke @"MethodCallTest$Y::sx()void";
-                    invoke @"MethodCallTest$Y::sy()void";
-                    invoke @"MethodCallTest$Y::sx()void";
-                    invoke @"MethodCallTest$Y::sy()void";
+                func @"test" (%0 : java.type:"MethodCallTest$Y")java.type:"void" -> {
+                    invoke %0 @"MethodCallTest$Y::x():void";
+                    invoke %0 @"MethodCallTest$Y::y():void";
+                    invoke @"MethodCallTest$Y::sx():void";
+                    invoke @"MethodCallTest$Y::sy():void";
+                    invoke @"MethodCallTest$Y::sx():void";
+                    invoke @"MethodCallTest$Y::sy():void";
                     return;
                 };
                 """)
@@ -245,18 +245,18 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : MethodCallTest$Y)void -> {
-                %1 : Var<MethodCallTest$Y> = var %0 @"y";
-                %2 : MethodCallTest$Y = var.load %1;
-                invoke %2 @"MethodCallTest$Y::x()void";
-                %3 : MethodCallTest$Y = var.load %1;
-                invoke %3 @"MethodCallTest$Y::y()void";
-                %4 : MethodCallTest$Y = var.load %1;
-                invoke @"MethodCallTest$Y::sx()void";
-                %5 : MethodCallTest$Y = var.load %1;
-                invoke @"MethodCallTest$Y::sy()void";
-                invoke @"MethodCallTest$Y::sx()void";
-                invoke @"MethodCallTest$Y::sy()void";
+            func @"test9" (%0 : java.type:"MethodCallTest$Y")java.type:"void" -> {
+                %1 : Var<java.type:"MethodCallTest$Y"> = var %0 @"y";
+                %2 : java.type:"MethodCallTest$Y" = var.load %1;
+                invoke %2 @"MethodCallTest$Y::x():void";
+                %3 : java.type:"MethodCallTest$Y" = var.load %1;
+                invoke %3 @"MethodCallTest$Y::y():void";
+                %4 : java.type:"MethodCallTest$Y" = var.load %1;
+                invoke @"MethodCallTest$Y::sx():void";
+                %5 : java.type:"MethodCallTest$Y" = var.load %1;
+                invoke @"MethodCallTest$Y::sy():void";
+                invoke @"MethodCallTest$Y::sx():void";
+                invoke @"MethodCallTest$Y::sy():void";
                 return;
             };
             """)
@@ -273,17 +273,17 @@ public class MethodCallTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0 : java.util.ArrayList<java.lang.String>)void -> {
-                %1 : Var<java.util.ArrayList<java.lang.String>> = var %0 @"al";
-                %2 : java.util.ArrayList<java.lang.String> = var.load %1;
-                %3 : int = constant @"0";
-                %4 : java.lang.String = invoke %2 %3 @"java.util.ArrayList::get(int)java.lang.Object";
-                %5 : Var<java.lang.String> = var %4 @"s";
-                %6 : java.util.ArrayList<java.lang.String> = var.load %1;
-                %7 : Var<java.util.List<java.lang.String>> = var %6 @"l";
-                %8 : java.util.List<java.lang.String> = var.load %7;
-                %9 : int = constant @"0";
-                %10 : java.lang.String = invoke %8 %9 @"java.util.List::get(int)java.lang.Object";
+            func @"test10" (%0 : java.type:"java.util.ArrayList<java.lang.String>")java.type:"void" -> {
+                %1 : Var<java.type:"java.util.ArrayList<java.lang.String>"> = var %0 @"al";
+                %2 : java.type:"java.util.ArrayList<java.lang.String>" = var.load %1;
+                %3 : java.type:"int" = constant @"0";
+                %4 : java.type:"java.lang.String" = invoke %2 %3 @"java.util.ArrayList::get(int):java.lang.Object";
+                %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
+                %6 : java.type:"java.util.ArrayList<java.lang.String>" = var.load %1;
+                %7 : Var<java.type:"java.util.List<java.lang.String>"> = var %6 @"l";
+                %8 : java.type:"java.util.List<java.lang.String>" = var.load %7;
+                %9 : java.type:"int" = constant @"0";
+                %10 : java.type:"java.lang.String" = invoke %8 %9 @"java.util.List::get(int):java.lang.Object";
                 var.store %5 %10;
                 return;
             };

--- a/test/langtools/tools/javac/reflect/MethodReferenceTest.java
+++ b/test/langtools/tools/javac/reflect/MethodReferenceTest.java
@@ -45,14 +45,14 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.Consumer<java.lang.String> = lambda (%2 : java.lang.String)void -> {
-                    %3 : Var<java.lang.String> = var %2 @"x$0";
-                    %4 : java.lang.String = var.load %3;
-                    invoke %4 @"MethodReferenceTest::m_s(java.lang.String)void";
+            func @"test1" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Consumer<java.lang.String>" = lambda (%2 : java.type:"java.lang.String")java.type:"void" -> {
+                    %3 : Var<java.type:"java.lang.String"> = var %2 @"x$0";
+                    %4 : java.type:"java.lang.String" = var.load %3;
+                    invoke %4 @"MethodReferenceTest::m_s(java.lang.String):void";
                     return;
                 };
-                %5 : Var<java.util.function.Consumer<java.lang.String>> = var %1 @"c";
+                %5 : Var<java.type:"java.util.function.Consumer<java.lang.String>"> = var %1 @"c";
                 return;
             };
             """)
@@ -62,16 +62,16 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.BiConsumer<MethodReferenceTest, java.lang.String> = lambda (%2 : MethodReferenceTest, %3 : java.lang.String)void -> {
-                    %4 : Var<MethodReferenceTest> = var %2 @"rec$";
-                    %5 : Var<java.lang.String> = var %3 @"x$0";
-                    %6 : MethodReferenceTest = var.load %4;
-                    %7 : java.lang.String = var.load %5;
-                    invoke %6 %7 @"MethodReferenceTest::m(java.lang.String)void";
+            func @"test2" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.BiConsumer<MethodReferenceTest, java.lang.String>" = lambda (%2 : java.type:"MethodReferenceTest", %3 : java.type:"java.lang.String")java.type:"void" -> {
+                    %4 : Var<java.type:"MethodReferenceTest"> = var %2 @"rec$";
+                    %5 : Var<java.type:"java.lang.String"> = var %3 @"x$0";
+                    %6 : java.type:"MethodReferenceTest" = var.load %4;
+                    %7 : java.type:"java.lang.String" = var.load %5;
+                    invoke %6 %7 @"MethodReferenceTest::m(java.lang.String):void";
                     return;
                 };
-                %8 : Var<java.util.function.BiConsumer<MethodReferenceTest, java.lang.String>> = var %1 @"bc";
+                %8 : Var<java.type:"java.util.function.BiConsumer<MethodReferenceTest, java.lang.String>"> = var %1 @"bc";
                 return;
             };
             """)
@@ -81,14 +81,14 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.Consumer<java.lang.String> = lambda (%2 : java.lang.String)void -> {
-                    %3 : Var<java.lang.String> = var %2 @"x$0";
-                    %4 : java.lang.String = var.load %3;
-                    invoke %0 %4 @"MethodReferenceTest::m(java.lang.String)void";
+            func @"test3" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Consumer<java.lang.String>" = lambda (%2 : java.type:"java.lang.String")java.type:"void" -> {
+                    %3 : Var<java.type:"java.lang.String"> = var %2 @"x$0";
+                    %4 : java.type:"java.lang.String" = var.load %3;
+                    invoke %0 %4 @"MethodReferenceTest::m(java.lang.String):void";
                     return;
                 };
-                %5 : Var<java.util.function.Consumer<java.lang.String>> = var %1 @"c";
+                %5 : Var<java.type:"java.util.function.Consumer<java.lang.String>"> = var %1 @"c";
                 return;
             };
             """)
@@ -104,18 +104,18 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : MethodReferenceTest)void -> {
-                %1 : java.lang.String = constant @"s";
-                %2 : MethodReferenceTest$A<java.lang.String> = invoke %0 %1 @"MethodReferenceTest::a(java.lang.Object)MethodReferenceTest$A";
-                %3 : Var<MethodReferenceTest$A<java.lang.String>> = var %2 @"rec$";
-                %4 : java.util.function.Function<java.lang.String, java.lang.String> = lambda (%5 : java.lang.String)java.lang.String -> {
-                    %6 : Var<java.lang.String> = var %5 @"x$0";
-                    %7 : MethodReferenceTest$A<java.lang.String> = var.load %3;
-                    %8 : java.lang.String = var.load %6;
-                    %9 : java.lang.String = invoke %7 %8 @"MethodReferenceTest$A::m(java.lang.Object)java.lang.Object";
+            func @"test4" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @"s";
+                %2 : java.type:"MethodReferenceTest$A<java.lang.String>" = invoke %0 %1 @"MethodReferenceTest::a(java.lang.Object):MethodReferenceTest$A";
+                %3 : Var<java.type:"MethodReferenceTest$A<java.lang.String>"> = var %2 @"rec$";
+                %4 : java.type:"java.util.function.Function<java.lang.String, java.lang.String>" = lambda (%5 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                    %6 : Var<java.type:"java.lang.String"> = var %5 @"x$0";
+                    %7 : java.type:"MethodReferenceTest$A<java.lang.String>" = var.load %3;
+                    %8 : java.type:"java.lang.String" = var.load %6;
+                    %9 : java.type:"java.lang.String" = invoke %7 %8 @"MethodReferenceTest$A::m(java.lang.Object):java.lang.Object";
                     return %9;
                 };
-                %10 : Var<java.util.function.Function<java.lang.String, java.lang.String>> = var %4 @"f";
+                %10 : Var<java.type:"java.util.function.Function<java.lang.String, java.lang.String>"> = var %4 @"f";
                 return;
             };
             """)
@@ -125,17 +125,17 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : MethodReferenceTest)void -> {
-                %1 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                %2 : Var<java.io.PrintStream> = var %1 @"rec$";
-                %3 : java.util.function.Consumer<java.lang.String> = lambda (%4 : java.lang.String)void -> {
-                    %5 : Var<java.lang.String> = var %4 @"x$0";
-                    %6 : java.io.PrintStream = var.load %2;
-                    %7 : java.lang.String = var.load %5;
-                    invoke %6 %7 @"java.io.PrintStream::println(java.lang.String)void";
+            func @"test5" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                %2 : Var<java.type:"java.io.PrintStream"> = var %1 @"rec$";
+                %3 : java.type:"java.util.function.Consumer<java.lang.String>" = lambda (%4 : java.type:"java.lang.String")java.type:"void" -> {
+                    %5 : Var<java.type:"java.lang.String"> = var %4 @"x$0";
+                    %6 : java.type:"java.io.PrintStream" = var.load %2;
+                    %7 : java.type:"java.lang.String" = var.load %5;
+                    invoke %6 %7 @"java.io.PrintStream::println(java.lang.String):void";
                     return;
                 };
-                %8 : Var<java.util.function.Consumer<java.lang.String>> = var %3 @"c3";
+                %8 : Var<java.type:"java.util.function.Consumer<java.lang.String>"> = var %3 @"c3";
                 return;
             };
             """)
@@ -149,15 +149,15 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.Function<java.lang.Integer, MethodReferenceTest$X> = lambda (%2 : java.lang.Integer)MethodReferenceTest$X -> {
-                    %3 : Var<java.lang.Integer> = var %2 @"x$0";
-                    %4 : java.lang.Integer = var.load %3;
-                    %5 : int = invoke %4 @"java.lang.Integer::intValue()int";
-                    %6 : MethodReferenceTest$X = new %5 @"MethodReferenceTest$X::<new>(int)";
+            func @"test6" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Function<java.lang.Integer, MethodReferenceTest$X>" = lambda (%2 : java.type:"java.lang.Integer")java.type:"MethodReferenceTest$X" -> {
+                    %3 : Var<java.type:"java.lang.Integer"> = var %2 @"x$0";
+                    %4 : java.type:"java.lang.Integer" = var.load %3;
+                    %5 : java.type:"int" = invoke %4 @"java.lang.Integer::intValue():int";
+                    %6 : java.type:"MethodReferenceTest$X" = new %5 @"MethodReferenceTest$X::(int)";
                     return %6;
                 };
-                %7 : Var<java.util.function.Function<java.lang.Integer, MethodReferenceTest$X>> = var %1 @"xNew";
+                %7 : Var<java.type:"java.util.function.Function<java.lang.Integer, MethodReferenceTest$X>"> = var %1 @"xNew";
                 return;
             };
             """)
@@ -167,12 +167,12 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>> = lambda ()MethodReferenceTest$A<java.lang.String> -> {
-                    %2 : MethodReferenceTest$A<java.lang.String> = new %0 @"MethodReferenceTest$A::<new>(MethodReferenceTest)";
+            func @"test7" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>>" = lambda ()java.type:"MethodReferenceTest$A<java.lang.String>" -> {
+                    %2 : java.type:"MethodReferenceTest$A<java.lang.String>" = new %0 @"MethodReferenceTest$A::(MethodReferenceTest)";
                     return %2;
                 };
-                %3 : Var<java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>>> = var %1 @"aNew";
+                %3 : Var<java.type:"java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>>"> = var %1 @"aNew";
                 return;
             };
             """)
@@ -182,14 +182,14 @@ public class MethodReferenceTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]> = lambda (%2 : int)MethodReferenceTest$A<java.lang.String>[] -> {
-                    %3 : Var<int> = var %2 @"x$0";
-                    %4 : int = var.load %3;
-                    %5 : MethodReferenceTest$A[] = new %4 @"MethodReferenceTest$A[]::<new>(int)";
+            func @"test8" (%0 : java.type:"MethodReferenceTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]>" = lambda (%2 : java.type:"int")java.type:"MethodReferenceTest$A<java.lang.String>[]" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"x$0";
+                    %4 : java.type:"int" = var.load %3;
+                    %5 : java.type:"MethodReferenceTest$A[]" = new %4 @"MethodReferenceTest$A[]::(int)";
                     return %5;
                 };
-                %6 : Var<java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]>> = var %1 @"aNewArray";
+                %6 : Var<java.type:"java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]>"> = var %1 @"aNewArray";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/MethodReferenceTest.java
+++ b/test/langtools/tools/javac/reflect/MethodReferenceTest.java
@@ -106,13 +106,13 @@ public class MethodReferenceTest {
     @IR("""
             func @"test4" (%0 : MethodReferenceTest)void -> {
                 %1 : java.lang.String = constant @"s";
-                %2 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = invoke %0 %1 @"MethodReferenceTest::a(java.lang.Object).<MethodReferenceTest, MethodReferenceTest$A>";
-                %3 : Var<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>> = var %2 @"rec$";
+                %2 : MethodReferenceTest$A<java.lang.String> = invoke %0 %1 @"MethodReferenceTest::a(java.lang.Object)MethodReferenceTest$A";
+                %3 : Var<MethodReferenceTest$A<java.lang.String>> = var %2 @"rec$";
                 %4 : java.util.function.Function<java.lang.String, java.lang.String> = lambda (%5 : java.lang.String)java.lang.String -> {
                     %6 : Var<java.lang.String> = var %5 @"x$0";
-                    %7 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = var.load %3;
+                    %7 : MethodReferenceTest$A<java.lang.String> = var.load %3;
                     %8 : java.lang.String = var.load %6;
-                    %9 : java.lang.String = invoke %7 %8 @".<MethodReferenceTest, MethodReferenceTest$A>::m(java.lang.Object)java.lang.Object";
+                    %9 : java.lang.String = invoke %7 %8 @"MethodReferenceTest$A::m(java.lang.Object)java.lang.Object";
                     return %9;
                 };
                 %10 : Var<java.util.function.Function<java.lang.String, java.lang.String>> = var %4 @"f";
@@ -168,11 +168,11 @@ public class MethodReferenceTest {
     @CodeReflection
     @IR("""
             func @"test7" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.Supplier<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>> = lambda ().<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> -> {
-                    %2 : .<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>> = new %0 @".<MethodReferenceTest, MethodReferenceTest$A>::<new>(MethodReferenceTest)";
+                %1 : java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>> = lambda ()MethodReferenceTest$A<java.lang.String> -> {
+                    %2 : MethodReferenceTest$A<java.lang.String> = new %0 @"MethodReferenceTest$A::<new>(MethodReferenceTest)";
                     return %2;
                 };
-                %3 : Var<java.util.function.Supplier<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>>> = var %1 @"aNew";
+                %3 : Var<java.util.function.Supplier<MethodReferenceTest$A<java.lang.String>>> = var %1 @"aNew";
                 return;
             };
             """)
@@ -183,13 +183,13 @@ public class MethodReferenceTest {
     @CodeReflection
     @IR("""
             func @"test8" (%0 : MethodReferenceTest)void -> {
-                %1 : java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>[]> = lambda (%2 : int).<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>[] -> {
+                %1 : java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]> = lambda (%2 : int)MethodReferenceTest$A<java.lang.String>[] -> {
                     %3 : Var<int> = var %2 @"x$0";
                     %4 : int = var.load %3;
-                    %5 : .<MethodReferenceTest, MethodReferenceTest$A>[] = new %4 @".<MethodReferenceTest, MethodReferenceTest$A>[]::<new>(int)";
+                    %5 : MethodReferenceTest$A[] = new %4 @"MethodReferenceTest$A[]::<new>(int)";
                     return %5;
                 };
-                %6 : Var<java.util.function.IntFunction<.<MethodReferenceTest, MethodReferenceTest$A<java.lang.String>>[]>> = var %1 @"aNewArray";
+                %6 : Var<java.util.function.IntFunction<MethodReferenceTest$A<java.lang.String>[]>> = var %1 @"aNewArray";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/NewArrayTest.java
+++ b/test/langtools/tools/javac/reflect/NewArrayTest.java
@@ -37,10 +37,10 @@ public class NewArrayTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : NewArrayTest)void -> {
-                %1 : int = constant @"10";
-                %2 : int[] = new %1 @"int[]::<new>(int)";
-                %3 : Var<int[]> = var %2 @"a";
+            func @"test1" (%0 : java.type:"NewArrayTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"10";
+                %2 : java.type:"int[]" = new %1 @"int[]::(int)";
+                %3 : Var<java.type:"int[]"> = var %2 @"a";
                 return;
             };
             """)
@@ -50,13 +50,13 @@ public class NewArrayTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : NewArrayTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"l";
-                %3 : int = var.load %2;
-                %4 : int = constant @"10";
-                %5 : int = add %3 %4;
-                %6 : int[] = new %5 @"int[]::<new>(int)";
-                %7 : Var<int[]> = var %6 @"a";
+            func @"test2" (%0 : java.type:"NewArrayTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"l";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = constant @"10";
+                %5 : java.type:"int" = add %3 %4;
+                %6 : java.type:"int[]" = new %5 @"int[]::(int)";
+                %7 : Var<java.type:"int[]"> = var %6 @"a";
                 return;
             };
             """)
@@ -66,10 +66,10 @@ public class NewArrayTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : NewArrayTest)void -> {
-                %1 : int = constant @"10";
-                %2 : java.lang.String[] = new %1 @"java.lang.String[]::<new>(int)";
-                %3 : Var<java.lang.String[]> = var %2 @"a";
+            func @"test3" (%0 : java.type:"NewArrayTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"10";
+                %2 : java.type:"java.lang.String[]" = new %1 @"java.lang.String[]::(int)";
+                %3 : Var<java.type:"java.lang.String[]"> = var %2 @"a";
                 return;
             };
             """)
@@ -79,10 +79,10 @@ public class NewArrayTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : NewArrayTest)void -> {
-                %1 : int = constant @"10";
-                %2 : java.lang.String[][] = new %1 @"java.lang.String[][]::<new>(int)";
-                %3 : Var<java.lang.String[][]> = var %2 @"a";
+            func @"test4" (%0 : java.type:"NewArrayTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"10";
+                %2 : java.type:"java.lang.String[][]" = new %1 @"java.lang.String[][]::(int)";
+                %3 : Var<java.type:"java.lang.String[][]"> = var %2 @"a";
                 return;
             };
             """)
@@ -92,11 +92,11 @@ public class NewArrayTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : NewArrayTest)void -> {
-                %1 : int = constant @"10";
-                %2 : int = constant @"10";
-                %3 : java.lang.String[][] = new %1 %2 @"java.lang.String[][]::<new>(int, int)";
-                %4 : Var<java.lang.String[][]> = var %3 @"a";
+            func @"test5" (%0 : java.type:"NewArrayTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"10";
+                %2 : java.type:"int" = constant @"10";
+                %3 : java.type:"java.lang.String[][]" = new %1 %2 @"java.lang.String[][]::(int, int)";
+                %4 : Var<java.type:"java.lang.String[][]"> = var %3 @"a";
                 return;
             };
             """)
@@ -106,30 +106,30 @@ public class NewArrayTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : NewArrayTest)void -> {
-                %1 : int = constant @"3";
-                %2 : java.lang.String[][] = new %1 @"java.lang.String[][]::<new>(int)";
-                %3 : int = constant @"2";
-                %4 : java.lang.String[] = new %3 @"java.lang.String[]::<new>(int)";
-                %5 : java.lang.String = constant @"one";
-                %6 : int = constant @"0";
+            func @"test6" (%0 : java.type:"NewArrayTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"3";
+                %2 : java.type:"java.lang.String[][]" = new %1 @"java.lang.String[][]::(int)";
+                %3 : java.type:"int" = constant @"2";
+                %4 : java.type:"java.lang.String[]" = new %3 @"java.lang.String[]::(int)";
+                %5 : java.type:"java.lang.String" = constant @"one";
+                %6 : java.type:"int" = constant @"0";
                 array.store %4 %6 %5;
-                %7 : java.lang.String = constant @"two";
-                %8 : int = constant @"1";
+                %7 : java.type:"java.lang.String" = constant @"two";
+                %8 : java.type:"int" = constant @"1";
                 array.store %4 %8 %7;
-                %9 : int = constant @"0";
+                %9 : java.type:"int" = constant @"0";
                 array.store %2 %9 %4;
-                %10 : int = constant @"1";
-                %11 : java.lang.String[] = new %10 @"java.lang.String[]::<new>(int)";
-                %12 : java.lang.String = constant @"three";
-                %13 : int = constant @"0";
+                %10 : java.type:"int" = constant @"1";
+                %11 : java.type:"java.lang.String[]" = new %10 @"java.lang.String[]::(int)";
+                %12 : java.type:"java.lang.String" = constant @"three";
+                %13 : java.type:"int" = constant @"0";
                 array.store %11 %13 %12;
-                %14 : int = constant @"1";
+                %14 : java.type:"int" = constant @"1";
                 array.store %2 %14 %11;
-                %15 : java.lang.String[] = constant @null;
-                %16 : int = constant @"2";
+                %15 : java.type:"java.lang.String[]" = constant @null;
+                %16 : java.type:"int" = constant @"2";
                 array.store %2 %16 %15;
-                %17 : Var<java.lang.String[][]> = var %2 @"a";
+                %17 : Var<java.type:"java.lang.String[][]"> = var %2 @"a";
                 return;
             };
             """)
@@ -139,30 +139,30 @@ public class NewArrayTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : NewArrayTest)void -> {
-                %1 : int = constant @"3";
-                %2 : java.lang.String[][] = new %1 @"java.lang.String[][]::<new>(int)";
-                %3 : int = constant @"2";
-                %4 : java.lang.String[] = new %3 @"java.lang.String[]::<new>(int)";
-                %5 : java.lang.String = constant @"one";
-                %6 : int = constant @"0";
+            func @"test7" (%0 : java.type:"NewArrayTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"3";
+                %2 : java.type:"java.lang.String[][]" = new %1 @"java.lang.String[][]::(int)";
+                %3 : java.type:"int" = constant @"2";
+                %4 : java.type:"java.lang.String[]" = new %3 @"java.lang.String[]::(int)";
+                %5 : java.type:"java.lang.String" = constant @"one";
+                %6 : java.type:"int" = constant @"0";
                 array.store %4 %6 %5;
-                %7 : java.lang.String = constant @"two";
-                %8 : int = constant @"1";
+                %7 : java.type:"java.lang.String" = constant @"two";
+                %8 : java.type:"int" = constant @"1";
                 array.store %4 %8 %7;
-                %9 : int = constant @"0";
+                %9 : java.type:"int" = constant @"0";
                 array.store %2 %9 %4;
-                %10 : int = constant @"1";
-                %11 : java.lang.String[] = new %10 @"java.lang.String[]::<new>(int)";
-                %12 : java.lang.String = constant @"three";
-                %13 : int = constant @"0";
+                %10 : java.type:"int" = constant @"1";
+                %11 : java.type:"java.lang.String[]" = new %10 @"java.lang.String[]::(int)";
+                %12 : java.type:"java.lang.String" = constant @"three";
+                %13 : java.type:"int" = constant @"0";
                 array.store %11 %13 %12;
-                %14 : int = constant @"1";
+                %14 : java.type:"int" = constant @"1";
                 array.store %2 %14 %11;
-                %15 : java.lang.String[] = constant @null;
-                %16 : int = constant @"2";
+                %15 : java.type:"java.lang.String[]" = constant @null;
+                %16 : java.type:"int" = constant @"2";
                 array.store %2 %16 %15;
-                %17 : Var<java.lang.String[][]> = var %2 @"a";
+                %17 : Var<java.type:"java.lang.String[][]"> = var %2 @"a";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -97,8 +97,8 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test3" (%0 : NewTest)void -> {
-                %1 : .<NewTest, NewTest$B> = new %0 @".<NewTest, NewTest$B>::<new>(NewTest)";
-                %2 : Var<.<NewTest, NewTest$B>> = var %1 @"b";
+                %1 : NewTest$B = new %0 @"NewTest$B::<new>(NewTest)";
+                %2 : Var<NewTest$B> = var %1 @"b";
                 return;
             };
             """)
@@ -111,8 +111,8 @@ public class NewTest {
             func @"test4" (%0 : NewTest)void -> {
                 %1 : int = constant @"1";
                 %2 : int = constant @"2";
-                %3 : .<NewTest, NewTest$B> = new %0 %1 %2 @".<NewTest, NewTest$B>::<new>(NewTest, int, int)";
-                %4 : Var<.<NewTest, NewTest$B>> = var %3 @"b";
+                %3 : NewTest$B = new %0 %1 %2 @"NewTest$B::<new>(NewTest, int, int)";
+                %4 : Var<NewTest$B> = var %3 @"b";
                 return;
             };
             """)
@@ -123,8 +123,8 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test5" (%0 : NewTest)void -> {
-                %1 : .<NewTest, NewTest$B> = new %0 @".<NewTest, NewTest$B>::<new>(NewTest)";
-                %2 : Var<.<NewTest, NewTest$B>> = var %1 @"b";
+                %1 : NewTest$B = new %0 @"NewTest$B::<new>(NewTest)";
+                %2 : Var<NewTest$B> = var %1 @"b";
                 return;
             };
             """)
@@ -135,9 +135,9 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test6" (%0 : NewTest)void -> {
-                %1 : .<NewTest, NewTest$B> = field.load %0 @"NewTest::f().<NewTest, NewTest$B>";
-                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @".<.<NewTest, NewTest$B>, NewTest$B$C>::<new>(.<NewTest, NewTest$B>)";
-                %3 : Var<.<.<NewTest, NewTest$B>, NewTest$B$C>> = var %2 @"c";
+                %1 : NewTest$B = field.load %0 @"NewTest::f()NewTest$B";
+                %2 : NewTest$B$C = new %1 @"NewTest$B$C::<new>(NewTest$B)";
+                %3 : Var<NewTest$B$C> = var %2 @"c";
                 return;
             };
             """)
@@ -148,9 +148,9 @@ public class NewTest {
     @CodeReflection
     @IR("""
             func @"test7" (%0 : NewTest)void -> {
-                %1 : .<NewTest, NewTest$B> = invoke %0 @"NewTest::b().<NewTest, NewTest$B>";
-                %2 : .<.<NewTest, NewTest$B>, NewTest$B$C> = new %1 @".<.<NewTest, NewTest$B>, NewTest$B$C>::<new>(.<NewTest, NewTest$B>)";
-                %3 : Var<.<.<NewTest, NewTest$B>, NewTest$B$C>> = var %2 @"c";
+                %1 : NewTest$B = invoke %0 @"NewTest::b()NewTest$B";
+                %2 : NewTest$B$C = new %1 @"NewTest$B$C::<new>(NewTest$B)";
+                %3 : Var<NewTest$B$C> = var %2 @"c";
                 return;
             };
             """)
@@ -190,10 +190,10 @@ public class NewTest {
                 %3 : Var<java.util.List<java.lang.String>> = var %1 @"l1";
                 %4 : Var<java.util.List<java.lang.Number>> = var %2 @"l2";
                 %5 : java.util.List<java.lang.String> = var.load %3;
-                %6 : .<NewTest, NewTest$BG<java.lang.String>> = new %0 %5 @".<NewTest, NewTest$BG>::<new>(NewTest, java.util.List)";
+                %6 : NewTest$BG<java.lang.String> = new %0 %5 @"NewTest$BG::<new>(NewTest, java.util.List)";
                 %7 : java.util.List<java.lang.Number> = var.load %4;
-                %8 : .<.<NewTest, NewTest$BG<java.lang.String>>, NewTest$BG$CG<java.lang.Number>> = new %6 %7 @".<.<NewTest, NewTest$BG>, NewTest$BG$CG>::<new>(.<NewTest, NewTest$BG<java.lang.String>>, java.util.List)";
-                %9 : Var<.<.<NewTest, NewTest$BG<java.lang.String>>, NewTest$BG$CG<java.lang.Number>>> = var %8 @"numberCG";
+                %8 : NewTest$BG<java.lang.String>$CG<java.lang.Number> = new %6 %7 @"NewTest$BG$CG::<new>(NewTest$BG<java.lang.String>, java.util.List)";
+                %9 : Var<NewTest$BG<java.lang.String>$CG<java.lang.Number>> = var %8 @"numberCG";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -38,10 +38,10 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test0" (%0 : NewTest)void -> {
-                %1 : java.lang.String = constant @"1";
-                %2 : java.math.BigDecimal = new %1 @"java.math.BigDecimal::<new>(java.lang.String)";
-                %3 : Var<java.math.BigDecimal> = var %2 @"a";
+            func @"test0" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @"1";
+                %2 : java.type:"java.math.BigDecimal" = new %1 @"java.math.BigDecimal::(java.lang.String)";
+                %3 : Var<java.type:"java.math.BigDecimal"> = var %2 @"a";
                 return;
             };
             """)
@@ -57,9 +57,9 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : NewTest)void -> {
-                %1 : NewTest$A = new @"NewTest$A::<new>()";
-                %2 : Var<NewTest$A> = var %1 @"a";
+            func @"test1" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"NewTest$A" = new @"NewTest$A::()";
+                %2 : Var<java.type:"NewTest$A"> = var %1 @"a";
                 return;
             };
             """)
@@ -69,11 +69,11 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : NewTest)void -> {
-                %1 : int = constant @"1";
-                %2 : int = constant @"2";
-                %3 : NewTest$A = new %1 %2 @"NewTest$A::<new>(int, int)";
-                %4 : Var<NewTest$A> = var %3 @"a";
+            func @"test2" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"NewTest$A" = new %1 %2 @"NewTest$A::(int, int)";
+                %4 : Var<java.type:"NewTest$A"> = var %3 @"a";
                 return;
             };
             """)
@@ -96,9 +96,9 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : NewTest)void -> {
-                %1 : NewTest$B = new %0 @"NewTest$B::<new>(NewTest)";
-                %2 : Var<NewTest$B> = var %1 @"b";
+            func @"test3" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"NewTest$B" = new %0 @"NewTest$B::(NewTest)";
+                %2 : Var<java.type:"NewTest$B"> = var %1 @"b";
                 return;
             };
             """)
@@ -108,11 +108,11 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : NewTest)void -> {
-                %1 : int = constant @"1";
-                %2 : int = constant @"2";
-                %3 : NewTest$B = new %0 %1 %2 @"NewTest$B::<new>(NewTest, int, int)";
-                %4 : Var<NewTest$B> = var %3 @"b";
+            func @"test4" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"1";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"NewTest$B" = new %0 %1 %2 @"NewTest$B::(NewTest, int, int)";
+                %4 : Var<java.type:"NewTest$B"> = var %3 @"b";
                 return;
             };
             """)
@@ -122,9 +122,9 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : NewTest)void -> {
-                %1 : NewTest$B = new %0 @"NewTest$B::<new>(NewTest)";
-                %2 : Var<NewTest$B> = var %1 @"b";
+            func @"test5" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"NewTest$B" = new %0 @"NewTest$B::(NewTest)";
+                %2 : Var<java.type:"NewTest$B"> = var %1 @"b";
                 return;
             };
             """)
@@ -134,10 +134,10 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : NewTest)void -> {
-                %1 : NewTest$B = field.load %0 @"NewTest::f()NewTest$B";
-                %2 : NewTest$B$C = new %1 @"NewTest$B$C::<new>(NewTest$B)";
-                %3 : Var<NewTest$B$C> = var %2 @"c";
+            func @"test6" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"NewTest$B" = field.load %0 @"NewTest::f:NewTest$B";
+                %2 : java.type:"NewTest$B$C" = new %1 @"NewTest$B$C::(NewTest$B)";
+                %3 : Var<java.type:"NewTest$B$C"> = var %2 @"c";
                 return;
             };
             """)
@@ -147,10 +147,10 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : NewTest)void -> {
-                %1 : NewTest$B = invoke %0 @"NewTest::b()NewTest$B";
-                %2 : NewTest$B$C = new %1 @"NewTest$B$C::<new>(NewTest$B)";
-                %3 : Var<NewTest$B$C> = var %2 @"c";
+            func @"test7" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"NewTest$B" = invoke %0 @"NewTest::b():NewTest$B";
+                %2 : java.type:"NewTest$B$C" = new %1 @"NewTest$B$C::(NewTest$B)";
+                %3 : Var<java.type:"NewTest$B$C"> = var %2 @"c";
                 return;
             };
             """)
@@ -164,11 +164,11 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : NewTest, %1 : java.util.List<java.lang.String>)void -> {
-                %2 : Var<java.util.List<java.lang.String>> = var %1 @"l";
-                %3 : java.util.List<java.lang.String> = var.load %2;
-                %4 : NewTest$AG<java.lang.String> = new %3 @"NewTest$AG::<new>(java.util.List)";
-                %5 : Var<NewTest$AG<java.lang.String>> = var %4 @"a";
+            func @"test8" (%0 : java.type:"NewTest", %1 : java.type:"java.util.List<java.lang.String>")java.type:"void" -> {
+                %2 : Var<java.type:"java.util.List<java.lang.String>"> = var %1 @"l";
+                %3 : java.type:"java.util.List<java.lang.String>" = var.load %2;
+                %4 : java.type:"NewTest$AG<java.lang.String>" = new %3 @"NewTest$AG::(java.util.List)";
+                %5 : Var<java.type:"NewTest$AG<java.lang.String>"> = var %4 @"a";
                 return;
             };
             """)
@@ -186,16 +186,16 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : NewTest, %1 : java.util.List<java.lang.String>, %2 : java.util.List<java.lang.Number>)void -> {
-                %3 : Var<java.util.List<java.lang.String>> = var %1 @"l1";
-                %4 : Var<java.util.List<java.lang.Number>> = var %2 @"l2";
-                %5 : java.util.List<java.lang.String> = var.load %3;
-                %6 : NewTest$BG<java.lang.String> = new %0 %5 @"NewTest$BG::<new>(NewTest, java.util.List)";
-                %7 : java.util.List<java.lang.Number> = var.load %4;
-                %8 : NewTest$BG<java.lang.String>$CG<java.lang.Number> = new %6 %7 @"NewTest$BG$CG::<new>(NewTest$BG<java.lang.String>, java.util.List)";
-                %9 : Var<NewTest$BG<java.lang.String>$CG<java.lang.Number>> = var %8 @"numberCG";
-                return;
-            };
+            func @"test9" (%0 : java.type:"NewTest", %1 : java.type:"java.util.List<java.lang.String>", %2 : java.type:"java.util.List<java.lang.Number>")java.type:"void" -> {
+                  %3 : Var<java.type:"java.util.List<java.lang.String>"> = var %1 @"l1";
+                  %4 : Var<java.type:"java.util.List<java.lang.Number>"> = var %2 @"l2";
+                  %5 : java.type:"java.util.List<java.lang.String>" = var.load %3;
+                  %6 : java.type:"NewTest$BG<java.lang.String>" = new %0 %5 @"NewTest$BG::(NewTest, java.util.List)";
+                  %7 : java.type:"java.util.List<java.lang.Number>" = var.load %4;
+                  %8 : java.type:"NewTest$BG<java.lang.String>$CG<java.lang.Number>" = new %6 %7 @"NewTest$BG$CG::(NewTest$BG<java.lang.String>, java.util.List)";
+                  %9 : Var<java.type:"NewTest$BG<java.lang.String>$CG<java.lang.Number>"> = var %8 @"numberCG";
+                  return;
+              };
             """)
     void test9(List<String> l1, List<Number> l2) {
         BG<String>.CG<Number> numberCG = new BG<String>(l1).new CG<Number>(l2);
@@ -204,10 +204,10 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0 : NewTest)void -> {
-                %1 : int = constant @"10";
-                %2 : int[] = new %1 @"int[]::<new>(int)";
-                %3 : Var<int[]> = var %2 @"i";
+            func @"test10" (%0 : java.type:"NewTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"10";
+                %2 : java.type:"int[]" = new %1 @"int[]::(int)";
+                %3 : Var<java.type:"int[]"> = var %2 @"i";
                 return;
             };
             """)
@@ -217,17 +217,17 @@ public class NewTest {
 
     @CodeReflection
     @IR("""
-            func @"test11" (%0 : NewTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = var.load %2;
-                %4 : int = var.load %2;
-                %5 : int = constant @"1";
-                %6 : int = add %4 %5;
-                %7 : int = var.load %2;
-                %8 : int = constant @"2";
-                %9 : int = add %7 %8;
-                %10 : java.lang.String[][][] = new %3 %6 %9 @"java.lang.String[][][]::<new>(int, int, int)";
-                %11 : Var<java.lang.String[][][]> = var %10 @"s";
+            func @"test11" (%0 : java.type:"NewTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"int" = var.load %2;
+                %5 : java.type:"int" = constant @"1";
+                %6 : java.type:"int" = add %4 %5;
+                %7 : java.type:"int" = var.load %2;
+                %8 : java.type:"int" = constant @"2";
+                %9 : java.type:"int" = add %7 %8;
+                %10 : java.type:"java.lang.String[][][]" = new %3 %6 %9 @"java.lang.String[][][]::(int, int, int)";
+                %11 : Var<java.type:"java.lang.String[][][]"> = var %10 @"s";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/NullTest.java
+++ b/test/langtools/tools/javac/reflect/NullTest.java
@@ -39,9 +39,9 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : NullTest)void -> {
-                %1 : java.lang.String = constant @null;
-                %2 : Var<java.lang.String> = var %1 @"s";
+            func @"test1" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
                 return;
             };
             """)
@@ -51,10 +51,10 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : NullTest)void -> {
-                %1 : java.lang.Object = constant @null;
-                %2 : java.lang.String = cast %1 @"java.lang.String";
-                %3 : Var<java.lang.String> = var %2 @"s";
+            func @"test2" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Object" = constant @null;
+                %2 : java.type:"java.lang.String" = cast %1 @"java.lang.String";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"s";
                 return;
             };
             """)
@@ -64,19 +64,19 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : NullTest, %1 : boolean)java.lang.String -> {
-                %2 : Var<boolean> = var %1 @"cond";
-                %3 : java.lang.String = java.cexpression
-                    ^cond()boolean -> {
-                        %4 : boolean = var.load %2;
+            func @"test3" (%0 : java.type:"NullTest", %1 : java.type:"boolean")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = var.load %2;
                         yield %4;
                     }
-                    ^truepart()java.lang.String -> {
-                        %5 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %5 : java.type:"java.lang.String" = constant @null;
                         yield %5;
                     }
-                    ^falsepart()java.lang.String -> {
-                        %6 : java.lang.String = constant @"";
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"java.lang.String" = constant @"";
                         yield %6;
                     };
                 return %3;
@@ -88,19 +88,19 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : NullTest, %1 : boolean)java.lang.String -> {
-                %2 : Var<boolean> = var %1 @"cond";
-                %3 : java.lang.String = java.cexpression
-                    ^cond()boolean -> {
-                        %4 : boolean = var.load %2;
+            func @"test4" (%0 : java.type:"NullTest", %1 : java.type:"boolean")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = var.load %2;
                         yield %4;
                     }
-                    ^truepart()java.lang.String -> {
-                        %5 : java.lang.String = constant @"";
+                    ()java.type:"java.lang.String" -> {
+                        %5 : java.type:"java.lang.String" = constant @"";
                         yield %5;
                     }
-                    ^falsepart()java.lang.String -> {
-                        %6 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"java.lang.String" = constant @null;
                         yield %6;
                     };
                 return %3;
@@ -112,19 +112,19 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : NullTest, %1 : boolean)java.lang.String -> {
-                %2 : Var<boolean> = var %1 @"cond";
-                %3 : java.lang.String = java.cexpression
-                    ^cond()boolean -> {
-                        %4 : boolean = var.load %2;
+            func @"test5" (%0 : java.type:"NullTest", %1 : java.type:"boolean")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = var.load %2;
                         yield %4;
                     }
-                    ^truepart()java.lang.String -> {
-                        %5 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %5 : java.type:"java.lang.String" = constant @null;
                         yield %5;
                     }
-                    ^falsepart()java.lang.String -> {
-                        %6 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"java.lang.String" = constant @null;
                         yield %6;
                     };
                 return %3;
@@ -136,22 +136,22 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : NullTest, %1 : boolean)java.lang.String -> {
-                %2 : Var<boolean> = var %1 @"cond";
-                %3 : java.lang.Object = java.cexpression
-                    ^cond()boolean -> {
-                        %4 : boolean = var.load %2;
+            func @"test6" (%0 : java.type:"NullTest", %1 : java.type:"boolean")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"boolean"> = var %1 @"cond";
+                %3 : java.type:"java.lang.Object" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"boolean" = var.load %2;
                         yield %4;
                     }
-                    ^truepart()java.lang.Object -> {
-                        %5 : java.lang.Object = constant @null;
+                    ()java.type:"java.lang.Object" -> {
+                        %5 : java.type:"java.lang.Object" = constant @null;
                         yield %5;
                     }
-                    ^falsepart()java.lang.Object -> {
-                        %6 : java.lang.Object = constant @null;
+                    ()java.type:"java.lang.Object" -> {
+                        %6 : java.type:"java.lang.Object" = constant @null;
                         yield %6;
                     };
-                %7 : java.lang.String = cast %3 @"java.lang.String";
+                %7 : java.type:"java.lang.String" = cast %3 @"java.lang.String";
                 return %7;
             };
             """)
@@ -161,26 +161,26 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.String = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test7" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.String" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @"";
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"java.lang.String" = constant @"";
                         yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @null;
-                        yield %9;
+                    ()java.type:"java.lang.String" -> {
+                        %10 : java.type:"java.lang.String" = constant @null;
+                        yield %10;
                     };
                 return %4;
             };
@@ -194,26 +194,26 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test8" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.String = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test8" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.String" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"java.lang.String" = constant @null;
                         yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @"";
-                        yield %9;
+                    ()java.type:"java.lang.String" -> {
+                        %10 : java.type:"java.lang.String" = constant @"";
+                        yield %10;
                     };
                 return %4;
             };
@@ -227,26 +227,26 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test9" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.String = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test9" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.String" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"java.lang.String" = constant @null;
                         yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @null;
-                        yield %9;
+                    ()java.type:"java.lang.String" -> {
+                        %10 : java.type:"java.lang.String" = constant @null;
+                        yield %10;
                     };
                 return %4;
             };
@@ -260,29 +260,29 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test10" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.Object = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test10" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.Object" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.Object -> {
-                        %8 : java.lang.Object = constant @null;
+                    ()java.type:"java.lang.Object" -> {
+                        %8 : java.type:"java.lang.Object" = constant @null;
                         yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.Object -> {
-                        %9 : java.lang.Object = constant @null;
-                        yield %9;
+                    ()java.type:"java.lang.Object" -> {
+                        %10 : java.type:"java.lang.Object" = constant @null;
+                        yield %10;
                     };
-                %10 : java.lang.String = cast %4 @"java.lang.String";
-                return %10;
+                %11 : java.type:"java.lang.String" = cast %4 @"java.lang.String";
+                return %11;
             };
             """)
     String test10(int cond) {
@@ -294,26 +294,26 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test11" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.String = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test11" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.String" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @"";
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"java.lang.String" = constant @"";
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @null;
-                        java.yield %9;
+                    ()java.type:"java.lang.String" -> {
+                        %10 : java.type:"java.lang.String" = constant @null;
+                        java.yield %10;
                     };
                 return %4;
             };
@@ -327,26 +327,26 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test12" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.String = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test12" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.String" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"java.lang.String" = constant @null;
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @"";
-                        java.yield %9;
+                    ()java.type:"java.lang.String" -> {
+                        %10 : java.type:"java.lang.String" = constant @"";
+                        java.yield %10;
                     };
                 return %4;
             };
@@ -360,26 +360,26 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test13" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.String = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test13" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.String" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @null;
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"java.lang.String" = constant @null;
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @null;
-                        java.yield %9;
+                    ()java.type:"java.lang.String" -> {
+                        %10 : java.type:"java.lang.String" = constant @null;
+                        java.yield %10;
                     };
                 return %4;
             };
@@ -393,29 +393,29 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test14" (%0 : NullTest, %1 : int)java.lang.String -> {
-                %2 : Var<int> = var %1 @"cond";
-                %3 : int = var.load %2;
-                %4 : java.lang.Object = java.switch.expression %3
-                    ^constantCaseLabel(%5 : int)boolean -> {
-                        %6 : int = constant @"1";
-                        %7 : boolean = eq %5 %6;
+            func @"test14" (%0 : java.type:"NullTest", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"int"> = var %1 @"cond";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"java.lang.Object" = java.switch.expression %3
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
                         yield %7;
                     }
-                    ()java.lang.Object -> {
-                        %8 : java.lang.Object = constant @null;
+                    ()java.type:"java.lang.Object" -> {
+                        %8 : java.type:"java.lang.Object" = constant @null;
                         java.yield %8;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %9 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
                         yield %9;
                     }
-                    ()java.lang.Object -> {
-                        %9 : java.lang.Object = constant @null;
-                        java.yield %9;
+                    ()java.type:"java.lang.Object" -> {
+                        %10 : java.type:"java.lang.Object" = constant @null;
+                        java.yield %10;
                     };
-                %10 : java.lang.String = cast %4 @"java.lang.String";
-                return %10;
+                %11 : java.type:"java.lang.String" = cast %4 @"java.lang.String";
+                return %11;
             };
             """)
     String test14(int cond) {
@@ -427,9 +427,9 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test15" (%0 : NullTest)java.util.function.Supplier<java.lang.String> -> {
-                %1 : java.util.function.Supplier<java.lang.String> = lambda ()java.lang.String -> {
-                    %2 : java.lang.String = constant @null;
+            func @"test15" (%0 : java.type:"NullTest")java.type:"java.util.function.Supplier<java.lang.String>" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.String>" = lambda ()java.type:"java.lang.String" -> {
+                    %2 : java.type:"java.lang.String" = constant @null;
                     return %2;
                 };
                 return %1;
@@ -443,9 +443,9 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test16" (%0 : NullTest)void -> {
-                %1 : java.lang.String = constant @null;
-                invoke %1 @invoke.kind="STATIC" @invoke.varargs="true" @"NullTest::m(java.lang.String, java.lang.String[])void";
+            func @"test16" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                invoke %1 @"NullTest::m(java.lang.String, java.lang.String[]):void" @invoke.kind="STATIC" @invoke.varargs="true";
                 return;
             };
             """)
@@ -455,10 +455,10 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test17" (%0 : NullTest)void -> {
-                %1 : java.lang.String = constant @null;
-                %2 : java.lang.String[] = constant @null;
-                invoke %1 %2 @invoke.kind="STATIC" @invoke.varargs="false" @"NullTest::m(java.lang.String, java.lang.String[])void";
+            func @"test17" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                %2 : java.type:"java.lang.String[]" = constant @null;
+                invoke %1 %2 @"NullTest::m(java.lang.String, java.lang.String[]):void";
                 return;
             };
             """)
@@ -468,11 +468,11 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test18" (%0 : NullTest)void -> {
-                %1 : java.lang.String = constant @null;
-                %2 : java.lang.String = constant @null;
-                %3 : java.lang.String = constant @null;
-                invoke %1 %2 %3 @invoke.kind="STATIC" @invoke.varargs="true" @"NullTest::m(java.lang.String, java.lang.String[])void";
+            func @"test18" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                %2 : java.type:"java.lang.String" = constant @null;
+                %3 : java.type:"java.lang.String" = constant @null;
+                invoke %1 %2 %3 @"NullTest::m(java.lang.String, java.lang.String[]):void" @invoke.kind="STATIC" @invoke.varargs="true";
                 return;
             };
             """)
@@ -486,9 +486,9 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test19" (%0 : NullTest)void -> {
-                %1 : java.lang.String = constant @null;
-                %2 : NullTest$Box = new %1 @new.varargs="true" @"NullTest$Box::<new>(java.lang.String, java.lang.String[])";
+            func @"test19" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                %2 : java.type:"NullTest$Box" = new %1 @"NullTest$Box::(java.lang.String, java.lang.String[])" @new.varargs="true";
                 return;
             };
             """)
@@ -498,10 +498,10 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test20" (%0 : NullTest)void -> {
-                %1 : java.lang.String = constant @null;
-                %2 : java.lang.String[] = constant @null;
-                %3 : NullTest$Box = new %1 %2 @"NullTest$Box::<new>(java.lang.String, java.lang.String[])";
+            func @"test20" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                %2 : java.type:"java.lang.String[]" = constant @null;
+                %3 : java.type:"NullTest$Box" = new %1 %2 @"NullTest$Box::(java.lang.String, java.lang.String[])";
                 return;
             };
             """)
@@ -511,11 +511,11 @@ public class NullTest {
 
     @CodeReflection
     @IR("""
-            func @"test21" (%0 : NullTest)void -> {
-                %1 : java.lang.String = constant @null;
-                %2 : java.lang.String = constant @null;
-                %3 : java.lang.String = constant @null;
-                %4 : NullTest$Box = new %1 %2 %3 @new.varargs="true" @"NullTest$Box::<new>(java.lang.String, java.lang.String[])";
+            func @"test21" (%0 : java.type:"NullTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @null;
+                %2 : java.type:"java.lang.String" = constant @null;
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : java.type:"NullTest$Box" = new %1 %2 %3 @"NullTest$Box::(java.lang.String, java.lang.String[])" @new.varargs="true";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/PatternTest2.java
+++ b/test/langtools/tools/javac/reflect/PatternTest2.java
@@ -11,18 +11,18 @@ public class PatternTest2 {
     record R<T extends Number> (T n) {}
 
     @IR("""
-            func @"f" (%0 : java.lang.Object)boolean -> {
-                %1 : Var<java.lang.Object> = var %0 @"o";
-                %2 : java.lang.Object = var.load %1;
-                %3 : java.lang.Integer = constant @null;
-                %4 : Var<java.lang.Integer> = var %3 @"i";
-                %5 : boolean = pattern.match %2
-                    ()jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<#T<PatternTest2$R, java.lang.Number>>> -> {
-                        %6 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> = pattern.type @"i";
-                        %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<#T<PatternTest2$R, java.lang.Number>>> = pattern.record %6 @"(#T<PatternTest2$R, java.lang.Number> n)PatternTest2$R<#T<PatternTest2$R, java.lang.Number>>";
+            func @"f" (%0 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.Integer" = constant @null;
+                %4 : Var<java.type:"java.lang.Integer"> = var %3 @"i";
+                %5 : java.type:"boolean" = pattern.match %2
+                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<PatternTest2$R::<T extends java.lang.Number>>>" -> {
+                        %6 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" = pattern.type @"i";
+                        %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternTest2$R<PatternTest2$R::<T extends java.lang.Number>>>" = pattern.record %6 @"(PatternTest2$R::<T extends java.lang.Number> n)PatternTest2$R<PatternTest2$R::<T extends java.lang.Number>>";
                         yield %7;
                     }
-                    (%8 : java.lang.Integer)void -> {
+                    (%8 : java.type:"java.lang.Integer")java.type:"void" -> {
                         var.store %4 %8;
                         yield;
                     };

--- a/test/langtools/tools/javac/reflect/PatternsTest.java
+++ b/test/langtools/tools/javac/reflect/PatternsTest.java
@@ -38,21 +38,21 @@ public class PatternsTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : PatternsTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.Object = var.load %2;
-                %4 : java.lang.String = constant @null;
-                %5 : Var<java.lang.String> = var %4 @"s";
-                %6 : boolean = pattern.match %3
-                    ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                        %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+            func @"test1" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"java.lang.String" = constant @null;
+                %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
+                %6 : java.type:"boolean" = pattern.match %3
+                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                        %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                         yield %7;
                     }
-                    ^match(%8 : java.lang.String)void -> {
+                    (%8 : java.type:"java.lang.String")java.type:"void" -> {
                         var.store %5 %8;
                         yield;
                     };
-                %9 : Var<boolean> = var %6 @"x";
+                %9 : Var<java.type:"boolean"> = var %6 @"x";
                 return;
             };
             """)
@@ -62,30 +62,30 @@ public class PatternsTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : PatternsTest, %1 : java.lang.Object)java.lang.String -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.String = constant @null;
-                %4 : Var<java.lang.String> = var %3 @"s";
+            func @"test2" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"s";
                 java.if
-                    ()boolean -> {
-                        %5 : java.lang.Object = var.load %2;
-                        %6 : boolean = pattern.match %5
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.Object" = var.load %2;
+                        %6 : java.type:"boolean" = pattern.match %5
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                 yield %7;
                             }
-                            ^match(%8 : java.lang.String)void -> {
+                            (%8 : java.type:"java.lang.String")java.type:"void" -> {
                                 var.store %4 %8;
                                 yield;
                             };
                         yield %6;
                     }
-                    ^then()void -> {
-                        %9 : java.lang.String = var.load %4;
+                    ()java.type:"void" -> {
+                        %9 : java.type:"java.lang.String" = var.load %4;
                         return %9;
                     }
-                    ^else()void -> {
-                        %10 : java.lang.String = constant @"";
+                    ()java.type:"void" -> {
+                        %10 : java.type:"java.lang.String" = constant @"";
                         return %10;
                     };
                 unreachable;
@@ -101,33 +101,33 @@ public class PatternsTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : PatternsTest, %1 : java.lang.Object)java.lang.String -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.String = constant @null;
-                %4 : Var<java.lang.String> = var %3 @"s";
+            func @"test3" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"s";
                 java.if
-                    ()boolean -> {
-                        %5 : java.lang.Object = var.load %2;
-                        %6 : boolean = pattern.match %5
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.Object" = var.load %2;
+                        %6 : java.type:"boolean" = pattern.match %5
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                 yield %7;
                             }
-                            ^match(%8 : java.lang.String)void -> {
+                            (%8 : java.type:"java.lang.String")java.type:"void" -> {
                                 var.store %4 %8;
                                 yield;
                             };
-                        %9 : boolean = not %6;
+                        %9 : java.type:"boolean" = not %6;
                         yield %9;
                     }
-                    ^then()void -> {
-                        %10 : java.lang.String = constant @"";
+                    ()java.type:"void" -> {
+                        %10 : java.type:"java.lang.String" = constant @"";
                         return %10;
                     }
-                    ^else()void -> {
+                    ()java.type:"void" -> {
                         yield;
                     };
-                %11 : java.lang.String = var.load %4;
+                %11 : java.type:"java.lang.String" = var.load %4;
                 return %11;
             };
             """)
@@ -155,27 +155,27 @@ public class PatternsTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : PatternsTest, %1 : PatternsTest$Rectangle)void -> {
-                %2 : Var<PatternsTest$Rectangle> = var %1 @"r";
-                %3 : PatternsTest$ConcretePoint = constant @null;
-                %4 : Var<PatternsTest$ConcretePoint> = var %3 @"p";
-                %5 : PatternsTest$Color = constant @null;
-                %6 : Var<PatternsTest$Color> = var %5 @"c";
-                %7 : PatternsTest$ColoredPoint = constant @null;
-                %8 : Var<PatternsTest$ColoredPoint> = var %7 @"lr";
+            func @"test4" (%0 : java.type:"PatternsTest", %1 : java.type:"PatternsTest$Rectangle")java.type:"void" -> {
+                %2 : Var<java.type:"PatternsTest$Rectangle"> = var %1 @"r";
+                %3 : java.type:"PatternsTest$ConcretePoint" = constant @null;
+                %4 : Var<java.type:"PatternsTest$ConcretePoint"> = var %3 @"p";
+                %5 : java.type:"PatternsTest$Color" = constant @null;
+                %6 : Var<java.type:"PatternsTest$Color"> = var %5 @"c";
+                %7 : java.type:"PatternsTest$ColoredPoint" = constant @null;
+                %8 : Var<java.type:"PatternsTest$ColoredPoint"> = var %7 @"lr";
                 java.if
-                    ()boolean -> {
-                        %9 : PatternsTest$Rectangle = var.load %2;
-                        %10 : boolean = pattern.match %9
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle> -> {
-                                %11 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$ConcretePoint> = pattern.type @"p";
-                                %12 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$Color> = pattern.type @"c";
-                                %13 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$ColoredPoint> = pattern.record %11 %12 @"(PatternsTest$ConcretePoint p, PatternsTest$Color c)PatternsTest$ColoredPoint";
-                                %14 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$ColoredPoint> = pattern.type @"lr";
-                                %15 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle> = pattern.record %13 %14 @"(PatternsTest$Point upperLeft, PatternsTest$Point lowerRight)PatternsTest$Rectangle";
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"PatternsTest$Rectangle" = var.load %2;
+                        %10 : java.type:"boolean" = pattern.match %9
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle>" -> {
+                                %11 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$ConcretePoint>" = pattern.type @"p";
+                                %12 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$Color>" = pattern.type @"c";
+                                %13 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$ColoredPoint>" = pattern.record %11 %12 @"(PatternsTest$ConcretePoint p, PatternsTest$Color c)PatternsTest$ColoredPoint";
+                                %14 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$ColoredPoint>" = pattern.type @"lr";
+                                %15 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle>" = pattern.record %13 %14 @"(PatternsTest$Point upperLeft, PatternsTest$Point lowerRight)PatternsTest$Rectangle";
                                 yield %15;
                             }
-                            ^match(%16 : PatternsTest$ConcretePoint, %17 : PatternsTest$Color, %18 : PatternsTest$ColoredPoint)void -> {
+                            (%16 : java.type:"PatternsTest$ConcretePoint", %17 : java.type:"PatternsTest$Color", %18 : java.type:"PatternsTest$ColoredPoint")java.type:"void" -> {
                                 var.store %4 %16;
                                 var.store %6 %17;
                                 var.store %8 %18;
@@ -183,22 +183,22 @@ public class PatternsTest {
                             };
                         yield %10;
                     }
-                    ^then()void -> {
-                        %19 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %20 : PatternsTest$ConcretePoint = var.load %4;
-                        invoke %19 %20 @"java.io.PrintStream::println(java.lang.Object)void";
-                        %21 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %22 : PatternsTest$Color = var.load %6;
-                        invoke %21 %22 @"java.io.PrintStream::println(java.lang.Object)void";
-                        %23 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %24 : PatternsTest$ColoredPoint = var.load %8;
-                        invoke %23 %24 @"java.io.PrintStream::println(java.lang.Object)void";
+                    ()java.type:"void" -> {
+                        %19 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %20 : java.type:"PatternsTest$ConcretePoint" = var.load %4;
+                        invoke %19 %20 @"java.io.PrintStream::println(java.lang.Object):void";
+                        %21 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %22 : java.type:"PatternsTest$Color" = var.load %6;
+                        invoke %21 %22 @"java.io.PrintStream::println(java.lang.Object):void";
+                        %23 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %24 : java.type:"PatternsTest$ColoredPoint" = var.load %8;
+                        invoke %23 %24 @"java.io.PrintStream::println(java.lang.Object):void";
                         yield;
                     }
-                    ^else()void -> {
-                        %25 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %26 : java.lang.String = constant @"NO MATCH";
-                        invoke %25 %26 @"java.io.PrintStream::println(java.lang.String)void";
+                    ()java.type:"void" -> {
+                        %25 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %26 : java.type:"java.lang.String" = constant @"NO MATCH";
+                        invoke %25 %26 @"java.io.PrintStream::println(java.lang.String):void";
                         yield;
                     };
                 return;
@@ -220,28 +220,28 @@ public class PatternsTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : PatternsTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.String = constant @null;
-                %4 : Var<java.lang.String> = var %3 @"s";
+            func @"test5" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"s";
                 java.while
-                    ^cond()boolean -> {
-                        %5 : java.lang.Object = var.load %2;
-                        %6 : boolean = pattern.match %5
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.Object" = var.load %2;
+                        %6 : java.type:"boolean" = pattern.match %5
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                 yield %7;
                             }
-                            ^match(%8 : java.lang.String)void -> {
+                            (%8 : java.type:"java.lang.String")java.type:"void" -> {
                                 var.store %4 %8;
                                 yield;
                             };
                         yield %6;
                     }
-                    ^body()void -> {
-                        %9 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %10 : java.lang.String = var.load %4;
-                        invoke %9 %10 @"java.io.PrintStream::println(java.lang.String)void";
+                    ()java.type:"void" -> {
+                        %9 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %10 : java.type:"java.lang.String" = var.load %4;
+                        invoke %9 %10 @"java.io.PrintStream::println(java.lang.String):void";
                         java.continue;
                     };
                 return;
@@ -255,31 +255,31 @@ public class PatternsTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : PatternsTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.String = constant @null;
-                %4 : Var<java.lang.String> = var %3 @"s";
+            func @"test6" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"s";
                 java.do.while
-                    ^body()void -> {
+                    ()java.type:"void" -> {
                         java.continue;
                     }
-                    ^cond()boolean -> {
-                        %5 : java.lang.Object = var.load %2;
-                        %6 : boolean = pattern.match %5
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.Object" = var.load %2;
+                        %6 : java.type:"boolean" = pattern.match %5
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                 yield %7;
                             }
-                            ^match(%8 : java.lang.String)void -> {
+                            (%8 : java.type:"java.lang.String")java.type:"void" -> {
                                 var.store %4 %8;
                                 yield;
                             };
-                        %9 : boolean = not %6;
+                        %9 : java.type:"boolean" = not %6;
                         yield %9;
                     };
-                %10 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                %11 : java.lang.String = var.load %4;
-                invoke %10 %11 @"java.io.PrintStream::println(java.lang.String)void";
+                %10 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                %11 : java.type:"java.lang.String" = var.load %4;
+                invoke %10 %11 @"java.io.PrintStream::println(java.lang.String):void";
                 return;
             };
             """)
@@ -292,32 +292,32 @@ public class PatternsTest {
 
     @CodeReflection
     @IR("""
-            func @"test7" (%0 : PatternsTest, %1 : java.lang.Object)void -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.Number = constant @null;
-                %4 : Var<java.lang.Number> = var %3 @"n";
+            func @"test7" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Number" = constant @null;
+                %4 : Var<java.type:"java.lang.Number"> = var %3 @"n";
                 java.for
-                    ^init()Var<int> -> {
-                        %5 : int = constant @"0";
-                        %6 : Var<int> = var %5 @"i";
+                    ()Var<java.type:"int"> -> {
+                        %5 : java.type:"int" = constant @"0";
+                        %6 : Var<java.type:"int"> = var %5 @"i";
                         yield %6;
                     }
-                    ^cond(%7 : Var<int>)boolean -> {
-                        %8 : boolean = java.cand
-                            ()boolean -> {
-                                %9 : int = var.load %7;
-                                %10 : int = constant @"10";
-                                %11 : boolean = lt %9 %10;
+                    (%7 : Var<java.type:"int">)java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %9 : java.type:"int" = var.load %7;
+                                %10 : java.type:"int" = constant @"10";
+                                %11 : java.type:"boolean" = lt %9 %10;
                                 yield %11;
                             }
-                            ()boolean -> {
-                                %12 : java.lang.Object = var.load %2;
-                                %13 : boolean = pattern.match %12
-                                    ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> -> {
-                                        %14 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> = pattern.type @"n";
+                            ()java.type:"boolean" -> {
+                                %12 : java.type:"java.lang.Object" = var.load %2;
+                                %13 : java.type:"boolean" = pattern.match %12
+                                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" -> {
+                                        %14 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" = pattern.type @"n";
                                         yield %14;
                                     }
-                                    ^match(%15 : java.lang.Number)void -> {
+                                    (%15 : java.type:"java.lang.Number")java.type:"void" -> {
                                         var.store %4 %15;
                                         yield;
                                     };
@@ -325,18 +325,18 @@ public class PatternsTest {
                             };
                         yield %8;
                     }
-                    ^update(%16 : Var<int>)void -> {
-                        %17 : int = var.load %16;
-                        %18 : java.lang.Number = var.load %4;
-                        %19 : int = invoke %18 @"java.lang.Number::intValue()int";
-                        %20 : int = add %17 %19;
+                    (%16 : Var<java.type:"int">)java.type:"void" -> {
+                        %17 : java.type:"int" = var.load %16;
+                        %18 : java.type:"java.lang.Number" = var.load %4;
+                        %19 : java.type:"int" = invoke %18 @"java.lang.Number::intValue():int";
+                        %20 : java.type:"int" = add %17 %19;
                         var.store %16 %20;
                         yield;
                     }
-                    ^body(%21 : Var<int>)void -> {
-                        %22 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %23 : java.lang.Number = var.load %4;
-                        invoke %22 %23 @"java.io.PrintStream::println(java.lang.Object)void";
+                    (%21 : Var<java.type:"int">)java.type:"void" -> {
+                        %22 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %23 : java.type:"java.lang.Number" = var.load %4;
+                        invoke %22 %23 @"java.io.PrintStream::println(java.lang.Object):void";
                         java.continue;
                     };
                 return;
@@ -350,21 +350,21 @@ public class PatternsTest {
     }
 
     @IR("""
-            func @"test8" (%0 : PatternsTest, %1 : java.lang.Object)boolean -> {
-                   %2 : Var<java.lang.Object> = var %1 @"o";
-                   %3 : java.lang.Object = var.load %2;
-                   %4 : java.lang.String = constant @null;
-                   %5 : Var<java.lang.String> = var %4;
-                   %6 : boolean = pattern.match %3
-                       ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                           %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type;
-                           yield %7;
-                       }
-                       (%8 : java.lang.String)void -> {
-                           var.store %5 %8;
-                           yield;
-                       };
-                   return %6;
+            func @"test8" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"java.lang.String" = constant @null;
+                %5 : Var<java.type:"java.lang.String"> = var %4;
+                %6 : java.type:"boolean" = pattern.match %3
+                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                        %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type;
+                        yield %7;
+                    }
+                    (%8 : java.type:"java.lang.String")java.type:"void" -> {
+                        var.store %5 %8;
+                        yield;
+                    };
+                return %6;
             };
             """)
     @CodeReflection
@@ -373,19 +373,19 @@ public class PatternsTest {
     }
 
     @IR("""
-            func @"test9" (%0 : PatternsTest, %1 : java.lang.Object)boolean -> {
-                %2 : Var<java.lang.Object> = var %1 @"o";
-                %3 : java.lang.Object = var.load %2;
-                %4 : PatternsTest$ConcretePoint = constant @null;
-                %5 : Var<PatternsTest$ConcretePoint> = var %4 @"cp";
-                %6 : boolean = pattern.match %3
-                    ()jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle> -> {
-                        %7 : jdk.incubator.code.op.ExtendedOp$Pattern$MatchAll = pattern.match.all;
-                        %8 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$ConcretePoint> = pattern.type @"cp";
-                        %9 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle> = pattern.record %7 %8 @"(PatternsTest$Point upperLeft, PatternsTest$Point lowerRight)PatternsTest$Rectangle";
+            func @"test9" (%0 : java.type:"PatternsTest", %1 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"PatternsTest$ConcretePoint" = constant @null;
+                %5 : Var<java.type:"PatternsTest$ConcretePoint"> = var %4 @"cp";
+                %6 : java.type:"boolean" = pattern.match %3
+                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle>" -> {
+                        %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$MatchAll" = pattern.match.all;
+                        %8 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<PatternsTest$ConcretePoint>" = pattern.type @"cp";
+                        %9 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<PatternsTest$Rectangle>" = pattern.record %7 %8 @"(PatternsTest$Point upperLeft, PatternsTest$Point lowerRight)PatternsTest$Rectangle";
                         yield %9;
                     }
-                    (%10 : PatternsTest$ConcretePoint)void -> {
+                    (%10 : java.type:"PatternsTest$ConcretePoint")java.type:"void" -> {
                         var.store %5 %10;
                         yield;
                     };
@@ -398,23 +398,23 @@ public class PatternsTest {
     }
 
     @IR("""
-            func @"test10" (%0 : int)boolean -> {
-                  %1 : Var<int> = var %0 @"i";
-                  %2 : int = var.load %1;
-                  %3 : int = constant @"0";
-                  %4 : byte = conv %3;
-                  %5 : Var<byte> = var %4 @"b";
-                  %6 : boolean = pattern.match %2
-                      ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<byte> -> {
-                          %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<byte> = pattern.type @"b";
-                          yield %7;
-                      }
-                      (%8 : byte)void -> {
-                          var.store %5 %8;
-                          yield;
-                      };
-                  return %6;
-              };
+            func @"test10" (%0 : java.type:"int")java.type:"boolean" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @"0";
+                %4 : java.type:"byte" = conv %3;
+                %5 : Var<java.type:"byte"> = var %4 @"b";
+                %6 : java.type:"boolean" = pattern.match %2
+                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<byte>" -> {
+                        %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<byte>" = pattern.type @"b";
+                        yield %7;
+                    }
+                    (%8 : java.type:"byte")java.type:"void" -> {
+                        var.store %5 %8;
+                        yield;
+                    };
+                return %6;
+            };
             """)
     @CodeReflection
     static boolean test10(int i) {
@@ -422,23 +422,23 @@ public class PatternsTest {
     }
 
     @IR("""
-            func @"test11" (%0 : int)boolean -> {
-                  %1 : Var<int> = var %0 @"i";
-                  %2 : int = var.load %1;
-                  %3 : int = constant @"0";
-                  %4 : short = conv %3;
-                  %5 : Var<short> = var %4 @"s";
-                  %6 : boolean = pattern.match %2
-                      ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<short> -> {
-                          %7 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<short> = pattern.type @"s";
-                          yield %7;
-                      }
-                      (%8 : short)void -> {
-                          var.store %5 %8;
-                          yield;
-                      };
-                  return %6;
-              };
+            func @"test11" (%0 : java.type:"int")java.type:"boolean" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @"0";
+                %4 : java.type:"short" = conv %3;
+                %5 : Var<java.type:"short"> = var %4 @"s";
+                %6 : java.type:"boolean" = pattern.match %2
+                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<short>" -> {
+                        %7 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<short>" = pattern.type @"s";
+                        yield %7;
+                    }
+                    (%8 : java.type:"short")java.type:"void" -> {
+                        var.store %5 %8;
+                        yield;
+                    };
+                return %6;
+            };
             """)
     @CodeReflection
     static boolean test11(int i) {

--- a/test/langtools/tools/javac/reflect/PrimitiveCastTest.java
+++ b/test/langtools/tools/javac/reflect/PrimitiveCastTest.java
@@ -36,28 +36,28 @@ public class PrimitiveCastTest {
 
     @CodeReflection
     @IR("""
-            func @"testFromDouble" (%0 : PrimitiveCastTest, %1 : double)void -> {
-                %2 : Var<double> = var %1 @"v";
-                %3 : double = var.load %2;
-                %4 : Var<double> = var %3 @"d";
-                %5 : double = var.load %2;
-                %6 : float = conv %5;
-                %7 : Var<float> = var %6 @"f";
-                %8 : double = var.load %2;
-                %9 : long = conv %8;
-                %10 : Var<long> = var %9 @"l";
-                %11 : double = var.load %2;
-                %12 : int = conv %11;
-                %13 : Var<int> = var %12 @"i";
-                %14 : double = var.load %2;
-                %15 : short = conv %14;
-                %16 : Var<short> = var %15 @"s";
-                %17 : double = var.load %2;
-                %18 : char = conv %17;
-                %19 : Var<char> = var %18 @"c";
-                %20 : double = var.load %2;
-                %21 : byte = conv %20;
-                %22 : Var<byte> = var %21 @"b";
+            func @"testFromDouble" (%0 : java.type:"PrimitiveCastTest", %1 : java.type:"double")java.type:"void" -> {
+                %2 : Var<java.type:"double"> = var %1 @"v";
+                %3 : java.type:"double" = var.load %2;
+                %4 : Var<java.type:"double"> = var %3 @"d";
+                %5 : java.type:"double" = var.load %2;
+                %6 : java.type:"float" = conv %5;
+                %7 : Var<java.type:"float"> = var %6 @"f";
+                %8 : java.type:"double" = var.load %2;
+                %9 : java.type:"long" = conv %8;
+                %10 : Var<java.type:"long"> = var %9 @"l";
+                %11 : java.type:"double" = var.load %2;
+                %12 : java.type:"int" = conv %11;
+                %13 : Var<java.type:"int"> = var %12 @"i";
+                %14 : java.type:"double" = var.load %2;
+                %15 : java.type:"short" = conv %14;
+                %16 : Var<java.type:"short"> = var %15 @"s";
+                %17 : java.type:"double" = var.load %2;
+                %18 : java.type:"char" = conv %17;
+                %19 : Var<java.type:"char"> = var %18 @"c";
+                %20 : java.type:"double" = var.load %2;
+                %21 : java.type:"byte" = conv %20;
+                %22 : Var<java.type:"byte"> = var %21 @"b";
                 return;
             };
             """)
@@ -74,28 +74,28 @@ public class PrimitiveCastTest {
 
     @CodeReflection
     @IR("""
-            func @"testFromFloat" (%0 : PrimitiveCastTest, %1 : float)void -> {
-                %2 : Var<float> = var %1 @"v";
-                %3 : float = var.load %2;
-                %4 : double = conv %3;
-                %5 : Var<double> = var %4 @"d";
-                %6 : float = var.load %2;
-                %7 : Var<float> = var %6 @"f";
-                %8 : float = var.load %2;
-                %9 : long = conv %8;
-                %10 : Var<long> = var %9 @"l";
-                %11 : float = var.load %2;
-                %12 : int = conv %11;
-                %13 : Var<int> = var %12 @"i";
-                %14 : float = var.load %2;
-                %15 : short = conv %14;
-                %16 : Var<short> = var %15 @"s";
-                %17 : float = var.load %2;
-                %18 : char = conv %17;
-                %19 : Var<char> = var %18 @"c";
-                %20 : float = var.load %2;
-                %21 : byte = conv %20;
-                %22 : Var<byte> = var %21 @"b";
+            func @"testFromFloat" (%0 : java.type:"PrimitiveCastTest", %1 : java.type:"float")java.type:"void" -> {
+                %2 : Var<java.type:"float"> = var %1 @"v";
+                %3 : java.type:"float" = var.load %2;
+                %4 : java.type:"double" = conv %3;
+                %5 : Var<java.type:"double"> = var %4 @"d";
+                %6 : java.type:"float" = var.load %2;
+                %7 : Var<java.type:"float"> = var %6 @"f";
+                %8 : java.type:"float" = var.load %2;
+                %9 : java.type:"long" = conv %8;
+                %10 : Var<java.type:"long"> = var %9 @"l";
+                %11 : java.type:"float" = var.load %2;
+                %12 : java.type:"int" = conv %11;
+                %13 : Var<java.type:"int"> = var %12 @"i";
+                %14 : java.type:"float" = var.load %2;
+                %15 : java.type:"short" = conv %14;
+                %16 : Var<java.type:"short"> = var %15 @"s";
+                %17 : java.type:"float" = var.load %2;
+                %18 : java.type:"char" = conv %17;
+                %19 : Var<java.type:"char"> = var %18 @"c";
+                %20 : java.type:"float" = var.load %2;
+                %21 : java.type:"byte" = conv %20;
+                %22 : Var<java.type:"byte"> = var %21 @"b";
                 return;
             };
             """)
@@ -112,28 +112,28 @@ public class PrimitiveCastTest {
 
     @CodeReflection
     @IR("""
-            func @"testFromLong" (%0 : PrimitiveCastTest, %1 : long)void -> {
-                %2 : Var<long> = var %1 @"v";
-                %3 : long = var.load %2;
-                %4 : double = conv %3;
-                %5 : Var<double> = var %4 @"d";
-                %6 : long = var.load %2;
-                %7 : float = conv %6;
-                %8 : Var<float> = var %7 @"f";
-                %9 : long = var.load %2;
-                %10 : Var<long> = var %9 @"l";
-                %11 : long = var.load %2;
-                %12 : int = conv %11;
-                %13 : Var<int> = var %12 @"i";
-                %14 : long = var.load %2;
-                %15 : short = conv %14;
-                %16 : Var<short> = var %15 @"s";
-                %17 : long = var.load %2;
-                %18 : char = conv %17;
-                %19 : Var<char> = var %18 @"c";
-                %20 : long = var.load %2;
-                %21 : byte = conv %20;
-                %22 : Var<byte> = var %21 @"b";
+            func @"testFromLong" (%0 : java.type:"PrimitiveCastTest", %1 : java.type:"long")java.type:"void" -> {
+                %2 : Var<java.type:"long"> = var %1 @"v";
+                %3 : java.type:"long" = var.load %2;
+                %4 : java.type:"double" = conv %3;
+                %5 : Var<java.type:"double"> = var %4 @"d";
+                %6 : java.type:"long" = var.load %2;
+                %7 : java.type:"float" = conv %6;
+                %8 : Var<java.type:"float"> = var %7 @"f";
+                %9 : java.type:"long" = var.load %2;
+                %10 : Var<java.type:"long"> = var %9 @"l";
+                %11 : java.type:"long" = var.load %2;
+                %12 : java.type:"int" = conv %11;
+                %13 : Var<java.type:"int"> = var %12 @"i";
+                %14 : java.type:"long" = var.load %2;
+                %15 : java.type:"short" = conv %14;
+                %16 : Var<java.type:"short"> = var %15 @"s";
+                %17 : java.type:"long" = var.load %2;
+                %18 : java.type:"char" = conv %17;
+                %19 : Var<java.type:"char"> = var %18 @"c";
+                %20 : java.type:"long" = var.load %2;
+                %21 : java.type:"byte" = conv %20;
+                %22 : Var<java.type:"byte"> = var %21 @"b";
                 return;
             };
             """)
@@ -150,28 +150,28 @@ public class PrimitiveCastTest {
 
     @CodeReflection
     @IR("""
-            func @"testFromInt" (%0 : PrimitiveCastTest, %1 : int)void -> {
-                %2 : Var<int> = var %1 @"v";
-                %3 : int = var.load %2;
-                %4 : double = conv %3;
-                %5 : Var<double> = var %4 @"d";
-                %6 : int = var.load %2;
-                %7 : float = conv %6;
-                %8 : Var<float> = var %7 @"f";
-                %9 : int = var.load %2;
-                %10 : long = conv %9;
-                %11 : Var<long> = var %10 @"l";
-                %12 : int = var.load %2;
-                %13 : Var<int> = var %12 @"i";
-                %14 : int = var.load %2;
-                %15 : short = conv %14;
-                %16 : Var<short> = var %15 @"s";
-                %17 : int = var.load %2;
-                %18 : char = conv %17;
-                %19 : Var<char> = var %18 @"c";
-                %20 : int = var.load %2;
-                %21 : byte = conv %20;
-                %22 : Var<byte> = var %21 @"b";
+            func @"testFromInt" (%0 : java.type:"PrimitiveCastTest", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"int"> = var %1 @"v";
+                %3 : java.type:"int" = var.load %2;
+                %4 : java.type:"double" = conv %3;
+                %5 : Var<java.type:"double"> = var %4 @"d";
+                %6 : java.type:"int" = var.load %2;
+                %7 : java.type:"float" = conv %6;
+                %8 : Var<java.type:"float"> = var %7 @"f";
+                %9 : java.type:"int" = var.load %2;
+                %10 : java.type:"long" = conv %9;
+                %11 : Var<java.type:"long"> = var %10 @"l";
+                %12 : java.type:"int" = var.load %2;
+                %13 : Var<java.type:"int"> = var %12 @"i";
+                %14 : java.type:"int" = var.load %2;
+                %15 : java.type:"short" = conv %14;
+                %16 : Var<java.type:"short"> = var %15 @"s";
+                %17 : java.type:"int" = var.load %2;
+                %18 : java.type:"char" = conv %17;
+                %19 : Var<java.type:"char"> = var %18 @"c";
+                %20 : java.type:"int" = var.load %2;
+                %21 : java.type:"byte" = conv %20;
+                %22 : Var<java.type:"byte"> = var %21 @"b";
                 return;
             };
             """)
@@ -188,28 +188,28 @@ public class PrimitiveCastTest {
 
     @CodeReflection
     @IR("""
-            func @"testFromShort" (%0 : PrimitiveCastTest, %1 : short)void -> {
-                %2 : Var<short> = var %1 @"v";
-                %3 : short = var.load %2;
-                %4 : double = conv %3;
-                %5 : Var<double> = var %4 @"d";
-                %6 : short = var.load %2;
-                %7 : float = conv %6;
-                %8 : Var<float> = var %7 @"f";
-                %9 : short = var.load %2;
-                %10 : long = conv %9;
-                %11 : Var<long> = var %10 @"l";
-                %12 : short = var.load %2;
-                %13 : int = conv %12;
-                %14 : Var<int> = var %13 @"i";
-                %15 : short = var.load %2;
-                %16 : Var<short> = var %15 @"s";
-                %17 : short = var.load %2;
-                %18 : char = conv %17;
-                %19 : Var<char> = var %18 @"c";
-                %20 : short = var.load %2;
-                %21 : byte = conv %20;
-                %22 : Var<byte> = var %21 @"b";
+            func @"testFromShort" (%0 : java.type:"PrimitiveCastTest", %1 : java.type:"short")java.type:"void" -> {
+                %2 : Var<java.type:"short"> = var %1 @"v";
+                %3 : java.type:"short" = var.load %2;
+                %4 : java.type:"double" = conv %3;
+                %5 : Var<java.type:"double"> = var %4 @"d";
+                %6 : java.type:"short" = var.load %2;
+                %7 : java.type:"float" = conv %6;
+                %8 : Var<java.type:"float"> = var %7 @"f";
+                %9 : java.type:"short" = var.load %2;
+                %10 : java.type:"long" = conv %9;
+                %11 : Var<java.type:"long"> = var %10 @"l";
+                %12 : java.type:"short" = var.load %2;
+                %13 : java.type:"int" = conv %12;
+                %14 : Var<java.type:"int"> = var %13 @"i";
+                %15 : java.type:"short" = var.load %2;
+                %16 : Var<java.type:"short"> = var %15 @"s";
+                %17 : java.type:"short" = var.load %2;
+                %18 : java.type:"char" = conv %17;
+                %19 : Var<java.type:"char"> = var %18 @"c";
+                %20 : java.type:"short" = var.load %2;
+                %21 : java.type:"byte" = conv %20;
+                %22 : Var<java.type:"byte"> = var %21 @"b";
                 return;
             };
             """)
@@ -226,28 +226,28 @@ public class PrimitiveCastTest {
 
     @CodeReflection
     @IR("""
-            func @"testFromChar" (%0 : PrimitiveCastTest, %1 : char)void -> {
-                %2 : Var<char> = var %1 @"v";
-                %3 : char = var.load %2;
-                %4 : double = conv %3;
-                %5 : Var<double> = var %4 @"d";
-                %6 : char = var.load %2;
-                %7 : float = conv %6;
-                %8 : Var<float> = var %7 @"f";
-                %9 : char = var.load %2;
-                %10 : long = conv %9;
-                %11 : Var<long> = var %10 @"l";
-                %12 : char = var.load %2;
-                %13 : int = conv %12;
-                %14 : Var<int> = var %13 @"i";
-                %15 : char = var.load %2;
-                %16 : short = conv %15;
-                %17 : Var<short> = var %16 @"s";
-                %18 : char = var.load %2;
-                %19 : Var<char> = var %18 @"c";
-                %20 : char = var.load %2;
-                %21 : byte = conv %20;
-                %22 : Var<byte> = var %21 @"b";
+            func @"testFromChar" (%0 : java.type:"PrimitiveCastTest", %1 : java.type:"char")java.type:"void" -> {
+                %2 : Var<java.type:"char"> = var %1 @"v";
+                %3 : java.type:"char" = var.load %2;
+                %4 : java.type:"double" = conv %3;
+                %5 : Var<java.type:"double"> = var %4 @"d";
+                %6 : java.type:"char" = var.load %2;
+                %7 : java.type:"float" = conv %6;
+                %8 : Var<java.type:"float"> = var %7 @"f";
+                %9 : java.type:"char" = var.load %2;
+                %10 : java.type:"long" = conv %9;
+                %11 : Var<java.type:"long"> = var %10 @"l";
+                %12 : java.type:"char" = var.load %2;
+                %13 : java.type:"int" = conv %12;
+                %14 : Var<java.type:"int"> = var %13 @"i";
+                %15 : java.type:"char" = var.load %2;
+                %16 : java.type:"short" = conv %15;
+                %17 : Var<java.type:"short"> = var %16 @"s";
+                %18 : java.type:"char" = var.load %2;
+                %19 : Var<java.type:"char"> = var %18 @"c";
+                %20 : java.type:"char" = var.load %2;
+                %21 : java.type:"byte" = conv %20;
+                %22 : Var<java.type:"byte"> = var %21 @"b";
                 return;
             };
             """)
@@ -264,28 +264,28 @@ public class PrimitiveCastTest {
 
     @CodeReflection
     @IR("""
-            func @"testFromByte" (%0 : PrimitiveCastTest, %1 : byte)void -> {
-                %2 : Var<byte> = var %1 @"v";
-                %3 : byte = var.load %2;
-                %4 : double = conv %3;
-                %5 : Var<double> = var %4 @"d";
-                %6 : byte = var.load %2;
-                %7 : float = conv %6;
-                %8 : Var<float> = var %7 @"f";
-                %9 : byte = var.load %2;
-                %10 : long = conv %9;
-                %11 : Var<long> = var %10 @"l";
-                %12 : byte = var.load %2;
-                %13 : int = conv %12;
-                %14 : Var<int> = var %13 @"i";
-                %15 : byte = var.load %2;
-                %16 : short = conv %15;
-                %17 : Var<short> = var %16 @"s";
-                %18 : byte = var.load %2;
-                %19 : char = conv %18;
-                %20 : Var<char> = var %19 @"c";
-                %21 : byte = var.load %2;
-                %22 : Var<byte> = var %21 @"b";
+            func @"testFromByte" (%0 : java.type:"PrimitiveCastTest", %1 : java.type:"byte")java.type:"void" -> {
+                %2 : Var<java.type:"byte"> = var %1 @"v";
+                %3 : java.type:"byte" = var.load %2;
+                %4 : java.type:"double" = conv %3;
+                %5 : Var<java.type:"double"> = var %4 @"d";
+                %6 : java.type:"byte" = var.load %2;
+                %7 : java.type:"float" = conv %6;
+                %8 : Var<java.type:"float"> = var %7 @"f";
+                %9 : java.type:"byte" = var.load %2;
+                %10 : java.type:"long" = conv %9;
+                %11 : Var<java.type:"long"> = var %10 @"l";
+                %12 : java.type:"byte" = var.load %2;
+                %13 : java.type:"int" = conv %12;
+                %14 : Var<java.type:"int"> = var %13 @"i";
+                %15 : java.type:"byte" = var.load %2;
+                %16 : java.type:"short" = conv %15;
+                %17 : Var<java.type:"short"> = var %16 @"s";
+                %18 : java.type:"byte" = var.load %2;
+                %19 : java.type:"char" = conv %18;
+                %20 : Var<java.type:"char"> = var %19 @"c";
+                %21 : java.type:"byte" = var.load %2;
+                %22 : Var<java.type:"byte"> = var %21 @"b";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/QuotableIntersectionTest.java
+++ b/test/langtools/tools/javac/reflect/QuotableIntersectionTest.java
@@ -39,21 +39,21 @@ import java.util.function.IntUnaryOperator;
 
 public class QuotableIntersectionTest {
     @IR("""
-            func @"f" ()void -> {
-                  %0 : jdk.incubator.code.Quotable = lambda ()void -> {
-                      return;
-                  };
-                  return;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda ()java.type:"void" -> {
+                    return;
+                };
+                return;
             };
             """)
     static final Quotable QUOTED_NO_PARAM_VOID = (Quotable & Runnable) () -> {
     };
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : jdk.incubator.code.Quotable = lambda ()int -> {
-                    %2 : int = constant @"1";
-                    return %2;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda ()java.type:"int" -> {
+                    %1 : java.type:"int" = constant @"1";
+                    return %1;
                 };
                 return;
             };
@@ -61,25 +61,25 @@ public class QuotableIntersectionTest {
     static final Quotable QUOTED_NO_PARAM_CONST = (Quotable & IntSupplier) () -> 1;
 
     @IR("""
-            func @"f" ()void -> {
-                  %0 : jdk.incubator.code.Quotable = lambda (%1 : int)int -> {
-                      %2 : Var<int> = var %1 @"x";
-                      %3 : int = var.load %2;
-                      return %3;
-                  };
-                  return;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"x";
+                    %3 : java.type:"int" = var.load %2;
+                    return %3;
+                };
+                return;
             };
             """)
     static final Quotable QUOTED_ID = (Quotable & IntUnaryOperator) x -> x;
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : jdk.incubator.code.Quotable = lambda (%1 : int, %2 : int)int -> {
-                    %3 : Var<int> = var %1 @"x";
-                    %4 : Var<int> = var %2 @"y";
-                    %5 : int = var.load %3;
-                    %6 : int = var.load %4;
-                    %7 : int = add %5 %6;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda (%1 : java.type:"int", %2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %1 @"x";
+                    %4 : Var<java.type:"int"> = var %2 @"y";
+                    %5 : java.type:"int" = var.load %3;
+                    %6 : java.type:"int" = var.load %4;
+                    %7 : java.type:"int" = add %5 %6;
                     return %7;
                 };
                 return;
@@ -88,9 +88,9 @@ public class QuotableIntersectionTest {
     static final Quotable QUOTED_PLUS = (Quotable & IntBinaryOperator) (x, y) -> x + y;
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : jdk.incubator.code.Quotable = lambda ()void -> {
-                    %1 : java.lang.AssertionError = new @"java.lang.AssertionError::<new>()";
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda ()java.type:"void" -> {
+                    %1 : java.type:"java.lang.AssertionError" = new @"java.lang.AssertionError::()";
                     throw %1;
                 };
                 return;
@@ -101,13 +101,13 @@ public class QuotableIntersectionTest {
     };
 
     @IR("""
-            func @"f" (%1 : Var<int>)void -> {
-                %2 : jdk.incubator.code.Quotable = lambda (%4 : int)int -> {
-                    %5 : Var<int> = var %4 @"y";
-                    %6 : int = var.load %1;
-                    %7 : int = var.load %5;
-                    %8 : int = add %6 %7;
-                    return %8;
+            func @"f" (%0 : Var<java.type:"int">)java.type:"void" -> {
+                %1 : java.type:"jdk.incubator.code.Quotable" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"y";
+                    %4 : java.type:"int" = var.load %0;
+                    %5 : java.type:"int" = var.load %3;
+                    %6 : java.type:"int" = add %4 %5;
+                    return %6;
                 };
                 return;
             };
@@ -127,15 +127,15 @@ public class QuotableIntersectionTest {
     }
 
     @IR("""
-            func @"f" (%0 : QuotableIntersectionTest$Context)void -> {
-                %1 : jdk.incubator.code.Quotable = lambda (%3 : int)int -> {
-                    %4 : Var<int> = var %3 @"z";
-                    %5 : int = field.load %0 @"QuotableIntersectionTest$Context::x()int";
-                    %6 : int = field.load %0 @"QuotableIntersectionTest$Context::y()int";
-                    %7 : int = add %5 %6;
-                    %8 : int = var.load %4;
-                    %9 : int = add %7 %8;
-                    return %9;
+            func @"f" (%0 : java.type:"QuotableIntersectionTest$Context")java.type:"void" -> {
+                %1 : java.type:"jdk.incubator.code.Quotable" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"z";
+                    %4 : java.type:"int" = field.load %0 @"QuotableIntersectionTest$Context::x:int";
+                    %5 : java.type:"int" = field.load %0 @"QuotableIntersectionTest$Context::y:int";
+                    %6 : java.type:"int" = add %4 %5;
+                    %7 : java.type:"int" = var.load %3;
+                    %8 : java.type:"int" = add %6 %7;
+                    return %8;
                 };
                 return;
             };
@@ -144,16 +144,16 @@ public class QuotableIntersectionTest {
 
     @CodeReflection
     @IR("""
-            func @"captureParam" (%0 : int)void -> {
-                %1 : Var<int> = var %0 @"x";
-                %2 : java.util.function.IntUnaryOperator = lambda (%3 : int)int -> {
-                    %4 : Var<int> = var %3 @"y";
-                    %5 : int = var.load %1;
-                    %6 : int = var.load %4;
-                    %7 : int = add %5 %6;
+            func @"captureParam" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"x";
+                %2 : java.type:"java.util.function.IntUnaryOperator" = lambda (%3 : java.type:"int")java.type:"int" -> {
+                    %4 : Var<java.type:"int"> = var %3 @"y";
+                    %5 : java.type:"int" = var.load %1;
+                    %6 : java.type:"int" = var.load %4;
+                    %7 : java.type:"int" = add %5 %6;
                     return %7;
                 };
-                %8 : Var<java.util.function.IntUnaryOperator> = var %2 @"op";
+                %8 : Var<java.type:"java.util.function.IntUnaryOperator"> = var %2 @"op";
                 return;
             };
             """)
@@ -165,17 +165,17 @@ public class QuotableIntersectionTest {
 
     @CodeReflection
     @IR("""
-            func @"captureField" (%0 : QuotableIntersectionTest)void -> {
-                %1 : java.util.function.IntUnaryOperator = lambda (%2 : int)int -> {
-                    %3 : Var<int> = var %2 @"z";
-                    %4 : int = field.load %0 @"QuotableIntersectionTest::x()int";
-                    %5 : int = field.load %0 @"QuotableIntersectionTest::y()int";
-                    %6 : int = add %4 %5;
-                    %7 : int = var.load %3;
-                    %8 : int = add %6 %7;
+            func @"captureField" (%0 : java.type:"QuotableIntersectionTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.IntUnaryOperator" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"z";
+                    %4 : java.type:"int" = field.load %0 @"QuotableIntersectionTest::x:int";
+                    %5 : java.type:"int" = field.load %0 @"QuotableIntersectionTest::y:int";
+                    %6 : java.type:"int" = add %4 %5;
+                    %7 : java.type:"int" = var.load %3;
+                    %8 : java.type:"int" = add %6 %7;
                     return %8;
                 };
-                %9 : Var<java.util.function.IntUnaryOperator> = var %1 @"op";
+                %9 : Var<java.type:"java.util.function.IntUnaryOperator"> = var %1 @"op";
                 return;
             };
             """)
@@ -187,12 +187,12 @@ public class QuotableIntersectionTest {
     }
 
     @IR("""
-            func @"f" ()void -> {
-                  %0 : jdk.incubator.code.Quotable = lambda ()void -> {
-                      invoke @"QuotableIntersectionTest::m()void";
-                      return;
-                  };
-                  return;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda ()java.type:"void" -> {
+                    invoke @"QuotableIntersectionTest::m():void";
+                    return;
+                };
+                return;
             };
             """)
     static final Quotable QUOTED_NO_PARAM_VOID_REF = (Quotable & Runnable) QuotableIntersectionTest::m;
@@ -202,24 +202,24 @@ public class QuotableIntersectionTest {
     }
 
     @IR("""
-            func @"f" ()void -> {
-                  %0 : jdk.incubator.code.Quotable = lambda (%1 : int)int -> {
-                      %2 : Var<int> = var %1 @"x$0";
-                      %3 : int = var.load %2;
-                      %4 : int = invoke %3 @"QuotableIntersectionTest::g(int)int";
-                      return %4;
-                  };
-                  return;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"x$0";
+                    %3 : java.type:"int" = var.load %2;
+                    %4 : java.type:"int" = invoke %3 @"QuotableIntersectionTest::g(int):int";
+                    return %4;
+                };
+                return;
             };
             """)
     static final Quotable QUOTED_INT_PARAM_INT_RET_REF = (Quotable & IntUnaryOperator) QuotableIntersectionTest::g;
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : jdk.incubator.code.Quotable = lambda (%1 : int)int[] -> {
-                    %2 : Var<int> = var %1 @"x$0";
-                    %3 : int = var.load %2;
-                    %4 : int[] = new %3 @"int[]::<new>(int)";
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"jdk.incubator.code.Quotable" = lambda (%1 : java.type:"int")java.type:"int[]" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"x$0";
+                    %3 : java.type:"int" = var.load %2;
+                    %4 : java.type:"int[]" = new %3 @"int[]::(int)";
                     return %4;
                 };
                 return;
@@ -238,12 +238,12 @@ public class QuotableIntersectionTest {
     }
 
     @IR("""
-            func @"f" (%0 : QuotableIntersectionTest$ContextRef)void -> {
-                %1 : jdk.incubator.code.Quotable = lambda (%3 : int)int -> {
-                    %4 : Var<int> = var %3 @"x$0";
-                    %5 : int = var.load %4;
-                    %6 : int = invoke %0 %5 @"QuotableIntersectionTest$ContextRef::g(int)int";
-                    return %6;
+            func @"f" (%0 : java.type:"QuotableIntersectionTest$ContextRef")java.type:"void" -> {
+                %1 : java.type:"jdk.incubator.code.Quotable" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"x$0";
+                    %4 : java.type:"int" = var.load %3;
+                    %5 : java.type:"int" = invoke %0 %4 @"QuotableIntersectionTest$ContextRef::g(int):int";
+                    return %5;
                 };
                 return;
             };

--- a/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
+++ b/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
@@ -42,8 +42,8 @@ public class QuotableSubtypeTest {
     interface QuotableRunnable extends Runnable, Quotable { }
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableRunnable = lambda ()void -> {
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
                     return;
                 };
                 return;
@@ -54,24 +54,24 @@ public class QuotableSubtypeTest {
     interface QuotableIntSupplier extends IntSupplier, Quotable { }
 
     @IR("""
-           func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableIntSupplier = lambda ()int -> {
-                    %2 : int = constant @"1";
-                    return %2;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableIntSupplier" = lambda ()java.type:"int" -> {
+                    %1 : java.type:"int" = constant @"1";
+                    return %1;
                 };
                 return;
-           };
+            };
             """)
     static final QuotableIntSupplier QUOTED_NO_PARAM_CONST = () -> 1;
 
     interface QuotableIntUnaryOperator extends IntUnaryOperator, Quotable { }
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableIntUnaryOperator = lambda (%2 : int)int -> {
-                    %3 : Var<int> = var %2 @"x";
-                    %4 : int = var.load %3;
-                    return %4;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator" = lambda (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"x";
+                    %3 : java.type:"int" = var.load %2;
+                    return %3;
                 };
                 return;
             };
@@ -81,24 +81,24 @@ public class QuotableSubtypeTest {
     interface QuotableIntBinaryOperator extends IntBinaryOperator, Quotable { }
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableIntBinaryOperator = lambda (%2 : int, %3 : int)int -> {
-                    %4 : Var<int> = var %2 @"x";
-                    %5 : Var<int> = var %3 @"y";
-                    %6 : int = var.load %4;
-                    %7 : int = var.load %5;
-                    %8 : int = add %6 %7;
-                    return %8;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableIntBinaryOperator" = lambda (%1 : java.type:"int", %2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %1 @"x";
+                    %4 : Var<java.type:"int"> = var %2 @"y";
+                    %5 : java.type:"int" = var.load %3;
+                    %6 : java.type:"int" = var.load %4;
+                    %7 : java.type:"int" = add %5 %6;
+                    return %7;
                 };
                 return;
             };
             """)
     static final QuotableIntBinaryOperator QUOTED_PLUS = (x, y) -> x + y;
     @IR("""
-            func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableRunnable = lambda ()void -> {
-                    %2 : java.lang.AssertionError = new @"java.lang.AssertionError::<new>()";
-                    throw %2;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                    %1 : java.type:"java.lang.AssertionError" = new @"java.lang.AssertionError::()";
+                    throw %1;
                 };
                 return;
             };
@@ -106,13 +106,13 @@ public class QuotableSubtypeTest {
     static final QuotableRunnable QUOTED_THROW_NO_PARAM = () -> { throw new AssertionError(); };
 
     @IR("""
-            func @"f" (%1 : Var<int>)void -> {
-                %0 : QuotableSubtypeTest$QuotableIntUnaryOperator = lambda (%4 : int)int -> {
-                    %5 : Var<int> = var %4 @"y";
-                    %6 : int = var.load %1;
-                    %7 : int = var.load %5;
-                    %8 : int = add %6 %7;
-                    return %8;
+            func @"f" (%0 : Var<java.type:"int">)java.type:"void" -> {
+                %1 : java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"y";
+                    %4 : java.type:"int" = var.load %0;
+                    %5 : java.type:"int" = var.load %3;
+                    %6 : java.type:"int" = add %4 %5;
+                    return %6;
                 };
                 return;
             };
@@ -132,15 +132,15 @@ public class QuotableSubtypeTest {
     }
 
     @IR("""
-            func @"f" (%0 : QuotableSubtypeTest$Context)void -> {
-                %1 : QuotableSubtypeTest$QuotableIntUnaryOperator = lambda (%3 : int)int -> {
-                    %4 : Var<int> = var %3 @"z";
-                    %5 : int = field.load %0 @"QuotableSubtypeTest$Context::x()int";
-                    %6 : int = field.load %0 @"QuotableSubtypeTest$Context::y()int";
-                    %7 : int = add %5 %6;
-                    %8 : int = var.load %4;
-                    %9 : int = add %7 %8;
-                    return %9;
+            func @"f" (%0 : java.type:"QuotableSubtypeTest$Context")java.type:"void" -> {
+                %1 : java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"z";
+                    %4 : java.type:"int" = field.load %0 @"QuotableSubtypeTest$Context::x:int";
+                    %5 : java.type:"int" = field.load %0 @"QuotableSubtypeTest$Context::y:int";
+                    %6 : java.type:"int" = add %4 %5;
+                    %7 : java.type:"int" = var.load %3;
+                    %8 : java.type:"int" = add %6 %7;
+                    return %8;
                 };
                 return;
             };
@@ -149,16 +149,16 @@ public class QuotableSubtypeTest {
 
     @CodeReflection
     @IR("""
-            func @"captureParam" (%0 : int)void -> {
-                %1 : Var<int> = var %0 @"x";
-                %2 : QuotableSubtypeTest$QuotableIntUnaryOperator = lambda (%3 : int)int -> {
-                    %4 : Var<int> = var %3 @"y";
-                    %5 : int = var.load %1;
-                    %6 : int = var.load %4;
-                    %7 : int = add %5 %6;
+            func @"captureParam" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"x";
+                %2 : java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator" = lambda (%3 : java.type:"int")java.type:"int" -> {
+                    %4 : Var<java.type:"int"> = var %3 @"y";
+                    %5 : java.type:"int" = var.load %1;
+                    %6 : java.type:"int" = var.load %4;
+                    %7 : java.type:"int" = add %5 %6;
                     return %7;
                 };
-                %8 : Var<QuotableSubtypeTest$QuotableIntUnaryOperator> = var %2 @"op";
+                %8 : Var<java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator"> = var %2 @"op";
                 return;
             };
             """)
@@ -170,17 +170,17 @@ public class QuotableSubtypeTest {
 
     @CodeReflection
     @IR("""
-            func @"captureField" (%0 : QuotableSubtypeTest)void -> {
-                %1 : QuotableSubtypeTest$QuotableIntUnaryOperator = lambda (%2 : int)int -> {
-                    %3 : Var<int> = var %2 @"z";
-                    %4 : int = field.load %0 @"QuotableSubtypeTest::x()int";
-                    %5 : int = field.load %0 @"QuotableSubtypeTest::y()int";
-                    %6 : int = add %4 %5;
-                    %7 : int = var.load %3;
-                    %8 : int = add %6 %7;
+            func @"captureField" (%0 : java.type:"QuotableSubtypeTest")java.type:"void" -> {
+                %1 : java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"z";
+                    %4 : java.type:"int" = field.load %0 @"QuotableSubtypeTest::x:int";
+                    %5 : java.type:"int" = field.load %0 @"QuotableSubtypeTest::y:int";
+                    %6 : java.type:"int" = add %4 %5;
+                    %7 : java.type:"int" = var.load %3;
+                    %8 : java.type:"int" = add %6 %7;
                     return %8;
                 };
-                %9 : Var<QuotableSubtypeTest$QuotableIntUnaryOperator> = var %1 @"op";
+                %9 : Var<java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator"> = var %1 @"op";
                 return;
             };
             """)
@@ -191,9 +191,9 @@ public class QuotableSubtypeTest {
     static void m() { }
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableRunnable = lambda ()void -> {
-                    invoke @"QuotableSubtypeTest::m()void";
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                    invoke @"QuotableSubtypeTest::m():void";
                     return;
                 };
                 return;
@@ -204,12 +204,12 @@ public class QuotableSubtypeTest {
     static int g(int i) { return i; }
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableIntUnaryOperator = lambda (%2 : int)int -> {
-                    %3 : Var<int> = var %2 @"x$0";
-                    %4 : int = var.load %3;
-                    %5 : int = invoke %4 @"QuotableSubtypeTest::g(int)int";
-                    return %5;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator" = lambda (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"x$0";
+                    %3 : java.type:"int" = var.load %2;
+                    %4 : java.type:"int" = invoke %3 @"QuotableSubtypeTest::g(int):int";
+                    return %4;
                 };
                 return;
             };
@@ -219,12 +219,12 @@ public class QuotableSubtypeTest {
     interface QuotableIntFunction<A> extends Quotable, IntFunction<A> { }
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : QuotableSubtypeTest$QuotableIntFunction<int[]> = lambda (%2 : int)int[] -> {
-                    %3 : Var<int> = var %2 @"x$0";
-                    %4 : int = var.load %3;
-                    %5 : int[] = new %4 @"int[]::<new>(int)";
-                    return %5;
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"QuotableSubtypeTest$QuotableIntFunction<int[]>" = lambda (%1 : java.type:"int")java.type:"int[]" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"x$0";
+                    %3 : java.type:"int" = var.load %2;
+                    %4 : java.type:"int[]" = new %3 @"int[]::(int)";
+                    return %4;
                 };
                 return;
             };
@@ -240,12 +240,12 @@ public class QuotableSubtypeTest {
     }
 
     @IR("""
-            func @"f" (%0 : QuotableSubtypeTest$ContextRef)void -> {
-                %1 : QuotableSubtypeTest$QuotableIntUnaryOperator = lambda (%3 : int)int -> {
-                    %4 : Var<int> = var %3 @"x$0";
-                    %5 : int = var.load %4;
-                    %6 : int = invoke %0 %5 @"QuotableSubtypeTest$ContextRef::g(int)int";
-                    return %6;
+            func @"f" (%0 : java.type:"QuotableSubtypeTest$ContextRef")java.type:"void" -> {
+                %1 : java.type:"QuotableSubtypeTest$QuotableIntUnaryOperator" = lambda (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"x$0";
+                    %4 : java.type:"int" = var.load %3;
+                    %5 : java.type:"int" = invoke %0 %4 @"QuotableSubtypeTest$ContextRef::g(int):int";
+                    return %5;
                 };
                 return;
             };

--- a/test/langtools/tools/javac/reflect/QuotedTest.java
+++ b/test/langtools/tools/javac/reflect/QuotedTest.java
@@ -35,8 +35,8 @@ import jdk.incubator.code.CodeReflection;
 
 public class QuotedTest {
     @IR("""
-            func @"f" ()void -> {
-                 %0 : func<void> = closure ()void -> {
+            func @"f" ()java.type:"void" -> {
+                %0 : func<java.type:"void"> = closure ()java.type:"void" -> {
                     return;
                 };
                 return;
@@ -46,10 +46,10 @@ public class QuotedTest {
     };
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : func<int> = closure ()int -> {
-                    %2 : int = constant @"1";
-                    return %2;
+            func @"f" ()java.type:"void" -> {
+                %0 : func<java.type:"int"> = closure ()java.type:"int" -> {
+                    %1 : java.type:"int" = constant @"1";
+                    return %1;
                 };
                 return;
             };
@@ -57,11 +57,11 @@ public class QuotedTest {
     static final Quoted QUOTED_NO_PARAM_CONST = () -> 1;
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : func<int, int> = closure (%2 : int)int -> {
-                    %3 : Var<int> = var %2 @"x";
-                    %4 : int = var.load %3;
-                    return %4;
+            func @"f" ()java.type:"void" -> {
+                %0 : func<java.type:"int", java.type:"int"> = closure (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"x";
+                    %3 : java.type:"int" = var.load %2;
+                    return %3;
                 };
                 return;
             };
@@ -69,14 +69,14 @@ public class QuotedTest {
     static final Quoted QUOTED_ID = (int x) -> x;
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : func<int, int, int> = closure (%2 : int, %3 : int)int -> {
-                    %4 : Var<int> = var %2 @"x";
-                    %5 : Var<int> = var %3 @"y";
-                    %6 : int = var.load %4;
-                    %7 : int = var.load %5;
-                    %8 : int = add %6 %7;
-                    return %8;
+            func @"f" ()java.type:"void" -> {
+                %0 : func<java.type:"int", java.type:"int", java.type:"int"> = closure (%1 : java.type:"int", %2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %1 @"x";
+                    %4 : Var<java.type:"int"> = var %2 @"y";
+                    %5 : java.type:"int" = var.load %3;
+                    %6 : java.type:"int" = var.load %4;
+                    %7 : java.type:"int" = add %5 %6;
+                    return %7;
                 };
                 return;
             };
@@ -84,10 +84,10 @@ public class QuotedTest {
     static final Quoted QUOTED_PLUS = (int x, int y) -> x + y;
 
     @IR("""
-            func @"f" ()void -> {
-                %0 : func<java.lang.Object> = closure ()java.lang.Object -> {
-                    %2 : java.lang.AssertionError = new @"java.lang.AssertionError::<new>()";
-                    throw %2;
+            func @"f" ()java.type:"void" -> {
+                %0 : func<java.type:"java.lang.Object"> = closure ()java.type:"java.lang.Object" -> {
+                    %1 : java.type:"java.lang.AssertionError" = new @"java.lang.AssertionError::()";
+                    throw %1;
                 };
                 return;
             };
@@ -99,13 +99,13 @@ public class QuotedTest {
     // can we write out the root op then extract the closure ?
 
     @IR("""
-            func @"f" (%1: Var<int>)void -> {
-                %0 : func<int, int> = closure (%4 : int)int -> {
-                    %5 : Var<int> = var %4 @"y";
-                    %6 : int = var.load %1;
-                    %7 : int = var.load %5;
-                    %8 : int = add %6 %7;
-                    return %8;
+            func @"f" (%0 : Var<java.type:"int">)java.type:"void" -> {
+                %1 : func<java.type:"int", java.type:"int"> = closure (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"y";
+                    %4 : java.type:"int" = var.load %0;
+                    %5 : java.type:"int" = var.load %3;
+                    %6 : java.type:"int" = add %4 %5;
+                    return %6;
                 };
                 return;
             };
@@ -125,15 +125,15 @@ public class QuotedTest {
     }
 
     @IR("""
-            func @"f" (%0 : QuotedTest$Context)void -> {
-                %1 : func<int, int> = closure (%3 : int)int -> {
-                    %4 : Var<int> = var %3 @"z";
-                    %5 : int = field.load %0 @"QuotedTest$Context::x()int";
-                    %6 : int = field.load %0 @"QuotedTest$Context::y()int";
-                    %7 : int = add %5 %6;
-                    %8 : int = var.load %4;
-                    %9 : int = add %7 %8;
-                    return %9;
+            func @"f" (%0 : java.type:"QuotedTest$Context")java.type:"void" -> {
+                %1 : func<java.type:"int", java.type:"int"> = closure (%2 : java.type:"int")java.type:"int" -> {
+                    %3 : Var<java.type:"int"> = var %2 @"z";
+                    %4 : java.type:"int" = field.load %0 @"QuotedTest$Context::x:int";
+                    %5 : java.type:"int" = field.load %0 @"QuotedTest$Context::y:int";
+                    %6 : java.type:"int" = add %4 %5;
+                    %7 : java.type:"int" = var.load %3;
+                    %8 : java.type:"int" = add %6 %7;
+                    return %8;
                 };
                 return;
             };
@@ -142,19 +142,19 @@ public class QuotedTest {
 
     @CodeReflection
     @IR("""
-            func @"captureParam" (%0 : int)void -> {
-                %1 : Var<int> = var %0 @"x";
-                %2 : jdk.incubator.code.Quoted = quoted ()void -> {
-                    %3 : func<int, int> = closure (%4 : int)int -> {
-                        %5 : Var<int> = var %4 @"y";
-                        %6 : int = var.load %1;
-                        %7 : int = var.load %5;
-                        %8 : int = add %6 %7;
+            func @"captureParam" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"x";
+                %2 : java.type:"jdk.incubator.code.Quoted" = quoted ()java.type:"void" -> {
+                    %3 : func<java.type:"int", java.type:"int"> = closure (%4 : java.type:"int")java.type:"int" -> {
+                        %5 : Var<java.type:"int"> = var %4 @"y";
+                        %6 : java.type:"int" = var.load %1;
+                        %7 : java.type:"int" = var.load %5;
+                        %8 : java.type:"int" = add %6 %7;
                         return %8;
                     };
                     yield %3;
                 };
-                %9 : Var<jdk.incubator.code.Quoted> = var %2 @"op";
+                %9 : Var<java.type:"jdk.incubator.code.Quoted"> = var %2 @"op";
                 return;
             };
             """)
@@ -166,20 +166,20 @@ public class QuotedTest {
 
     @CodeReflection
     @IR("""
-            func @"captureField" (%0 : QuotedTest)void -> {
-                %1 : jdk.incubator.code.Quoted = quoted ()void -> {
-                    %2 : func<int, int> = closure (%3 : int)int -> {
-                        %4 : Var<int> = var %3 @"z";
-                        %5 : int = field.load %0 @"QuotedTest::x()int";
-                        %6 : int = field.load %0 @"QuotedTest::y()int";
-                        %7 : int = add %5 %6;
-                        %8 : int = var.load %4;
-                        %9 : int = add %7 %8;
+            func @"captureField" (%0 : java.type:"QuotedTest")java.type:"void" -> {
+                %1 : java.type:"jdk.incubator.code.Quoted" = quoted ()java.type:"void" -> {
+                    %2 : func<java.type:"int", java.type:"int"> = closure (%3 : java.type:"int")java.type:"int" -> {
+                        %4 : Var<java.type:"int"> = var %3 @"z";
+                        %5 : java.type:"int" = field.load %0 @"QuotedTest::x:int";
+                        %6 : java.type:"int" = field.load %0 @"QuotedTest::y:int";
+                        %7 : java.type:"int" = add %5 %6;
+                        %8 : java.type:"int" = var.load %4;
+                        %9 : java.type:"int" = add %7 %8;
                         return %9;
                     };
                     yield %2;
                 };
-                %10 : Var<jdk.incubator.code.Quoted> = var %1 @"op";
+                %10 : Var<java.type:"jdk.incubator.code.Quoted"> = var %1 @"op";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/StringConcatTest.java
+++ b/test/langtools/tools/javac/reflect/StringConcatTest.java
@@ -10,12 +10,12 @@ import jdk.incubator.code.CodeReflection;
 public class StringConcatTest {
 
     @IR("""
-            func @"test1" (%0 : java.lang.String, %1 : int)java.lang.String -> {
-                %2 : Var<java.lang.String> = var %0 @"a";
-                %3 : Var<int> = var %1 @"b";
-                %4 : java.lang.String = var.load %2;
-                %5 : int = var.load %3;
-                %6 : java.lang.String = concat %4 %5;
+            func @"test1" (%0 : java.type:"java.lang.String", %1 : java.type:"int")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %0 @"a";
+                %3 : Var<java.type:"int"> = var %1 @"b";
+                %4 : java.type:"java.lang.String" = var.load %2;
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"java.lang.String" = concat %4 %5;
                 return %6;
             };
             """)
@@ -25,14 +25,14 @@ public class StringConcatTest {
     }
 
     @IR("""
-            func @"test2" (%0 : java.lang.String, %1 : char)java.lang.String -> {
-                %2 : Var<java.lang.String> = var %0 @"a";
-                %3 : Var<char> = var %1 @"b";
-                %4 : java.lang.String = var.load %2;
-                %5 : char = var.load %3;
-                %6 : java.lang.String = concat %4 %5;
+            func @"test2" (%0 : java.type:"java.lang.String", %1 : java.type:"char")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %0 @"a";
+                %3 : Var<java.type:"char"> = var %1 @"b";
+                %4 : java.type:"java.lang.String" = var.load %2;
+                %5 : java.type:"char" = var.load %3;
+                %6 : java.type:"java.lang.String" = concat %4 %5;
                 var.store %2 %6;
-                %7 : java.lang.String = var.load %2;
+                %7 : java.type:"java.lang.String" = var.load %2;
                 return %7;
             };
             """)
@@ -43,14 +43,14 @@ public class StringConcatTest {
     }
 
     @IR("""
-            func @"test3" (%0 : java.lang.String, %1 : float)java.lang.String -> {
-                %2 : Var<java.lang.String> = var %0 @"a";
-                %3 : Var<float> = var %1 @"b";
-                %4 : java.lang.String = var.load %2;
-                %5 : float = var.load %3;
-                %6 : java.lang.String = concat %4 %5;
+            func @"test3" (%0 : java.type:"java.lang.String", %1 : java.type:"float")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %0 @"a";
+                %3 : Var<java.type:"float"> = var %1 @"b";
+                %4 : java.type:"java.lang.String" = var.load %2;
+                %5 : java.type:"float" = var.load %3;
+                %6 : java.type:"java.lang.String" = concat %4 %5;
                 var.store %2 %6;
-                %7 : java.lang.String = var.load %2;
+                %7 : java.type:"java.lang.String" = var.load %2;
                 return %7;
             };
             """)

--- a/test/langtools/tools/javac/reflect/SuperTest.java
+++ b/test/langtools/tools/javac/reflect/SuperTest.java
@@ -42,23 +42,23 @@ public class SuperTest extends SuperClass implements SuperInterface {
 
     @CodeReflection
     @IR("""
-            func @"superClassFieldAccess" (%0 : SuperTest)void -> {
-                %1 : int = field.load %0 @"SuperClass::f()int";
-                %2 : Var<int> = var %1 @"i";
-                %3 : int = constant @"1";
-                field.store %0 %3 @"SuperClass::f()int";
-                %4 : int = field.load %0 @"SuperClass::f()int";
+            func @"superClassFieldAccess" (%0 : java.type:"SuperTest")java.type:"void" -> {
+                %1 : java.type:"int" = field.load %0 @"SuperClass::f:int";
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                %3 : java.type:"int" = constant @"1";
+                field.store %0 %3 @"SuperClass::f:int";
+                %4 : java.type:"int" = field.load %0 @"SuperClass::f:int";
                 var.store %2 %4;
-                %5 : int = constant @"1";
-                field.store %0 %5 @"SuperClass::f()int";
-                %6 : int = field.load @"SuperClass::sf()int";
+                %5 : java.type:"int" = constant @"1";
+                field.store %0 %5 @"SuperClass::f:int";
+                %6 : java.type:"int" = field.load @"SuperClass::sf:int";
                 var.store %2 %6;
-                %7 : int = constant @"1";
-                field.store %7 @"SuperClass::sf()int";
-                %8 : int = field.load @"SuperClass::sf()int";
+                %7 : java.type:"int" = constant @"1";
+                field.store %7 @"SuperClass::sf:int";
+                %8 : java.type:"int" = field.load @"SuperClass::sf:int";
                 var.store %2 %8;
-                %9 : int = constant @"1";
-                field.store %9 @"SuperClass::sf()int";
+                %9 : java.type:"int" = constant @"1";
+                field.store %9 @"SuperClass::sf:int";
                 return;
             };
             """)
@@ -76,11 +76,11 @@ public class SuperTest extends SuperClass implements SuperInterface {
 
     @CodeReflection
     @IR("""
-            func @"superClassMethodInvocation" (%0 : SuperTest)void -> {
-                invoke %0 @invoke.kind="SUPER" @"SuperClass::get()void";
-                invoke %0 @invoke.kind="SUPER" @"SuperClass::get()void";
-                invoke @"SuperClass::sget()void";
-                invoke @"SuperClass::sget()void";
+            func @"superClassMethodInvocation" (%0 : java.type:"SuperTest")java.type:"void" -> {
+                invoke %0 @"SuperClass::get():void" @invoke.kind="SUPER";
+                invoke %0 @"SuperClass::get():void" @invoke.kind="SUPER";
+                invoke @"SuperClass::sget():void";
+                invoke @"SuperClass::sget():void";
                 return;
             };
             """)
@@ -94,8 +94,8 @@ public class SuperTest extends SuperClass implements SuperInterface {
 
     @CodeReflection
     @IR("""
-            func @"superInterfaceMethodInvocation" (%0 : SuperTest)void -> {
-                invoke %0 @invoke.kind="SUPER" @"SuperInterface::get()void";
+            func @"superInterfaceMethodInvocation" (%0 : java.type:"SuperTest")java.type:"void" -> {
+                invoke %0 @"SuperInterface::get():void" @invoke.kind="SUPER";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
@@ -39,44 +39,44 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"constantCaseLabelRule" (%0 : java.lang.String)java.lang.Object -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.Object = java.switch.expression %2
-                    ^constantCaseLabel(%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.String = constant @"FOO";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"constantCaseLabelRule" (%0 : java.type:"java.lang.String")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"FOO";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.Object -> {
-                        %7 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %7 : java.type:"java.lang.String" = constant @"FOO";
                         yield %7;
                     }
-                    ^constantCaseLabel(%8 : java.lang.String)boolean -> {
-                        %9 : java.lang.String = constant @"BAR";
-                        %10 : boolean = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%8 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"boolean" = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %10;
                     }
-                    ()java.lang.Object -> {
-                        %11 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %11 : java.type:"java.lang.String" = constant @"FOO";
                         yield %11;
                     }
-                    ^constantCaseLabel(%12 : java.lang.String)boolean -> {
-                        %13 : java.lang.String = constant @"BAZ";
-                        %14 : boolean = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%12 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %13 : java.type:"java.lang.String" = constant @"BAZ";
+                        %14 : java.type:"boolean" = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %14;
                     }
-                    ()java.lang.Object -> {
-                        %15 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %15 : java.type:"java.lang.String" = constant @"FOO";
                         yield %15;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
-                    }
-                    ()java.lang.Object -> {
-                        %16 : java.lang.String = constant @"";
+                    ()java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = constant @"true";
                         yield %16;
+                    }
+                    ()java.type:"java.lang.Object" -> {
+                        %17 : java.type:"java.lang.String" = constant @"";
+                        yield %17;
                     };
                 return %3;
             };
@@ -92,40 +92,40 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"constantCaseLabelsRule" (%0 : java.lang.String)java.lang.Object -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.Object = java.switch.expression %2
-                    ^constantCaseLabel(%4 : java.lang.String)boolean -> {
-                        %5 : boolean = java.cor
-                            ()boolean -> {
-                                %6 : java.lang.String = constant @"FOO";
-                                %7 : boolean = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"constantCaseLabelsRule" (%0 : java.type:"java.lang.String")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %6 : java.type:"java.lang.String" = constant @"FOO";
+                                %7 : java.type:"boolean" = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %7;
                             }
-                            ()boolean -> {
-                                %8 : java.lang.String = constant @"BAR";
-                                %9 : boolean = invoke %4 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %8 : java.type:"java.lang.String" = constant @"BAR";
+                                %9 : java.type:"boolean" = invoke %4 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %9;
                             }
-                            ()boolean -> {
-                                %10 : java.lang.String = constant @"BAZ";
-                                %11 : boolean = invoke %4 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %10 : java.type:"java.lang.String" = constant @"BAZ";
+                                %11 : java.type:"boolean" = invoke %4 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %11;
                             };
                         yield %5;
                     }
-                    ()java.lang.Object -> {
-                        %12 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %12 : java.type:"java.lang.String" = constant @"FOO";
                         yield %12;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %14 : boolean = constant @"true";
-                        yield %14;
+                    ()java.type:"boolean" -> {
+                        %13 : java.type:"boolean" = constant @"true";
+                        yield %13;
                     }
-                    ()java.lang.Object -> {
-                        %13 : java.lang.String = constant @"";
-                        java.yield %13;
+                    ()java.type:"java.lang.Object" -> {
+                        %14 : java.type:"java.lang.String" = constant @"";
+                        java.yield %14;
                     };
                 return %3;
             };
@@ -141,44 +141,44 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"constantCaseLabelStatement" (%0 : java.lang.String)java.lang.Object -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.Object = java.switch.expression %2
-                    ^constantCaseLabel(%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.String = constant @"FOO";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"constantCaseLabelStatement" (%0 : java.type:"java.lang.String")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"FOO";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.Object -> {
-                        %7 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %7 : java.type:"java.lang.String" = constant @"FOO";
                         java.yield %7;
                     }
-                    ^constantCaseLabel(%8 : java.lang.String)boolean -> {
-                        %9 : java.lang.String = constant @"BAR";
-                        %10 : boolean = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%8 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"boolean" = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %10;
                     }
-                    ()java.lang.Object -> {
-                        %11 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %11 : java.type:"java.lang.String" = constant @"FOO";
                         java.yield %11;
                     }
-                    ^constantCaseLabel(%12 : java.lang.String)boolean -> {
-                        %13 : java.lang.String = constant @"BAZ";
-                        %14 : boolean = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%12 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %13 : java.type:"java.lang.String" = constant @"BAZ";
+                        %14 : java.type:"boolean" = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %14;
                     }
-                    ()java.lang.Object -> {
-                        %15 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %15 : java.type:"java.lang.String" = constant @"FOO";
                         java.yield %15;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = constant @"true";
+                        yield %16;
                     }
-                    ()java.lang.Object -> {
-                        %16 : java.lang.String = constant @"";
-                        java.yield %16;
+                    ()java.type:"java.lang.Object" -> {
+                        %17 : java.type:"java.lang.String" = constant @"";
+                        java.yield %17;
                     };
                 return %3;
             };
@@ -194,41 +194,41 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"constantCaseLabelsStatement" (%0 : java.lang.String)java.lang.Object -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.Object = java.switch.expression %2
-                    ^constantCaseLabel(%4 : java.lang.String)boolean -> {
-                        %5 : boolean = java.cor
-                            ()boolean -> {
-                                %6 : java.lang.String = constant @"FOO";
-                                %7 : boolean = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"constantCaseLabelsStatement" (%0 : java.type:"java.lang.String")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %6 : java.type:"java.lang.String" = constant @"FOO";
+                                %7 : java.type:"boolean" = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %7;
                             }
-                            ()boolean -> {
-                                %8 : java.lang.String = constant @"BAR";
-                                %9 : boolean = invoke %4 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %8 : java.type:"java.lang.String" = constant @"BAR";
+                                %9 : java.type:"boolean" = invoke %4 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %9;
                             }
-                            ()boolean -> {
-                                %10 : java.lang.String = constant @"BAZ";
-                                %11 : boolean = invoke %4 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %10 : java.type:"java.lang.String" = constant @"BAZ";
+                                %11 : java.type:"boolean" = invoke %4 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %11;
                             };
                         yield %5;
                     }
-                    ()java.lang.Object -> {
-                        %12 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.Object" -> {
+                        %12 : java.type:"java.lang.String" = constant @"FOO";
                         java.yield %12;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %13 : java.type:"boolean" = constant @"true";
+                        yield %13;
                     }
-                    ()java.lang.Object -> {
-                        java.block ()void -> {
-                            %13 : java.lang.String = constant @"";
-                            java.yield %13;
+                    ()java.type:"java.lang.Object" -> {
+                        java.block ()java.type:"void" -> {
+                            %14 : java.type:"java.lang.String" = constant @"";
+                            java.yield %14;
                         };
                         unreachable;
                     };
@@ -244,35 +244,35 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"constantCaseLabelStatements" (%0 : java.lang.String)java.lang.Object -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.Object = java.switch.expression %2
-                    ^constantCaseLabel(%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.String = constant @"FOO";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"constantCaseLabelStatements" (%0 : java.type:"java.lang.String")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"FOO";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.Object -> {
-                        java.block ()void -> {
-                            %7 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                            %8 : java.lang.String = constant @"FOO";
-                            invoke %7 %8 @"java.io.PrintStream::println(java.lang.String)void";
+                    ()java.type:"java.lang.Object" -> {
+                        java.block ()java.type:"void" -> {
+                            %7 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                            %8 : java.type:"java.lang.String" = constant @"FOO";
+                            invoke %7 %8 @"java.io.PrintStream::println(java.lang.String):void";
                             yield;
                         };
-                        java.block ()void -> {
-                            %9 : java.lang.String = constant @"FOO";
+                        java.block ()java.type:"void" -> {
+                            %9 : java.type:"java.lang.String" = constant @"FOO";
                             java.yield %9;
                         };
                         unreachable;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %11 : boolean = constant @"true";
-                        yield %11;
+                    ()java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = constant @"true";
+                        yield %10;
                     }
-                    ()java.lang.Object -> {
-                        %10 : java.lang.String = constant @"";
-                        java.yield %10;
+                    ()java.type:"java.lang.Object" -> {
+                        %11 : java.type:"java.lang.String" = constant @"";
+                        java.yield %11;
                     };
                 return %3;
             };
@@ -291,31 +291,31 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"constantCaseLabelFallthrough" (%0 : java.lang.String)java.lang.Object -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.Object = java.switch.expression %2
-                    ^constantCaseLabel(%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.String = constant @"FOO";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"constantCaseLabelFallthrough" (%0 : java.type:"java.lang.String")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"FOO";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.Object -> {
-                        java.block ()void -> {
-                            %7 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                            %8 : java.lang.String = constant @"FOO";
-                            invoke %7 %8 @"java.io.PrintStream::println(java.lang.String)void";
+                    ()java.type:"java.lang.Object" -> {
+                        java.block ()java.type:"void" -> {
+                            %7 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                            %8 : java.type:"java.lang.String" = constant @"FOO";
+                            invoke %7 %8 @"java.io.PrintStream::println(java.lang.String):void";
                             yield;
                         };
                         java.switch.fallthrough;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %10 : boolean = constant @"true";
-                        yield %10;
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @"true";
+                        yield %9;
                     }
-                    ()java.lang.Object -> {
-                        %9 : java.lang.String = constant @"";
-                        java.yield %9;
+                    ()java.type:"java.lang.Object" -> {
+                        %10 : java.type:"java.lang.String" = constant @"";
+                        java.yield %10;
                     };
                 return %3;
             };
@@ -334,54 +334,54 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"patternCaseLabel" (%0 : java.lang.Object)java.lang.Object -> {
-                %1 : Var<java.lang.Object> = var %0 @"r";
-                %2 : java.lang.Object = var.load %1;
-                %3 : java.lang.Number = constant @null;
-                %4 : Var<java.lang.Number> = var %3 @"n";
-                %5 : java.lang.String = constant @null;
-                %6 : Var<java.lang.String> = var %5 @"s";
-                %7 : java.lang.Object = java.switch.expression %2
-                    ^patternCaseLabel(%8 : java.lang.Object)boolean -> {
-                        %9 : boolean = pattern.match %8
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A> -> {
-                                %10 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> = pattern.type @"n";
-                                %11 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A> = pattern.record %10 @"(java.lang.Number n)SwitchExpressionTest$A";
+            func @"patternCaseLabel" (%0 : java.type:"java.lang.Object")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"r";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.Number" = constant @null;
+                %4 : Var<java.type:"java.lang.Number"> = var %3 @"n";
+                %5 : java.type:"java.lang.String" = constant @null;
+                %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
+                %7 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%8 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = pattern.match %8
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A>" -> {
+                                %10 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" = pattern.type @"n";
+                                %11 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A>" = pattern.record %10 @"(java.lang.Number n)SwitchExpressionTest$A";
                                 yield %11;
                             }
-                            ^match(%12 : java.lang.Number)void -> {
+                            (%12 : java.type:"java.lang.Number")java.type:"void" -> {
                                 var.store %4 %12;
                                 yield;
                             };
                         yield %9;
                     }
-                    ()java.lang.Object -> {
-                        %13 : java.lang.Number = var.load %4;
+                    ()java.type:"java.lang.Object" -> {
+                        %13 : java.type:"java.lang.Number" = var.load %4;
                         java.yield %13;
                     }
-                    ^patternCaseLabel(%14 : java.lang.Object)boolean -> {
-                        %15 : boolean = pattern.match %14
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                %16 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    (%14 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %15 : java.type:"boolean" = pattern.match %14
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %16 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                 yield %16;
                             }
-                            ^match(%17 : java.lang.String)void -> {
+                            (%17 : java.type:"java.lang.String")java.type:"void" -> {
                                 var.store %6 %17;
                                 yield;
                             };
                         yield %15;
                     }
-                    ()java.lang.Object -> {
-                        %18 : java.lang.String = var.load %6;
+                    ()java.type:"java.lang.Object" -> {
+                        %18 : java.type:"java.lang.String" = var.load %6;
                         java.yield %18;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %10 : boolean = constant @"true";
-                        yield %10;
+                    ()java.type:"boolean" -> {
+                        %19 : java.type:"boolean" = constant @"true";
+                        yield %19;
                     }
-                    ()java.lang.Object -> {
-                        %19 : java.lang.String = constant @"";
-                        java.yield %19;
+                    ()java.type:"java.lang.Object" -> {
+                        %20 : java.type:"java.lang.String" = constant @"";
+                        java.yield %20;
                     };
                 return %7;
             };
@@ -402,94 +402,94 @@ public class SwitchExpressionTest {
 
     @CodeReflection
     @IR("""
-            func @"patternCaseLabelGuard" (%0 : java.lang.Object)java.lang.Object -> {
-                %1 : Var<java.lang.Object> = var %0 @"r";
-                %2 : java.lang.Object = var.load %1;
-                %3 : java.lang.Number = constant @null;
-                %4 : Var<java.lang.Number> = var %3 @"n";
-                %5 : java.lang.String = constant @null;
-                %6 : Var<java.lang.String> = var %5 @"s";
-                %7 : java.lang.String = constant @null;
-                %8 : Var<java.lang.String> = var %7 @"s";
-                %9 : java.lang.Object = java.switch.expression %2
-                    ^patternCaseLabel(%10 : java.lang.Object)boolean -> {
-                        %11 : boolean = pattern.match %10
-                            ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A> -> {
-                                %12 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> = pattern.type @"n";
-                                %13 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A> = pattern.record %12 @"(java.lang.Number n)SwitchExpressionTest$A";
+            func @"patternCaseLabelGuard" (%0 : java.type:"java.lang.Object")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"r";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.Number" = constant @null;
+                %4 : Var<java.type:"java.lang.Number"> = var %3 @"n";
+                %5 : java.type:"java.lang.String" = constant @null;
+                %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
+                %7 : java.type:"java.lang.String" = constant @null;
+                %8 : Var<java.type:"java.lang.String"> = var %7 @"s";
+                %9 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%10 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %11 : java.type:"boolean" = pattern.match %10
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A>" -> {
+                                %12 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" = pattern.type @"n";
+                                %13 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchExpressionTest$A>" = pattern.record %12 @"(java.lang.Number n)SwitchExpressionTest$A";
                                 yield %13;
                             }
-                            ^match(%14 : java.lang.Number)void -> {
+                            (%14 : java.type:"java.lang.Number")java.type:"void" -> {
                                 var.store %4 %14;
                                 yield;
                             };
                         yield %11;
                     }
-                    ()java.lang.Object -> {
-                        %15 : java.lang.Number = var.load %4;
+                    ()java.type:"java.lang.Object" -> {
+                        %15 : java.type:"java.lang.Number" = var.load %4;
                         java.yield %15;
                     }
-                    ^patternCaseLabel(%16 : java.lang.Object)boolean -> {
-                        %17 : boolean = java.cand
-                            ()boolean -> {
-                                %18 : boolean = pattern.match %16
-                                    ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                        %19 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    (%16 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %18 : java.type:"boolean" = pattern.match %16
+                                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                        %19 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                         yield %19;
                                     }
-                                    ^match(%20 : java.lang.String)void -> {
+                                    (%20 : java.type:"java.lang.String")java.type:"void" -> {
                                         var.store %6 %20;
                                         yield;
                                     };
                                 yield %18;
                             }
-                            ()boolean -> {
-                                %21 : java.lang.String = var.load %6;
-                                %22 : int = invoke %21 @"java.lang.String::length()int";
-                                %23 : int = constant @"5";
-                                %24 : boolean = lt %22 %23;
+                            ()java.type:"boolean" -> {
+                                %21 : java.type:"java.lang.String" = var.load %6;
+                                %22 : java.type:"int" = invoke %21 @"java.lang.String::length():int";
+                                %23 : java.type:"int" = constant @"5";
+                                %24 : java.type:"boolean" = lt %22 %23;
                                 yield %24;
                             };
                         yield %17;
                     }
-                    ()java.lang.Object -> {
-                        %25 : java.lang.String = var.load %6;
+                    ()java.type:"java.lang.Object" -> {
+                        %25 : java.type:"java.lang.String" = var.load %6;
                         java.yield %25;
                     }
-                    ^patternCaseLabel(%26 : java.lang.Object)boolean -> {
-                        %27 : boolean = java.cand
-                            ()boolean -> {
-                                %28 : boolean = pattern.match %26
-                                    ^pattern()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                        %29 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    (%26 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %27 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %28 : java.type:"boolean" = pattern.match %26
+                                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                        %29 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                         yield %29;
                                     }
-                                    ^match(%30 : java.lang.String)void -> {
+                                    (%30 : java.type:"java.lang.String")java.type:"void" -> {
                                         var.store %8 %30;
                                         yield;
                                     };
                                 yield %28;
                             }
-                            ()boolean -> {
-                                %31 : java.lang.String = var.load %8;
-                                %32 : int = invoke %31 @"java.lang.String::length()int";
-                                %33 : int = constant @"10";
-                                %34 : boolean = lt %32 %33;
+                            ()java.type:"boolean" -> {
+                                %31 : java.type:"java.lang.String" = var.load %8;
+                                %32 : java.type:"int" = invoke %31 @"java.lang.String::length():int";
+                                %33 : java.type:"int" = constant @"10";
+                                %34 : java.type:"boolean" = lt %32 %33;
                                 yield %34;
                             };
                         yield %27;
                     }
-                    ()java.lang.Object -> {
-                        %35 : java.lang.String = var.load %8;
+                    ()java.type:"java.lang.Object" -> {
+                        %35 : java.type:"java.lang.String" = var.load %8;
                         java.yield %35;
                     }
-                    ^defaultCaseLabel()boolean -> {
-                        %37 : boolean = constant @"true";
-                        yield %37;
+                    ()java.type:"boolean" -> {
+                        %36 : java.type:"boolean" = constant @"true";
+                        yield %36;
                     }
-                    ()java.lang.Object -> {
-                        %36 : java.lang.String = constant @"";
-                        java.yield %36;
+                    ()java.type:"java.lang.Object" -> {
+                        %37 : java.type:"java.lang.String" = constant @"";
+                        java.yield %37;
                     };
                 return %9;
             };

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
@@ -11,44 +11,44 @@ import jdk.incubator.code.CodeReflection;
 public class SwitchExpressionTest2 {
 
     @IR("""
-            func @"caseConstantRuleExpression" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.String = constant @"FOO";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"caseConstantRuleExpression" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"FOO";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.String -> {
-                        %7 : java.lang.String = constant @"BAR";
+                    ()java.type:"java.lang.String" -> {
+                        %7 : java.type:"java.lang.String" = constant @"BAR";
                         yield %7;
                     }
-                    (%8 : java.lang.String)boolean -> {
-                        %9 : java.lang.String = constant @"BAR";
-                        %10 : boolean = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%8 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"boolean" = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %10;
                     }
-                    ()java.lang.String -> {
-                        %11 : java.lang.String = constant @"BAZ";
+                    ()java.type:"java.lang.String" -> {
+                        %11 : java.type:"java.lang.String" = constant @"BAZ";
                         yield %11;
                     }
-                    (%12 : java.lang.String)boolean -> {
-                        %13 : java.lang.String = constant @"BAZ";
-                        %14 : boolean = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%12 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %13 : java.type:"java.lang.String" = constant @"BAZ";
+                        %14 : java.type:"boolean" = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %14;
                     }
-                    ()java.lang.String -> {
-                        %15 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.String" -> {
+                        %15 : java.type:"java.lang.String" = constant @"FOO";
                         yield %15;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
-                    }
-                    ()java.lang.String -> {
-                        %16 : java.lang.String = constant @"";
+                    ()java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = constant @"true";
                         yield %16;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"";
+                        yield %17;
                     };
                 return %3;
             };
@@ -64,44 +64,44 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"caseConstantRuleBlock" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"r";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.String = constant @"FOO";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"caseConstantRuleBlock" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"FOO";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.String -> {
-                        %7 : java.lang.String = constant @"BAR";
+                    ()java.type:"java.lang.String" -> {
+                        %7 : java.type:"java.lang.String" = constant @"BAR";
                         java.yield %7;
                     }
-                    (%8 : java.lang.String)boolean -> {
-                        %9 : java.lang.String = constant @"BAR";
-                        %10 : boolean = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%8 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"boolean" = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %10;
                     }
-                    ()java.lang.String -> {
-                        %11 : java.lang.String = constant @"BAZ";
+                    ()java.type:"java.lang.String" -> {
+                        %11 : java.type:"java.lang.String" = constant @"BAZ";
                         java.yield %11;
                     }
-                    (%12 : java.lang.String)boolean -> {
-                        %13 : java.lang.String = constant @"BAZ";
-                        %14 : boolean = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%12 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %13 : java.type:"java.lang.String" = constant @"BAZ";
+                        %14 : java.type:"boolean" = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %14;
                     }
-                    ()java.lang.String -> {
-                        %15 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.String" -> {
+                        %15 : java.type:"java.lang.String" = constant @"FOO";
                         java.yield %15;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = constant @"true";
+                        yield %16;
                     }
-                    ()java.lang.String -> {
-                        %16 : java.lang.String = constant @"";
-                        java.yield %16;
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"";
+                        java.yield %17;
                     };
                 return %3;
             };
@@ -125,44 +125,44 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"caseConstantStatement" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"s";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.String = constant @"FOO";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"caseConstantStatement" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"FOO";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.String -> {
-                        %7 : java.lang.String = constant @"BAR";
+                    ()java.type:"java.lang.String" -> {
+                        %7 : java.type:"java.lang.String" = constant @"BAR";
                         java.yield %7;
                     }
-                    (%8 : java.lang.String)boolean -> {
-                        %9 : java.lang.String = constant @"BAR";
-                        %10 : boolean = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%8 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"boolean" = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %10;
                     }
-                    ()java.lang.String -> {
-                        %11 : java.lang.String = constant @"BAZ";
+                    ()java.type:"java.lang.String" -> {
+                        %11 : java.type:"java.lang.String" = constant @"BAZ";
                         java.yield %11;
                     }
-                    (%12 : java.lang.String)boolean -> {
-                        %13 : java.lang.String = constant @"BAZ";
-                        %14 : boolean = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%12 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %13 : java.type:"java.lang.String" = constant @"BAZ";
+                        %14 : java.type:"boolean" = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %14;
                     }
-                    ()java.lang.String -> {
-                        %15 : java.lang.String = constant @"FOO";
+                    ()java.type:"java.lang.String" -> {
+                        %15 : java.type:"java.lang.String" = constant @"FOO";
                         java.yield %15;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = constant @"true";
+                        yield %16;
                     }
-                    ()java.lang.String -> {
-                        %16 : java.lang.String = constant @"";
-                        java.yield %16;
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"";
+                        java.yield %17;
                     };
                 return %3;
             };
@@ -178,51 +178,51 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"caseConstantMultiLabels" (%0 : char)java.lang.String -> {
-                %1 : Var<char> = var %0 @"c";
-                %2 : char = var.load %1;
-                %3 : char = invoke %2 @"java.lang.Character::toLowerCase(char)char";
-                %4 : java.lang.String = java.switch.expression %3
-                    (%5 : char)boolean -> {
-                        %6 : boolean = java.cor
-                            ()boolean -> {
-                                %7 : char = constant @"a";
-                                %8 : boolean = eq %5 %7;
+            func @"caseConstantMultiLabels" (%0 : java.type:"char")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"char"> = var %0 @"c";
+                %2 : java.type:"char" = var.load %1;
+                %3 : java.type:"char" = invoke %2 @"java.lang.Character::toLowerCase(char):char";
+                %4 : java.type:"java.lang.String" = java.switch.expression %3
+                    (%5 : java.type:"char")java.type:"boolean" -> {
+                        %6 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %7 : java.type:"char" = constant @"a";
+                                %8 : java.type:"boolean" = eq %5 %7;
                                 yield %8;
                             }
-                            ()boolean -> {
-                                %9 : char = constant @"e";
-                                %10 : boolean = eq %5 %9;
+                            ()java.type:"boolean" -> {
+                                %9 : java.type:"char" = constant @"e";
+                                %10 : java.type:"boolean" = eq %5 %9;
                                 yield %10;
                             }
-                            ()boolean -> {
-                                %11 : char = constant @"i";
-                                %12 : boolean = eq %5 %11;
+                            ()java.type:"boolean" -> {
+                                %11 : java.type:"char" = constant @"i";
+                                %12 : java.type:"boolean" = eq %5 %11;
                                 yield %12;
                             }
-                            ()boolean -> {
-                                %13 : char = constant @"o";
-                                %14 : boolean = eq %5 %13;
+                            ()java.type:"boolean" -> {
+                                %13 : java.type:"char" = constant @"o";
+                                %14 : java.type:"boolean" = eq %5 %13;
                                 yield %14;
                             }
-                            ()boolean -> {
-                                %15 : char = constant @"u";
-                                %16 : boolean = eq %5 %15;
+                            ()java.type:"boolean" -> {
+                                %15 : java.type:"char" = constant @"u";
+                                %16 : java.type:"boolean" = eq %5 %15;
                                 yield %16;
                             };
                         yield %6;
                     }
-                    ()java.lang.String -> {
-                        %17 : java.lang.String = constant @"vowel";
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"vowel";
                         java.yield %17;
                     }
-                    ()boolean -> {
-                        %19 : boolean = constant @"true";
-                        yield %19;
+                    ()java.type:"boolean" -> {
+                        %18 : java.type:"boolean" = constant @"true";
+                        yield %18;
                     }
-                    ()java.lang.String -> {
-                        %18 : java.lang.String = constant @"consonant";
-                        java.yield %18;
+                    ()java.type:"java.lang.String" -> {
+                        %19 : java.type:"java.lang.String" = constant @"consonant";
+                        java.yield %19;
                     };
                 return %4;
             };
@@ -236,37 +236,37 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"caseConstantThrow" (%0 : java.lang.Integer)java.lang.String -> {
-                %1 : Var<java.lang.Integer> = var %0 @"i";
-                %2 : java.lang.Integer = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : java.lang.Integer)boolean -> {
-                        %5 : int = constant @"8";
-                        %6 : java.lang.Integer = invoke %5 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                        %7 : boolean = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"caseConstantThrow" (%0 : java.type:"java.lang.Integer")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Integer"> = var %0 @"i";
+                %2 : java.type:"java.lang.Integer" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.Integer")java.type:"boolean" -> {
+                        %5 : java.type:"int" = constant @"8";
+                        %6 : java.type:"java.lang.Integer" = invoke %5 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        %7 : java.type:"boolean" = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.IllegalArgumentException = new @"java.lang.IllegalArgumentException::<new>()";
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"java.lang.IllegalArgumentException" = new @"java.lang.IllegalArgumentException::()";
                         throw %8;
                     }
-                    (%9 : java.lang.Integer)boolean -> {
-                        %10 : int = constant @"9";
-                        %11 : java.lang.Integer = invoke %10 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                        %12 : boolean = invoke %9 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%9 : java.type:"java.lang.Integer")java.type:"boolean" -> {
+                        %10 : java.type:"int" = constant @"9";
+                        %11 : java.type:"java.lang.Integer" = invoke %10 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        %12 : java.type:"boolean" = invoke %9 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %12;
                     }
-                    ()java.lang.String -> {
-                        %13 : java.lang.String = constant @"NINE";
+                    ()java.type:"java.lang.String" -> {
+                        %13 : java.type:"java.lang.String" = constant @"NINE";
                         yield %13;
                     }
-                    ()boolean -> {
-                        %15 : boolean = constant @"true";
-                        yield %15;
-                    }
-                    ()java.lang.String -> {
-                        %14 : java.lang.String = constant @"An integer";
+                    ()java.type:"boolean" -> {
+                        %14 : java.type:"boolean" = constant @"true";
                         yield %14;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %15 : java.type:"java.lang.String" = constant @"An integer";
+                        yield %15;
                     };
                 return %3;
             };
@@ -281,26 +281,26 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"caseConstantNullLabel" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"s";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : java.lang.String)boolean -> {
-                        %5 : java.lang.Object = constant @null;
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"caseConstantNullLabel" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.Object" = constant @null;
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.String -> {
-                        %7 : java.lang.String = constant @"null";
+                    ()java.type:"java.lang.String" -> {
+                        %7 : java.type:"java.lang.String" = constant @"null";
                         yield %7;
                     }
-                    ()boolean -> {
-                        %9 : boolean = constant @"true";
-                        yield %9;
-                    }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @"non null";
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = constant @"true";
                         yield %8;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"java.lang.String" = constant @"non null";
+                        yield %9;
                     };
                 return %3;
             };
@@ -324,34 +324,34 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"caseConstantFallThrough" (%0 : char)java.lang.String -> {
-                %1 : Var<char> = var %0 @"c";
-                %2 : char = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : char)boolean -> {
-                        %5 : char = constant @"A";
-                        %6 : boolean = eq %4 %5;
+            func @"caseConstantFallThrough" (%0 : java.type:"char")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"char"> = var %0 @"c";
+                %2 : java.type:"char" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"char")java.type:"boolean" -> {
+                        %5 : java.type:"char" = constant @"A";
+                        %6 : java.type:"boolean" = eq %4 %5;
                         yield %6;
                     }
-                    ()java.lang.String -> {
+                    ()java.type:"java.lang.String" -> {
                         java.switch.fallthrough;
                     }
-                    (%7 : char)boolean -> {
-                        %8 : char = constant @"B";
-                        %9 : boolean = eq %7 %8;
+                    (%7 : java.type:"char")java.type:"boolean" -> {
+                        %8 : java.type:"char" = constant @"B";
+                        %9 : java.type:"boolean" = eq %7 %8;
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %10 : java.lang.String = constant @"A or B";
+                    ()java.type:"java.lang.String" -> {
+                        %10 : java.type:"java.lang.String" = constant @"A or B";
                         java.yield %10;
                     }
-                    ()boolean -> {
-                        %12 : boolean = constant @"true";
-                        yield %12;
+                    ()java.type:"boolean" -> {
+                        %11 : java.type:"boolean" = constant @"true";
+                        yield %11;
                     }
-                    ()java.lang.String -> {
-                        %11 : java.lang.String = constant @"Neither A nor B";
-                        java.yield %11;
+                    ()java.type:"java.lang.String" -> {
+                        %12 : java.type:"java.lang.String" = constant @"Neither A nor B";
+                        java.yield %12;
                     };
                 return %3;
             };
@@ -371,76 +371,76 @@ public class SwitchExpressionTest2 {
         MON, TUE, WED, THU, FRI, SAT, SUN
     }
     @IR("""
-            func @"caseConstantEnum" (%0 : SwitchExpressionTest2$Day)int -> {
-                %1 : Var<SwitchExpressionTest2$Day> = var %0 @"d";
-                %2 : SwitchExpressionTest2$Day = var.load %1;
-                %3 : int = java.switch.expression %2
-                    (%4 : SwitchExpressionTest2$Day)boolean -> {
-                        %5 : boolean = java.cor
-                            ()boolean -> {
-                                %6 : SwitchExpressionTest2$Day = field.load @"SwitchExpressionTest2$Day::MON()SwitchExpressionTest2$Day";
-                                %7 : boolean = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"caseConstantEnum" (%0 : java.type:"SwitchExpressionTest2$Day")java.type:"int" -> {
+                %1 : Var<java.type:"SwitchExpressionTest2$Day"> = var %0 @"d";
+                %2 : java.type:"SwitchExpressionTest2$Day" = var.load %1;
+                %3 : java.type:"int" = java.switch.expression %2
+                    (%4 : java.type:"SwitchExpressionTest2$Day")java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %6 : java.type:"SwitchExpressionTest2$Day" = field.load @"SwitchExpressionTest2$Day::MON:SwitchExpressionTest2$Day";
+                                %7 : java.type:"boolean" = invoke %4 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %7;
                             }
-                            ()boolean -> {
-                                %8 : SwitchExpressionTest2$Day = field.load @"SwitchExpressionTest2$Day::FRI()SwitchExpressionTest2$Day";
-                                %9 : boolean = invoke %4 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %8 : java.type:"SwitchExpressionTest2$Day" = field.load @"SwitchExpressionTest2$Day::FRI:SwitchExpressionTest2$Day";
+                                %9 : java.type:"boolean" = invoke %4 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %9;
                             }
-                            ()boolean -> {
-                                %10 : SwitchExpressionTest2$Day = field.load @"SwitchExpressionTest2$Day::SUN()SwitchExpressionTest2$Day";
-                                %11 : boolean = invoke %4 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %10 : java.type:"SwitchExpressionTest2$Day" = field.load @"SwitchExpressionTest2$Day::SUN:SwitchExpressionTest2$Day";
+                                %11 : java.type:"boolean" = invoke %4 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %11;
                             };
                         yield %5;
                     }
-                    ()int -> {
-                        %12 : int = constant @"6";
+                    ()java.type:"int" -> {
+                        %12 : java.type:"int" = constant @"6";
                         yield %12;
                     }
-                    (%13 : SwitchExpressionTest2$Day)boolean -> {
-                        %14 : SwitchExpressionTest2$Day = field.load @"SwitchExpressionTest2$Day::TUE()SwitchExpressionTest2$Day";
-                        %15 : boolean = invoke %13 %14 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%13 : java.type:"SwitchExpressionTest2$Day")java.type:"boolean" -> {
+                        %14 : java.type:"SwitchExpressionTest2$Day" = field.load @"SwitchExpressionTest2$Day::TUE:SwitchExpressionTest2$Day";
+                        %15 : java.type:"boolean" = invoke %13 %14 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %15;
                     }
-                    ()int -> {
-                        %16 : int = constant @"7";
+                    ()java.type:"int" -> {
+                        %16 : java.type:"int" = constant @"7";
                         yield %16;
                     }
-                    (%17 : SwitchExpressionTest2$Day)boolean -> {
-                        %18 : boolean = java.cor
-                            ()boolean -> {
-                                %19 : SwitchExpressionTest2$Day = field.load @"SwitchExpressionTest2$Day::THU()SwitchExpressionTest2$Day";
-                                %20 : boolean = invoke %17 %19 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%17 : java.type:"SwitchExpressionTest2$Day")java.type:"boolean" -> {
+                        %18 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %19 : java.type:"SwitchExpressionTest2$Day" = field.load @"SwitchExpressionTest2$Day::THU:SwitchExpressionTest2$Day";
+                                %20 : java.type:"boolean" = invoke %17 %19 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %20;
                             }
-                            ()boolean -> {
-                                %21 : SwitchExpressionTest2$Day = field.load @"SwitchExpressionTest2$Day::SAT()SwitchExpressionTest2$Day";
-                                %22 : boolean = invoke %17 %21 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %21 : java.type:"SwitchExpressionTest2$Day" = field.load @"SwitchExpressionTest2$Day::SAT:SwitchExpressionTest2$Day";
+                                %22 : java.type:"boolean" = invoke %17 %21 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                                 yield %22;
                             };
                         yield %18;
                     }
-                    ()int -> {
-                        %23 : int = constant @"8";
+                    ()java.type:"int" -> {
+                        %23 : java.type:"int" = constant @"8";
                         yield %23;
                     }
-                    (%24 : SwitchExpressionTest2$Day)boolean -> {
-                        %25 : SwitchExpressionTest2$Day = field.load @"SwitchExpressionTest2$Day::WED()SwitchExpressionTest2$Day";
-                        %26 : boolean = invoke %24 %25 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%24 : java.type:"SwitchExpressionTest2$Day")java.type:"boolean" -> {
+                        %25 : java.type:"SwitchExpressionTest2$Day" = field.load @"SwitchExpressionTest2$Day::WED:SwitchExpressionTest2$Day";
+                        %26 : java.type:"boolean" = invoke %24 %25 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %26;
                     }
-                    ()int -> {
-                        %27 : int = constant @"9";
+                    ()java.type:"int" -> {
+                        %27 : java.type:"int" = constant @"9";
                         yield %27;
                     }
-                    ()boolean -> {
-                        %29 : boolean = constant @"true";
-                        yield %29;
+                    ()java.type:"boolean" -> {
+                        %28 : java.type:"boolean" = constant @"true";
+                        yield %28;
                     }
-                    ()int -> {
-                        %28 : java.lang.MatchException = new @"java.lang.MatchException::<new>()";
-                        throw %28;
+                    ()java.type:"int" -> {
+                        %29 : java.type:"java.lang.MatchException" = new @"java.lang.MatchException::()";
+                        throw %29;
                     };
                 return %3;
             };
@@ -459,170 +459,170 @@ public class SwitchExpressionTest2 {
         static final int c1 = 12;
     }
     @IR("""
-            func @"caseConstantOtherKindsOfExpr" (%0 : int)java.lang.String -> {
-                %1 : Var<int> = var %0 @"i";
-                %2 : int = constant @"11";
-                %3 : Var<int> = var %2 @"eleven";
-                %4 : int = var.load %1;
-                %5 : java.lang.String = java.switch.expression %4
-                    (%6 : int)boolean -> {
-                        %7 : int = constant @"1";
-                        %8 : int = constant @"15";
-                        %9 : int = and %7 %8;
-                        %10 : boolean = eq %6 %9;
+            func @"caseConstantOtherKindsOfExpr" (%0 : java.type:"int")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = constant @"11";
+                %3 : Var<java.type:"int"> = var %2 @"eleven";
+                %4 : java.type:"int" = var.load %1;
+                %5 : java.type:"java.lang.String" = java.switch.expression %4
+                    (%6 : java.type:"int")java.type:"boolean" -> {
+                        %7 : java.type:"int" = constant @"1";
+                        %8 : java.type:"int" = constant @"15";
+                        %9 : java.type:"int" = and %7 %8;
+                        %10 : java.type:"boolean" = eq %6 %9;
                         yield %10;
                     }
-                    ()java.lang.String -> {
-                        %11 : java.lang.String = constant @"1";
+                    ()java.type:"java.lang.String" -> {
+                        %11 : java.type:"java.lang.String" = constant @"1";
                         yield %11;
                     }
-                    (%12 : int)boolean -> {
-                        %13 : int = constant @"4";
-                        %14 : int = constant @"1";
-                        %15 : int = ashr %13 %14;
-                        %16 : boolean = eq %12 %15;
+                    (%12 : java.type:"int")java.type:"boolean" -> {
+                        %13 : java.type:"int" = constant @"4";
+                        %14 : java.type:"int" = constant @"1";
+                        %15 : java.type:"int" = ashr %13 %14;
+                        %16 : java.type:"boolean" = eq %12 %15;
                         yield %16;
                     }
-                    ()java.lang.String -> {
-                        %17 : java.lang.String = constant @"2";
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"2";
                         yield %17;
                     }
-                    (%18 : int)boolean -> {
-                        %19 : long = constant @"3";
-                        %20 : int = conv %19;
-                        %21 : boolean = eq %18 %20;
+                    (%18 : java.type:"int")java.type:"boolean" -> {
+                        %19 : java.type:"long" = constant @"3";
+                        %20 : java.type:"int" = conv %19;
+                        %21 : java.type:"boolean" = eq %18 %20;
                         yield %21;
                     }
-                    ()java.lang.String -> {
-                        %22 : java.lang.String = constant @"3";
+                    ()java.type:"java.lang.String" -> {
+                        %22 : java.type:"java.lang.String" = constant @"3";
                         yield %22;
                     }
-                    (%23 : int)boolean -> {
-                        %24 : int = constant @"2";
-                        %25 : int = constant @"1";
-                        %26 : int = lshl %24 %25;
-                        %27 : boolean = eq %23 %26;
+                    (%23 : java.type:"int")java.type:"boolean" -> {
+                        %24 : java.type:"int" = constant @"2";
+                        %25 : java.type:"int" = constant @"1";
+                        %26 : java.type:"int" = lshl %24 %25;
+                        %27 : java.type:"boolean" = eq %23 %26;
                         yield %27;
                     }
-                    ()java.lang.String -> {
-                        %28 : java.lang.String = constant @"4";
+                    ()java.type:"java.lang.String" -> {
+                        %28 : java.type:"java.lang.String" = constant @"4";
                         yield %28;
                     }
-                    (%29 : int)boolean -> {
-                        %30 : int = constant @"10";
-                        %31 : int = constant @"2";
-                        %32 : int = div %30 %31;
-                        %33 : boolean = eq %29 %32;
+                    (%29 : java.type:"int")java.type:"boolean" -> {
+                        %30 : java.type:"int" = constant @"10";
+                        %31 : java.type:"int" = constant @"2";
+                        %32 : java.type:"int" = div %30 %31;
+                        %33 : java.type:"boolean" = eq %29 %32;
                         yield %33;
                     }
-                    ()java.lang.String -> {
-                        %34 : java.lang.String = constant @"5";
+                    ()java.type:"java.lang.String" -> {
+                        %34 : java.type:"java.lang.String" = constant @"5";
                         yield %34;
                     }
-                    (%35 : int)boolean -> {
-                        %36 : int = constant @"12";
-                        %37 : int = constant @"6";
-                        %38 : int = sub %36 %37;
-                        %39 : boolean = eq %35 %38;
+                    (%35 : java.type:"int")java.type:"boolean" -> {
+                        %36 : java.type:"int" = constant @"12";
+                        %37 : java.type:"int" = constant @"6";
+                        %38 : java.type:"int" = sub %36 %37;
+                        %39 : java.type:"boolean" = eq %35 %38;
                         yield %39;
                     }
-                    ()java.lang.String -> {
-                        %40 : java.lang.String = constant @"6";
+                    ()java.type:"java.lang.String" -> {
+                        %40 : java.type:"java.lang.String" = constant @"6";
                         yield %40;
                     }
-                    (%41 : int)boolean -> {
-                        %42 : int = constant @"3";
-                        %43 : int = constant @"4";
-                        %44 : int = add %42 %43;
-                        %45 : boolean = eq %41 %44;
+                    (%41 : java.type:"int")java.type:"boolean" -> {
+                        %42 : java.type:"int" = constant @"3";
+                        %43 : java.type:"int" = constant @"4";
+                        %44 : java.type:"int" = add %42 %43;
+                        %45 : java.type:"boolean" = eq %41 %44;
                         yield %45;
                     }
-                    ()java.lang.String -> {
-                        %46 : java.lang.String = constant @"7";
+                    ()java.type:"java.lang.String" -> {
+                        %46 : java.type:"java.lang.String" = constant @"7";
                         yield %46;
                     }
-                    (%47 : int)boolean -> {
-                        %48 : int = constant @"2";
-                        %49 : int = constant @"2";
-                        %50 : int = mul %48 %49;
-                        %51 : int = constant @"2";
-                        %52 : int = mul %50 %51;
-                        %53 : boolean = eq %47 %52;
+                    (%47 : java.type:"int")java.type:"boolean" -> {
+                        %48 : java.type:"int" = constant @"2";
+                        %49 : java.type:"int" = constant @"2";
+                        %50 : java.type:"int" = mul %48 %49;
+                        %51 : java.type:"int" = constant @"2";
+                        %52 : java.type:"int" = mul %50 %51;
+                        %53 : java.type:"boolean" = eq %47 %52;
                         yield %53;
                     }
-                    ()java.lang.String -> {
-                        %54 : java.lang.String = constant @"8";
+                    ()java.type:"java.lang.String" -> {
+                        %54 : java.type:"java.lang.String" = constant @"8";
                         yield %54;
                     }
-                    (%55 : int)boolean -> {
-                        %56 : int = constant @"8";
-                        %57 : int = constant @"1";
-                        %58 : int = or %56 %57;
-                        %59 : boolean = eq %55 %58;
+                    (%55 : java.type:"int")java.type:"boolean" -> {
+                        %56 : java.type:"int" = constant @"8";
+                        %57 : java.type:"int" = constant @"1";
+                        %58 : java.type:"int" = or %56 %57;
+                        %59 : java.type:"boolean" = eq %55 %58;
                         yield %59;
                     }
-                    ()java.lang.String -> {
-                        %60 : java.lang.String = constant @"9";
+                    ()java.type:"java.lang.String" -> {
+                        %60 : java.type:"java.lang.String" = constant @"9";
                         yield %60;
                     }
-                    (%61 : int)boolean -> {
-                        %62 : int = constant @"10";
-                        %63 : boolean = eq %61 %62;
+                    (%61 : java.type:"int")java.type:"boolean" -> {
+                        %62 : java.type:"int" = constant @"10";
+                        %63 : java.type:"boolean" = eq %61 %62;
                         yield %63;
                     }
-                    ()java.lang.String -> {
-                        %64 : java.lang.String = constant @"10";
+                    ()java.type:"java.lang.String" -> {
+                        %64 : java.type:"java.lang.String" = constant @"10";
                         yield %64;
                     }
-                    (%65 : int)boolean -> {
-                        %66 : int = var.load %3;
-                        %67 : boolean = eq %65 %66;
+                    (%65 : java.type:"int")java.type:"boolean" -> {
+                        %66 : java.type:"int" = var.load %3;
+                        %67 : java.type:"boolean" = eq %65 %66;
                         yield %67;
                     }
-                    ()java.lang.String -> {
-                        %68 : java.lang.String = constant @"11";
+                    ()java.type:"java.lang.String" -> {
+                        %68 : java.type:"java.lang.String" = constant @"11";
                         yield %68;
                     }
-                    (%69 : int)boolean -> {
-                        %70 : int = field.load @"SwitchExpressionTest2$Constants::c1()int";
-                        %71 : boolean = eq %69 %70;
+                    (%69 : java.type:"int")java.type:"boolean" -> {
+                        %70 : java.type:"int" = field.load @"SwitchExpressionTest2$Constants::c1:int";
+                        %71 : java.type:"boolean" = eq %69 %70;
                         yield %71;
                     }
-                    ()java.lang.String -> {
-                        %72 : int = field.load @"SwitchExpressionTest2$Constants::c1()int";
-                        %73 : java.lang.String = invoke %72 @"java.lang.String::valueOf(int)java.lang.String";
+                    ()java.type:"java.lang.String" -> {
+                        %72 : java.type:"int" = field.load @"SwitchExpressionTest2$Constants::c1:int";
+                        %73 : java.type:"java.lang.String" = invoke %72 @"java.lang.String::valueOf(int):java.lang.String";
                         yield %73;
                     }
-                    (%74 : int)boolean -> {
-                        %75 : int = java.cexpression
-                            ()boolean -> {
-                                %76 : int = constant @"1";
-                                %77 : int = constant @"0";
-                                %78 : boolean = gt %76 %77;
+                    (%74 : java.type:"int")java.type:"boolean" -> {
+                        %75 : java.type:"int" = java.cexpression
+                            ()java.type:"boolean" -> {
+                                %76 : java.type:"int" = constant @"1";
+                                %77 : java.type:"int" = constant @"0";
+                                %78 : java.type:"boolean" = gt %76 %77;
                                 yield %78;
                             }
-                            ()int -> {
-                                %79 : int = constant @"13";
+                            ()java.type:"int" -> {
+                                %79 : java.type:"int" = constant @"13";
                                 yield %79;
                             }
-                            ()int -> {
-                                %80 : int = constant @"133";
+                            ()java.type:"int" -> {
+                                %80 : java.type:"int" = constant @"133";
                                 yield %80;
                             };
-                        %81 : boolean = eq %74 %75;
+                        %81 : java.type:"boolean" = eq %74 %75;
                         yield %81;
                     }
-                    ()java.lang.String -> {
-                        %82 : java.lang.String = constant @"13";
+                    ()java.type:"java.lang.String" -> {
+                        %82 : java.type:"java.lang.String" = constant @"13";
                         yield %82;
                     }
-                    ()boolean -> {
-                        %84 : boolean = constant @"true";
-                        yield %84;
-                    }
-                    ()java.lang.String -> {
-                        %83 : java.lang.String = constant @"an int";
+                    ()java.type:"boolean" -> {
+                        %83 : java.type:"boolean" = constant @"true";
                         yield %83;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %84 : java.type:"java.lang.String" = constant @"an int";
+                        yield %84;
                     };
                 return %5;
             };
@@ -651,52 +651,52 @@ public class SwitchExpressionTest2 {
     // these are the conversions that applies in switch
 
     @IR("""
-            func @"caseConstantConv" (%0 : short)java.lang.String -> {
-                %1 : Var<short> = var %0 @"a";
-                %2 : int = constant @"1";
-                %3 : short = conv %2;
-                %4 : Var<short> = var %3 @"s";
-                %5 : int = constant @"2";
-                %6 : byte = conv %5;
-                %7 : Var<byte> = var %6 @"b";
-                %8 : short = var.load %1;
-                %9 : java.lang.String = java.switch.expression %8
-                    (%10 : short)boolean -> {
-                        %11 : short = var.load %4;
-                        %12 : boolean = eq %10 %11;
+            func @"caseConstantConv" (%0 : java.type:"short")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"short"> = var %0 @"a";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"short" = conv %2;
+                %4 : Var<java.type:"short"> = var %3 @"s";
+                %5 : java.type:"int" = constant @"2";
+                %6 : java.type:"byte" = conv %5;
+                %7 : Var<java.type:"byte"> = var %6 @"b";
+                %8 : java.type:"short" = var.load %1;
+                %9 : java.type:"java.lang.String" = java.switch.expression %8
+                    (%10 : java.type:"short")java.type:"boolean" -> {
+                        %11 : java.type:"short" = var.load %4;
+                        %12 : java.type:"boolean" = eq %10 %11;
                         yield %12;
                     }
-                    ()java.lang.String -> {
-                        %13 : java.lang.String = constant @"one";
+                    ()java.type:"java.lang.String" -> {
+                        %13 : java.type:"java.lang.String" = constant @"one";
                         yield %13;
                     }
-                    (%14 : short)boolean -> {
-                        %15 : byte = var.load %7;
-                        %16 : short = conv %15;
-                        %17 : boolean = eq %14 %16;
+                    (%14 : java.type:"short")java.type:"boolean" -> {
+                        %15 : java.type:"byte" = var.load %7;
+                        %16 : java.type:"short" = conv %15;
+                        %17 : java.type:"boolean" = eq %14 %16;
                         yield %17;
                     }
-                    ()java.lang.String -> {
-                        %18 : java.lang.String = constant @"three";
+                    ()java.type:"java.lang.String" -> {
+                        %18 : java.type:"java.lang.String" = constant @"three";
                         yield %18;
                     }
-                    (%19 : short)boolean -> {
-                        %20 : int = constant @"3";
-                        %21 : short = conv %20;
-                        %22 : boolean = eq %19 %21;
+                    (%19 : java.type:"short")java.type:"boolean" -> {
+                        %20 : java.type:"int" = constant @"3";
+                        %21 : java.type:"short" = conv %20;
+                        %22 : java.type:"boolean" = eq %19 %21;
                         yield %22;
                     }
-                    ()java.lang.String -> {
-                        %23 : java.lang.String = constant @"two";
+                    ()java.type:"java.lang.String" -> {
+                        %23 : java.type:"java.lang.String" = constant @"two";
                         yield %23;
                     }
-                    ()boolean -> {
-                        %25 : boolean = constant @"true";
-                        yield %25;
-                    }
-                    ()java.lang.String -> {
-                        %24 : java.lang.String = constant @"default";
+                    ()java.type:"boolean" -> {
+                        %24 : java.type:"boolean" = constant @"true";
                         yield %24;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %25 : java.type:"java.lang.String" = constant @"default";
+                        yield %25;
                     };
                 return %9;
             };
@@ -714,41 +714,41 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"caseConstantConv2" (%0 : java.lang.Byte)java.lang.String -> {
-                %1 : Var<java.lang.Byte> = var %0 @"a";
-                %2 : int = constant @"2";
-                %3 : byte = conv %2;
-                %4 : Var<byte> = var %3 @"b";
-                %5 : java.lang.Byte = var.load %1;
-                %6 : java.lang.String = java.switch.expression %5
-                    (%7 : java.lang.Byte)boolean -> {
-                        %8 : int = constant @"1";
-                        %9 : byte = conv %8;
-                        %10 : java.lang.Byte = invoke %9 @"java.lang.Byte::valueOf(byte)java.lang.Byte";
-                        %11 : boolean = invoke %7 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"caseConstantConv2" (%0 : java.type:"java.lang.Byte")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Byte"> = var %0 @"a";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"byte" = conv %2;
+                %4 : Var<java.type:"byte"> = var %3 @"b";
+                %5 : java.type:"java.lang.Byte" = var.load %1;
+                %6 : java.type:"java.lang.String" = java.switch.expression %5
+                    (%7 : java.type:"java.lang.Byte")java.type:"boolean" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"byte" = conv %8;
+                        %10 : java.type:"java.lang.Byte" = invoke %9 @"java.lang.Byte::valueOf(byte):java.lang.Byte";
+                        %11 : java.type:"boolean" = invoke %7 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %11;
                     }
-                    ()java.lang.String -> {
-                        %12 : java.lang.String = constant @"one";
+                    ()java.type:"java.lang.String" -> {
+                        %12 : java.type:"java.lang.String" = constant @"one";
                         yield %12;
                     }
-                    (%13 : java.lang.Byte)boolean -> {
-                        %14 : byte = var.load %4;
-                        %15 : java.lang.Byte = invoke %14 @"java.lang.Byte::valueOf(byte)java.lang.Byte";
-                        %16 : boolean = invoke %13 %15 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%13 : java.type:"java.lang.Byte")java.type:"boolean" -> {
+                        %14 : java.type:"byte" = var.load %4;
+                        %15 : java.type:"java.lang.Byte" = invoke %14 @"java.lang.Byte::valueOf(byte):java.lang.Byte";
+                        %16 : java.type:"boolean" = invoke %13 %15 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %16;
                     }
-                    ()java.lang.String -> {
-                        %17 : java.lang.String = constant @"two";
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"two";
                         yield %17;
                     }
-                    ()boolean -> {
-                        %19 : boolean = constant @"true";
-                        yield %19;
-                    }
-                    ()java.lang.String -> {
-                        %18 : java.lang.String = constant @"default";
+                    ()java.type:"boolean" -> {
+                        %18 : java.type:"boolean" = constant @"true";
                         yield %18;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %19 : java.type:"java.lang.String" = constant @"default";
+                        yield %19;
                     };
                 return %6;
             };
@@ -766,35 +766,35 @@ public class SwitchExpressionTest2 {
 
     enum E { F, G }
     @IR("""
-            func @"noDefaultLabelEnum" (%0 : SwitchExpressionTest2$E)java.lang.String -> {
-                %1 : Var<SwitchExpressionTest2$E> = var %0 @"e";
-                %2 : SwitchExpressionTest2$E = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : SwitchExpressionTest2$E)boolean -> {
-                        %5 : SwitchExpressionTest2$E = field.load @"SwitchExpressionTest2$E::F()SwitchExpressionTest2$E";
-                        %6 : boolean = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"noDefaultLabelEnum" (%0 : java.type:"SwitchExpressionTest2$E")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"SwitchExpressionTest2$E"> = var %0 @"e";
+                %2 : java.type:"SwitchExpressionTest2$E" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"SwitchExpressionTest2$E")java.type:"boolean" -> {
+                        %5 : java.type:"SwitchExpressionTest2$E" = field.load @"SwitchExpressionTest2$E::F:SwitchExpressionTest2$E";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %6;
                     }
-                    ()java.lang.String -> {
-                        %7 : java.lang.String = constant @"f";
+                    ()java.type:"java.lang.String" -> {
+                        %7 : java.type:"java.lang.String" = constant @"f";
                         yield %7;
                     }
-                    (%8 : SwitchExpressionTest2$E)boolean -> {
-                        %9 : SwitchExpressionTest2$E = field.load @"SwitchExpressionTest2$E::G()SwitchExpressionTest2$E";
-                        %10 : boolean = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%8 : java.type:"SwitchExpressionTest2$E")java.type:"boolean" -> {
+                        %9 : java.type:"SwitchExpressionTest2$E" = field.load @"SwitchExpressionTest2$E::G:SwitchExpressionTest2$E";
+                        %10 : java.type:"boolean" = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %10;
                     }
-                    ()java.lang.String -> {
-                        %11 : java.lang.String = constant @"g";
+                    ()java.type:"java.lang.String" -> {
+                        %11 : java.type:"java.lang.String" = constant @"g";
                         yield %11;
                     }
-                    ()boolean -> {
-                        %13 : boolean = constant @"true";
-                        yield %13;
+                    ()java.type:"boolean" -> {
+                        %12 : java.type:"boolean" = constant @"true";
+                        yield %12;
                     }
-                    ()java.lang.String -> {
-                        %12 : java.lang.MatchException = new @"java.lang.MatchException::<new>()";
-                        throw %12;
+                    ()java.type:"java.lang.String" -> {
+                        %13 : java.type:"java.lang.MatchException" = new @"java.lang.MatchException::()";
+                        throw %13;
                     };
                 return %3;
             };
@@ -808,35 +808,35 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"unconditionalPattern" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"s";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.Object = constant @null;
-                %4 : Var<java.lang.Object> = var %3 @"o";
-                %5 : java.lang.String = java.switch.expression %2
-                    (%6 : java.lang.String)boolean -> {
-                        %7 : java.lang.String = constant @"A";
-                        %8 : boolean = invoke %6 %7 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"unconditionalPattern" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.Object" = constant @null;
+                %4 : Var<java.type:"java.lang.Object"> = var %3 @"o";
+                %5 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%6 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %7 : java.type:"java.lang.String" = constant @"A";
+                        %8 : java.type:"boolean" = invoke %6 %7 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %8;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @"Alphabet";
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"java.lang.String" = constant @"Alphabet";
                         yield %9;
                     }
-                    (%10 : java.lang.String)boolean -> {
-                        %11 : boolean = pattern.match %10
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object> -> {
-                                %12 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object> = pattern.type @"o";
+                    (%10 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %11 : java.type:"boolean" = pattern.match %10
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object>" -> {
+                                %12 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object>" = pattern.type @"o";
                                 yield %12;
                             }
-                            (%13 : java.lang.Object)void -> {
+                            (%13 : java.type:"java.lang.Object")java.type:"void" -> {
                                 var.store %4 %13;
                                 yield;
                             };
                         yield %11;
                     }
-                    ()java.lang.String -> {
-                        %14 : java.lang.String = constant @"default";
+                    ()java.type:"java.lang.String" -> {
+                        %14 : java.type:"java.lang.String" = constant @"default";
                         yield %14;
                     };
                 return %5;
@@ -854,53 +854,53 @@ public class SwitchExpressionTest2 {
     record B() implements A {}
     final class C implements A {}
     @IR("""
-            func @"noDefault" (%0 : SwitchExpressionTest2$A)java.lang.String -> {
-                %1 : Var<SwitchExpressionTest2$A> = var %0 @"a";
-                %2 : SwitchExpressionTest2$A = var.load %1;
-                %3 : SwitchExpressionTest2$B = constant @null;
-                %4 : Var<SwitchExpressionTest2$B> = var %3 @"b";
-                %5 : SwitchExpressionTest2$C = constant @null;
-                %6 : Var<SwitchExpressionTest2$C> = var %5 @"c";
-                %7 : java.lang.String = java.switch.expression %2
-                    (%8 : SwitchExpressionTest2$A)boolean -> {
-                        %9 : boolean = pattern.match %8
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$B> -> {
-                                %10 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$B> = pattern.type @"b";
+            func @"noDefault" (%0 : java.type:"SwitchExpressionTest2$A")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"SwitchExpressionTest2$A"> = var %0 @"a";
+                %2 : java.type:"SwitchExpressionTest2$A" = var.load %1;
+                %3 : java.type:"SwitchExpressionTest2$B" = constant @null;
+                %4 : Var<java.type:"SwitchExpressionTest2$B"> = var %3 @"b";
+                %5 : java.type:"SwitchExpressionTest2$C" = constant @null;
+                %6 : Var<java.type:"SwitchExpressionTest2$C"> = var %5 @"c";
+                %7 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%8 : java.type:"SwitchExpressionTest2$A")java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = pattern.match %8
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$B>" -> {
+                                %10 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$B>" = pattern.type @"b";
                                 yield %10;
                             }
-                            (%11 : SwitchExpressionTest2$B)void -> {
+                            (%11 : java.type:"SwitchExpressionTest2$B")java.type:"void" -> {
                                 var.store %4 %11;
                                 yield;
                             };
                         yield %9;
                     }
-                    ()java.lang.String -> {
-                        %12 : java.lang.String = constant @"B";
+                    ()java.type:"java.lang.String" -> {
+                        %12 : java.type:"java.lang.String" = constant @"B";
                         yield %12;
                     }
-                    (%13 : SwitchExpressionTest2$A)boolean -> {
-                        %14 : boolean = pattern.match %13
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$C> -> {
-                                %15 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$C> = pattern.type @"c";
+                    (%13 : java.type:"SwitchExpressionTest2$A")java.type:"boolean" -> {
+                        %14 : java.type:"boolean" = pattern.match %13
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$C>" -> {
+                                %15 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$C>" = pattern.type @"c";
                                 yield %15;
                             }
-                            (%16 : SwitchExpressionTest2$C)void -> {
+                            (%16 : java.type:"SwitchExpressionTest2$C")java.type:"void" -> {
                                 var.store %6 %16;
                                 yield;
                             };
                         yield %14;
                     }
-                    ()java.lang.String -> {
-                        %17 : java.lang.String = constant @"C";
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"C";
                         yield %17;
                     }
-                    ()boolean -> {
-                        %19 : boolean = constant @"true";
-                        yield %19;
+                    ()java.type:"boolean" -> {
+                        %18 : java.type:"boolean" = constant @"true";
+                        yield %18;
                     }
-                    ()java.lang.String -> {
-                        %18 : java.lang.MatchException = new @"java.lang.MatchException::<new>()";
-                        throw %18;
+                    ()java.type:"java.lang.String" -> {
+                        %19 : java.type:"java.lang.MatchException" = new @"java.lang.MatchException::()";
+                        throw %19;
                     };
                 return %7;
             };
@@ -914,35 +914,35 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
-            func @"defaultNotTheLastLabel" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"s";
-                %2 : java.lang.String = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%5 : java.lang.String)boolean -> {
-                        %6 : java.lang.String = constant @"M";
-                        %7 : boolean = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+            func @"defaultNotTheLastLabel" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"M";
+                        %6 : java.type:"boolean" = invoke %4 %5 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %6;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %7 : java.type:"java.lang.String" = constant @"Mow";
                         yield %7;
                     }
-                    ()java.lang.String -> {
-                        %8 : java.lang.String = constant @"Mow";
-                        yield %8;
+                    (%8 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %9 : java.type:"java.lang.String" = constant @"A";
+                        %10 : java.type:"boolean" = invoke %8 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %10;
                     }
-                    (%9 : java.lang.String)boolean -> {
-                        %10 : java.lang.String = constant @"A";
-                        %11 : boolean = invoke %9 %10 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    ()java.type:"java.lang.String" -> {
+                        %11 : java.type:"java.lang.String" = constant @"Aow";
                         yield %11;
                     }
-                    ()java.lang.String -> {
-                        %12 : java.lang.String = constant @"Aow";
+                    ()java.type:"boolean" -> {
+                        %12 : java.type:"boolean" = constant @"true";
                         yield %12;
                     }
-                    ()boolean -> {
-                        %13 : boolean = constant @"true";
+                    ()java.type:"java.lang.String" -> {
+                        %13 : java.type:"java.lang.String" = constant @"else";
                         yield %13;
-                    }
-                    ()java.lang.String -> {
-                        %4 : java.lang.String = constant @"else";
-                        yield %4;
                     };
                 return %3;
             };

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
@@ -859,8 +859,8 @@ public class SwitchExpressionTest2 {
                 %2 : SwitchExpressionTest2$A = var.load %1;
                 %3 : SwitchExpressionTest2$B = constant @null;
                 %4 : Var<SwitchExpressionTest2$B> = var %3 @"b";
-                %5 : .<SwitchExpressionTest2, SwitchExpressionTest2$C> = constant @null;
-                %6 : Var<.<SwitchExpressionTest2, SwitchExpressionTest2$C>> = var %5 @"c";
+                %5 : SwitchExpressionTest2$C = constant @null;
+                %6 : Var<SwitchExpressionTest2$C> = var %5 @"c";
                 %7 : java.lang.String = java.switch.expression %2
                     (%8 : SwitchExpressionTest2$A)boolean -> {
                         %9 : boolean = pattern.match %8
@@ -880,11 +880,11 @@ public class SwitchExpressionTest2 {
                     }
                     (%13 : SwitchExpressionTest2$A)boolean -> {
                         %14 : boolean = pattern.match %13
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<.<SwitchExpressionTest2, SwitchExpressionTest2$C>> -> {
-                                %15 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<.<SwitchExpressionTest2, SwitchExpressionTest2$C>> = pattern.type @"c";
+                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$C> -> {
+                                %15 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchExpressionTest2$C> = pattern.type @"c";
                                 yield %15;
                             }
-                            (%16 : .<SwitchExpressionTest2, SwitchExpressionTest2$C>)void -> {
+                            (%16 : SwitchExpressionTest2$C)void -> {
                                 var.store %6 %16;
                                 yield;
                             };

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -13,62 +13,62 @@ import java.util.Stack;
 public class SwitchStatementTest {
 
     @IR("""
-            func @"caseConstantRuleExpression" (%0 : java.lang.String)java.lang.String -> {
-                  %1 : Var<java.lang.String> = var %0 @"r";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"s";
-                  %4 : java.lang.String = var.load %1;
-                  java.switch.statement %4
-                      (%5 : java.lang.String)boolean -> {
-                          %6 : java.lang.String = constant @"FOO";
-                          %7 : boolean = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %7;
-                      }
-                      ()void -> {
-                          %8 : java.lang.String = var.load %3;
-                          %9 : java.lang.String = constant @"BAR";
-                          %10 : java.lang.String = concat %8 %9;
-                          var.store %3 %10;
-                          yield;
-                      }
-                      (%11 : java.lang.String)boolean -> {
-                          %12 : java.lang.String = constant @"BAR";
-                          %13 : boolean = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %13;
-                      }
-                      ()void -> {
-                          %14 : java.lang.String = var.load %3;
-                          %15 : java.lang.String = constant @"BAZ";
-                          %16 : java.lang.String = concat %14 %15;
-                          var.store %3 %16;
-                          yield;
-                      }
-                      (%17 : java.lang.String)boolean -> {
-                          %18 : java.lang.String = constant @"BAZ";
-                          %19 : boolean = invoke %17 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %19;
-                      }
-                      ()void -> {
-                          %20 : java.lang.String = var.load %3;
-                          %21 : java.lang.String = constant @"FOO";
-                          %22 : java.lang.String = concat %20 %21;
-                          var.store %3 %22;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %26 : boolean = constant @"true";
-                          yield %26;
-                      }
-                      ()void -> {
-                          %23 : java.lang.String = var.load %3;
-                          %24 : java.lang.String = constant @"else";
-                          %25 : java.lang.String = concat %23 %24;
-                          var.store %3 %25;
-                          yield;
-                      };
-                  %26 : java.lang.String = var.load %3;
-                  return %26;
-              };
+            func @"caseConstantRuleExpression" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"s";
+                %4 : java.type:"java.lang.String" = var.load %1;
+                java.switch.statement %4
+                    (%5 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %6 : java.type:"java.lang.String" = constant @"FOO";
+                        %7 : java.type:"boolean" = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %7;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"java.lang.String" = concat %8 %9;
+                        var.store %3 %10;
+                        yield;
+                    }
+                    (%11 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %12 : java.type:"java.lang.String" = constant @"BAR";
+                        %13 : java.type:"boolean" = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %13;
+                    }
+                    ()java.type:"void" -> {
+                        %14 : java.type:"java.lang.String" = var.load %3;
+                        %15 : java.type:"java.lang.String" = constant @"BAZ";
+                        %16 : java.type:"java.lang.String" = concat %14 %15;
+                        var.store %3 %16;
+                        yield;
+                    }
+                    (%17 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %18 : java.type:"java.lang.String" = constant @"BAZ";
+                        %19 : java.type:"boolean" = invoke %17 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %19;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"FOO";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %3 %22;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
+                    }
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.String" = var.load %3;
+                        %25 : java.type:"java.lang.String" = constant @"else";
+                        %26 : java.type:"java.lang.String" = concat %24 %25;
+                        var.store %3 %26;
+                        yield;
+                    };
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
+            };
             """)
     @CodeReflection
     public static String caseConstantRuleExpression(String r) {
@@ -83,62 +83,62 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantRuleBlock" (%0 : java.lang.String)java.lang.String -> {
-                  %1 : Var<java.lang.String> = var %0 @"r";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"s";
-                  %4 : java.lang.String = var.load %1;
-                  java.switch.statement %4
-                      (%5 : java.lang.String)boolean -> {
-                          %6 : java.lang.String = constant @"FOO";
-                          %7 : boolean = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %7;
-                      }
-                      ()void -> {
-                          %8 : java.lang.String = var.load %3;
-                          %9 : java.lang.String = constant @"BAR";
-                          %10 : java.lang.String = concat %8 %9;
-                          var.store %3 %10;
-                          yield;
-                      }
-                      (%11 : java.lang.String)boolean -> {
-                          %12 : java.lang.String = constant @"BAR";
-                          %13 : boolean = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %13;
-                      }
-                      ()void -> {
-                          %14 : java.lang.String = var.load %3;
-                          %15 : java.lang.String = constant @"BAZ";
-                          %16 : java.lang.String = concat %14 %15;
-                          var.store %3 %16;
-                          yield;
-                      }
-                      (%17 : java.lang.String)boolean -> {
-                          %18 : java.lang.String = constant @"BAZ";
-                          %19 : boolean = invoke %17 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %19;
-                      }
-                      ()void -> {
-                          %20 : java.lang.String = var.load %3;
-                          %21 : java.lang.String = constant @"FOO";
-                          %22 : java.lang.String = concat %20 %21;
-                          var.store %3 %22;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %26 : boolean = constant @"true";
-                          yield %26;
-                      }
-                      ()void -> {
-                          %23 : java.lang.String = var.load %3;
-                          %24 : java.lang.String = constant @"else";
-                          %25 : java.lang.String = concat %23 %24;
-                          var.store %3 %25;
-                          yield;
-                      };
-                  %26 : java.lang.String = var.load %3;
-                  return %26;
-              };
+            func @"caseConstantRuleBlock" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"r";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"s";
+                %4 : java.type:"java.lang.String" = var.load %1;
+                java.switch.statement %4
+                    (%5 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %6 : java.type:"java.lang.String" = constant @"FOO";
+                        %7 : java.type:"boolean" = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %7;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"java.lang.String" = concat %8 %9;
+                        var.store %3 %10;
+                        yield;
+                    }
+                    (%11 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %12 : java.type:"java.lang.String" = constant @"BAR";
+                        %13 : java.type:"boolean" = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %13;
+                    }
+                    ()java.type:"void" -> {
+                        %14 : java.type:"java.lang.String" = var.load %3;
+                        %15 : java.type:"java.lang.String" = constant @"BAZ";
+                        %16 : java.type:"java.lang.String" = concat %14 %15;
+                        var.store %3 %16;
+                        yield;
+                    }
+                    (%17 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %18 : java.type:"java.lang.String" = constant @"BAZ";
+                        %19 : java.type:"boolean" = invoke %17 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %19;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"FOO";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %3 %22;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
+                    }
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.String" = var.load %3;
+                        %25 : java.type:"java.lang.String" = constant @"else";
+                        %26 : java.type:"java.lang.String" = concat %24 %25;
+                        var.store %3 %26;
+                        yield;
+                    };
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
+            };
             """)
     @CodeReflection
     public static String caseConstantRuleBlock(String r) {
@@ -161,62 +161,62 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantStatement" (%0 : java.lang.String)java.lang.String -> {
-                  %1 : Var<java.lang.String> = var %0 @"s";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : java.lang.String = var.load %1;
-                  java.switch.statement %4
-                      (%5 : java.lang.String)boolean -> {
-                          %6 : java.lang.String = constant @"FOO";
-                          %7 : boolean = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %7;
-                      }
-                      ()void -> {
-                          %8 : java.lang.String = var.load %3;
-                          %9 : java.lang.String = constant @"BAR";
-                          %10 : java.lang.String = concat %8 %9;
-                          var.store %3 %10;
-                          java.break;
-                      }
-                      (%11 : java.lang.String)boolean -> {
-                          %12 : java.lang.String = constant @"BAR";
-                          %13 : boolean = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %13;
-                      }
-                      ()void -> {
-                          %14 : java.lang.String = var.load %3;
-                          %15 : java.lang.String = constant @"BAZ";
-                          %16 : java.lang.String = concat %14 %15;
-                          var.store %3 %16;
-                          java.break;
-                      }
-                      (%17 : java.lang.String)boolean -> {
-                          %18 : java.lang.String = constant @"BAZ";
-                          %19 : boolean = invoke %17 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %19;
-                      }
-                      ()void -> {
-                          %20 : java.lang.String = var.load %3;
-                          %21 : java.lang.String = constant @"FOO";
-                          %22 : java.lang.String = concat %20 %21;
-                          var.store %3 %22;
-                          java.break;
-                      }
-                      ()boolean -> {
-                          %26 : boolean = constant @"true";
-                          yield %26;
-                      }
-                      ()void -> {
-                          %23 : java.lang.String = var.load %3;
-                          %24 : java.lang.String = constant @"else";
-                          %25 : java.lang.String = concat %23 %24;
-                          var.store %3 %25;
-                          yield;
-                      };
-                  %26 : java.lang.String = var.load %3;
-                  return %26;
-              };
+            func @"caseConstantStatement" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.String" = var.load %1;
+                java.switch.statement %4
+                    (%5 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %6 : java.type:"java.lang.String" = constant @"FOO";
+                        %7 : java.type:"boolean" = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %7;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"java.lang.String" = constant @"BAR";
+                        %10 : java.type:"java.lang.String" = concat %8 %9;
+                        var.store %3 %10;
+                        java.break;
+                    }
+                    (%11 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %12 : java.type:"java.lang.String" = constant @"BAR";
+                        %13 : java.type:"boolean" = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %13;
+                    }
+                    ()java.type:"void" -> {
+                        %14 : java.type:"java.lang.String" = var.load %3;
+                        %15 : java.type:"java.lang.String" = constant @"BAZ";
+                        %16 : java.type:"java.lang.String" = concat %14 %15;
+                        var.store %3 %16;
+                        java.break;
+                    }
+                    (%17 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %18 : java.type:"java.lang.String" = constant @"BAZ";
+                        %19 : java.type:"boolean" = invoke %17 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %19;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"FOO";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %3 %22;
+                        java.break;
+                    }
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
+                    }
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.String" = var.load %3;
+                        %25 : java.type:"java.lang.String" = constant @"else";
+                        %26 : java.type:"java.lang.String" = concat %24 %25;
+                        var.store %3 %26;
+                        yield;
+                    };
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
+            };
             """)
     @CodeReflection
     private static String caseConstantStatement(String s) {
@@ -238,62 +238,62 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantMultiLabels" (%0 : char)java.lang.String -> {
-                %1 : Var<char> = var %0 @"c";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : char = var.load %1;
-                %5 : char = invoke %4 @"java.lang.Character::toLowerCase(char)char";
+            func @"caseConstantMultiLabels" (%0 : java.type:"char")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"char"> = var %0 @"c";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"char" = var.load %1;
+                %5 : java.type:"char" = invoke %4 @"java.lang.Character::toLowerCase(char):char";
                 java.switch.statement %5
-                    (%6 : char)boolean -> {
-                        %7 : boolean = java.cor
-                            ()boolean -> {
-                                %8 : char = constant @"a";
-                                %9 : boolean = eq %6 %8;
+                    (%6 : java.type:"char")java.type:"boolean" -> {
+                        %7 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %8 : java.type:"char" = constant @"a";
+                                %9 : java.type:"boolean" = eq %6 %8;
                                 yield %9;
                             }
-                            ()boolean -> {
-                                %10 : char = constant @"e";
-                                %11 : boolean = eq %6 %10;
+                            ()java.type:"boolean" -> {
+                                %10 : java.type:"char" = constant @"e";
+                                %11 : java.type:"boolean" = eq %6 %10;
                                 yield %11;
                             }
-                            ()boolean -> {
-                                %12 : char = constant @"i";
-                                %13 : boolean = eq %6 %12;
+                            ()java.type:"boolean" -> {
+                                %12 : java.type:"char" = constant @"i";
+                                %13 : java.type:"boolean" = eq %6 %12;
                                 yield %13;
                             }
-                            ()boolean -> {
-                                %14 : char = constant @"o";
-                                %15 : boolean = eq %6 %14;
+                            ()java.type:"boolean" -> {
+                                %14 : java.type:"char" = constant @"o";
+                                %15 : java.type:"boolean" = eq %6 %14;
                                 yield %15;
                             }
-                            ()boolean -> {
-                                %16 : char = constant @"u";
-                                %17 : boolean = eq %6 %16;
+                            ()java.type:"boolean" -> {
+                                %16 : java.type:"char" = constant @"u";
+                                %17 : java.type:"boolean" = eq %6 %16;
                                 yield %17;
                             };
                         yield %7;
                     }
-                    ()void -> {
-                        %18 : java.lang.String = var.load %3;
-                        %19 : java.lang.String = constant @"vowel";
-                        %20 : java.lang.String = concat %18 %19;
+                    ()java.type:"void" -> {
+                        %18 : java.type:"java.lang.String" = var.load %3;
+                        %19 : java.type:"java.lang.String" = constant @"vowel";
+                        %20 : java.type:"java.lang.String" = concat %18 %19;
                         var.store %3 %20;
                         java.break;
                     }
-                    ()boolean -> {
-                        %24 : boolean = constant @"true";
-                        yield %24;
+                    ()java.type:"boolean" -> {
+                        %21 : java.type:"boolean" = constant @"true";
+                        yield %21;
                     }
-                    ()void -> {
-                        %21 : java.lang.String = var.load %3;
-                        %22 : java.lang.String = constant @"consonant";
-                        %23 : java.lang.String = concat %21 %22;
-                        var.store %3 %23;
+                    ()java.type:"void" -> {
+                        %22 : java.type:"java.lang.String" = var.load %3;
+                        %23 : java.type:"java.lang.String" = constant @"consonant";
+                        %24 : java.type:"java.lang.String" = concat %22 %23;
+                        var.store %3 %24;
                         yield;
                     };
-                %24 : java.lang.String = var.load %3;
-                return %24;
+                %25 : java.type:"java.lang.String" = var.load %3;
+                return %25;
             };
             """)
     @CodeReflection
@@ -310,48 +310,48 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantThrow" (%0 : java.lang.Integer)java.lang.String -> {
-                %1 : Var<java.lang.Integer> = var %0 @"i";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : java.lang.Integer = var.load %1;
+            func @"caseConstantThrow" (%0 : java.type:"java.lang.Integer")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Integer"> = var %0 @"i";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Integer" = var.load %1;
                 java.switch.statement %4
-                    (%5 : java.lang.Integer)boolean -> {
-                        %6 : int = constant @"8";
-                        %7 : java.lang.Integer = invoke %6 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                        %8 : boolean = invoke %5 %7 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%5 : java.type:"java.lang.Integer")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"8";
+                        %7 : java.type:"java.lang.Integer" = invoke %6 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        %8 : java.type:"boolean" = invoke %5 %7 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %8;
                     }
-                    ()void -> {
-                        %9 : java.lang.IllegalArgumentException = new @"java.lang.IllegalArgumentException::<new>()";
+                    ()java.type:"void" -> {
+                        %9 : java.type:"java.lang.IllegalArgumentException" = new @"java.lang.IllegalArgumentException::()";
                         throw %9;
                     }
-                    (%10 : java.lang.Integer)boolean -> {
-                        %11 : int = constant @"9";
-                        %12 : java.lang.Integer = invoke %11 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                        %13 : boolean = invoke %10 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%10 : java.type:"java.lang.Integer")java.type:"boolean" -> {
+                        %11 : java.type:"int" = constant @"9";
+                        %12 : java.type:"java.lang.Integer" = invoke %11 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        %13 : java.type:"boolean" = invoke %10 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %13;
                     }
-                    ()void -> {
-                        %14 : java.lang.String = var.load %3;
-                        %15 : java.lang.String = constant @"Nine";
-                        %16 : java.lang.String = concat %14 %15;
+                    ()java.type:"void" -> {
+                        %14 : java.type:"java.lang.String" = var.load %3;
+                        %15 : java.type:"java.lang.String" = constant @"Nine";
+                        %16 : java.type:"java.lang.String" = concat %14 %15;
                         var.store %3 %16;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = constant @"true";
                         yield %17;
                     }
-                    ()void -> {
-                        %17 : java.lang.String = var.load %3;
-                        %18 : java.lang.String = constant @"An integer";
-                        %19 : java.lang.String = concat %17 %18;
-                        var.store %3 %19;
+                    ()java.type:"void" -> {
+                        %18 : java.type:"java.lang.String" = var.load %3;
+                        %19 : java.type:"java.lang.String" = constant @"An integer";
+                        %20 : java.type:"java.lang.String" = concat %18 %19;
+                        var.store %3 %20;
                         yield;
                     };
-                %20 : java.lang.String = var.load %3;
-                return %20;
+                %21 : java.type:"java.lang.String" = var.load %3;
+                return %21;
             };
             """)
     @CodeReflection
@@ -366,37 +366,37 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantNullLabel" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"s";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : java.lang.String = var.load %1;
+            func @"caseConstantNullLabel" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.String" = var.load %1;
                 java.switch.statement %4
-                    (%5 : java.lang.String)boolean -> {
-                        %6 : java.lang.Object = constant @null;
-                        %7 : boolean = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%5 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %6 : java.type:"java.lang.Object" = constant @null;
+                        %7 : java.type:"boolean" = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %7;
                     }
-                    ()void -> {
-                        %8 : java.lang.String = var.load %3;
-                        %9 : java.lang.String = constant @"null";
-                        %10 : java.lang.String = concat %8 %9;
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"java.lang.String" = constant @"null";
+                        %10 : java.type:"java.lang.String" = concat %8 %9;
                         var.store %3 %10;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %11 : java.type:"boolean" = constant @"true";
+                        yield %11;
                     }
-                    ()void -> {
-                        %11 : java.lang.String = var.load %3;
-                        %12 : java.lang.String = constant @"non null";
-                        %13 : java.lang.String = concat %11 %12;
-                        var.store %3 %13;
+                    ()java.type:"void" -> {
+                        %12 : java.type:"java.lang.String" = var.load %3;
+                        %13 : java.type:"java.lang.String" = constant @"non null";
+                        %14 : java.type:"java.lang.String" = concat %12 %13;
+                        var.store %3 %14;
                         yield;
                     };
-                %14 : java.lang.String = var.load %3;
-                return %14;
+                %15 : java.type:"java.lang.String" = var.load %3;
+                return %15;
             };
             """)
     @CodeReflection
@@ -421,46 +421,46 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantFallThrough" (%0 : char)java.lang.String -> {
-                  %1 : Var<char> = var %0 @"c";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : char = var.load %1;
-                  java.switch.statement %4
-                      (%5 : char)boolean -> {
-                          %6 : char = constant @"A";
-                          %7 : boolean = eq %5 %6;
-                          yield %7;
-                      }
-                      ()void -> {
-                          java.switch.fallthrough;
-                      }
-                      (%8 : char)boolean -> {
-                          %9 : char = constant @"B";
-                          %10 : boolean = eq %8 %9;
-                          yield %10;
-                      }
-                      ()void -> {
-                          %11 : java.lang.String = var.load %3;
-                          %12 : java.lang.String = constant @"A or B";
-                          %13 : java.lang.String = concat %11 %12;
-                          var.store %3 %13;
-                          java.break;
-                      }
-                      ()boolean -> {
-                          %17 : boolean = constant @"true";
-                          yield %17;
-                      }
-                      ()void -> {
-                          %14 : java.lang.String = var.load %3;
-                          %15 : java.lang.String = constant @"Neither A nor B";
-                          %16 : java.lang.String = concat %14 %15;
-                          var.store %3 %16;
-                          yield;
-                      };
-                  %17 : java.lang.String = var.load %3;
-                  return %17;
-              };
+            func @"caseConstantFallThrough" (%0 : java.type:"char")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"char"> = var %0 @"c";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"char" = var.load %1;
+                java.switch.statement %4
+                    (%5 : java.type:"char")java.type:"boolean" -> {
+                        %6 : java.type:"char" = constant @"A";
+                        %7 : java.type:"boolean" = eq %5 %6;
+                        yield %7;
+                    }
+                    ()java.type:"void" -> {
+                        java.switch.fallthrough;
+                    }
+                    (%8 : java.type:"char")java.type:"boolean" -> {
+                        %9 : java.type:"char" = constant @"B";
+                        %10 : java.type:"boolean" = eq %8 %9;
+                        yield %10;
+                    }
+                    ()java.type:"void" -> {
+                        %11 : java.type:"java.lang.String" = var.load %3;
+                        %12 : java.type:"java.lang.String" = constant @"A or B";
+                        %13 : java.type:"java.lang.String" = concat %11 %12;
+                        var.store %3 %13;
+                        java.break;
+                    }
+                    ()java.type:"boolean" -> {
+                        %14 : java.type:"boolean" = constant @"true";
+                        yield %14;
+                    }
+                    ()java.type:"void" -> {
+                        %15 : java.type:"java.lang.String" = var.load %3;
+                        %16 : java.type:"java.lang.String" = constant @"Neither A nor B";
+                        %17 : java.type:"java.lang.String" = concat %15 %16;
+                        var.store %3 %17;
+                        yield;
+                    };
+                %18 : java.type:"java.lang.String" = var.load %3;
+                return %18;
+            };
             """)
     @CodeReflection
     private static String caseConstantFallThrough(char c) {
@@ -480,86 +480,86 @@ public class SwitchStatementTest {
         MON, TUE, WED, THU, FRI, SAT, SUN
     }
     @IR("""
-            func @"caseConstantEnum" (%0 : SwitchStatementTest$Day)java.lang.String -> {
-                  %1 : Var<SwitchStatementTest$Day> = var %0 @"d";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : SwitchStatementTest$Day = var.load %1;
-                  java.switch.statement %4
-                      (%5 : SwitchStatementTest$Day)boolean -> {
-                          %6 : boolean = java.cor
-                              ()boolean -> {
-                                  %7 : SwitchStatementTest$Day = field.load @"SwitchStatementTest$Day::MON()SwitchStatementTest$Day";
-                                  %8 : boolean = invoke %5 %7 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                                  yield %8;
-                              }
-                              ()boolean -> {
-                                  %9 : SwitchStatementTest$Day = field.load @"SwitchStatementTest$Day::FRI()SwitchStatementTest$Day";
-                                  %10 : boolean = invoke %5 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                                  yield %10;
-                              }
-                              ()boolean -> {
-                                  %11 : SwitchStatementTest$Day = field.load @"SwitchStatementTest$Day::SUN()SwitchStatementTest$Day";
-                                  %12 : boolean = invoke %5 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                                  yield %12;
-                              };
-                          yield %6;
-                      }
-                      ()void -> {
-                          %13 : java.lang.String = var.load %3;
-                          %14 : int = constant @"6";
-                          %15 : java.lang.String = concat %13 %14;
-                          var.store %3 %15;
-                          yield;
-                      }
-                      (%16 : SwitchStatementTest$Day)boolean -> {
-                          %17 : SwitchStatementTest$Day = field.load @"SwitchStatementTest$Day::TUE()SwitchStatementTest$Day";
-                          %18 : boolean = invoke %16 %17 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %18;
-                      }
-                      ()void -> {
-                          %19 : java.lang.String = var.load %3;
-                          %20 : int = constant @"7";
-                          %21 : java.lang.String = concat %19 %20;
-                          var.store %3 %21;
-                          yield;
-                      }
-                      (%22 : SwitchStatementTest$Day)boolean -> {
-                          %23 : boolean = java.cor
-                              ()boolean -> {
-                                  %24 : SwitchStatementTest$Day = field.load @"SwitchStatementTest$Day::THU()SwitchStatementTest$Day";
-                                  %25 : boolean = invoke %22 %24 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                                  yield %25;
-                              }
-                              ()boolean -> {
-                                  %26 : SwitchStatementTest$Day = field.load @"SwitchStatementTest$Day::SAT()SwitchStatementTest$Day";
-                                  %27 : boolean = invoke %22 %26 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                                  yield %27;
-                              };
-                          yield %23;
-                      }
-                      ()void -> {
-                          %28 : java.lang.String = var.load %3;
-                          %29 : int = constant @"8";
-                          %30 : java.lang.String = concat %28 %29;
-                          var.store %3 %30;
-                          yield;
-                      }
-                      (%31 : SwitchStatementTest$Day)boolean -> {
-                          %32 : SwitchStatementTest$Day = field.load @"SwitchStatementTest$Day::WED()SwitchStatementTest$Day";
-                          %33 : boolean = invoke %31 %32 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %33;
-                      }
-                      ()void -> {
-                          %34 : java.lang.String = var.load %3;
-                          %35 : int = constant @"9";
-                          %36 : java.lang.String = concat %34 %35;
-                          var.store %3 %36;
-                          yield;
-                      };
-                  %37 : java.lang.String = var.load %3;
-                  return %37;
-              };
+            func @"caseConstantEnum" (%0 : java.type:"SwitchStatementTest$Day")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"SwitchStatementTest$Day"> = var %0 @"d";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"SwitchStatementTest$Day" = var.load %1;
+                java.switch.statement %4
+                    (%5 : java.type:"SwitchStatementTest$Day")java.type:"boolean" -> {
+                        %6 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %7 : java.type:"SwitchStatementTest$Day" = field.load @"SwitchStatementTest$Day::MON:SwitchStatementTest$Day";
+                                %8 : java.type:"boolean" = invoke %5 %7 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                                yield %8;
+                            }
+                            ()java.type:"boolean" -> {
+                                %9 : java.type:"SwitchStatementTest$Day" = field.load @"SwitchStatementTest$Day::FRI:SwitchStatementTest$Day";
+                                %10 : java.type:"boolean" = invoke %5 %9 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                                yield %10;
+                            }
+                            ()java.type:"boolean" -> {
+                                %11 : java.type:"SwitchStatementTest$Day" = field.load @"SwitchStatementTest$Day::SUN:SwitchStatementTest$Day";
+                                %12 : java.type:"boolean" = invoke %5 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                                yield %12;
+                            };
+                        yield %6;
+                    }
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.String" = var.load %3;
+                        %14 : java.type:"int" = constant @"6";
+                        %15 : java.type:"java.lang.String" = concat %13 %14;
+                        var.store %3 %15;
+                        yield;
+                    }
+                    (%16 : java.type:"SwitchStatementTest$Day")java.type:"boolean" -> {
+                        %17 : java.type:"SwitchStatementTest$Day" = field.load @"SwitchStatementTest$Day::TUE:SwitchStatementTest$Day";
+                        %18 : java.type:"boolean" = invoke %16 %17 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %18;
+                    }
+                    ()java.type:"void" -> {
+                        %19 : java.type:"java.lang.String" = var.load %3;
+                        %20 : java.type:"int" = constant @"7";
+                        %21 : java.type:"java.lang.String" = concat %19 %20;
+                        var.store %3 %21;
+                        yield;
+                    }
+                    (%22 : java.type:"SwitchStatementTest$Day")java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %24 : java.type:"SwitchStatementTest$Day" = field.load @"SwitchStatementTest$Day::THU:SwitchStatementTest$Day";
+                                %25 : java.type:"boolean" = invoke %22 %24 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                                yield %25;
+                            }
+                            ()java.type:"boolean" -> {
+                                %26 : java.type:"SwitchStatementTest$Day" = field.load @"SwitchStatementTest$Day::SAT:SwitchStatementTest$Day";
+                                %27 : java.type:"boolean" = invoke %22 %26 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                                yield %27;
+                            };
+                        yield %23;
+                    }
+                    ()java.type:"void" -> {
+                        %28 : java.type:"java.lang.String" = var.load %3;
+                        %29 : java.type:"int" = constant @"8";
+                        %30 : java.type:"java.lang.String" = concat %28 %29;
+                        var.store %3 %30;
+                        yield;
+                    }
+                    (%31 : java.type:"SwitchStatementTest$Day")java.type:"boolean" -> {
+                        %32 : java.type:"SwitchStatementTest$Day" = field.load @"SwitchStatementTest$Day::WED:SwitchStatementTest$Day";
+                        %33 : java.type:"boolean" = invoke %31 %32 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %33;
+                    }
+                    ()java.type:"void" -> {
+                        %34 : java.type:"java.lang.String" = var.load %3;
+                        %35 : java.type:"int" = constant @"9";
+                        %36 : java.type:"java.lang.String" = concat %34 %35;
+                        var.store %3 %36;
+                        yield;
+                    };
+                %37 : java.type:"java.lang.String" = var.load %3;
+                return %37;
+            };
             """)
     @CodeReflection
     private static String caseConstantEnum(Day d) {
@@ -578,217 +578,217 @@ public class SwitchStatementTest {
         static final int c1 = 12;
     }
     @IR("""
-            func @"caseConstantOtherKindsOfExpr" (%0 : int)java.lang.String -> {
-                  %1 : Var<int> = var %0 @"i";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : int = constant @"11";
-                  %5 : Var<int> = var %4 @"eleven";
-                  %6 : int = var.load %1;
-                  java.switch.statement %6
-                      (%7 : int)boolean -> {
-                          %8 : int = constant @"1";
-                          %9 : int = constant @"15";
-                          %10 : int = and %8 %9;
-                          %11 : boolean = eq %7 %10;
-                          yield %11;
-                      }
-                      ()void -> {
-                          %12 : java.lang.String = var.load %3;
-                          %13 : int = constant @"1";
-                          %14 : java.lang.String = concat %12 %13;
-                          var.store %3 %14;
-                          yield;
-                      }
-                      (%15 : int)boolean -> {
-                          %16 : int = constant @"4";
-                          %17 : int = constant @"1";
-                          %18 : int = ashr %16 %17;
-                          %19 : boolean = eq %15 %18;
-                          yield %19;
-                      }
-                      ()void -> {
-                          %20 : java.lang.String = var.load %3;
-                          %21 : java.lang.String = constant @"2";
-                          %22 : java.lang.String = concat %20 %21;
-                          var.store %3 %22;
-                          yield;
-                      }
-                      (%23 : int)boolean -> {
-                          %24 : long = constant @"3";
-                          %25 : int = conv %24;
-                          %26 : boolean = eq %23 %25;
-                          yield %26;
-                      }
-                      ()void -> {
-                          %27 : java.lang.String = var.load %3;
-                          %28 : int = constant @"3";
-                          %29 : java.lang.String = concat %27 %28;
-                          var.store %3 %29;
-                          yield;
-                      }
-                      (%30 : int)boolean -> {
-                          %31 : int = constant @"2";
-                          %32 : int = constant @"1";
-                          %33 : int = lshl %31 %32;
-                          %34 : boolean = eq %30 %33;
-                          yield %34;
-                      }
-                      ()void -> {
-                          %35 : java.lang.String = var.load %3;
-                          %36 : int = constant @"4";
-                          %37 : java.lang.String = concat %35 %36;
-                          var.store %3 %37;
-                          yield;
-                      }
-                      (%38 : int)boolean -> {
-                          %39 : int = constant @"10";
-                          %40 : int = constant @"2";
-                          %41 : int = div %39 %40;
-                          %42 : boolean = eq %38 %41;
-                          yield %42;
-                      }
-                      ()void -> {
-                          %43 : java.lang.String = var.load %3;
-                          %44 : int = constant @"5";
-                          %45 : java.lang.String = concat %43 %44;
-                          var.store %3 %45;
-                          yield;
-                      }
-                      (%46 : int)boolean -> {
-                          %47 : int = constant @"12";
-                          %48 : int = constant @"6";
-                          %49 : int = sub %47 %48;
-                          %50 : boolean = eq %46 %49;
-                          yield %50;
-                      }
-                      ()void -> {
-                          %51 : java.lang.String = var.load %3;
-                          %52 : int = constant @"6";
-                          %53 : java.lang.String = concat %51 %52;
-                          var.store %3 %53;
-                          yield;
-                      }
-                      (%54 : int)boolean -> {
-                          %55 : int = constant @"3";
-                          %56 : int = constant @"4";
-                          %57 : int = add %55 %56;
-                          %58 : boolean = eq %54 %57;
-                          yield %58;
-                      }
-                      ()void -> {
-                          %59 : java.lang.String = var.load %3;
-                          %60 : int = constant @"7";
-                          %61 : java.lang.String = concat %59 %60;
-                          var.store %3 %61;
-                          yield;
-                      }
-                      (%62 : int)boolean -> {
-                          %63 : int = constant @"2";
-                          %64 : int = constant @"2";
-                          %65 : int = mul %63 %64;
-                          %66 : int = constant @"2";
-                          %67 : int = mul %65 %66;
-                          %68 : boolean = eq %62 %67;
-                          yield %68;
-                      }
-                      ()void -> {
-                          %69 : java.lang.String = var.load %3;
-                          %70 : int = constant @"8";
-                          %71 : java.lang.String = concat %69 %70;
-                          var.store %3 %71;
-                          yield;
-                      }
-                      (%72 : int)boolean -> {
-                          %73 : int = constant @"8";
-                          %74 : int = constant @"1";
-                          %75 : int = or %73 %74;
-                          %76 : boolean = eq %72 %75;
-                          yield %76;
-                      }
-                      ()void -> {
-                          %77 : java.lang.String = var.load %3;
-                          %78 : int = constant @"9";
-                          %79 : java.lang.String = concat %77 %78;
-                          var.store %3 %79;
-                          yield;
-                      }
-                      (%80 : int)boolean -> {
-                          %81 : int = constant @"10";
-                          %82 : boolean = eq %80 %81;
-                          yield %82;
-                      }
-                      ()void -> {
-                          %83 : java.lang.String = var.load %3;
-                          %84 : int = constant @"10";
-                          %85 : java.lang.String = concat %83 %84;
-                          var.store %3 %85;
-                          yield;
-                      }
-                      (%86 : int)boolean -> {
-                          %87 : int = var.load %5;
-                          %88 : boolean = eq %86 %87;
-                          yield %88;
-                      }
-                      ()void -> {
-                          %89 : java.lang.String = var.load %3;
-                          %90 : int = constant @"11";
-                          %91 : java.lang.String = concat %89 %90;
-                          var.store %3 %91;
-                          yield;
-                      }
-                      (%92 : int)boolean -> {
-                          %93 : int = field.load @"SwitchStatementTest$Constants::c1()int";
-                          %94 : boolean = eq %92 %93;
-                          yield %94;
-                      }
-                      ()void -> {
-                          %95 : java.lang.String = var.load %3;
-                          %96 : int = field.load @"SwitchStatementTest$Constants::c1()int";
-                          %97 : java.lang.String = concat %95 %96;
-                          var.store %3 %97;
-                          yield;
-                      }
-                      (%98 : int)boolean -> {
-                          %99 : int = java.cexpression
-                              ()boolean -> {
-                                  %100 : int = constant @"1";
-                                  %101 : int = constant @"0";
-                                  %102 : boolean = gt %100 %101;
-                                  yield %102;
-                              }
-                              ()int -> {
-                                  %103 : int = constant @"13";
-                                  yield %103;
-                              }
-                              ()int -> {
-                                  %104 : int = constant @"133";
-                                  yield %104;
-                              };
-                          %105 : boolean = eq %98 %99;
-                          yield %105;
-                      }
-                      ()void -> {
-                          %106 : java.lang.String = var.load %3;
-                          %107 : int = constant @"13";
-                          %108 : java.lang.String = concat %106 %107;
-                          var.store %3 %108;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %109 : boolean = constant @"true";
-                          yield %109;
-                      }
-                      ()void -> {
-                          %110 : java.lang.String = var.load %3;
-                          %111 : java.lang.String = constant @"an int";
-                          %112 : java.lang.String = concat %110 %111;
-                          var.store %3 %112;
-                          yield;
-                      };
-                  %113 : java.lang.String = var.load %3;
-                  return %113;
-              };
+            func @"caseConstantOtherKindsOfExpr" (%0 : java.type:"int")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"int" = constant @"11";
+                %5 : Var<java.type:"int"> = var %4 @"eleven";
+                %6 : java.type:"int" = var.load %1;
+                java.switch.statement %6
+                    (%7 : java.type:"int")java.type:"boolean" -> {
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"int" = constant @"15";
+                        %10 : java.type:"int" = and %8 %9;
+                        %11 : java.type:"boolean" = eq %7 %10;
+                        yield %11;
+                    }
+                    ()java.type:"void" -> {
+                        %12 : java.type:"java.lang.String" = var.load %3;
+                        %13 : java.type:"int" = constant @"1";
+                        %14 : java.type:"java.lang.String" = concat %12 %13;
+                        var.store %3 %14;
+                        yield;
+                    }
+                    (%15 : java.type:"int")java.type:"boolean" -> {
+                        %16 : java.type:"int" = constant @"4";
+                        %17 : java.type:"int" = constant @"1";
+                        %18 : java.type:"int" = ashr %16 %17;
+                        %19 : java.type:"boolean" = eq %15 %18;
+                        yield %19;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"2";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %3 %22;
+                        yield;
+                    }
+                    (%23 : java.type:"int")java.type:"boolean" -> {
+                        %24 : java.type:"long" = constant @"3";
+                        %25 : java.type:"int" = conv %24;
+                        %26 : java.type:"boolean" = eq %23 %25;
+                        yield %26;
+                    }
+                    ()java.type:"void" -> {
+                        %27 : java.type:"java.lang.String" = var.load %3;
+                        %28 : java.type:"int" = constant @"3";
+                        %29 : java.type:"java.lang.String" = concat %27 %28;
+                        var.store %3 %29;
+                        yield;
+                    }
+                    (%30 : java.type:"int")java.type:"boolean" -> {
+                        %31 : java.type:"int" = constant @"2";
+                        %32 : java.type:"int" = constant @"1";
+                        %33 : java.type:"int" = lshl %31 %32;
+                        %34 : java.type:"boolean" = eq %30 %33;
+                        yield %34;
+                    }
+                    ()java.type:"void" -> {
+                        %35 : java.type:"java.lang.String" = var.load %3;
+                        %36 : java.type:"int" = constant @"4";
+                        %37 : java.type:"java.lang.String" = concat %35 %36;
+                        var.store %3 %37;
+                        yield;
+                    }
+                    (%38 : java.type:"int")java.type:"boolean" -> {
+                        %39 : java.type:"int" = constant @"10";
+                        %40 : java.type:"int" = constant @"2";
+                        %41 : java.type:"int" = div %39 %40;
+                        %42 : java.type:"boolean" = eq %38 %41;
+                        yield %42;
+                    }
+                    ()java.type:"void" -> {
+                        %43 : java.type:"java.lang.String" = var.load %3;
+                        %44 : java.type:"int" = constant @"5";
+                        %45 : java.type:"java.lang.String" = concat %43 %44;
+                        var.store %3 %45;
+                        yield;
+                    }
+                    (%46 : java.type:"int")java.type:"boolean" -> {
+                        %47 : java.type:"int" = constant @"12";
+                        %48 : java.type:"int" = constant @"6";
+                        %49 : java.type:"int" = sub %47 %48;
+                        %50 : java.type:"boolean" = eq %46 %49;
+                        yield %50;
+                    }
+                    ()java.type:"void" -> {
+                        %51 : java.type:"java.lang.String" = var.load %3;
+                        %52 : java.type:"int" = constant @"6";
+                        %53 : java.type:"java.lang.String" = concat %51 %52;
+                        var.store %3 %53;
+                        yield;
+                    }
+                    (%54 : java.type:"int")java.type:"boolean" -> {
+                        %55 : java.type:"int" = constant @"3";
+                        %56 : java.type:"int" = constant @"4";
+                        %57 : java.type:"int" = add %55 %56;
+                        %58 : java.type:"boolean" = eq %54 %57;
+                        yield %58;
+                    }
+                    ()java.type:"void" -> {
+                        %59 : java.type:"java.lang.String" = var.load %3;
+                        %60 : java.type:"int" = constant @"7";
+                        %61 : java.type:"java.lang.String" = concat %59 %60;
+                        var.store %3 %61;
+                        yield;
+                    }
+                    (%62 : java.type:"int")java.type:"boolean" -> {
+                        %63 : java.type:"int" = constant @"2";
+                        %64 : java.type:"int" = constant @"2";
+                        %65 : java.type:"int" = mul %63 %64;
+                        %66 : java.type:"int" = constant @"2";
+                        %67 : java.type:"int" = mul %65 %66;
+                        %68 : java.type:"boolean" = eq %62 %67;
+                        yield %68;
+                    }
+                    ()java.type:"void" -> {
+                        %69 : java.type:"java.lang.String" = var.load %3;
+                        %70 : java.type:"int" = constant @"8";
+                        %71 : java.type:"java.lang.String" = concat %69 %70;
+                        var.store %3 %71;
+                        yield;
+                    }
+                    (%72 : java.type:"int")java.type:"boolean" -> {
+                        %73 : java.type:"int" = constant @"8";
+                        %74 : java.type:"int" = constant @"1";
+                        %75 : java.type:"int" = or %73 %74;
+                        %76 : java.type:"boolean" = eq %72 %75;
+                        yield %76;
+                    }
+                    ()java.type:"void" -> {
+                        %77 : java.type:"java.lang.String" = var.load %3;
+                        %78 : java.type:"int" = constant @"9";
+                        %79 : java.type:"java.lang.String" = concat %77 %78;
+                        var.store %3 %79;
+                        yield;
+                    }
+                    (%80 : java.type:"int")java.type:"boolean" -> {
+                        %81 : java.type:"int" = constant @"10";
+                        %82 : java.type:"boolean" = eq %80 %81;
+                        yield %82;
+                    }
+                    ()java.type:"void" -> {
+                        %83 : java.type:"java.lang.String" = var.load %3;
+                        %84 : java.type:"int" = constant @"10";
+                        %85 : java.type:"java.lang.String" = concat %83 %84;
+                        var.store %3 %85;
+                        yield;
+                    }
+                    (%86 : java.type:"int")java.type:"boolean" -> {
+                        %87 : java.type:"int" = var.load %5;
+                        %88 : java.type:"boolean" = eq %86 %87;
+                        yield %88;
+                    }
+                    ()java.type:"void" -> {
+                        %89 : java.type:"java.lang.String" = var.load %3;
+                        %90 : java.type:"int" = constant @"11";
+                        %91 : java.type:"java.lang.String" = concat %89 %90;
+                        var.store %3 %91;
+                        yield;
+                    }
+                    (%92 : java.type:"int")java.type:"boolean" -> {
+                        %93 : java.type:"int" = field.load @"SwitchStatementTest$Constants::c1:int";
+                        %94 : java.type:"boolean" = eq %92 %93;
+                        yield %94;
+                    }
+                    ()java.type:"void" -> {
+                        %95 : java.type:"java.lang.String" = var.load %3;
+                        %96 : java.type:"int" = field.load @"SwitchStatementTest$Constants::c1:int";
+                        %97 : java.type:"java.lang.String" = concat %95 %96;
+                        var.store %3 %97;
+                        yield;
+                    }
+                    (%98 : java.type:"int")java.type:"boolean" -> {
+                        %99 : java.type:"int" = java.cexpression
+                            ()java.type:"boolean" -> {
+                                %100 : java.type:"int" = constant @"1";
+                                %101 : java.type:"int" = constant @"0";
+                                %102 : java.type:"boolean" = gt %100 %101;
+                                yield %102;
+                            }
+                            ()java.type:"int" -> {
+                                %103 : java.type:"int" = constant @"13";
+                                yield %103;
+                            }
+                            ()java.type:"int" -> {
+                                %104 : java.type:"int" = constant @"133";
+                                yield %104;
+                            };
+                        %105 : java.type:"boolean" = eq %98 %99;
+                        yield %105;
+                    }
+                    ()java.type:"void" -> {
+                        %106 : java.type:"java.lang.String" = var.load %3;
+                        %107 : java.type:"int" = constant @"13";
+                        %108 : java.type:"java.lang.String" = concat %106 %107;
+                        var.store %3 %108;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %109 : java.type:"boolean" = constant @"true";
+                        yield %109;
+                    }
+                    ()java.type:"void" -> {
+                        %110 : java.type:"java.lang.String" = var.load %3;
+                        %111 : java.type:"java.lang.String" = constant @"an int";
+                        %112 : java.type:"java.lang.String" = concat %110 %111;
+                        var.store %3 %112;
+                        yield;
+                    };
+                %113 : java.type:"java.lang.String" = var.load %3;
+                return %113;
+            };
             """)
     @CodeReflection
     private static String caseConstantOtherKindsOfExpr(int i) {
@@ -814,70 +814,70 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantConv" (%0 : short)java.lang.String -> {
-                  %1 : Var<short> = var %0 @"a";
-                  %2 : int = constant @"1";
-                  %3 : short = conv %2;
-                  %4 : Var<short> = var %3 @"s";
-                  %5 : int = constant @"2";
-                  %6 : byte = conv %5;
-                  %7 : Var<byte> = var %6 @"b";
-                  %8 : java.lang.String = constant @"";
-                  %9 : Var<java.lang.String> = var %8 @"r";
-                  %10 : short = var.load %1;
-                  java.switch.statement %10
-                      (%11 : short)boolean -> {
-                          %12 : short = var.load %4;
-                          %13 : boolean = eq %11 %12;
-                          yield %13;
-                      }
-                      ()void -> {
-                          %14 : java.lang.String = var.load %9;
-                          %15 : java.lang.String = constant @"one";
-                          %16 : java.lang.String = concat %14 %15;
-                          var.store %9 %16;
-                          yield;
-                      }
-                      (%17 : short)boolean -> {
-                          %18 : byte = var.load %7;
-                          %19 : short = conv %18;
-                          %20 : boolean = eq %17 %19;
-                          yield %20;
-                      }
-                      ()void -> {
-                          %21 : java.lang.String = var.load %9;
-                          %22 : java.lang.String = constant @"two";
-                          %23 : java.lang.String = concat %21 %22;
-                          var.store %9 %23;
-                          yield;
-                      }
-                      (%24 : short)boolean -> {
-                          %25 : int = constant @"3";
-                          %26 : short = conv %25;
-                          %27 : boolean = eq %24 %26;
-                          yield %27;
-                      }
-                      ()void -> {
-                          %28 : java.lang.String = var.load %9;
-                          %29 : java.lang.String = constant @"three";
-                          %30 : java.lang.String = concat %28 %29;
-                          var.store %9 %30;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %17 : boolean = constant @"true";
-                          yield %17;
-                      }
-                      ()void -> {
-                          %31 : java.lang.String = var.load %9;
-                          %32 : java.lang.String = constant @"else";
-                          %33 : java.lang.String = concat %31 %32;
-                          var.store %9 %33;
-                          yield;
-                      };
-                  %34 : java.lang.String = var.load %9;
-                  return %34;
-              };
+            func @"caseConstantConv" (%0 : java.type:"short")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"short"> = var %0 @"a";
+                %2 : java.type:"int" = constant @"1";
+                %3 : java.type:"short" = conv %2;
+                %4 : Var<java.type:"short"> = var %3 @"s";
+                %5 : java.type:"int" = constant @"2";
+                %6 : java.type:"byte" = conv %5;
+                %7 : Var<java.type:"byte"> = var %6 @"b";
+                %8 : java.type:"java.lang.String" = constant @"";
+                %9 : Var<java.type:"java.lang.String"> = var %8 @"r";
+                %10 : java.type:"short" = var.load %1;
+                java.switch.statement %10
+                    (%11 : java.type:"short")java.type:"boolean" -> {
+                        %12 : java.type:"short" = var.load %4;
+                        %13 : java.type:"boolean" = eq %11 %12;
+                        yield %13;
+                    }
+                    ()java.type:"void" -> {
+                        %14 : java.type:"java.lang.String" = var.load %9;
+                        %15 : java.type:"java.lang.String" = constant @"one";
+                        %16 : java.type:"java.lang.String" = concat %14 %15;
+                        var.store %9 %16;
+                        yield;
+                    }
+                    (%17 : java.type:"short")java.type:"boolean" -> {
+                        %18 : java.type:"byte" = var.load %7;
+                        %19 : java.type:"short" = conv %18;
+                        %20 : java.type:"boolean" = eq %17 %19;
+                        yield %20;
+                    }
+                    ()java.type:"void" -> {
+                        %21 : java.type:"java.lang.String" = var.load %9;
+                        %22 : java.type:"java.lang.String" = constant @"two";
+                        %23 : java.type:"java.lang.String" = concat %21 %22;
+                        var.store %9 %23;
+                        yield;
+                    }
+                    (%24 : java.type:"short")java.type:"boolean" -> {
+                        %25 : java.type:"int" = constant @"3";
+                        %26 : java.type:"short" = conv %25;
+                        %27 : java.type:"boolean" = eq %24 %26;
+                        yield %27;
+                    }
+                    ()java.type:"void" -> {
+                        %28 : java.type:"java.lang.String" = var.load %9;
+                        %29 : java.type:"java.lang.String" = constant @"three";
+                        %30 : java.type:"java.lang.String" = concat %28 %29;
+                        var.store %9 %30;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %31 : java.type:"boolean" = constant @"true";
+                        yield %31;
+                    }
+                    ()java.type:"void" -> {
+                        %32 : java.type:"java.lang.String" = var.load %9;
+                        %33 : java.type:"java.lang.String" = constant @"else";
+                        %34 : java.type:"java.lang.String" = concat %32 %33;
+                        var.store %9 %34;
+                        yield;
+                    };
+                %35 : java.type:"java.lang.String" = var.load %9;
+                return %35;
+            };
             """)
     @CodeReflection
     static String caseConstantConv(short a) {
@@ -894,55 +894,55 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseConstantConv2" (%0 : java.lang.Byte)java.lang.String -> {
-                %1 : Var<java.lang.Byte> = var %0 @"a";
-                %2 : int = constant @"2";
-                %3 : byte = conv %2;
-                %4 : Var<byte> = var %3 @"b";
-                %5 : java.lang.String = constant @"";
-                %6 : Var<java.lang.String> = var %5 @"r";
-                %7 : java.lang.Byte = var.load %1;
+            func @"caseConstantConv2" (%0 : java.type:"java.lang.Byte")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Byte"> = var %0 @"a";
+                %2 : java.type:"int" = constant @"2";
+                %3 : java.type:"byte" = conv %2;
+                %4 : Var<java.type:"byte"> = var %3 @"b";
+                %5 : java.type:"java.lang.String" = constant @"";
+                %6 : Var<java.type:"java.lang.String"> = var %5 @"r";
+                %7 : java.type:"java.lang.Byte" = var.load %1;
                 java.switch.statement %7
-                    (%8 : java.lang.Byte)boolean -> {
-                        %9 : int = constant @"1";
-                        %10 : byte = conv %9;
-                        %11 : java.lang.Byte = invoke %10 @"java.lang.Byte::valueOf(byte)java.lang.Byte";
-                        %12 : boolean = invoke %8 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%8 : java.type:"java.lang.Byte")java.type:"boolean" -> {
+                        %9 : java.type:"int" = constant @"1";
+                        %10 : java.type:"byte" = conv %9;
+                        %11 : java.type:"java.lang.Byte" = invoke %10 @"java.lang.Byte::valueOf(byte):java.lang.Byte";
+                        %12 : java.type:"boolean" = invoke %8 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %12;
                     }
-                    ()void -> {
-                        %13 : java.lang.String = var.load %6;
-                        %14 : java.lang.String = constant @"one";
-                        %15 : java.lang.String = concat %13 %14;
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.String" = var.load %6;
+                        %14 : java.type:"java.lang.String" = constant @"one";
+                        %15 : java.type:"java.lang.String" = concat %13 %14;
                         var.store %6 %15;
                         yield;
                     }
-                    (%16 : java.lang.Byte)boolean -> {
-                        %17 : byte = var.load %4;
-                        %18 : java.lang.Byte = invoke %17 @"java.lang.Byte::valueOf(byte)java.lang.Byte";
-                        %19 : boolean = invoke %16 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%16 : java.type:"java.lang.Byte")java.type:"boolean" -> {
+                        %17 : java.type:"byte" = var.load %4;
+                        %18 : java.type:"java.lang.Byte" = invoke %17 @"java.lang.Byte::valueOf(byte):java.lang.Byte";
+                        %19 : java.type:"boolean" = invoke %16 %18 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %19;
                     }
-                    ()void -> {
-                        %20 : java.lang.String = var.load %6;
-                        %21 : java.lang.String = constant @"two";
-                        %22 : java.lang.String = concat %20 %21;
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %6;
+                        %21 : java.type:"java.lang.String" = constant @"two";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
                         var.store %6 %22;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
                     }
-                    ()void -> {
-                        %23 : java.lang.String = var.load %6;
-                        %24 : java.lang.String = constant @"default";
-                        %25 : java.lang.String = concat %23 %24;
-                        var.store %6 %25;
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.String" = var.load %6;
+                        %25 : java.type:"java.lang.String" = constant @"default";
+                        %26 : java.type:"java.lang.String" = concat %24 %25;
+                        var.store %6 %26;
                         yield;
                     };
-                %26 : java.lang.String = var.load %6;
-                return %26;
+                %27 : java.type:"java.lang.String" = var.load %6;
+                return %27;
             };
             """)
     @CodeReflection
@@ -958,39 +958,39 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"nonEnhancedSwStatNoDefault" (%0 : int)java.lang.String -> {
-                  %1 : Var<int> = var %0 @"a";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : int = var.load %1;
-                  java.switch.statement %4
-                      (%5 : int)boolean -> {
-                          %6 : int = constant @"1";
-                          %7 : boolean = eq %5 %6;
-                          yield %7;
-                      }
-                      ()void -> {
-                          %8 : java.lang.String = var.load %3;
-                          %9 : java.lang.String = constant @"1";
-                          %10 : java.lang.String = concat %8 %9;
-                          var.store %3 %10;
-                          yield;
-                      }
-                      (%11 : int)boolean -> {
-                          %12 : int = constant @"2";
-                          %13 : boolean = eq %11 %12;
-                          yield %13;
-                      }
-                      ()void -> {
-                          %14 : java.lang.String = var.load %3;
-                          %15 : int = constant @"2";
-                          %16 : java.lang.String = concat %14 %15;
-                          var.store %3 %16;
-                          yield;
-                      };
-                  %17 : java.lang.String = var.load %3;
-                  return %17;
-              };
+            func @"nonEnhancedSwStatNoDefault" (%0 : java.type:"int")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"int"> = var %0 @"a";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"int" = var.load %1;
+                java.switch.statement %4
+                    (%5 : java.type:"int")java.type:"boolean" -> {
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"boolean" = eq %5 %6;
+                        yield %7;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"java.lang.String" = constant @"1";
+                        %10 : java.type:"java.lang.String" = concat %8 %9;
+                        var.store %3 %10;
+                        yield;
+                    }
+                    (%11 : java.type:"int")java.type:"boolean" -> {
+                        %12 : java.type:"int" = constant @"2";
+                        %13 : java.type:"boolean" = eq %11 %12;
+                        yield %13;
+                    }
+                    ()java.type:"void" -> {
+                        %14 : java.type:"java.lang.String" = var.load %3;
+                        %15 : java.type:"int" = constant @"2";
+                        %16 : java.type:"java.lang.String" = concat %14 %15;
+                        var.store %3 %16;
+                        yield;
+                    };
+                %17 : java.type:"java.lang.String" = var.load %3;
+                return %17;
+            };
             """)
     @CodeReflection
     static String nonEnhancedSwStatNoDefault(int a) {
@@ -1004,61 +1004,61 @@ public class SwitchStatementTest {
 
     enum E {A, B}
     @IR("""
-            func @"enhancedSwStatNoDefault1" (%0 : SwitchStatementTest$E)java.lang.String -> {
-                  %1 : Var<SwitchStatementTest$E> = var %0 @"e";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : SwitchStatementTest$E = var.load %1;
-                  java.switch.statement %4
-                      (%5 : SwitchStatementTest$E)boolean -> {
-                          %6 : SwitchStatementTest$E = field.load @"SwitchStatementTest$E::A()SwitchStatementTest$E";
-                          %7 : boolean = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %7;
-                      }
-                      ()void -> {
-                          %8 : java.lang.String = var.load %3;
-                          %9 : SwitchStatementTest$E = field.load @"SwitchStatementTest$E::A()SwitchStatementTest$E";
-                          %10 : java.lang.String = cast %9 @"java.lang.String";
-                          %11 : java.lang.String = concat %8 %10;
-                          var.store %3 %11;
-                          yield;
-                      }
-                      (%12 : SwitchStatementTest$E)boolean -> {
-                          %13 : SwitchStatementTest$E = field.load @"SwitchStatementTest$E::B()SwitchStatementTest$E";
-                          %14 : boolean = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %14;
-                      }
-                      ()void -> {
-                          %15 : java.lang.String = var.load %3;
-                          %16 : SwitchStatementTest$E = field.load @"SwitchStatementTest$E::B()SwitchStatementTest$E";
-                          %17 : java.lang.String = cast %16 @"java.lang.String";
-                          %18 : java.lang.String = concat %15 %17;
-                          var.store %3 %18;
-                          yield;
-                      }
-                      (%19 : SwitchStatementTest$E)boolean -> {
-                          %20 : java.lang.Object = constant @null;
-                          %21 : boolean = invoke %19 %20 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %21;
-                      }
-                      ()void -> {
-                          %22 : java.lang.String = var.load %3;
-                          %23 : java.lang.String = constant @"null";
-                          %24 : java.lang.String = concat %22 %23;
-                          var.store %3 %24;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %17 : boolean = constant @"true";
-                          yield %17;
-                      }
-                      ()void -> {
-                          %25 : java.lang.MatchException = new @"java.lang.MatchException::<new>()";
-                          throw %25;
-                      };
-                  %26 : java.lang.String = var.load %3;
-                  return %26;
-              };
+            func @"enhancedSwStatNoDefault1" (%0 : java.type:"SwitchStatementTest$E")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"SwitchStatementTest$E"> = var %0 @"e";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"SwitchStatementTest$E" = var.load %1;
+                java.switch.statement %4
+                    (%5 : java.type:"SwitchStatementTest$E")java.type:"boolean" -> {
+                        %6 : java.type:"SwitchStatementTest$E" = field.load @"SwitchStatementTest$E::A:SwitchStatementTest$E";
+                        %7 : java.type:"boolean" = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %7;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"SwitchStatementTest$E" = field.load @"SwitchStatementTest$E::A:SwitchStatementTest$E";
+                        %10 : java.type:"java.lang.String" = cast %9 @"java.lang.String";
+                        %11 : java.type:"java.lang.String" = concat %8 %10;
+                        var.store %3 %11;
+                        yield;
+                    }
+                    (%12 : java.type:"SwitchStatementTest$E")java.type:"boolean" -> {
+                        %13 : java.type:"SwitchStatementTest$E" = field.load @"SwitchStatementTest$E::B:SwitchStatementTest$E";
+                        %14 : java.type:"boolean" = invoke %12 %13 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %14;
+                    }
+                    ()java.type:"void" -> {
+                        %15 : java.type:"java.lang.String" = var.load %3;
+                        %16 : java.type:"SwitchStatementTest$E" = field.load @"SwitchStatementTest$E::B:SwitchStatementTest$E";
+                        %17 : java.type:"java.lang.String" = cast %16 @"java.lang.String";
+                        %18 : java.type:"java.lang.String" = concat %15 %17;
+                        var.store %3 %18;
+                        yield;
+                    }
+                    (%19 : java.type:"SwitchStatementTest$E")java.type:"boolean" -> {
+                        %20 : java.type:"java.lang.Object" = constant @null;
+                        %21 : java.type:"boolean" = invoke %19 %20 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %21;
+                    }
+                    ()java.type:"void" -> {
+                        %22 : java.type:"java.lang.String" = var.load %3;
+                        %23 : java.type:"java.lang.String" = constant @"null";
+                        %24 : java.type:"java.lang.String" = concat %22 %23;
+                        var.store %3 %24;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %25 : java.type:"boolean" = constant @"true";
+                        yield %25;
+                    }
+                    ()java.type:"void" -> {
+                        %26 : java.type:"java.lang.MatchException" = new @"java.lang.MatchException::()";
+                        throw %26;
+                    };
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
+            };
             """)
     @CodeReflection
     static String enhancedSwStatNoDefault1(E e) {
@@ -1075,64 +1075,64 @@ public class SwitchStatementTest {
     record K() implements I {}
     static final class J implements I {}
     @IR("""
-            func @"enhancedSwStatNoDefault2" (%0 : SwitchStatementTest$I)java.lang.String -> {
-                %1 : Var<SwitchStatementTest$I> = var %0 @"i";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : SwitchStatementTest$I = var.load %1;
-                %5 : SwitchStatementTest$K = constant @null;
-                %6 : Var<SwitchStatementTest$K> = var %5 @"k";
-                %7 : SwitchStatementTest$J = constant @null;
-                %8 : Var<SwitchStatementTest$J> = var %7 @"j";
+            func @"enhancedSwStatNoDefault2" (%0 : java.type:"SwitchStatementTest$I")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"SwitchStatementTest$I"> = var %0 @"i";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"SwitchStatementTest$I" = var.load %1;
+                %5 : java.type:"SwitchStatementTest$K" = constant @null;
+                %6 : Var<java.type:"SwitchStatementTest$K"> = var %5 @"k";
+                %7 : java.type:"SwitchStatementTest$J" = constant @null;
+                %8 : Var<java.type:"SwitchStatementTest$J"> = var %7 @"j";
                 java.switch.statement %4
-                    (%9 : SwitchStatementTest$I)boolean -> {
-                        %10 : boolean = pattern.match %9
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$K> -> {
-                                %11 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$K> = pattern.type @"k";
+                    (%9 : java.type:"SwitchStatementTest$I")java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = pattern.match %9
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$K>" -> {
+                                %11 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$K>" = pattern.type @"k";
                                 yield %11;
                             }
-                            (%12 : SwitchStatementTest$K)void -> {
+                            (%12 : java.type:"SwitchStatementTest$K")java.type:"void" -> {
                                 var.store %6 %12;
                                 yield;
                             };
                         yield %10;
                     }
-                    ()void -> {
-                        %13 : java.lang.String = var.load %3;
-                        %14 : java.lang.String = constant @"K";
-                        %15 : java.lang.String = concat %13 %14;
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.String" = var.load %3;
+                        %14 : java.type:"java.lang.String" = constant @"K";
+                        %15 : java.type:"java.lang.String" = concat %13 %14;
                         var.store %3 %15;
                         yield;
                     }
-                    (%16 : SwitchStatementTest$I)boolean -> {
-                        %17 : boolean = pattern.match %16
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$J> -> {
-                                %18 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$J> = pattern.type @"j";
+                    (%16 : java.type:"SwitchStatementTest$I")java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = pattern.match %16
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$J>" -> {
+                                %18 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<SwitchStatementTest$J>" = pattern.type @"j";
                                 yield %18;
                             }
-                            (%19 : SwitchStatementTest$J)void -> {
+                            (%19 : java.type:"SwitchStatementTest$J")java.type:"void" -> {
                                 var.store %8 %19;
                                 yield;
                             };
                         yield %17;
                     }
-                    ()void -> {
-                        %20 : java.lang.String = var.load %3;
-                        %21 : java.lang.String = constant @"J";
-                        %22 : java.lang.String = concat %20 %21;
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"J";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
                         var.store %3 %22;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
                     }
-                    ()void -> {
-                        %23 : java.lang.MatchException = new @"java.lang.MatchException::<new>()";
-                        throw %23;
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.MatchException" = new @"java.lang.MatchException::()";
+                        throw %24;
                     };
-                %24 : java.lang.String = var.load %3;
-                return %24;
+                %25 : java.type:"java.lang.String" = var.load %3;
+                return %25;
             };
             """)
     @CodeReflection
@@ -1146,46 +1146,46 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"enhancedSwStatUnconditionalPattern" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"s";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : java.lang.String = var.load %1;
-                %5 : java.lang.Object = constant @null;
-                %6 : Var<java.lang.Object> = var %5 @"o";
+            func @"enhancedSwStatUnconditionalPattern" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.String" = var.load %1;
+                %5 : java.type:"java.lang.Object" = constant @null;
+                %6 : Var<java.type:"java.lang.Object"> = var %5 @"o";
                 java.switch.statement %4
-                    (%7 : java.lang.String)boolean -> {
-                        %8 : java.lang.String = constant @"A";
-                        %9 : boolean = invoke %7 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%7 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %8 : java.type:"java.lang.String" = constant @"A";
+                        %9 : java.type:"boolean" = invoke %7 %8 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %9;
                     }
-                    ()void -> {
-                        %10 : java.lang.String = var.load %3;
-                        %11 : java.lang.String = constant @"A";
-                        %12 : java.lang.String = concat %10 %11;
+                    ()java.type:"void" -> {
+                        %10 : java.type:"java.lang.String" = var.load %3;
+                        %11 : java.type:"java.lang.String" = constant @"A";
+                        %12 : java.type:"java.lang.String" = concat %10 %11;
                         var.store %3 %12;
                         yield;
                     }
-                    (%13 : java.lang.String)boolean -> {
-                        %14 : boolean = pattern.match %13
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object> -> {
-                                %15 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object> = pattern.type @"o";
+                    (%13 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %14 : java.type:"boolean" = pattern.match %13
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object>" -> {
+                                %15 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Object>" = pattern.type @"o";
                                 yield %15;
                             }
-                            (%16 : java.lang.Object)void -> {
+                            (%16 : java.type:"java.lang.Object")java.type:"void" -> {
                                 var.store %6 %16;
                                 yield;
                             };
                         yield %14;
                     }
-                    ()void -> {
-                        %17 : java.lang.String = var.load %3;
-                        %18 : java.lang.String = constant @"obj";
-                        %19 : java.lang.String = concat %17 %18;
+                    ()java.type:"void" -> {
+                        %17 : java.type:"java.lang.String" = var.load %3;
+                        %18 : java.type:"java.lang.String" = constant @"obj";
+                        %19 : java.type:"java.lang.String" = concat %17 %18;
                         var.store %3 %19;
                         yield;
                     };
-                %20 : java.lang.String = var.load %3;
+                %20 : java.type:"java.lang.String" = var.load %3;
                 return %20;
             };
             """)
@@ -1200,68 +1200,68 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"casePatternRuleExpression" (%0 : java.lang.Object)java.lang.String -> {
-                  %1 : Var<java.lang.Object> = var %0 @"o";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : java.lang.Object = var.load %1;
-                  %5 : java.lang.Integer = constant @null;
-                  %6 : Var<java.lang.Integer> = var %5 @"i";
-                  %7 : java.lang.String = constant @null;
-                  %8 : Var<java.lang.String> = var %7 @"s";
-                  java.switch.statement %4
-                      (%9 : java.lang.Object)boolean -> {
-                          %10 : boolean = pattern.match %9
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> -> {
-                                  %11 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> = pattern.type @"i";
-                                  yield %11;
-                              }
-                              (%12 : java.lang.Integer)void -> {
-                                  var.store %6 %12;
-                                  yield;
-                              };
-                          yield %10;
-                      }
-                      ()void -> {
-                          %13 : java.lang.String = var.load %3;
-                          %14 : java.lang.String = constant @"integer";
-                          %15 : java.lang.String = concat %13 %14;
-                          var.store %3 %15;
-                          yield;
-                      }
-                      (%16 : java.lang.Object)boolean -> {
-                          %17 : boolean = pattern.match %16
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                  %18 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
-                                  yield %18;
-                              }
-                              (%19 : java.lang.String)void -> {
-                                  var.store %8 %19;
-                                  yield;
-                              };
-                          yield %17;
-                      }
-                      ()void -> {
-                          %20 : java.lang.String = var.load %3;
-                          %21 : java.lang.String = constant @"string";
-                          %22 : java.lang.String = concat %20 %21;
-                          var.store %3 %22;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %17 : boolean = constant @"true";
-                          yield %17;
-                      }
-                      ()void -> {
-                          %23 : java.lang.String = var.load %3;
-                          %24 : java.lang.String = constant @"else";
-                          %25 : java.lang.String = concat %23 %24;
-                          var.store %3 %25;
-                          yield;
-                      };
-                  %26 : java.lang.String = var.load %3;
-                  return %26;
-              };
+            func @"casePatternRuleExpression" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.Integer" = constant @null;
+                %6 : Var<java.type:"java.lang.Integer"> = var %5 @"i";
+                %7 : java.type:"java.lang.String" = constant @null;
+                %8 : Var<java.type:"java.lang.String"> = var %7 @"s";
+                java.switch.statement %4
+                    (%9 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = pattern.match %9
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" -> {
+                                %11 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" = pattern.type @"i";
+                                yield %11;
+                            }
+                            (%12 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                var.store %6 %12;
+                                yield;
+                            };
+                        yield %10;
+                    }
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.String" = var.load %3;
+                        %14 : java.type:"java.lang.String" = constant @"integer";
+                        %15 : java.type:"java.lang.String" = concat %13 %14;
+                        var.store %3 %15;
+                        yield;
+                    }
+                    (%16 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = pattern.match %16
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %18 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
+                                yield %18;
+                            }
+                            (%19 : java.type:"java.lang.String")java.type:"void" -> {
+                                var.store %8 %19;
+                                yield;
+                            };
+                        yield %17;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"string";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %3 %22;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
+                    }
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.String" = var.load %3;
+                        %25 : java.type:"java.lang.String" = constant @"else";
+                        %26 : java.type:"java.lang.String" = concat %24 %25;
+                        var.store %3 %26;
+                        yield;
+                    };
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
+            };
             """)
     @CodeReflection
     private static String casePatternRuleExpression(Object o) {
@@ -1275,68 +1275,68 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"casePatternRuleBlock" (%0 : java.lang.Object)java.lang.String -> {
-                  %1 : Var<java.lang.Object> = var %0 @"o";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : java.lang.Object = var.load %1;
-                  %5 : java.lang.Integer = constant @null;
-                  %6 : Var<java.lang.Integer> = var %5 @"i";
-                  %7 : java.lang.String = constant @null;
-                  %8 : Var<java.lang.String> = var %7 @"s";
-                  java.switch.statement %4
-                      (%9 : java.lang.Object)boolean -> {
-                          %10 : boolean = pattern.match %9
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> -> {
-                                  %11 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> = pattern.type @"i";
-                                  yield %11;
-                              }
-                              (%12 : java.lang.Integer)void -> {
-                                  var.store %6 %12;
-                                  yield;
-                              };
-                          yield %10;
-                      }
-                      ()void -> {
-                          %13 : java.lang.String = var.load %3;
-                          %14 : java.lang.String = constant @"integer";
-                          %15 : java.lang.String = concat %13 %14;
-                          var.store %3 %15;
-                          yield;
-                      }
-                      (%16 : java.lang.Object)boolean -> {
-                          %17 : boolean = pattern.match %16
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                  %18 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
-                                  yield %18;
-                              }
-                              (%19 : java.lang.String)void -> {
-                                  var.store %8 %19;
-                                  yield;
-                              };
-                          yield %17;
-                      }
-                      ()void -> {
-                          %20 : java.lang.String = var.load %3;
-                          %21 : java.lang.String = constant @"string";
-                          %22 : java.lang.String = concat %20 %21;
-                          var.store %3 %22;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %17 : boolean = constant @"true";
-                          yield %17;
-                      }
-                      ()void -> {
-                          %23 : java.lang.String = var.load %3;
-                          %24 : java.lang.String = constant @"else";
-                          %25 : java.lang.String = concat %23 %24;
-                          var.store %3 %25;
-                          yield;
-                      };
-                  %26 : java.lang.String = var.load %3;
-                  return %26;
-              };
+            func @"casePatternRuleBlock" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.Integer" = constant @null;
+                %6 : Var<java.type:"java.lang.Integer"> = var %5 @"i";
+                %7 : java.type:"java.lang.String" = constant @null;
+                %8 : Var<java.type:"java.lang.String"> = var %7 @"s";
+                java.switch.statement %4
+                    (%9 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = pattern.match %9
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" -> {
+                                %11 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" = pattern.type @"i";
+                                yield %11;
+                            }
+                            (%12 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                var.store %6 %12;
+                                yield;
+                            };
+                        yield %10;
+                    }
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.String" = var.load %3;
+                        %14 : java.type:"java.lang.String" = constant @"integer";
+                        %15 : java.type:"java.lang.String" = concat %13 %14;
+                        var.store %3 %15;
+                        yield;
+                    }
+                    (%16 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = pattern.match %16
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %18 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
+                                yield %18;
+                            }
+                            (%19 : java.type:"java.lang.String")java.type:"void" -> {
+                                var.store %8 %19;
+                                yield;
+                            };
+                        yield %17;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"string";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %3 %22;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
+                    }
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.String" = var.load %3;
+                        %25 : java.type:"java.lang.String" = constant @"else";
+                        %26 : java.type:"java.lang.String" = concat %24 %25;
+                        var.store %3 %26;
+                        yield;
+                    };
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
+            };
             """)
     @CodeReflection
     private static String casePatternRuleBlock(Object o) {
@@ -1356,68 +1356,68 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"casePatternStatement" (%0 : java.lang.Object)java.lang.String -> {
-                  %1 : Var<java.lang.Object> = var %0 @"o";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : java.lang.Object = var.load %1;
-                  %5 : java.lang.Integer = constant @null;
-                  %6 : Var<java.lang.Integer> = var %5 @"i";
-                  %7 : java.lang.String = constant @null;
-                  %8 : Var<java.lang.String> = var %7 @"s";
-                  java.switch.statement %4
-                      (%9 : java.lang.Object)boolean -> {
-                          %10 : boolean = pattern.match %9
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> -> {
-                                  %11 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> = pattern.type @"i";
-                                  yield %11;
-                              }
-                              (%12 : java.lang.Integer)void -> {
-                                  var.store %6 %12;
-                                  yield;
-                              };
-                          yield %10;
-                      }
-                      ()void -> {
-                          %13 : java.lang.String = var.load %3;
-                          %14 : java.lang.String = constant @"integer";
-                          %15 : java.lang.String = concat %13 %14;
-                          var.store %3 %15;
-                          java.break;
-                      }
-                      (%16 : java.lang.Object)boolean -> {
-                          %17 : boolean = pattern.match %16
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                  %18 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
-                                  yield %18;
-                              }
-                              (%19 : java.lang.String)void -> {
-                                  var.store %8 %19;
-                                  yield;
-                              };
-                          yield %17;
-                      }
-                      ()void -> {
-                          %20 : java.lang.String = var.load %3;
-                          %21 : java.lang.String = constant @"string";
-                          %22 : java.lang.String = concat %20 %21;
-                          var.store %3 %22;
-                          java.break;
-                      }
-                      ()boolean -> {
-                          %17 : boolean = constant @"true";
-                          yield %17;
-                      }
-                      ()void -> {
-                          %23 : java.lang.String = var.load %3;
-                          %24 : java.lang.String = constant @"else";
-                          %25 : java.lang.String = concat %23 %24;
-                          var.store %3 %25;
-                          yield;
-                      };
-                  %26 : java.lang.String = var.load %3;
-                  return %26;
-              };
+            func @"casePatternStatement" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.Integer" = constant @null;
+                %6 : Var<java.type:"java.lang.Integer"> = var %5 @"i";
+                %7 : java.type:"java.lang.String" = constant @null;
+                %8 : Var<java.type:"java.lang.String"> = var %7 @"s";
+                java.switch.statement %4
+                    (%9 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = pattern.match %9
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" -> {
+                                %11 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" = pattern.type @"i";
+                                yield %11;
+                            }
+                            (%12 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                var.store %6 %12;
+                                yield;
+                            };
+                        yield %10;
+                    }
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.String" = var.load %3;
+                        %14 : java.type:"java.lang.String" = constant @"integer";
+                        %15 : java.type:"java.lang.String" = concat %13 %14;
+                        var.store %3 %15;
+                        java.break;
+                    }
+                    (%16 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = pattern.match %16
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %18 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
+                                yield %18;
+                            }
+                            (%19 : java.type:"java.lang.String")java.type:"void" -> {
+                                var.store %8 %19;
+                                yield;
+                            };
+                        yield %17;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %3;
+                        %21 : java.type:"java.lang.String" = constant @"string";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %3 %22;
+                        java.break;
+                    }
+                    ()java.type:"boolean" -> {
+                        %23 : java.type:"boolean" = constant @"true";
+                        yield %23;
+                    }
+                    ()java.type:"void" -> {
+                        %24 : java.type:"java.lang.String" = var.load %3;
+                        %25 : java.type:"java.lang.String" = constant @"else";
+                        %26 : java.type:"java.lang.String" = concat %24 %25;
+                        var.store %3 %26;
+                        yield;
+                    };
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
+            };
             """)
     @CodeReflection
     private static String casePatternStatement(Object o) {
@@ -1436,66 +1436,66 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"casePatternThrow" (%0 : java.lang.Object)java.lang.String -> {
-                %1 : Var<java.lang.Object> = var %0 @"o";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : java.lang.Object = var.load %1;
-                %5 : java.lang.Number = constant @null;
-                %6 : Var<java.lang.Number> = var %5 @"n";
-                %7 : java.lang.String = constant @null;
-                %8 : Var<java.lang.String> = var %7 @"s";
+            func @"casePatternThrow" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.Number" = constant @null;
+                %6 : Var<java.type:"java.lang.Number"> = var %5 @"n";
+                %7 : java.type:"java.lang.String" = constant @null;
+                %8 : Var<java.type:"java.lang.String"> = var %7 @"s";
                 java.switch.statement %4
-                    (%9 : java.lang.Object)boolean -> {
-                        %10 : boolean = pattern.match %9
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> -> {
-                                %11 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> = pattern.type @"n";
+                    (%9 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = pattern.match %9
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" -> {
+                                %11 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" = pattern.type @"n";
                                 yield %11;
                             }
-                            (%12 : java.lang.Number)void -> {
+                            (%12 : java.type:"java.lang.Number")java.type:"void" -> {
                                 var.store %6 %12;
                                 yield;
                             };
                         yield %10;
                     }
-                    ()void -> {
-                        %13 : java.lang.IllegalArgumentException = new @"java.lang.IllegalArgumentException::<new>()";
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.IllegalArgumentException" = new @"java.lang.IllegalArgumentException::()";
                         throw %13;
                     }
-                    (%14 : java.lang.Object)boolean -> {
-                        %15 : boolean = pattern.match %14
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                %16 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    (%14 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %15 : java.type:"boolean" = pattern.match %14
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %16 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                 yield %16;
                             }
-                            (%17 : java.lang.String)void -> {
+                            (%17 : java.type:"java.lang.String")java.type:"void" -> {
                                 var.store %8 %17;
                                 yield;
                             };
                         yield %15;
                     }
-                    ()void -> {
-                        %18 : java.lang.String = var.load %3;
-                        %19 : java.lang.String = constant @"a string";
-                        %20 : java.lang.String = concat %18 %19;
+                    ()java.type:"void" -> {
+                        %18 : java.type:"java.lang.String" = var.load %3;
+                        %19 : java.type:"java.lang.String" = constant @"a string";
+                        %20 : java.type:"java.lang.String" = concat %18 %19;
                         var.store %3 %20;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %21 : java.type:"boolean" = constant @"true";
+                        yield %21;
                     }
-                    ()void -> {
-                        %21 : java.lang.String = var.load %3;
-                        %22 : java.lang.Object = var.load %1;
-                        %23 : java.lang.Class<? extends java.lang.Object> = invoke %22 @"java.lang.Object::getClass()java.lang.Class";
-                        %24 : java.lang.String = invoke %23 @"java.lang.Class::getName()java.lang.String";
-                        %25 : java.lang.String = concat %21 %24;
-                        var.store %3 %25;
+                    ()java.type:"void" -> {
+                        %22 : java.type:"java.lang.String" = var.load %3;
+                        %23 : java.type:"java.lang.Object" = var.load %1;
+                        %24 : java.type:"java.lang.Class<?>" = invoke %23 @"java.lang.Object::getClass():java.lang.Class";
+                        %25 : java.type:"java.lang.String" = invoke %24 @"java.lang.Class::getName():java.lang.String";
+                        %26 : java.type:"java.lang.String" = concat %22 %25;
+                        var.store %3 %26;
                         yield;
                     };
-                %26 : java.lang.String = var.load %3;
-                return %26;
+                %27 : java.type:"java.lang.String" = var.load %3;
+                return %27;
             };
             """)
     @CodeReflection
@@ -1521,103 +1521,103 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"casePatternWithCaseConstant" (%0 : java.lang.Integer)java.lang.String -> {
-                  %1 : Var<java.lang.Integer> = var %0 @"a";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : java.lang.Integer = var.load %1;
-                  %5 : java.lang.Integer = constant @null;
-                  %6 : Var<java.lang.Integer> = var %5 @"i";
-                  %7 : java.lang.Integer = constant @null;
-                  %8 : Var<java.lang.Integer> = var %7 @"i";
-                  java.switch.statement %4
-                      (%9 : java.lang.Integer)boolean -> {
-                          %10 : int = constant @"42";
-                          %11 : java.lang.Integer = invoke %10 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                          %12 : boolean = invoke %9 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
-                          yield %12;
-                      }
-                      ()void -> {
-                          %13 : java.lang.String = var.load %3;
-                          %14 : java.lang.String = constant @"forty two";
-                          %15 : java.lang.String = concat %13 %14;
-                          var.store %3 %15;
-                          yield;
-                      }
-                      (%16 : java.lang.Integer)boolean -> {
-                          %17 : boolean = java.cand
-                              ()boolean -> {
-                                  %18 : boolean = pattern.match %16
-                                      ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> -> {
-                                          %19 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> = pattern.type @"i";
-                                          yield %19;
-                                      }
-                                      (%20 : java.lang.Integer)void -> {
-                                          var.store %6 %20;
-                                          yield;
-                                      };
-                                  yield %18;
-                              }
-                              ()boolean -> {
-                                  %21 : java.lang.Integer = var.load %6;
-                                  %22 : int = invoke %21 @"java.lang.Integer::intValue()int";
-                                  %23 : int = constant @"0";
-                                  %24 : boolean = gt %22 %23;
-                                  yield %24;
-                              };
-                          yield %17;
-                      }
-                      ()void -> {
-                          %25 : java.lang.String = var.load %3;
-                          %26 : java.lang.String = constant @"positive int";
-                          %27 : java.lang.String = concat %25 %26;
-                          var.store %3 %27;
-                          yield;
-                      }
-                      (%28 : java.lang.Integer)boolean -> {
-                          %29 : boolean = java.cand
-                              ()boolean -> {
-                                  %30 : boolean = pattern.match %28
-                                      ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> -> {
-                                          %31 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer> = pattern.type @"i";
-                                          yield %31;
-                                      }
-                                      (%32 : java.lang.Integer)void -> {
-                                          var.store %8 %32;
-                                          yield;
-                                      };
-                                  yield %30;
-                              }
-                              ()boolean -> {
-                                  %33 : java.lang.Integer = var.load %8;
-                                  %34 : int = invoke %33 @"java.lang.Integer::intValue()int";
-                                  %35 : int = constant @"0";
-                                  %36 : boolean = lt %34 %35;
-                                  yield %36;
-                              };
-                          yield %29;
-                      }
-                      ()void -> {
-                          %37 : java.lang.String = var.load %3;
-                          %38 : java.lang.String = constant @"negative int";
-                          %39 : java.lang.String = concat %37 %38;
-                          var.store %3 %39;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %17 : boolean = constant @"true";
-                          yield %17;
-                      }
-                      ()void -> {
-                          %40 : java.lang.String = var.load %3;
-                          %41 : java.lang.String = constant @"zero";
-                          %42 : java.lang.String = concat %40 %41;
-                          var.store %3 %42;
-                          yield;
-                      };
-                  %43 : java.lang.String = var.load %3;
-                  return %43;
-              };
+            func @"casePatternWithCaseConstant" (%0 : java.type:"java.lang.Integer")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Integer"> = var %0 @"a";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Integer" = var.load %1;
+                %5 : java.type:"java.lang.Integer" = constant @null;
+                %6 : Var<java.type:"java.lang.Integer"> = var %5 @"i";
+                %7 : java.type:"java.lang.Integer" = constant @null;
+                %8 : Var<java.type:"java.lang.Integer"> = var %7 @"i";
+                java.switch.statement %4
+                    (%9 : java.type:"java.lang.Integer")java.type:"boolean" -> {
+                        %10 : java.type:"int" = constant @"42";
+                        %11 : java.type:"java.lang.Integer" = invoke %10 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        %12 : java.type:"boolean" = invoke %9 %11 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %12;
+                    }
+                    ()java.type:"void" -> {
+                        %13 : java.type:"java.lang.String" = var.load %3;
+                        %14 : java.type:"java.lang.String" = constant @"forty two";
+                        %15 : java.type:"java.lang.String" = concat %13 %14;
+                        var.store %3 %15;
+                        yield;
+                    }
+                    (%16 : java.type:"java.lang.Integer")java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %18 : java.type:"boolean" = pattern.match %16
+                                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" -> {
+                                        %19 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" = pattern.type @"i";
+                                        yield %19;
+                                    }
+                                    (%20 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                        var.store %6 %20;
+                                        yield;
+                                    };
+                                yield %18;
+                            }
+                            ()java.type:"boolean" -> {
+                                %21 : java.type:"java.lang.Integer" = var.load %6;
+                                %22 : java.type:"int" = invoke %21 @"java.lang.Integer::intValue():int";
+                                %23 : java.type:"int" = constant @"0";
+                                %24 : java.type:"boolean" = gt %22 %23;
+                                yield %24;
+                            };
+                        yield %17;
+                    }
+                    ()java.type:"void" -> {
+                        %25 : java.type:"java.lang.String" = var.load %3;
+                        %26 : java.type:"java.lang.String" = constant @"positive int";
+                        %27 : java.type:"java.lang.String" = concat %25 %26;
+                        var.store %3 %27;
+                        yield;
+                    }
+                    (%28 : java.type:"java.lang.Integer")java.type:"boolean" -> {
+                        %29 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %30 : java.type:"boolean" = pattern.match %28
+                                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" -> {
+                                        %31 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Integer>" = pattern.type @"i";
+                                        yield %31;
+                                    }
+                                    (%32 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                        var.store %8 %32;
+                                        yield;
+                                    };
+                                yield %30;
+                            }
+                            ()java.type:"boolean" -> {
+                                %33 : java.type:"java.lang.Integer" = var.load %8;
+                                %34 : java.type:"int" = invoke %33 @"java.lang.Integer::intValue():int";
+                                %35 : java.type:"int" = constant @"0";
+                                %36 : java.type:"boolean" = lt %34 %35;
+                                yield %36;
+                            };
+                        yield %29;
+                    }
+                    ()java.type:"void" -> {
+                        %37 : java.type:"java.lang.String" = var.load %3;
+                        %38 : java.type:"java.lang.String" = constant @"negative int";
+                        %39 : java.type:"java.lang.String" = concat %37 %38;
+                        var.store %3 %39;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %40 : java.type:"boolean" = constant @"true";
+                        yield %40;
+                    }
+                    ()java.type:"void" -> {
+                        %41 : java.type:"java.lang.String" = var.load %3;
+                        %42 : java.type:"java.lang.String" = constant @"zero";
+                        %43 : java.type:"java.lang.String" = concat %41 %42;
+                        var.store %3 %43;
+                        yield;
+                    };
+                %44 : java.type:"java.lang.String" = var.load %3;
+                return %44;
+            };
             """)
     @CodeReflection
     static String casePatternWithCaseConstant(Integer a) {
@@ -1633,151 +1633,151 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"caseTypePattern" (%0 : java.lang.Object)java.lang.String -> {
-                  %1 : Var<java.lang.Object> = var %0 @"o";
-                  %2 : java.lang.String = constant @"";
-                  %3 : Var<java.lang.String> = var %2 @"r";
-                  %4 : java.lang.Object = var.load %1;
-                  %5 : java.lang.String = constant @null;
-                  %6 : Var<java.lang.String> = var %5;
-                  %7 : java.util.RandomAccess = constant @null;
-                  %8 : Var<java.util.RandomAccess> = var %7;
-                  %9 : int[] = constant @null;
-                  %10 : Var<int[]> = var %9;
-                  %11 : java.util.Stack[][] = constant @null;
-                  %12 : Var<java.util.Stack[][]> = var %11;
-                  %13 : java.util.Collection[][][] = constant @null;
-                  %14 : Var<java.util.Collection[][][]> = var %13;
-                  %15 : java.lang.Number = constant @null;
-                  %16 : Var<java.lang.Number> = var %15 @"n";
-                  java.switch.statement %4
-                      (%17 : java.lang.Object)boolean -> {
-                          %18 : boolean = pattern.match %17
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                  %19 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type;
-                                  yield %19;
-                              }
-                              (%20 : java.lang.String)void -> {
-                                  var.store %6 %20;
-                                  yield;
-                              };
-                          yield %18;
-                      }
-                      ()void -> {
-                          %21 : java.lang.String = var.load %3;
-                          %22 : java.lang.String = constant @"String";
-                          %23 : java.lang.String = concat %21 %22;
-                          var.store %3 %23;
-                          yield;
-                      }
-                      (%24 : java.lang.Object)boolean -> {
-                          %25 : boolean = pattern.match %24
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.RandomAccess> -> {
-                                  %26 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.RandomAccess> = pattern.type;
-                                  yield %26;
-                              }
-                              (%27 : java.util.RandomAccess)void -> {
-                                  var.store %8 %27;
-                                  yield;
-                              };
-                          yield %25;
-                      }
-                      ()void -> {
-                          %28 : java.lang.String = var.load %3;
-                          %29 : java.lang.String = constant @"RandomAccess";
-                          %30 : java.lang.String = concat %28 %29;
-                          var.store %3 %30;
-                          yield;
-                      }
-                      (%31 : java.lang.Object)boolean -> {
-                          %32 : boolean = pattern.match %31
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<int[]> -> {
-                                  %33 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<int[]> = pattern.type;
-                                  yield %33;
-                              }
-                              (%34 : int[])void -> {
-                                  var.store %10 %34;
-                                  yield;
-                              };
-                          yield %32;
-                      }
-                      ()void -> {
-                          %35 : java.lang.String = var.load %3;
-                          %36 : java.lang.String = constant @"int[]";
-                          %37 : java.lang.String = concat %35 %36;
-                          var.store %3 %37;
-                          yield;
-                      }
-                      (%38 : java.lang.Object)boolean -> {
-                          %39 : boolean = pattern.match %38
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Stack[][]> -> {
-                                  %40 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Stack[][]> = pattern.type;
-                                  yield %40;
-                              }
-                              (%41 : java.util.Stack[][])void -> {
-                                  var.store %12 %41;
-                                  yield;
-                              };
-                          yield %39;
-                      }
-                      ()void -> {
-                          %42 : java.lang.String = var.load %3;
-                          %43 : java.lang.String = constant @"Stack[][]";
-                          %44 : java.lang.String = concat %42 %43;
-                          var.store %3 %44;
-                          yield;
-                      }
-                      (%45 : java.lang.Object)boolean -> {
-                          %46 : boolean = pattern.match %45
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Collection[][][]> -> {
-                                  %47 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Collection[][][]> = pattern.type;
-                                  yield %47;
-                              }
-                              (%48 : java.util.Collection[][][])void -> {
-                                  var.store %14 %48;
-                                  yield;
-                              };
-                          yield %46;
-                      }
-                      ()void -> {
-                          %49 : java.lang.String = var.load %3;
-                          %50 : java.lang.String = constant @"Collection[][][]";
-                          %51 : java.lang.String = concat %49 %50;
-                          var.store %3 %51;
-                          yield;
-                      }
-                      (%52 : java.lang.Object)boolean -> {
-                          %53 : boolean = pattern.match %52
-                              ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> -> {
-                                  %54 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> = pattern.type @"n";
-                                  yield %54;
-                              }
-                              (%55 : java.lang.Number)void -> {
-                                  var.store %16 %55;
-                                  yield;
-                              };
-                          yield %53;
-                      }
-                      ()void -> {
-                          %56 : java.lang.String = var.load %3;
-                          %57 : java.lang.String = constant @"Number";
-                          %58 : java.lang.String = concat %56 %57;
-                          var.store %3 %58;
-                          yield;
-                      }
-                      ()boolean -> {
-                          %59 : boolean = constant @"true";
-                          yield %59;
-                      }
-                      ()void -> {
-                          %60 : java.lang.String = var.load %3;
-                          %61 : java.lang.String = constant @"something else";
-                          %62 : java.lang.String = concat %60 %61;
-                          var.store %3 %62;
-                          yield;
-                      };
-                  %63 : java.lang.String = var.load %3;
-                  return %63;
+            func @"caseTypePattern" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.String" = constant @null;
+                %6 : Var<java.type:"java.lang.String"> = var %5;
+                %7 : java.type:"java.util.RandomAccess" = constant @null;
+                %8 : Var<java.type:"java.util.RandomAccess"> = var %7;
+                %9 : java.type:"int[]" = constant @null;
+                %10 : Var<java.type:"int[]"> = var %9;
+                %11 : java.type:"java.util.Stack[][]" = constant @null;
+                %12 : Var<java.type:"java.util.Stack[][]"> = var %11;
+                %13 : java.type:"java.util.Collection[][][]" = constant @null;
+                %14 : Var<java.type:"java.util.Collection[][][]"> = var %13;
+                %15 : java.type:"java.lang.Number" = constant @null;
+                %16 : Var<java.type:"java.lang.Number"> = var %15 @"n";
+                java.switch.statement %4
+                    (%17 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %18 : java.type:"boolean" = pattern.match %17
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                %19 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type;
+                                yield %19;
+                            }
+                            (%20 : java.type:"java.lang.String")java.type:"void" -> {
+                                var.store %6 %20;
+                                yield;
+                            };
+                        yield %18;
+                    }
+                    ()java.type:"void" -> {
+                        %21 : java.type:"java.lang.String" = var.load %3;
+                        %22 : java.type:"java.lang.String" = constant @"String";
+                        %23 : java.type:"java.lang.String" = concat %21 %22;
+                        var.store %3 %23;
+                        yield;
+                    }
+                    (%24 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %25 : java.type:"boolean" = pattern.match %24
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.RandomAccess>" -> {
+                                %26 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.RandomAccess>" = pattern.type;
+                                yield %26;
+                            }
+                            (%27 : java.type:"java.util.RandomAccess")java.type:"void" -> {
+                                var.store %8 %27;
+                                yield;
+                            };
+                        yield %25;
+                    }
+                    ()java.type:"void" -> {
+                        %28 : java.type:"java.lang.String" = var.load %3;
+                        %29 : java.type:"java.lang.String" = constant @"RandomAccess";
+                        %30 : java.type:"java.lang.String" = concat %28 %29;
+                        var.store %3 %30;
+                        yield;
+                    }
+                    (%31 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %32 : java.type:"boolean" = pattern.match %31
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<int[]>" -> {
+                                %33 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<int[]>" = pattern.type;
+                                yield %33;
+                            }
+                            (%34 : java.type:"int[]")java.type:"void" -> {
+                                var.store %10 %34;
+                                yield;
+                            };
+                        yield %32;
+                    }
+                    ()java.type:"void" -> {
+                        %35 : java.type:"java.lang.String" = var.load %3;
+                        %36 : java.type:"java.lang.String" = constant @"int[]";
+                        %37 : java.type:"java.lang.String" = concat %35 %36;
+                        var.store %3 %37;
+                        yield;
+                    }
+                    (%38 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %39 : java.type:"boolean" = pattern.match %38
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Stack[][]>" -> {
+                                %40 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Stack[][]>" = pattern.type;
+                                yield %40;
+                            }
+                            (%41 : java.type:"java.util.Stack[][]")java.type:"void" -> {
+                                var.store %12 %41;
+                                yield;
+                            };
+                        yield %39;
+                    }
+                    ()java.type:"void" -> {
+                        %42 : java.type:"java.lang.String" = var.load %3;
+                        %43 : java.type:"java.lang.String" = constant @"Stack[][]";
+                        %44 : java.type:"java.lang.String" = concat %42 %43;
+                        var.store %3 %44;
+                        yield;
+                    }
+                    (%45 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %46 : java.type:"boolean" = pattern.match %45
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Collection[][][]>" -> {
+                                %47 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.util.Collection[][][]>" = pattern.type;
+                                yield %47;
+                            }
+                            (%48 : java.type:"java.util.Collection[][][]")java.type:"void" -> {
+                                var.store %14 %48;
+                                yield;
+                            };
+                        yield %46;
+                    }
+                    ()java.type:"void" -> {
+                        %49 : java.type:"java.lang.String" = var.load %3;
+                        %50 : java.type:"java.lang.String" = constant @"Collection[][][]";
+                        %51 : java.type:"java.lang.String" = concat %49 %50;
+                        var.store %3 %51;
+                        yield;
+                    }
+                    (%52 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %53 : java.type:"boolean" = pattern.match %52
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" -> {
+                                %54 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" = pattern.type @"n";
+                                yield %54;
+                            }
+                            (%55 : java.type:"java.lang.Number")java.type:"void" -> {
+                                var.store %16 %55;
+                                yield;
+                            };
+                        yield %53;
+                    }
+                    ()java.type:"void" -> {
+                        %56 : java.type:"java.lang.String" = var.load %3;
+                        %57 : java.type:"java.lang.String" = constant @"Number";
+                        %58 : java.type:"java.lang.String" = concat %56 %57;
+                        var.store %3 %58;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %59 : java.type:"boolean" = constant @"true";
+                        yield %59;
+                    }
+                    ()java.type:"void" -> {
+                        %60 : java.type:"java.lang.String" = var.load %3;
+                        %61 : java.type:"java.lang.String" = constant @"something else";
+                        %62 : java.type:"java.lang.String" = concat %60 %61;
+                        var.store %3 %62;
+                        yield;
+                    };
+                %63 : java.type:"java.lang.String" = var.load %3;
+                return %63;
             };
             """)
     @CodeReflection
@@ -1797,47 +1797,47 @@ public class SwitchStatementTest {
 
     record R(Number n) {}
     @IR("""
-            func @"caseRecordPattern" (%0 : java.lang.Object)java.lang.String -> {
-                %1 : Var<java.lang.Object> = var %0 @"o";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : java.lang.Object = var.load %1;
-                %5 : java.lang.Number = constant @null;
-                %6 : Var<java.lang.Number> = var %5 @"n";
+            func @"caseRecordPattern" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.Number" = constant @null;
+                %6 : Var<java.type:"java.lang.Number"> = var %5 @"n";
                 java.switch.statement %4
-                    (%7 : java.lang.Object)boolean -> {
-                        %8 : boolean = pattern.match %7
-                            ()jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R> -> {
-                                %9 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> = pattern.type @"n";
-                                %10 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R> = pattern.record %9 @"(java.lang.Number n)SwitchStatementTest$R";
+                    (%7 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = pattern.match %7
+                            ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R>" -> {
+                                %9 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" = pattern.type @"n";
+                                %10 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R>" = pattern.record %9 @"(java.lang.Number n)SwitchStatementTest$R";
                                 yield %10;
                             }
-                            (%11 : java.lang.Number)void -> {
+                            (%11 : java.type:"java.lang.Number")java.type:"void" -> {
                                 var.store %6 %11;
                                 yield;
                             };
                         yield %8;
                     }
-                    ()void -> {
-                        %12 : java.lang.String = var.load %3;
-                        %13 : java.lang.String = constant @"R(_)";
-                        %14 : java.lang.String = concat %12 %13;
+                    ()java.type:"void" -> {
+                        %12 : java.type:"java.lang.String" = var.load %3;
+                        %13 : java.type:"java.lang.String" = constant @"R(_)";
+                        %14 : java.type:"java.lang.String" = concat %12 %13;
                         var.store %3 %14;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %15 : java.type:"boolean" = constant @"true";
+                        yield %15;
                     }
-                    ()void -> {
-                        %15 : java.lang.String = var.load %3;
-                        %16 : java.lang.String = constant @"else";
-                        %17 : java.lang.String = concat %15 %16;
-                        var.store %3 %17;
+                    ()java.type:"void" -> {
+                        %16 : java.type:"java.lang.String" = var.load %3;
+                        %17 : java.type:"java.lang.String" = constant @"else";
+                        %18 : java.type:"java.lang.String" = concat %16 %17;
+                        var.store %3 %18;
                         yield;
                     };
-                %18 : java.lang.String = var.load %3;
-                return %18;
+                %19 : java.type:"java.lang.String" = var.load %3;
+                return %19;
             };
             """)
     @CodeReflection
@@ -1851,94 +1851,94 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"casePatternGuard" (%0 : java.lang.Object)java.lang.String -> {
-                %1 : Var<java.lang.Object> = var %0 @"obj";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : java.lang.Object = var.load %1;
-                %5 : java.lang.String = constant @null;
-                %6 : Var<java.lang.String> = var %5 @"s";
-                %7 : java.lang.Number = constant @null;
-                %8 : Var<java.lang.Number> = var %7 @"n";
+            func @"casePatternGuard" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"obj";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.String" = constant @null;
+                %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
+                %7 : java.type:"java.lang.Number" = constant @null;
+                %8 : Var<java.type:"java.lang.Number"> = var %7 @"n";
                 java.switch.statement %4
-                    (%9 : java.lang.Object)boolean -> {
-                        %10 : boolean = java.cand
-                            ()boolean -> {
-                                %11 : boolean = pattern.match %9
-                                    ()jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> -> {
-                                        %12 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String> = pattern.type @"s";
+                    (%9 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %11 : java.type:"boolean" = pattern.match %9
+                                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" -> {
+                                        %12 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
                                         yield %12;
                                     }
-                                    (%13 : java.lang.String)void -> {
+                                    (%13 : java.type:"java.lang.String")java.type:"void" -> {
                                         var.store %6 %13;
                                         yield;
                                     };
                                 yield %11;
                             }
-                            ()boolean -> {
-                                %14 : java.lang.String = var.load %6;
-                                %15 : int = invoke %14 @"java.lang.String::length()int";
-                                %16 : int = constant @"3";
-                                %17 : boolean = gt %15 %16;
+                            ()java.type:"boolean" -> {
+                                %14 : java.type:"java.lang.String" = var.load %6;
+                                %15 : java.type:"int" = invoke %14 @"java.lang.String::length():int";
+                                %16 : java.type:"int" = constant @"3";
+                                %17 : java.type:"boolean" = gt %15 %16;
                                 yield %17;
                             };
                         yield %10;
                     }
-                    ()void -> {
-                        %18 : java.lang.String = var.load %3;
-                        %19 : java.lang.String = constant @"str with length > %d";
-                        %20 : java.lang.String = var.load %6;
-                        %21 : int = invoke %20 @"java.lang.String::length()int";
-                        %22 : java.lang.Integer = invoke %21 @"java.lang.Integer::valueOf(int)java.lang.Integer";
-                        %23 : java.lang.String = invoke %19 %22 @invoke.kind="INSTANCE" @invoke.varargs="true" @"java.lang.String::formatted(java.lang.Object[])java.lang.String";
-                        %24 : java.lang.String = concat %18 %23;
+                    ()java.type:"void" -> {
+                        %18 : java.type:"java.lang.String" = var.load %3;
+                        %19 : java.type:"java.lang.String" = constant @"str with length > %d";
+                        %20 : java.type:"java.lang.String" = var.load %6;
+                        %21 : java.type:"int" = invoke %20 @"java.lang.String::length():int";
+                        %22 : java.type:"java.lang.Integer" = invoke %21 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        %23 : java.type:"java.lang.String" = invoke %19 %22 @"java.lang.String::formatted(java.lang.Object[]):java.lang.String" @invoke.kind="INSTANCE" @invoke.varargs="true";
+                        %24 : java.type:"java.lang.String" = concat %18 %23;
                         var.store %3 %24;
                         yield;
                     }
-                    (%25 : java.lang.Object)boolean -> {
-                        %26 : boolean = java.cand
-                            ()boolean -> {
-                                %27 : boolean = pattern.match %25
-                                    ()jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R> -> {
-                                        %28 : jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number> = pattern.type @"n";
-                                        %29 : jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R> = pattern.record %28 @"(java.lang.Number n)SwitchStatementTest$R";
+                    (%25 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %26 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %27 : java.type:"boolean" = pattern.match %25
+                                    ()java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R>" -> {
+                                        %28 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Type<java.lang.Number>" = pattern.type @"n";
+                                        %29 : java.type:"jdk.incubator.code.op.ExtendedOp$Pattern$Record<SwitchStatementTest$R>" = pattern.record %28 @"(java.lang.Number n)SwitchStatementTest$R";
                                         yield %29;
                                     }
-                                    (%30 : java.lang.Number)void -> {
+                                    (%30 : java.type:"java.lang.Number")java.type:"void" -> {
                                         var.store %8 %30;
                                         yield;
                                     };
                                 yield %27;
                             }
-                            ()boolean -> {
-                                %31 : java.lang.Number = var.load %8;
-                                %32 : java.lang.Class<? extends java.lang.Object> = invoke %31 @"java.lang.Object::getClass()java.lang.Class";
-                                %33 : java.lang.Class = constant @"java.lang.Double";
-                                %34 : boolean = invoke %32 %33 @"java.lang.Object::equals(java.lang.Object)boolean";
+                            ()java.type:"boolean" -> {
+                                %31 : java.type:"java.lang.Number" = var.load %8;
+                                %32 : java.type:"java.lang.Class<?>" = invoke %31 @"java.lang.Object::getClass():java.lang.Class";
+                                %33 : java.type:"java.lang.Class" = constant @"java.lang.Double";
+                                %34 : java.type:"boolean" = invoke %32 %33 @"java.lang.Object::equals(java.lang.Object):boolean";
                                 yield %34;
                             };
                         yield %26;
                     }
-                    ()void -> {
-                        %35 : java.lang.String = var.load %3;
-                        %36 : java.lang.String = constant @"R(Double)";
-                        %37 : java.lang.String = concat %35 %36;
+                    ()java.type:"void" -> {
+                        %35 : java.type:"java.lang.String" = var.load %3;
+                        %36 : java.type:"java.lang.String" = constant @"R(Double)";
+                        %37 : java.type:"java.lang.String" = concat %35 %36;
                         var.store %3 %37;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
-                        yield %17;
+                    ()java.type:"boolean" -> {
+                        %38 : java.type:"boolean" = constant @"true";
+                        yield %38;
                     }
-                    ()void -> {
-                        %38 : java.lang.String = var.load %3;
-                        %39 : java.lang.String = constant @"else";
-                        %40 : java.lang.String = concat %38 %39;
-                        var.store %3 %40;
+                    ()java.type:"void" -> {
+                        %39 : java.type:"java.lang.String" = var.load %3;
+                        %40 : java.type:"java.lang.String" = constant @"else";
+                        %41 : java.type:"java.lang.String" = concat %39 %40;
+                        var.store %3 %41;
                         yield;
                     };
-                %41 : java.lang.String = var.load %3;
-                return %41;
+                %42 : java.type:"java.lang.String" = var.load %3;
+                return %42;
             };
             """)
     @CodeReflection
@@ -1953,49 +1953,49 @@ public class SwitchStatementTest {
     }
 
     @IR("""
-            func @"defaultCaseNotTheLast" (%0 : java.lang.String)java.lang.String -> {
-                %1 : Var<java.lang.String> = var %0 @"s";
-                %2 : java.lang.String = constant @"";
-                %3 : Var<java.lang.String> = var %2 @"r";
-                %4 : java.lang.String = var.load %1;
+            func @"defaultCaseNotTheLast" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.String" = var.load %1;
                 java.switch.statement %4
-                    (%5 : java.lang.String)boolean -> {
-                        %6 : java.lang.String = constant @"M";
-                        %7 : boolean = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%5 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %6 : java.type:"java.lang.String" = constant @"M";
+                        %7 : java.type:"boolean" = invoke %5 %6 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %7;
                     }
-                    ()void -> {
-                        %8 : java.lang.String = var.load %3;
-                        %9 : java.lang.String = constant @"Mow";
-                        %10 : java.lang.String = concat %8 %9;
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"java.lang.String" = constant @"Mow";
+                        %10 : java.type:"java.lang.String" = concat %8 %9;
                         var.store %3 %10;
                         yield;
                     }
-                    (%11 : java.lang.String)boolean -> {
-                        %12 : java.lang.String = constant @"A";
-                        %13 : boolean = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object)boolean";
+                    (%11 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %12 : java.type:"java.lang.String" = constant @"A";
+                        %13 : java.type:"boolean" = invoke %11 %12 @"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
                         yield %13;
                     }
-                    ()void -> {
-                        %14 : java.lang.String = var.load %3;
-                        %15 : java.lang.String = constant @"Aow";
-                        %16 : java.lang.String = concat %14 %15;
+                    ()java.type:"void" -> {
+                        %14 : java.type:"java.lang.String" = var.load %3;
+                        %15 : java.type:"java.lang.String" = constant @"Aow";
+                        %16 : java.type:"java.lang.String" = concat %14 %15;
                         var.store %3 %16;
                         yield;
                     }
-                    ()boolean -> {
-                        %17 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = constant @"true";
                         yield %17;
                     }
-                    ()void -> {
-                        %17 : java.lang.String = var.load %3;
-                        %18 : java.lang.String = constant @"else";
-                        %19 : java.lang.String = concat %17 %18;
-                        var.store %3 %19;
+                    ()java.type:"void" -> {
+                        %18 : java.type:"java.lang.String" = var.load %3;
+                        %19 : java.type:"java.lang.String" = constant @"else";
+                        %20 : java.type:"java.lang.String" = concat %18 %19;
+                        var.store %3 %20;
                         yield;
                     };
-                %20 : java.lang.String = var.load %3;
-                return %20;
+                %21 : java.type:"java.lang.String" = var.load %3;
+                return %21;
             };
             """)
     @CodeReflection

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -1488,7 +1488,7 @@ public class SwitchStatementTest {
                     ()void -> {
                         %21 : java.lang.String = var.load %3;
                         %22 : java.lang.Object = var.load %1;
-                        %23 : java.lang.Class<+<java.lang.Object>> = invoke %22 @"java.lang.Object::getClass()java.lang.Class";
+                        %23 : java.lang.Class<? extends java.lang.Object> = invoke %22 @"java.lang.Object::getClass()java.lang.Class";
                         %24 : java.lang.String = invoke %23 @"java.lang.Class::getName()java.lang.String";
                         %25 : java.lang.String = concat %21 %24;
                         var.store %3 %25;
@@ -1912,7 +1912,7 @@ public class SwitchStatementTest {
                             }
                             ()boolean -> {
                                 %31 : java.lang.Number = var.load %8;
-                                %32 : java.lang.Class<+<java.lang.Object>> = invoke %31 @"java.lang.Object::getClass()java.lang.Class";
+                                %32 : java.lang.Class<? extends java.lang.Object> = invoke %31 @"java.lang.Object::getClass()java.lang.Class";
                                 %33 : java.lang.Class = constant @"java.lang.Double";
                                 %34 : boolean = invoke %32 %33 @"java.lang.Object::equals(java.lang.Object)boolean";
                                 yield %34;

--- a/test/langtools/tools/javac/reflect/SynchronizedTest.java
+++ b/test/langtools/tools/javac/reflect/SynchronizedTest.java
@@ -35,20 +35,20 @@ import jdk.incubator.code.CodeReflection;
 public class SynchronizedTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : SynchronizedTest, %1 : int)int -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test1" (%0 : java.type:"SynchronizedTest", %1 : java.type:"int")java.type:"int" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.synchronized
-                    ()SynchronizedTest -> {
+                    ()java.type:"SynchronizedTest" -> {
                         yield %0;
                     }
-                    ()void -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"1";
-                        %5 : int = add %3 %4;
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"1";
+                        %5 : java.type:"int" = add %3 %4;
                         var.store %2 %5;
                         yield;
                     };
-                %6 : int = var.load %2;
+                %6 : java.type:"int" = var.load %2;
                 return %6;
             };
             """)
@@ -65,21 +65,21 @@ public class SynchronizedTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : SynchronizedTest, %1 : int)int -> {
-                %2 : Var<int> = var %1 @"i";
+            func @"test2" (%0 : java.type:"SynchronizedTest", %1 : java.type:"int")java.type:"int" -> {
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.synchronized
-                    ()java.lang.Object -> {
-                        %3 : java.lang.Object = invoke @"SynchronizedTest::m()java.lang.Object";
+                    ()java.type:"java.lang.Object" -> {
+                        %3 : java.type:"java.lang.Object" = invoke @"SynchronizedTest::m():java.lang.Object";
                         yield %3;
                     }
-                    ()void -> {
-                        %4 : int = var.load %2;
-                        %5 : int = constant @"1";
-                        %6 : int = add %4 %5;
+                    ()java.type:"void" -> {
+                        %4 : java.type:"int" = var.load %2;
+                        %5 : java.type:"int" = constant @"1";
+                        %6 : java.type:"int" = add %4 %5;
                         var.store %2 %6;
                         yield;
                     };
-                %7 : int = var.load %2;
+                %7 : java.type:"int" = var.load %2;
                 return %7;
             };
             """)

--- a/test/langtools/tools/javac/reflect/ThrowTest.java
+++ b/test/langtools/tools/javac/reflect/ThrowTest.java
@@ -35,8 +35,8 @@ import jdk.incubator.code.CodeReflection;
 public class ThrowTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : ThrowTest)void -> {
-                %1 : java.lang.RuntimeException = new @"java.lang.RuntimeException::<new>()";
+            func @"test1" (%0 : java.type:"ThrowTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.RuntimeException" = new @"java.lang.RuntimeException::()";
                 throw %1;
             };
             """)

--- a/test/langtools/tools/javac/reflect/TryTest.java
+++ b/test/langtools/tools/javac/reflect/TryTest.java
@@ -36,23 +36,23 @@ public class TryTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : TryTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test1" (%0 : java.type:"TryTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.try
-                    ()void -> {
-                        %3 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = constant @"1";
                         var.store %2 %3;
                         yield;
                     }
-                    ^catch(%4 : java.lang.Exception)void -> {
-                        %5 : Var<java.lang.Exception> = var %4 @"e";
-                        %6 : int = constant @"2";
+                    (%4 : java.type:"java.lang.Exception")java.type:"void" -> {
+                        %5 : Var<java.type:"java.lang.Exception"> = var %4 @"e";
+                        %6 : java.type:"int" = constant @"2";
                         var.store %2 %6;
                         yield;
                     }
-                    ^finally()void -> {
-                        %7 : int = constant @"3";
+                    ()java.type:"void" -> {
+                        %7 : java.type:"int" = constant @"3";
                         var.store %2 %7;
                         yield;
                     };
@@ -72,17 +72,17 @@ public class TryTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : TryTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test2" (%0 : java.type:"TryTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.try
-                    ()void -> {
-                        %3 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = constant @"1";
                         var.store %2 %3;
                         yield;
                     }
-                    ^finally()void -> {
-                        %4 : int = constant @"3";
+                    ()java.type:"void" -> {
+                        %4 : java.type:"int" = constant @"3";
                         var.store %2 %4;
                         yield;
                     };
@@ -100,19 +100,19 @@ public class TryTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : TryTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test3" (%0 : java.type:"TryTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.try
-                    ()void -> {
-                        %3 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = constant @"1";
                         var.store %2 %3;
                         yield;
                     }
-                    ^catch(%4 : java.lang.Exception)void -> {
-                        %5 : Var<java.lang.Exception> = var %4 @"e";
-                        %6 : java.lang.Exception = var.load %5;
-                        invoke %6 @"java.lang.Exception::printStackTrace()void";
+                    (%4 : java.type:"java.lang.Exception")java.type:"void" -> {
+                        %5 : Var<java.type:"java.lang.Exception"> = var %4 @"e";
+                        %6 : java.type:"java.lang.Exception" = var.load %5;
+                        invoke %6 @"java.lang.Exception::printStackTrace():void";
                         yield;
                     };
                 return;
@@ -163,37 +163,37 @@ public class TryTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" (%0 : TryTest)void -> {
+            func @"test4" (%0 : java.type:"TryTest")java.type:"void" -> {
                 java.try
-                    ^resources()Tuple<Var<TryTest$A>, TryTest$B, Var<TryTest$C>> -> {
-                        %1 : TryTest$A = invoke %0 @"TryTest::a()TryTest$A";
-                        %2 : Var<TryTest$A> = var %1 @"a";
-                        %3 : TryTest$A = var.load %2;
-                        %4 : TryTest$B = field.load %3 @"TryTest$A::b()TryTest$B";
-                        %5 : TryTest$A = var.load %2;
-                        %6 : TryTest$B = field.load %5 @"TryTest$A::b()TryTest$B";
-                        %7 : TryTest$C = field.load %6 @"TryTest$B::c()TryTest$C";
-                        %8 : Var<TryTest$C> = var %7 @"c";
-                        %9 : Tuple<Var<TryTest$A>, TryTest$B, Var<TryTest$C>> = tuple %2 %4 %8;
+                    ()Tuple<Var<java.type:"TryTest$A">, java.type:"TryTest$B", Var<java.type:"TryTest$C">> -> {
+                        %1 : java.type:"TryTest$A" = invoke %0 @"TryTest::a():TryTest$A";
+                        %2 : Var<java.type:"TryTest$A"> = var %1 @"a";
+                        %3 : java.type:"TryTest$A" = var.load %2;
+                        %4 : java.type:"TryTest$B" = field.load %3 @"TryTest$A::b:TryTest$B";
+                        %5 : java.type:"TryTest$A" = var.load %2;
+                        %6 : java.type:"TryTest$B" = field.load %5 @"TryTest$A::b:TryTest$B";
+                        %7 : java.type:"TryTest$C" = field.load %6 @"TryTest$B::c:TryTest$C";
+                        %8 : Var<java.type:"TryTest$C"> = var %7 @"c";
+                        %9 : Tuple<Var<java.type:"TryTest$A">, java.type:"TryTest$B", Var<java.type:"TryTest$C">> = tuple %2 %4 %8;
                         yield %9;
                     }
-                    (%10 : Var<TryTest$A>, %11 : Var<TryTest$C>)void -> {
-                        %12 : TryTest$A = var.load %10;
-                        %13 : Var<TryTest$A> = var %12 @"_a";
-                        %14 : TryTest$C = var.load %11;
-                        %15 : Var<TryTest$C> = var %14 @"_c";
+                    (%10 : Var<java.type:"TryTest$A">, %11 : Var<java.type:"TryTest$C">)java.type:"void" -> {
+                        %12 : java.type:"TryTest$A" = var.load %10;
+                        %13 : Var<java.type:"TryTest$A"> = var %12 @"_a";
+                        %14 : java.type:"TryTest$C" = var.load %11;
+                        %15 : Var<java.type:"TryTest$C"> = var %14 @"_c";
                         yield;
                     }
-                    ^catch(%16 : java.lang.Throwable)void -> {
-                        %17 : Var<java.lang.Throwable> = var %16 @"t";
-                        %18 : java.lang.Throwable = var.load %17;
-                        invoke %18 @"java.lang.Throwable::printStackTrace()void";
+                    (%16 : java.type:"java.lang.Throwable")java.type:"void" -> {
+                        %17 : Var<java.type:"java.lang.Throwable"> = var %16 @"t";
+                        %18 : java.type:"java.lang.Throwable" = var.load %17;
+                        invoke %18 @"java.lang.Throwable::printStackTrace():void";
                         yield;
                     }
-                    ^finally()void -> {
-                        %19 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %20 : java.lang.String = constant @"F";
-                        invoke %19 %20 @"java.io.PrintStream::println(java.lang.String)void";
+                    ()java.type:"void" -> {
+                        %19 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %20 : java.type:"java.lang.String" = constant @"F";
+                        invoke %19 %20 @"java.io.PrintStream::println(java.lang.String):void";
                         yield;
                     };
                 return;
@@ -212,24 +212,24 @@ public class TryTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : TryTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test5" (%0 : java.type:"TryTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.try
-                    ()void -> {
-                        %3 : int = constant @"1";
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = constant @"1";
                         var.store %2 %3;
                         yield;
                     }
-                    ^catch(%4 : java.lang.NullPointerException)void -> {
-                        %5 : Var<java.lang.NullPointerException> = var %4 @"e";
-                        %6 : int = constant @"2";
+                    (%4 : java.type:"java.lang.NullPointerException")java.type:"void" -> {
+                        %5 : Var<java.type:"java.lang.NullPointerException"> = var %4 @"e";
+                        %6 : java.type:"int" = constant @"2";
                         var.store %2 %6;
                         yield;
                     }
-                    ^catch(%7 : java.lang.OutOfMemoryError)void -> {
-                        %8 : Var<java.lang.OutOfMemoryError> = var %7 @"e";
-                        %9 : int = constant @"3";
+                    (%7 : java.type:"java.lang.OutOfMemoryError")java.type:"void" -> {
+                        %8 : Var<java.type:"java.lang.OutOfMemoryError"> = var %7 @"e";
+                        %9 : java.type:"int" = constant @"3";
                         var.store %2 %9;
                         yield;
                     };
@@ -249,19 +249,19 @@ public class TryTest {
 
     @CodeReflection
     @IR("""
-            func @"test6" (%0 : TryTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test6" (%0 : java.type:"TryTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.try
-                    ()void -> {
+                    ()java.type:"void" -> {
                         return;
                     }
-                    ^catch(%3 : java.lang.Exception)void -> {
-                        %4 : Var<java.lang.Exception> = var %3 @"e";
-                        %5 : java.lang.Exception = var.load %4;
+                    (%3 : java.type:"java.lang.Exception")java.type:"void" -> {
+                        %4 : Var<java.type:"java.lang.Exception"> = var %3 @"e";
+                        %5 : java.type:"java.lang.Exception" = var.load %4;
                         throw %5;
                     }
-                    ^finally()void -> {
+                    ()java.type:"void" -> {
                         return;
                     };
                 unreachable;

--- a/test/langtools/tools/javac/reflect/UnaryopTest.java
+++ b/test/langtools/tools/javac/reflect/UnaryopTest.java
@@ -35,11 +35,11 @@ import jdk.incubator.code.CodeReflection;
 public class UnaryopTest {
     @CodeReflection
     @IR("""
-            func @"test" (%0 : int)int -> {
-                %1 : Var<int> = var %0 @"v" ;
-                %2 : int = var.load %1 ;
-                %3 : int = neg %2 ;
-                return %3 ;
+            func @"test" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"v";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = neg %2;
+                return %3;
             };
             """)
     static int test(int v) {
@@ -48,9 +48,9 @@ public class UnaryopTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : int)int -> {
-                %1 : Var<int> = var %0 @"v";
-                %2 : int = var.load %1;
+            func @"test2" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"v";
+                %2 : java.type:"int" = var.load %1;
                 return %2;
             };
             """)
@@ -60,11 +60,11 @@ public class UnaryopTest {
 
     @CodeReflection
     @IR("""
-            func @"test3"  (%0 : int)java.lang.Integer -> {
-                %1 : Var<int> = var %0 @"v" ;
-                %2 : int = var.load %1 ;
-                %3 : java.lang.Integer = invoke %2 @"java.lang.Integer::valueOf(int)java.lang.Integer" ;
-                return %3 ;
+            func @"test3" (%0 : java.type:"int")java.type:"java.lang.Integer" -> {
+                %1 : Var<java.type:"int"> = var %0 @"v";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"java.lang.Integer" = invoke %2 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                return %3;
             };
             """)
     // Tests that numeric promotion occurs
@@ -74,12 +74,12 @@ public class UnaryopTest {
 
     @CodeReflection
     @IR("""
-            func @"test4"  (%0 : java.lang.Integer)java.lang.Integer -> {
-                %1 : Var<java.lang.Integer> = var %0 @"v" ;
-                %2 : java.lang.Integer = var.load %1 ;
-                %3 : int = invoke %2 @"java.lang.Integer::intValue()int" ;
-                %4 : java.lang.Integer = invoke %3 @"java.lang.Integer::valueOf(int)java.lang.Integer" ;
-                return %4 ;
+            func @"test4" (%0 : java.type:"java.lang.Integer")java.type:"java.lang.Integer" -> {
+                %1 : Var<java.type:"java.lang.Integer"> = var %0 @"v";
+                %2 : java.type:"java.lang.Integer" = var.load %1;
+                %3 : java.type:"int" = invoke %2 @"java.lang.Integer::intValue():int";
+                %4 : java.type:"java.lang.Integer" = invoke %3 @"java.lang.Integer::valueOf(int):java.lang.Integer";
+                return %4;
             };
             """)
     // Tests that numeric promotion is retained
@@ -89,11 +89,11 @@ public class UnaryopTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : int)int -> {
-                %1 : Var<int> = var %0 @"v" ;
-                %2 : int = var.load %1 ;
-                %3 : int = compl %2 ;
-                return %3 ;
+            func @"test5" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"v";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = compl %2;
+                return %3;
             };
             """)
     static int test5(int v) {
@@ -101,30 +101,30 @@ public class UnaryopTest {
     }
 
     @IR("""
-            func @"test6" (%0 : byte)void -> {
-                  %1 : Var<byte> = var %0 @"b";
-                  %2 : byte = var.load %1;
-                  %3 : int = constant @"1";
-                  %4 : byte = conv %3;
-                  %5 : byte = add %2 %4;
-                  var.store %1 %5;
-                  %6 : byte = var.load %1;
-                  %7 : int = constant @"1";
-                  %8 : byte = conv %7;
-                  %9 : byte = sub %6 %8;
-                  var.store %1 %9;
-                  %10 : byte = var.load %1;
-                  %11 : int = constant @"1";
-                  %12 : byte = conv %11;
-                  %13 : byte = add %10 %12;
-                  var.store %1 %13;
-                  %14 : byte = var.load %1;
-                  %15 : int = constant @"1";
-                  %16 : byte = conv %15;
-                  %17 : byte = sub %14 %16;
-                  var.store %1 %17;
-                  return;
-              };
+            func @"test6" (%0 : java.type:"byte")java.type:"void" -> {
+                %1 : Var<java.type:"byte"> = var %0 @"b";
+                %2 : java.type:"byte" = var.load %1;
+                %3 : java.type:"int" = constant @"1";
+                %4 : java.type:"byte" = conv %3;
+                %5 : java.type:"byte" = add %2 %4;
+                var.store %1 %5;
+                %6 : java.type:"byte" = var.load %1;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"byte" = conv %7;
+                %9 : java.type:"byte" = sub %6 %8;
+                var.store %1 %9;
+                %10 : java.type:"byte" = var.load %1;
+                %11 : java.type:"int" = constant @"1";
+                %12 : java.type:"byte" = conv %11;
+                %13 : java.type:"byte" = add %10 %12;
+                var.store %1 %13;
+                %14 : java.type:"byte" = var.load %1;
+                %15 : java.type:"int" = constant @"1";
+                %16 : java.type:"byte" = conv %15;
+                %17 : java.type:"byte" = sub %14 %16;
+                var.store %1 %17;
+                return;
+            };
             """)
     @CodeReflection
     static void test6(byte b) {
@@ -135,30 +135,30 @@ public class UnaryopTest {
     }
 
     @IR("""
-            func @"test7" (%0 : short)void -> {
-                  %1 : Var<short> = var %0 @"s";
-                  %2 : short = var.load %1;
-                  %3 : int = constant @"1";
-                  %4 : short = conv %3;
-                  %5 : short = add %2 %4;
-                  var.store %1 %5;
-                  %6 : short = var.load %1;
-                  %7 : int = constant @"1";
-                  %8 : short = conv %7;
-                  %9 : short = sub %6 %8;
-                  var.store %1 %9;
-                  %10 : short = var.load %1;
-                  %11 : int = constant @"1";
-                  %12 : short = conv %11;
-                  %13 : short = add %10 %12;
-                  var.store %1 %13;
-                  %14 : short = var.load %1;
-                  %15 : int = constant @"1";
-                  %16 : short = conv %15;
-                  %17 : short = sub %14 %16;
-                  var.store %1 %17;
-                  return;
-              };
+            func @"test7" (%0 : java.type:"short")java.type:"void" -> {
+                %1 : Var<java.type:"short"> = var %0 @"s";
+                %2 : java.type:"short" = var.load %1;
+                %3 : java.type:"int" = constant @"1";
+                %4 : java.type:"short" = conv %3;
+                %5 : java.type:"short" = add %2 %4;
+                var.store %1 %5;
+                %6 : java.type:"short" = var.load %1;
+                %7 : java.type:"int" = constant @"1";
+                %8 : java.type:"short" = conv %7;
+                %9 : java.type:"short" = sub %6 %8;
+                var.store %1 %9;
+                %10 : java.type:"short" = var.load %1;
+                %11 : java.type:"int" = constant @"1";
+                %12 : java.type:"short" = conv %11;
+                %13 : java.type:"short" = add %10 %12;
+                var.store %1 %13;
+                %14 : java.type:"short" = var.load %1;
+                %15 : java.type:"int" = constant @"1";
+                %16 : java.type:"short" = conv %15;
+                %17 : java.type:"short" = sub %14 %16;
+                var.store %1 %17;
+                return;
+            };
             """)
     @CodeReflection
     static void test7(short s) {

--- a/test/langtools/tools/javac/reflect/UnreachableTest.java
+++ b/test/langtools/tools/javac/reflect/UnreachableTest.java
@@ -40,8 +40,8 @@ public class UnreachableTest {
 
     @CodeReflection
     @IR("""
-            func @"test1" ()void -> {
-                java.block ()void -> {
+            func @"test1" ()java.type:"void" -> {
+                java.block ()java.type:"void" -> {
                     return;
                 };
                 unreachable;
@@ -55,10 +55,10 @@ public class UnreachableTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : int)int -> {
-                %1 : Var<int> = var %0 @"i";
-                java.block ()void -> {
-                    %2 : int = var.load %1;
+            func @"test2" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                java.block ()java.type:"void" -> {
+                    %2 : java.type:"int" = var.load %1;
                     return %2;
                 };
                 unreachable;
@@ -72,19 +72,19 @@ public class UnreachableTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : int)int -> {
-                %1 : Var<int> = var %0 @"i";
+            func @"test3" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
                 java.if
-                    ()boolean -> {
-                        %2 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %2 : java.type:"boolean" = constant @"true";
                         yield %2;
                     }
-                    ()void -> {
-                        %3 : int = var.load %1;
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = var.load %1;
                         return %3;
                     }
-                    ()void -> {
-                        %4 : int = var.load %1;
+                    ()java.type:"void" -> {
+                        %4 : java.type:"int" = var.load %1;
                         return %4;
                     };
                 unreachable;
@@ -101,25 +101,25 @@ public class UnreachableTest {
 
     @CodeReflection
     @IR("""
-            func @"test4" ()void -> {
-                %0 : java.util.function.IntUnaryOperator = lambda (%1 : int)int -> {
-                    %2 : Var<int> = var %1 @"i";
+            func @"test4" ()java.type:"void" -> {
+                %0 : java.type:"java.util.function.IntUnaryOperator" = lambda (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"i";
                     java.if
-                        ()boolean -> {
-                            %3 : boolean = constant @"true";
+                        ()java.type:"boolean" -> {
+                            %3 : java.type:"boolean" = constant @"true";
                             yield %3;
                         }
-                        ()void -> {
-                            %4 : int = var.load %2;
+                        ()java.type:"void" -> {
+                            %4 : java.type:"int" = var.load %2;
                             return %4;
                         }
-                        ()void -> {
-                            %5 : int = var.load %2;
+                        ()java.type:"void" -> {
+                            %5 : java.type:"int" = var.load %2;
                             return %5;
                         };
                     unreachable;
                 };
-                %6 : Var<java.util.function.IntUnaryOperator> = var %0 @"f";
+                %6 : Var<java.type:"java.util.function.IntUnaryOperator"> = var %0 @"f";
                 return;
             };
             """)
@@ -135,35 +135,35 @@ public class UnreachableTest {
 
     @CodeReflection
     @IR("""
-            func @"test5" (%0 : int)void -> {
-                %1 : Var<int> = var %0 @"n";
-                %2 : int = var.load %1;
-                %3 : java.lang.String = java.switch.expression %2
-                    (%4 : int)boolean -> {
-                        %5 : int = constant @"42";
-                        %6 : boolean = eq %4 %5;
+            func @"test5" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"n";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%4 : java.type:"int")java.type:"boolean" -> {
+                        %5 : java.type:"int" = constant @"42";
+                        %6 : java.type:"boolean" = eq %4 %5;
                         yield %6;
                     }
-                    ()java.lang.String -> {
+                    ()java.type:"java.lang.String" -> {
                         java.while
-                            ()boolean -> {
-                                %7 : boolean = constant @"true";
+                            ()java.type:"boolean" -> {
+                                %7 : java.type:"boolean" = constant @"true";
                                 yield %7;
                             }
-                            ()void -> {
+                            ()java.type:"void" -> {
                                 java.continue;
                             };
                         unreachable;
                     }
-                    ()boolean -> {
-                        %8 : boolean = constant @"true";
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = constant @"true";
                         yield %8;
                     }
-                    ()java.lang.String -> {
-                        %9 : java.lang.String = constant @"";
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"java.lang.String" = constant @"";
                         yield %9;
                     };
-                %10 : Var<java.lang.String> = var %3 @"s";
+                %10 : Var<java.type:"java.lang.String"> = var %3 @"s";
                 return;
             };
             """)
@@ -175,21 +175,21 @@ public class UnreachableTest {
     }
 
     @IR("""
-            func @"f" ()void -> {
-                %1 : java.util.function.IntUnaryOperator = lambda (%2 : int)int -> {
-                    %3 : Var<int> = var %2 @"i";
+            func @"f" ()java.type:"void" -> {
+                %0 : java.type:"java.util.function.IntUnaryOperator" = lambda (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"i";
                     java.if
-                        ()boolean -> {
-                            %4 : boolean = constant @"true";
-                            yield %4;
+                        ()java.type:"boolean" -> {
+                            %3 : java.type:"boolean" = constant @"true";
+                            yield %3;
                         }
-                        ()void -> {
-                            %5 : int = var.load %3;
+                        ()java.type:"void" -> {
+                            %4 : java.type:"int" = var.load %2;
+                            return %4;
+                        }
+                        ()java.type:"void" -> {
+                            %5 : java.type:"int" = var.load %2;
                             return %5;
-                        }
-                        ()void -> {
-                            %6 : int = var.load %3;
-                            return %6;
                         };
                     unreachable;
                 };
@@ -205,21 +205,21 @@ public class UnreachableTest {
     };
 
     @IR("""
-            func @"f" ()void -> {
-                %1 : func<int, int> = closure (%2 : int)int -> {
-                    %3 : Var<int> = var %2 @"i";
+            func @"f" ()java.type:"void" -> {
+                %0 : func<java.type:"int", java.type:"int"> = closure (%1 : java.type:"int")java.type:"int" -> {
+                    %2 : Var<java.type:"int"> = var %1 @"i";
                     java.if
-                        ()boolean -> {
-                            %4 : boolean = constant @"true";
-                            yield %4;
+                        ()java.type:"boolean" -> {
+                            %3 : java.type:"boolean" = constant @"true";
+                            yield %3;
                         }
-                        ()void -> {
-                            %5 : int = var.load %3;
+                        ()java.type:"void" -> {
+                            %4 : java.type:"int" = var.load %2;
+                            return %4;
+                        }
+                        ()java.type:"void" -> {
+                            %5 : java.type:"int" = var.load %2;
                             return %5;
-                        }
-                        ()void -> {
-                            %6 : int = var.load %3;
-                            return %6;
                         };
                     unreachable;
                 };

--- a/test/langtools/tools/javac/reflect/WhileLoopTest.java
+++ b/test/langtools/tools/javac/reflect/WhileLoopTest.java
@@ -35,23 +35,23 @@ import jdk.incubator.code.CodeReflection;
 public class WhileLoopTest {
     @CodeReflection
     @IR("""
-            func @"test1" (%0 : WhileLoopTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test1" (%0 : java.type:"WhileLoopTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.while
-                    ^cond()boolean -> {
-                        %3 : int = var.load %2;
-                        %4 : int = constant @"10";
-                        %5 : boolean = lt %3 %4;
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"10";
+                        %5 : java.type:"boolean" = lt %3 %4;
                         yield %5;
                     }
-                    ^body()void -> {
-                        %6 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %7 : int = var.load %2;
-                        invoke %6 %7 @"java.io.PrintStream::println(int)void";
-                        %8 : int = var.load %2;
-                        %9 : int = constant @"1";
-                        %10 : int = add %8 %9;
+                    ()java.type:"void" -> {
+                        %6 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %7 : java.type:"int" = var.load %2;
+                        invoke %6 %7 @"java.io.PrintStream::println(int):void";
+                        %8 : java.type:"int" = var.load %2;
+                        %9 : java.type:"int" = constant @"1";
+                        %10 : java.type:"int" = add %8 %9;
                         var.store %2 %10;
                         java.continue;
                     };
@@ -68,22 +68,22 @@ public class WhileLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test2" (%0 : WhileLoopTest)int -> {
-              %1 : int = constant @"0";
-              %2 : Var<int> = var %1 @"i";
-              java.while
-                  ^cond()boolean -> {
-                      %3 : int = var.load %2;
-                      %4 : int = constant @"10";
-                      %5 : boolean = lt %3 %4;
-                      yield %5;
-                  }
-                  ^body()void -> {
-                      %6 : int = var.load %2;
-                      return %6;
-                  };
-              %7 : int = constant @"-1";
-              return %7;
+            func @"test2" (%0 : java.type:"WhileLoopTest")java.type:"int" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
+                java.while
+                    ()java.type:"boolean" -> {
+                        %3 : java.type:"int" = var.load %2;
+                        %4 : java.type:"int" = constant @"10";
+                        %5 : java.type:"boolean" = lt %3 %4;
+                        yield %5;
+                    }
+                    ()java.type:"void" -> {
+                        %6 : java.type:"int" = var.load %2;
+                        return %6;
+                    };
+                %7 : java.type:"int" = constant @"-1";
+                return %7;
             };
             """)
     int test2() {
@@ -96,24 +96,24 @@ public class WhileLoopTest {
 
     @CodeReflection
     @IR("""
-            func @"test3" (%0 : WhileLoopTest)void -> {
-                %1 : int = constant @"0";
-                %2 : Var<int> = var %1 @"i";
+            func @"test3" (%0 : java.type:"WhileLoopTest")java.type:"void" -> {
+                %1 : java.type:"int" = constant @"0";
+                %2 : Var<java.type:"int"> = var %1 @"i";
                 java.do.while
-                    ^body()void -> {
-                        %3 : java.io.PrintStream = field.load @"java.lang.System::out()java.io.PrintStream";
-                        %4 : int = var.load %2;
-                        invoke %3 %4 @"java.io.PrintStream::println(int)void";
-                        %5 : int = var.load %2;
-                        %6 : int = constant @"1";
-                        %7 : int = add %5 %6;
+                    ()java.type:"void" -> {
+                        %3 : java.type:"java.io.PrintStream" = field.load @"java.lang.System::out:java.io.PrintStream";
+                        %4 : java.type:"int" = var.load %2;
+                        invoke %3 %4 @"java.io.PrintStream::println(int):void";
+                        %5 : java.type:"int" = var.load %2;
+                        %6 : java.type:"int" = constant @"1";
+                        %7 : java.type:"int" = add %5 %6;
                         var.store %2 %7;
                         java.continue;
                     }
-                    ^cond()boolean -> {
-                        %8 : int = var.load %2;
-                        %9 : int = constant @"10";
-                        %10 : boolean = lt %8 %9;
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"int" = var.load %2;
+                        %9 : java.type:"int" = constant @"10";
+                        %10 : java.type:"boolean" = lt %8 %9;
                         yield %10;
                     };
                 return;
@@ -129,32 +129,32 @@ public class WhileLoopTest {
 
 
     @IR("""
-            func @"test4" ()void -> {
-                  %0 : boolean = constant @"true";
-                  %1 : java.lang.Boolean = invoke %0 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
-                  %2 : Var<java.lang.Boolean> = var %1 @"b";
-                  %3 : int = constant @"0";
-                  %4 : Var<int> = var %3 @"i";
-                  java.while
-                      ()boolean -> {
-                          %5 : java.lang.Boolean = var.load %2;
-                          %6 : boolean = invoke %5 @"java.lang.Boolean::booleanValue()boolean";
-                          yield %6;
-                      }
-                      ()void -> {
-                          %7 : int = var.load %4;
-                          %8 : int = constant @"1";
-                          %9 : int = add %7 %8;
-                          var.store %4 %9;
-                          %10 : int = var.load %4;
-                          %11 : int = constant @"10";
-                          %12 : boolean = lt %10 %11;
-                          %13 : java.lang.Boolean = invoke %12 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
-                          var.store %2 %13;
-                          java.continue;
-                      };
-                  return;
-              };
+            func @"test4" ()java.type:"void" -> {
+                %0 : java.type:"boolean" = constant @"true";
+                %1 : java.type:"java.lang.Boolean" = invoke %0 @"java.lang.Boolean::valueOf(boolean):java.lang.Boolean";
+                %2 : Var<java.type:"java.lang.Boolean"> = var %1 @"b";
+                %3 : java.type:"int" = constant @"0";
+                %4 : Var<java.type:"int"> = var %3 @"i";
+                java.while
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.Boolean" = var.load %2;
+                        %6 : java.type:"boolean" = invoke %5 @"java.lang.Boolean::booleanValue():boolean";
+                        yield %6;
+                    }
+                    ()java.type:"void" -> {
+                        %7 : java.type:"int" = var.load %4;
+                        %8 : java.type:"int" = constant @"1";
+                        %9 : java.type:"int" = add %7 %8;
+                        var.store %4 %9;
+                        %10 : java.type:"int" = var.load %4;
+                        %11 : java.type:"int" = constant @"10";
+                        %12 : java.type:"boolean" = lt %10 %11;
+                        %13 : java.type:"java.lang.Boolean" = invoke %12 @"java.lang.Boolean::valueOf(boolean):java.lang.Boolean";
+                        var.store %2 %13;
+                        java.continue;
+                    };
+                return;
+            };
             """)
     @CodeReflection
     static void test4() {
@@ -167,22 +167,22 @@ public class WhileLoopTest {
     }
 
     @IR("""
-            func @"test5" (%0 : int)void -> {
-                %1 : Var<int> = var %0 @"i";
-                %3 : Var<java.lang.Boolean> = var @"b";
+            func @"test5" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : Var<java.type:"java.lang.Boolean"> = var @"b";
                 java.do.while
-                    ()void -> {
-                        %4 : int = var.load %1;
-                        %5 : int = constant @"10";
-                        %6 : boolean = lt %4 %5;
-                        %7 : java.lang.Boolean = invoke %6 @"java.lang.Boolean::valueOf(boolean)java.lang.Boolean";
-                        var.store %3 %7;
+                    ()java.type:"void" -> {
+                        %3 : java.type:"int" = var.load %1;
+                        %4 : java.type:"int" = constant @"10";
+                        %5 : java.type:"boolean" = lt %3 %4;
+                        %6 : java.type:"java.lang.Boolean" = invoke %5 @"java.lang.Boolean::valueOf(boolean):java.lang.Boolean";
+                        var.store %2 %6;
                         java.continue;
                     }
-                    ()boolean -> {
-                        %8 : java.lang.Boolean = var.load %3;
-                        %9 : boolean = invoke %8 @"java.lang.Boolean::booleanValue()boolean";
-                        yield %9;
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"java.lang.Boolean" = var.load %2;
+                        %8 : java.type:"boolean" = invoke %7 @"java.lang.Boolean::booleanValue():boolean";
+                        yield %8;
                     };
                 return;
             };


### PR DESCRIPTION
This draft PR contains some preliminary work for making handling of Java type strings in code models more uniform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/423/head:pull/423` \
`$ git checkout pull/423`

Update a local copy of the PR: \
`$ git checkout pull/423` \
`$ git pull https://git.openjdk.org/babylon.git pull/423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 423`

View PR using the GUI difftool: \
`$ git pr show -t 423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/423.diff">https://git.openjdk.org/babylon/pull/423.diff</a>

</details>
