### PR TITLE
Removed hardcoded nvcc path

### DIFF
--- a/hat/backends/ffi/cuda/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/cpp/cuda_backend.cpp
@@ -74,9 +74,8 @@ PtxSource *PtxSource::nvcc(const char *cudaSource, size_t len) {
     int pid;
     cSource.write(cudaPath);
     if ((pid = fork()) == 0) {
-        //const char *path = "/usr/local/cuda-12.2/bin/nvcc";
         const char *path = "/usr/local/cuda/bin/nvcc";
-        const char *argv[]{"nvcc", "-ptx", cudaPath.c_str(), "-o", ptxPath.c_str(), nullptr};
+        const char *argv[]{"/usr/local/cuda/bin/nvcc", "-ptx", cudaPath.c_str(), "-o", ptxPath.c_str(), nullptr};
        // std::cerr << "child about to exec nvcc" << std::endl;
        // std::cerr << "path " << path<< " " << argv[1]<< " " << argv[2]<< " " << argv[3]<< " " << argv[4]<< std::endl;
         int stat = execvp(path, (char *const *) argv);
@@ -88,7 +87,7 @@ PtxSource *PtxSource::nvcc(const char *cudaSource, size_t len) {
         std::exit(1);
     } else {
         int status;
-       // std::cerr << "parent waiting for child nvcc exec" << std::endl;
+        //std::cerr << "parent waiting for child nvcc exec" << std::endl;
         pid_t result = wait(&status);
         //std::cerr << "child finished should be safe to read "<< ptxPath << std::endl;
         PtxSource *ptx= new PtxSource();
@@ -180,10 +179,10 @@ PtxSource *CudaBackend::nvcc(CudaSource *cudaSource){
     int pid;
     cudaSource->write(cudaPath);
     if ((pid = fork()) == 0) {
-        const char *path = "/usr/local/cuda-12.2/bin/nvcc";
-        const char *argv[]{"nvcc", "-ptx", cudaPath.c_str(), "-o", ptxPath.c_str(), nullptr};
-        // std::cerr << "child about to exec nvcc" << std::endl;
-        // std::cerr << "path " << path<< " " << argv[1]<< " " << argv[2]<< " " << argv[3]<< " " << argv[4]<< std::endl;
+        const char *path = "/usr/local/cuda/bin/nvcc";
+        const char *argv[]{"/usr/local/cuda/bin/nvcc", "-ptx", "-Wno-deprecated-gpu-targets", cudaPath.c_str(), "-o", ptxPath.c_str(), nullptr};
+         //std::cerr << "child about to exec nvcc" << std::endl;
+         //std::cerr << "path " << path<< " " << argv[1]<< " " << argv[2]<< " " << argv[3]<< " " << argv[4]<< " "<< argv[5]<< std::endl;
         int stat = execvp(path, (char *const *) argv);
         std::cerr << " nvcc stat = "<<stat << " errno="<< errno<< " '"<< std::strerror(errno)<< "'"<<std::endl;
         std::exit(errno);


### PR DESCRIPTION
Rookie mistake.   I had accidently hardcoded path to nvcc in nvidia backend.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/426/head:pull/426` \
`$ git checkout pull/426`

Update a local copy of the PR: \
`$ git checkout pull/426` \
`$ git pull https://git.openjdk.org/babylon.git pull/426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 426`

View PR using the GUI difftool: \
`$ git pr show -t 426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/426.diff">https://git.openjdk.org/babylon/pull/426.diff</a>

</details>
