### PR TITLE
Debug appropriate code element toString

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -55,6 +55,11 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         @Override
+        public String toString() {
+            return "%param@" + Integer.toHexString(hashCode());
+        }
+
+        @Override
         public Set<Value> dependsOn() {
             return Set.of();
         }
@@ -176,6 +181,11 @@ public final class Block implements CodeElement<Block, Op> {
         this.predecessors = new LinkedHashSet<>();
     }
 
+
+    @Override
+    public String toString() {
+        return "^block_" + index + "@" + Integer.toHexString(hashCode());
+    }
 
     /**
      * Returns this block's parent body.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -71,6 +71,11 @@ public final class Body implements CodeElement<Body, Block> {
         this.blocks = new ArrayList<>();
     }
 
+    @Override
+    public String toString() {
+        return "body@" + Integer.toHexString(hashCode());
+    }
+
     /**
      * Returns this body's parent operation.
      *

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -184,6 +184,11 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
 
         @Override
+        public String toString() {
+            return "%result@" + Integer.toHexString(hashCode());
+        }
+
+        @Override
         public Set<Value> dependsOn() {
             Set<Value> depends = new LinkedHashSet<>(op.operands());
             if (op instanceof Terminating) {


### PR DESCRIPTION
The `toString` of code elements (op, body, block) can be a little less verbose and better for debugging, especially so for blocks where we can include the index.