### PR TITLE
Add rocm/hip cmake rules -  hip backend work in progress

### DIFF
--- a/hat/backends/ffi/CMakeLists.txt
+++ b/hat/backends/ffi/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(backends)
 set(CMAKE_CXX_STANDARD 14)
-
 if ("${HAT_TARGET}EMPTY" STREQUAL "EMPTY")
     message("HAT_TARGET is empty")
 else ()

--- a/hat/backends/ffi/cuda/include/cuda_backend.h
+++ b/hat/backends/ffi/cuda/include/cuda_backend.h
@@ -51,8 +51,6 @@
 #include <iostream>
 #include <cuda.h>
 #include <builtin_types.h>
-//#include <cuda_runtime_api.h>
-#define CUDA_TYPES
 
 #include "shared.h"
 
@@ -77,6 +75,7 @@ struct WHERE{
         }
     }
 };
+
 class PtxSource: public Text  {
 public:
     PtxSource();
@@ -86,6 +85,7 @@ public:
     ~PtxSource() = default;
     static PtxSource *nvcc(const char *cudaSource, size_t len);
 };
+
 class CudaSource:public Text  {
 public:
     CudaSource(size_t len, char *text, bool isCopy);

--- a/hat/backends/ffi/hip/CMakeLists.txt
+++ b/hat/backends/ffi/hip/CMakeLists.txt
@@ -3,13 +3,24 @@ project(cuda_backend)
 
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(hip)
-if(hip_FOUND)
-	message("HIP")
-
-	if ("${HIP_BACKEND}EMPTY" STREQUAL "EMPTY")
-		set (HIP_BACKEND "${CMAKE_SOURCE_DIR}")
-		message("HIP_BACKEND=${HIP_BACKEND}")
+# this is the only way I can think of to get cmake to find FindHIP.cmake
+set(ROCM_PATH "/opt/rocm")
+list(APPEND CMAKE_MODULE_PATH "${ROCM_PATH}/lib/cmake/hip")
+# /opt/rocm-6.3.4/lib/cmake/hip/FindHIP.cmake
+# Weirdly the above does not set HIP_INCLUDE_DIR
+# This seems to set expected VARS but is not 
+# invoked  /opt/rocm-6.3.4/lib/cmake/hip/hip-config.cmake
+find_package(HIP)
+get_cmake_property(_variableNames VARIABLES)
+foreach (_variableName ${_variableNames})
+    message(STATUS "${_variableName}=${${_variableName}}")
+endforeach()
+if(HIP_FOUND)
+   if(HIP_READY) #  get rid of this once we figur out how to build
+    set(HIP_INCLUDE_DIR "/opt/rocm/include")
+    if ("${HIP_BACKEND}EMPTY" STREQUAL "EMPTY")
+      set (HIP_BACKEND "${CMAKE_SOURCE_DIR}")
+      message("HIP_BACKEND=${HIP_BACKEND}")
     endif()
 
     if ("${SHARED_BACKEND}EMPTY" STREQUAL "EMPTY")
@@ -18,31 +29,34 @@ if(hip_FOUND)
     endif()
 
     include_directories(
-            ${HIP_INCLUDE_DIR}
-            ${SHARED_BACKEND}/include
-            ${HIP_BACKEND}/include
+       ${HIP_INCLUDE_DIR}
+       ${SHARED_BACKEND}/include
+       ${HIP_BACKEND}/include
     )
 
     link_directories(
-            ${CMAKE_BINARY_DIR}
-            ${HIP_LIBRARY_DIR}
+       ${CMAKE_BINARY_DIR}
+       ${hip_LIB_INSTALL_DIR}
     )
 
     add_library(hip_backend SHARED
-	    ${SHARED_BACKEND}/cpp/shared.cpp
-	    ${HIP_BACKEND}/cpp/hip_backend.cpp
+       ${SHARED_BACKEND}/cpp/shared.cpp
+       ${HIP_BACKEND}/cpp/hip_backend.cpp
     )
 
-    target_link_libraries(hip_backend
-	    PRIVATE hip::host
-    )
+    #target_link_libraries(hip_backend
+    #   PRIVATE hip::host
+    #)
 
     add_executable(hip_info
-	    ${HIP_BACKEND}/cpp/info.cpp
+       ${HIP_BACKEND}/cpp/info.cpp
     )
 
     target_link_libraries(hip_info
-            hip_backend
-            hip::host
+       hip_backend
+     #  hip::host
     )
+  else()
+     message("FOUND HIP but CMakefile still broken")
+  endif()
 endif()


### PR DESCRIPTION
Trying to get the HIPBackend to build.  

Discovered that rocm/hip includes a 'FindHIP' so added that here..  Still working on getting the backend to build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/430/head:pull/430` \
`$ git checkout pull/430`

Update a local copy of the PR: \
`$ git checkout pull/430` \
`$ git pull https://git.openjdk.org/babylon.git pull/430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 430`

View PR using the GUI difftool: \
`$ git pr show -t 430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/430.diff">https://git.openjdk.org/babylon/pull/430.diff</a>

</details>
