### PR TITLE
Post dominator functionality

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -266,6 +266,138 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
+     * A synthetic block representing the post dominator of all blocks
+     * when two or more blocks have no successors.
+     * <p>
+     * Computing the immediate post dominators requires a single exit point,
+     * one block that has no successors. When there are two or more blocks
+     * with no successors then this block represents the immediate post
+     * dominator of those blocks
+     */
+    public static final Block IPDOM_EXIT;
+    static {
+        IPDOM_EXIT = new Block(null);
+        IPDOM_EXIT.index = Integer.MAX_VALUE;
+    }
+
+    /**
+     * Returns a map of block to its immediate post dominator.
+     * <p>
+     * If there are two or more blocks with no successors then
+     * a single exit point is synthesized using the {@link #IPDOM_EXIT}
+     * block, which represents the immediate post dominator of those blocks.
+     *
+     * @return a map of block to its immediate post dominator, as an unmodifiable map
+     */
+    public Map<Block, Block> immediatePostDominators() {
+        Map<Block, Block> pdoms = new HashMap<>();
+
+        // If there are multiple exit blocks (those with zero successors)
+        // then use the block IPDOM_EXIT that is the synthetic successor of
+        // the exit blocks
+        boolean nSuccessors = blocks.stream().filter(b -> b.successors().isEmpty()).count() > 1;
+
+        if (nSuccessors) {
+            pdoms.put(IPDOM_EXIT, IPDOM_EXIT);
+        } else {
+            Block exit = blocks.getLast();
+            assert blocks.stream().filter(b -> b.successors().isEmpty()).findFirst().orElseThrow() == exit;
+            pdoms.put(exit, exit);
+        }
+
+        // Blocks are sorted in reverse postorder
+        boolean changed;
+        do {
+            changed = false;
+            // Iterate in reverse through blocks in reverse postorder, except for exit block
+            for (int i = blocks.size() - (nSuccessors ? 1 : 2); i >= 0; i--) {
+                Block b = blocks.get(i);
+
+                // Find first processed successor of b
+                Block newIpdom = null;
+                Collection<Block> targets = b.successorTargets();
+                for (Block s : nSuccessors && targets.isEmpty() ? List.of(IPDOM_EXIT) : targets) {
+                    if (pdoms.containsKey(s)) {
+                        newIpdom = s;
+                        break;
+                    }
+                }
+
+                if (newIpdom == null) {
+                    // newIpdom can be null if all successors reference
+                    // prior blocks (back branch) yet to be encountered
+                    // in the dominator treee
+                    continue;
+                }
+
+                // For all other successors, s, of b
+                for (Block s : b.successorTargets()) {
+                    if (s == newIpdom) {
+                        continue;
+                    }
+
+                    if (pdoms.containsKey(s)) {
+                        // If already calculated
+                        newIpdom = postIntersect(pdoms, s, newIpdom, blocks.size());
+                    }
+                }
+
+                if (pdoms.get(b) != newIpdom) {
+                    pdoms.put(b, newIpdom);
+                    changed = true;
+                }
+            }
+        } while (changed);
+
+        return Collections.unmodifiableMap(pdoms);
+    }
+
+    static Block postIntersect(Map<Block, Block> doms, Block b1, Block b2, int exitIndex) {
+        while (b1 != b2) {
+            while (b1.index() < b2.index()) {
+                b1 = doms.get(b1);
+            }
+
+            while (b2.index() < b1.index()) {
+                b2 = doms.get(b2);
+            }
+        }
+
+        return b1;
+    }
+
+    /**
+     * Returns the post dominance frontier of each block in the body.
+     * <p>
+     * The post dominance frontier of block, {@code B} say, is the set of all blocks, {@code C} say,
+     * such that {@code B} post dominates a successor of {@code C} but does not strictly post dominate
+     * {@code C}.
+     *
+     * @return the post dominance frontier of each block in the body, as a modifiable map
+     */
+    public Map<Block, Set<Block>> postDominanceFrontier() {
+        // @@@ cache result?
+        Map<Block, Block> idoms = immediatePostDominators();
+        Map<Block, Set<Block>> df = new HashMap<>();
+
+        for (Block b : blocks) {
+            Set<Block> succs = b.successorTargets();
+
+            if (succs.size() > 1) {
+                for (Block s : succs) {
+                    Block runner = s;
+                    while (runner != idoms.get(b)) {
+                        df.computeIfAbsent(runner, _ -> new LinkedHashSet<>()).add(b);
+                        runner = idoms.get(runner);
+                    }
+                }
+            }
+        }
+
+        return df;
+    }
+
+    /**
      * Returns {@code true} if this body is dominated by the given body {@code dom}.
      * <p>
      * A body, {@code b} say, is dominated by {@code dom} if {@code b} is the same as {@code dom} or a descendant of

--- a/test/jdk/java/lang/reflect/code/TestDominate.java
+++ b/test/jdk/java/lang/reflect/code/TestDominate.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import jdk.incubator.code.Body;
+import jdk.incubator.code.parser.OpParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -50,6 +52,7 @@ import static jdk.incubator.code.op.CoreOp.func;
 
 public class TestDominate {
 
+    @Test
     public void testUnmodifiableIdoms() {
         CoreOp.FuncOp f = func("f", FunctionType.VOID).body(entry -> {
             Block.Builder ifBlock = entry.block();
@@ -71,6 +74,12 @@ public class TestDominate {
                 () -> idoms.put(f.body().entryBlock(), f.body().entryBlock()));
         Assert.assertThrows(UnsupportedOperationException.class,
                 idoms::clear);
+
+        Map<Block, Block> ipdoms = f.body().immediatePostDominators();
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> ipdoms.put(f.body().entryBlock(), f.body().entryBlock()));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                ipdoms::clear);
     }
 
     @Test
@@ -309,6 +318,106 @@ public class TestDominate {
         );
         Assert.assertEquals(df, dfExpected);
     }
+
+    @Test
+    public void testPostDominance() {
+        String m = """
+                func @"f" (%0 : java.type:"boolean")java.type:"void" -> {
+                    %5 : java.type:"void" = branch ^A;
+
+                  ^A:
+                    %8 : java.type:"void" = cbranch %0 ^B ^C;
+
+                  ^B:
+                    %11 : java.type:"void" = branch ^D;
+
+                  ^C:
+                    %13 : java.type:"void" = branch ^D;
+
+                  ^D:
+                    %15 : java.type:"void" = branch ^E;
+
+                  ^E:
+                    %15 : java.type:"void" = branch ^F;
+
+                  ^F:
+                    %16 : java.type:"void" = cbranch %0 ^E ^END;
+
+                  ^END:
+                    %18 : java.type:"void" = return;
+                };
+                """;
+        CoreOp.FuncOp f = (CoreOp.FuncOp) OpParser.fromStringOfFuncOp(m);
+
+        Map<Block, Block> ipdoms = f.body().immediatePostDominators();
+        Assert.assertFalse(ipdoms.containsKey(Body.IPDOM_EXIT));
+
+        Block exit = ipdoms.containsKey(Body.IPDOM_EXIT) ? Body.IPDOM_EXIT : f.body().blocks().getLast();
+        Node<String> domTree = buildDomTree(exit, ipdoms).transform(b -> Integer.toString(b.index()));
+        Node<String> domTreeExpected =
+                node("7",
+                        node("6",
+                                node("5",
+                                        node("4",
+                                                node("2"),
+                                                node("3"),
+                                                node("1",
+                                                        node("0"))))));
+        Assert.assertEquals(domTree, domTreeExpected);
+    }
+
+    @Test
+    public void testPostDominanceFrontier() {
+        String m = """
+                func @"f" (%0 : java.type:"boolean")java.type:"void" -> {
+                    %5 : java.type:"void" = cbranch %0 ^B ^F;
+
+                  ^B:
+                    %8 : java.type:"void" = cbranch %0 ^C ^D;
+
+                  ^C:
+                    %11 : java.type:"void" = branch ^E;
+
+                  ^D:
+                    %13 : java.type:"void" = branch ^E;
+
+                  ^E:
+                    %15 : java.type:"void" = branch ^F;
+
+                  ^F:
+                    %18 : java.type:"void" = return;
+                };
+                """;
+        CoreOp.FuncOp f = (CoreOp.FuncOp) OpParser.fromStringOfFuncOp(m);
+
+        Map<Block, Block> ipdoms = f.body().immediatePostDominators();
+        Assert.assertFalse(ipdoms.containsKey(Body.IPDOM_EXIT));
+
+        Block exit = ipdoms.containsKey(Body.IPDOM_EXIT) ? Body.IPDOM_EXIT : f.body().blocks().getLast();
+        Node<String> domTree = buildDomTree(exit, ipdoms).transform(b -> Integer.toString(b.index()));
+        Node<String> domTreeExpected =
+                node("5",
+                        node("4",
+                                node("1"),
+                                node("2"),
+                                node("3")),
+                        node("0"));
+        Assert.assertEquals(domTree, domTreeExpected);
+
+        Map<String, Set<String>> df = f.body().postDominanceFrontier().entrySet().stream()
+                .map(e -> Map.entry(Integer.toString(e.getKey().index()),
+                        e.getValue().stream().map(b -> Integer.toString(b.index())).collect(Collectors.toSet())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        Map<String, Set<String>> dfExpected = Map.ofEntries(
+                Map.entry("1", Set.of("0")),
+                Map.entry("2", Set.of("1")),
+                Map.entry("3", Set.of("1")),
+                Map.entry("4", Set.of("0"))
+        );
+        Assert.assertEquals(df, dfExpected);
+    }
+
 
     static Node<Block> buildDomTree(Block entryBlock, Map<Block, Block> idoms) {
         Map<Block, Node<Block>> m = new HashMap<>();


### PR DESCRIPTION
Add functionality to compute immediate post dominators and the post dominator frontier. Also include facilities to obtain a block's predecessor references and successor targets.