### PR TITLE
Juan Fumero reported this issue on Linux/OpenCL

### DIFF
--- a/hat/backends/ffi/opencl/cpp/opencl_backend_queue.cpp
+++ b/hat/backends/ffi/opencl/cpp/opencl_backend_queue.cpp
@@ -245,12 +245,17 @@ void OpenCLBackend::OpenCLQueue::wait(){
 
 void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend::CompilationUnit::Kernel *kernel){
     size_t dims = 1;
+    size_t global_work_size[]{
+       static_cast<size_t>(kernelContext->maxX),
+       static_cast<size_t>(0),// Todo: kernelContext->maxY
+       static_cast<size_t>(0),// Todo: kernelContext->maxZ
+    };
     cl_int status = clEnqueueNDRangeKernel(
             command_queue,
             dynamic_cast<OpenCLProgram::OpenCLKernel*>(kernel)->kernel,
             dims,
             nullptr,
-            reinterpret_cast<const size_t *>(&kernelContext->maxX),
+            global_work_size,
             nullptr,
             eventc,
             eventListPtr(),


### PR DESCRIPTION
Juan Fumero reported issue on one of his linux/OpenCL tests.

Code was reinterpreting a cast from address of int on local stack.  Even though we were only 'requesting' a dim of one.  The runtime was clearly accessing 'past' the value addressed.  This was a bad use of reinterpret cast. Code now creates a suitable size_t[3] array.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/439/head:pull/439` \
`$ git checkout pull/439`

Update a local copy of the PR: \
`$ git checkout pull/439` \
`$ git pull https://git.openjdk.org/babylon.git pull/439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 439`

View PR using the GUI difftool: \
`$ git pr show -t 439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/439.diff">https://git.openjdk.org/babylon/pull/439.diff</a>

</details>
