### PR TITLE
Dialect factory

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -430,12 +430,9 @@ import sun.invoke.util.Wrapper;
                     if (quotableOpGetterInfo.getReferenceKind() != MethodHandleInfo.REF_invokeStatic) {
                         mtype = mtype.insertParameterTypes(0, implClass);
                     }
-                    // load arguments to quotableOpGetter: ExtendedOp.FACTORY and CORE_TYPE_FACTORY
+                    // load arguments to quotableOpGetter: JavaOp.DIALECT_FACTORY
                     cob.fieldAccess(Opcode.GETSTATIC, CodeReflectionSupport.JAVA_OP_CLASS.describeConstable().get(),
-                            "FACTORY", CodeReflectionSupport.OP_FACTORY_CLASS.describeConstable().get());
-                    cob.fieldAccess(Opcode.GETSTATIC, CodeReflectionSupport.CORE_TYPE_FACTORY_CLASS.describeConstable().get(),
-                            "CORE_TYPE_FACTORY",
-                            CodeReflectionSupport.TYPE_ELEMENT_FACTORY_CLASS.describeConstable().get());
+                            "DIALECT_FACTORY", CodeReflectionSupport.DIALECT_FACTORY.describeConstable().get());
                     cob.invokevirtual(CD_MethodHandle, "invokeExact", mtype.describeConstable().get());
                     cob.checkcast(funcOpClassDesc);
                     cob.putstatic(lambdaClassEntry.asSymbol(), COMPILER_GENERATED_MODEL_FIELD_NAME, funcOpClassDesc);
@@ -507,10 +504,8 @@ import sun.invoke.util.Wrapper;
         static final Class<?> QUOTED_CLASS;
         static final Class<?> QUOTABLE_CLASS;
         static final MethodHandle HANDLE_MAKE_QUOTED;
+        static final Class<?> DIALECT_FACTORY;
         static final Class<?> JAVA_OP_CLASS;
-        static final Class<?> OP_FACTORY_CLASS;
-        static final Class<?> CORE_TYPE_FACTORY_CLASS;
-        static final Class<?> TYPE_ELEMENT_FACTORY_CLASS;
         static final Class<?> FUNC_OP_CLASS;
 
         static {
@@ -524,10 +519,8 @@ import sun.invoke.util.Wrapper;
                 MethodHandle makeQuoted = Lookup.IMPL_LOOKUP.findStatic(quotedHelper, "makeQuoted",
                         MethodType.methodType(QUOTED_CLASS, MethodHandles.Lookup.class, FUNC_OP_CLASS, Object[].class));
                 HANDLE_MAKE_QUOTED = makeQuoted.bindTo(Lookup.IMPL_LOOKUP);
+                DIALECT_FACTORY = cl.loadClass("jdk.incubator.code.dialect.DialectFactory");
                 JAVA_OP_CLASS = cl.loadClass("jdk.incubator.code.dialect.java.JavaOp");
-                OP_FACTORY_CLASS = cl.loadClass("jdk.incubator.code.dialect.OpFactory");
-                CORE_TYPE_FACTORY_CLASS = cl.loadClass("jdk.incubator.code.dialect.core.CoreTypeFactory");
-                TYPE_ELEMENT_FACTORY_CLASS = cl.loadClass("jdk.incubator.code.dialect.TypeElementFactory");
             } catch (Throwable ex) {
                 throw new ExceptionInInitializerError(ex);
             }

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -58,7 +58,6 @@ import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import static java.lang.constant.ConstantDescs.*;
 import static java.lang.invoke.MethodHandleNatives.Constants.NESTMATE_CLASS;
 import static java.lang.invoke.MethodHandleNatives.Constants.STRONG_LOADER_LINK;
-import static java.lang.invoke.MethodType.methodType;
 import jdk.internal.constant.ConstantUtils;
 import jdk.internal.constant.MethodTypeDescImpl;
 import jdk.internal.vm.annotation.Stable;
@@ -430,9 +429,6 @@ import sun.invoke.util.Wrapper;
                     if (quotableOpGetterInfo.getReferenceKind() != MethodHandleInfo.REF_invokeStatic) {
                         mtype = mtype.insertParameterTypes(0, implClass);
                     }
-                    // load arguments to quotableOpGetter: JavaOp.DIALECT_FACTORY
-                    cob.fieldAccess(Opcode.GETSTATIC, CodeReflectionSupport.JAVA_OP_CLASS.describeConstable().get(),
-                            "DIALECT_FACTORY", CodeReflectionSupport.DIALECT_FACTORY.describeConstable().get());
                     cob.invokevirtual(CD_MethodHandle, "invokeExact", mtype.describeConstable().get());
                     cob.checkcast(funcOpClassDesc);
                     cob.putstatic(lambdaClassEntry.asSymbol(), COMPILER_GENERATED_MODEL_FIELD_NAME, funcOpClassDesc);
@@ -504,8 +500,6 @@ import sun.invoke.util.Wrapper;
         static final Class<?> QUOTED_CLASS;
         static final Class<?> QUOTABLE_CLASS;
         static final MethodHandle HANDLE_MAKE_QUOTED;
-        static final Class<?> DIALECT_FACTORY;
-        static final Class<?> JAVA_OP_CLASS;
         static final Class<?> FUNC_OP_CLASS;
 
         static {
@@ -519,8 +513,6 @@ import sun.invoke.util.Wrapper;
                 MethodHandle makeQuoted = Lookup.IMPL_LOOKUP.findStatic(quotedHelper, "makeQuoted",
                         MethodType.methodType(QUOTED_CLASS, MethodHandles.Lookup.class, FUNC_OP_CLASS, Object[].class));
                 HANDLE_MAKE_QUOTED = makeQuoted.bindTo(Lookup.IMPL_LOOKUP);
-                DIALECT_FACTORY = cl.loadClass("jdk.incubator.code.dialect.DialectFactory");
-                JAVA_OP_CLASS = cl.loadClass("jdk.incubator.code.dialect.java.JavaOp");
             } catch (Throwable ex) {
                 throw new ExceptionInInitializerError(ex);
             }

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -599,7 +599,7 @@ import sun.invoke.util.Wrapper;
     * Generate method #quoted()
      */
     private void generateQuotedMethod(ClassBuilder clb) {
-        clb.withMethod(NAME_METHOD_QUOTED, CodeReflectionSupport.MTD_Quoted, ACC_PUBLIC + ACC_FINAL, new MethodBody(new Consumer<CodeBuilder>() {
+        clb.withMethod(NAME_METHOD_QUOTED, CodeReflectionSupport.MTD_Quoted, ACC_PRIVATE + ACC_FINAL, new MethodBody(new Consumer<CodeBuilder>() {
             @Override
             public void accept(CodeBuilder cob) {
                 cob.aload(0)

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -540,13 +540,13 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         Method opMethod;
         try {
             // @@@ Use method handle with full power mode
-            opMethod = method.getDeclaringClass().getDeclaredMethod(opMethodName, DialectFactory.class);
+            opMethod = method.getDeclaringClass().getDeclaredMethod(opMethodName);
         } catch (NoSuchMethodException e) {
             return Optional.empty();
         }
         opMethod.setAccessible(true);
         try {
-            FuncOp funcOp = (FuncOp) opMethod.invoke(null, JavaOp.DIALECT_FACTORY);
+            FuncOp funcOp = (FuncOp) opMethod.invoke(null);
             return Optional.of(funcOp);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -38,15 +38,10 @@ import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.util.Context;
-import jdk.incubator.code.dialect.DialectFactory;
 import jdk.incubator.code.internal.ReflectMethods;
 import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
-import jdk.incubator.code.dialect.java.JavaOp;
-import jdk.incubator.code.dialect.OpFactory;
-import jdk.incubator.code.dialect.core.CoreTypeFactory;
 import jdk.incubator.code.dialect.core.FunctionType;
 import jdk.incubator.code.dialect.java.MethodRef;
-import jdk.incubator.code.dialect.TypeElementFactory;
 import jdk.incubator.code.writer.OpWriter;
 import jdk.internal.access.SharedSecrets;
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -480,22 +480,28 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
 
     /**
-     * Returns the code model of the Quotable passed in.
-     * @param q the Quotable we want to get its code model.
-     * @return the code model of the Quotable passed in.
-     * @apiNote If the Quotable instance is a proxy instance, then the quoted code model is inaccessible and this method
-     * returns an empty optional.
+     * Returns the quoted code model of the given quotable reference, if present.
+     *
+     * @param q the quotable reference.
+     * @return the quoted code model or an empty optional if the
+     *         quoted code model is unavailable.
+     * @apiNote If the quotable reference is a proxy instance, then the
+     *          quoted code model is unavailable and this method
+     *          returns an empty optional.
      * @since 99
      */
     public static Optional<Quoted> ofQuotable(Quotable q) {
         Object oq = q;
         if (Proxy.isProxyClass(oq.getClass())) {
+            // @@@ The interpreter implements interpretation of
+            // lambdas using a proxy whose invocation handler
+            // supports the internal protocol to access the quoted instance
             oq = Proxy.getInvocationHandler(oq);
         }
 
         Method method;
         try {
-            method = oq.getClass().getMethod("__internal_quoted");
+            method = oq.getClass().getDeclaredMethod("__internal_quoted");
         } catch (NoSuchMethodException e) {
             return Optional.empty();
         }
@@ -511,7 +517,9 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Returns the code model of the method body, if present.
+     * Returns the code model of the given method's body, if present.
+     *
+     * @param method the method.
      * @return the code model of the method body.
      * @since 99
      */

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -38,6 +38,7 @@ import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.util.Context;
+import jdk.incubator.code.dialect.DialectFactory;
 import jdk.incubator.code.internal.ReflectMethods;
 import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
 import jdk.incubator.code.dialect.java.JavaOp;
@@ -539,14 +540,13 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         Method opMethod;
         try {
             // @@@ Use method handle with full power mode
-            opMethod = method.getDeclaringClass().getDeclaredMethod(opMethodName, OpFactory.class,
-                    TypeElementFactory.class);
+            opMethod = method.getDeclaringClass().getDeclaredMethod(opMethodName, DialectFactory.class);
         } catch (NoSuchMethodException e) {
             return Optional.empty();
         }
         opMethod.setAccessible(true);
         try {
-            FuncOp funcOp = (FuncOp) opMethod.invoke(null, JavaOp.FACTORY, CoreTypeFactory.CORE_TYPE_FACTORY);
+            FuncOp funcOp = (FuncOp) opMethod.invoke(null, JavaOp.DIALECT_FACTORY);
             return Optional.of(funcOp);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -51,13 +51,12 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.Quotable;
 import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
+import jdk.incubator.code.dialect.DialectFactory;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.CoreOp.*;
-import jdk.incubator.code.dialect.OpFactory;
 import jdk.incubator.code.dialect.java.*;
 import jdk.incubator.code.parser.OpParser;
 import jdk.incubator.code.dialect.core.FunctionType;
-import jdk.incubator.code.dialect.TypeElementFactory;
 import jdk.incubator.code.dialect.core.VarType;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,8 +89,9 @@ public final class BytecodeGenerator {
             StringConcatFactory.class.describeConstable().orElseThrow(),
             "makeConcat",
             CD_CallSite);
-    private static final MethodTypeDesc opMethodDesc = MethodTypeDesc.of(Op.class.describeConstable().get(),
-            OpFactory.class.describeConstable().get(), TypeElementFactory.class.describeConstable().get());
+
+    private static final MethodTypeDesc OP_METHOD_DESC = MethodTypeDesc.of(Op.class.describeConstable().get(),
+            DialectFactory.class.describeConstable().get());
 
     /**
      * Transforms the invokable operation to bytecode encapsulated in a method of hidden class and exposed
@@ -165,7 +165,7 @@ public final class BytecodeGenerator {
                 LambdaOp lop = lambdaSink.get(i);
                 if (quotable.get(i)) {
                     // return (FuncOp) OpParser.fromOpString(opText)
-                    clb.withMethod("op$lambda$" + i, opMethodDesc,
+                    clb.withMethod("op$lambda$" + i, OP_METHOD_DESC,
                         ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC | ClassFile.ACC_SYNTHETIC, mb -> mb.withCode(cb -> cb
                                 .loadConstant(quote(lop).toText())
                                 .invoke(Opcode.INVOKESTATIC, OpParser.class.describeConstable().get(),
@@ -900,7 +900,7 @@ public final class BytecodeGenerator {
                                         MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC,
                                                 className,
                                                 "op$lambda$" + lambdaIndex,
-                                                opMethodDesc)));
+                                                OP_METHOD_DESC)));
                                 quotable.set(lambdaSink.size());
                             } else {
                                 cob.invokedynamic(DynamicCallSiteDesc.of(

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -51,7 +51,6 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.Quotable;
 import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
-import jdk.incubator.code.dialect.DialectFactory;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.CoreOp.*;
 import jdk.incubator.code.dialect.java.*;
@@ -90,8 +89,7 @@ public final class BytecodeGenerator {
             "makeConcat",
             CD_CallSite);
 
-    private static final MethodTypeDesc OP_METHOD_DESC = MethodTypeDesc.of(Op.class.describeConstable().get(),
-            DialectFactory.class.describeConstable().get());
+    private static final MethodTypeDesc OP_METHOD_DESC = MethodTypeDesc.of(Op.class.describeConstable().get());
 
     /**
      * Transforms the invokable operation to bytecode encapsulated in a method of hidden class and exposed

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -164,7 +164,7 @@ public final class BytecodeGenerator {
                 if (quotable.get(i)) {
                     // return (FuncOp) OpParser.fromOpString(opText)
                     clb.withMethod("op$lambda$" + i, OP_METHOD_DESC,
-                        ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC | ClassFile.ACC_SYNTHETIC, mb -> mb.withCode(cb -> cb
+                        ClassFile.ACC_PRIVATE | ClassFile.ACC_STATIC | ClassFile.ACC_SYNTHETIC, mb -> mb.withCode(cb -> cb
                                 .loadConstant(quote(lop).toText())
                                 .invoke(Opcode.INVOKESTATIC, OpParser.class.describeConstable().get(),
                                         "fromStringOfFuncOp",

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/DialectFactory.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/DialectFactory.java
@@ -1,0 +1,15 @@
+package jdk.incubator.code.dialect;
+
+/**
+ * A dialect factory for constructing a dialect's operations and type elements from their
+ * externalized form.
+ *
+ * @param opFactory the operation factory.
+ * @param typeElementFactory the type element factory.
+ */
+public record DialectFactory(OpFactory opFactory, TypeElementFactory typeElementFactory) {
+
+    // OpFactory
+    // OpDeclaration
+    // TypeElementFactory
+}

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -27,7 +27,6 @@ package jdk.incubator.code.dialect.core;
 
 import java.lang.constant.ClassDesc;
 import jdk.incubator.code.*;
-import jdk.incubator.code.dialect.DialectFactory;
 import jdk.incubator.code.dialect.java.*;
 import jdk.incubator.code.dialect.ExternalizableOp;
 import jdk.incubator.code.dialect.OpFactory;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -27,6 +27,7 @@ package jdk.incubator.code.dialect.core;
 
 import java.lang.constant.ClassDesc;
 import jdk.incubator.code.*;
+import jdk.incubator.code.dialect.DialectFactory;
 import jdk.incubator.code.dialect.java.*;
 import jdk.incubator.code.dialect.ExternalizableOp;
 import jdk.incubator.code.dialect.OpFactory;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -27,12 +27,10 @@ package jdk.incubator.code.dialect.java;
 
 import java.lang.constant.ClassDesc;
 import jdk.incubator.code.*;
-import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.DialectFactory;
+import jdk.incubator.code.dialect.core.*;
 import jdk.incubator.code.dialect.ExternalizableOp;
 import jdk.incubator.code.dialect.OpFactory;
-import jdk.incubator.code.dialect.core.FunctionType;
-import jdk.incubator.code.dialect.core.TupleType;
-import jdk.incubator.code.dialect.core.VarType;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -5296,6 +5294,9 @@ public sealed abstract class JavaOp extends ExternalizableOp {
     // @@@ Compute lazily
     public static final OpFactory FACTORY = CoreOp.FACTORY.andThen(OpFactory.OP_FACTORY.get(JavaOp.class));
 
+    public static final DialectFactory DIALECT_FACTORY = new DialectFactory(
+            FACTORY,
+            CoreTypeFactory.CORE_TYPE_FACTORY);
 
     /**
      * Creates a lambda operation.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -109,10 +109,10 @@ public class CodeModelToAST {
     }
 
     public JCTree.JCMethodDecl transformFuncOpToAST(CoreOp.FuncOp funcOp, Name methodName) {
+        Assert.check(funcOp.parameters().isEmpty());
         Assert.check(funcOp.body().blocks().size() == 1);
 
-        var paramTypes = List.of(crSym.dialectFactoryType);
-        var mt = new Type.MethodType(paramTypes, crSym.opType, List.nil(), syms.methodClass);
+        var mt = new Type.MethodType(List.nil(), crSym.opType, List.nil(), syms.methodClass);
         MethodSymbol ms = new MethodSymbol(PUBLIC | STATIC | SYNTHETIC, methodName, mt, currClassSym);
         currClassSym.members().enter(ms);
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -33,21 +33,17 @@ public class CodeModelToAST {
     private final Env<AttrContext> attrEnv;
     private final Resolve resolve;
     private final Types types;
-    private final Symbol.ClassSymbol currClassSym;
-    private final CodeReflectionSymbols crSym;
     private final Map<Value, JCTree> valueToTree = new HashMap<>();
     private int localVarCount = 0; // used to name variables we introduce in the AST
 
     public CodeModelToAST(TreeMaker treeMaker, Names names, Symtab syms, Resolve resolve,
-                          Types types, Env<AttrContext> attrEnv, CodeReflectionSymbols crSym) {
+                          Types types, Env<AttrContext> attrEnv) {
         this.treeMaker = treeMaker;
         this.names = names;
         this.syms = syms;
         this.resolve = resolve;
         this.types = types;
         this.attrEnv = attrEnv;
-        this.currClassSym = attrEnv.enclClass.sym;
-        this.crSym = crSym;
     }
 
     private Type typeElementToType(TypeElement jt) {
@@ -108,17 +104,9 @@ public class CodeModelToAST {
         }
     }
 
-    public JCTree.JCMethodDecl transformFuncOpToAST(CoreOp.FuncOp funcOp, Name methodName) {
+    public JCTree.JCStatement transformFuncOpToAST(CoreOp.FuncOp funcOp, MethodSymbol ms) {
         Assert.check(funcOp.parameters().isEmpty());
         Assert.check(funcOp.body().blocks().size() == 1);
-
-        var mt = new Type.MethodType(List.nil(), crSym.opType, List.nil(), syms.methodClass);
-        MethodSymbol ms = new MethodSymbol(PRIVATE | STATIC | SYNTHETIC, methodName, mt, currClassSym);
-        currClassSym.members().enter(ms);
-
-        for (int i = 0; i < funcOp.parameters().size(); i++) {
-            valueToTree.put(funcOp.parameters().get(i), treeMaker.Ident(ms.params().get(i)));
-        }
 
         java.util.List<Value> rootValues = funcOp.traverse(new ArrayList<>(), (l, ce) -> {
             boolean isRoot = switch (ce) {
@@ -129,7 +117,7 @@ public class CodeModelToAST {
                 default -> false;
             };
             if (isRoot) {
-                l.add(((Op)ce).result());
+                l.add(((Op) ce).result());
             }
             return l;
         });
@@ -150,7 +138,7 @@ public class CodeModelToAST {
         }
         var mb = treeMaker.Block(0, stats.toList());
 
-        return treeMaker.MethodDef(ms, mb);
+        return mb;
     }
 
     private JCTree opToTree(Value v) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -22,6 +22,10 @@ import java.util.*;
 import static com.sun.tools.javac.code.Flags.*;
 
 public class CodeModelToAST {
+    private static final MethodRef M_BLOCK_BUILDER_OP = MethodRef.method(Block.Builder.class, "op",
+            Op.Result.class, Op.class);
+    private static final MethodRef M_BLOCK_BUILDER_PARAM = MethodRef.method(Block.Builder.class, "parameter",
+            Block.Parameter.class, TypeElement.class);
 
     private final TreeMaker treeMaker;
     private final Names names;
@@ -31,13 +35,8 @@ public class CodeModelToAST {
     private final Types types;
     private final Symbol.ClassSymbol currClassSym;
     private final CodeReflectionSymbols crSym;
-    private Symbol.MethodSymbol ms;
-    private int localVarCount = 0; // used to name variables we introduce in the AST
     private final Map<Value, JCTree> valueToTree = new HashMap<>();
-    private static final MethodRef M_BLOCK_BUILDER_OP = MethodRef.method(Block.Builder.class, "op",
-            Op.Result.class, Op.class);
-    private static final MethodRef M_BLOCK_BUILDER_PARAM = MethodRef.method(Block.Builder.class, "parameter",
-            Block.Parameter.class, TypeElement.class);
+    private int localVarCount = 0; // used to name variables we introduce in the AST
 
     public CodeModelToAST(TreeMaker treeMaker, Names names, Symtab syms, Resolve resolve,
                           Types types, Env<AttrContext> attrEnv, CodeReflectionSymbols crSym) {
@@ -112,9 +111,9 @@ public class CodeModelToAST {
     public JCTree.JCMethodDecl transformFuncOpToAST(CoreOp.FuncOp funcOp, Name methodName) {
         Assert.check(funcOp.body().blocks().size() == 1);
 
-        var paramTypes = List.of(crSym.opFactoryType, crSym.typeElementFactoryType);
+        var paramTypes = List.of(crSym.dialectFactoryType);
         var mt = new Type.MethodType(paramTypes, crSym.opType, List.nil(), syms.methodClass);
-        ms = new Symbol.MethodSymbol(PUBLIC | STATIC | SYNTHETIC, methodName, mt, currClassSym);
+        MethodSymbol ms = new MethodSymbol(PUBLIC | STATIC | SYNTHETIC, methodName, mt, currClassSym);
         currClassSym.members().enter(ms);
 
         for (int i = 0; i < funcOp.parameters().size(); i++) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeModelToAST.java
@@ -113,7 +113,7 @@ public class CodeModelToAST {
         Assert.check(funcOp.body().blocks().size() == 1);
 
         var mt = new Type.MethodType(List.nil(), crSym.opType, List.nil(), syms.methodClass);
-        MethodSymbol ms = new MethodSymbol(PUBLIC | STATIC | SYNTHETIC, methodName, mt, currClassSym);
+        MethodSymbol ms = new MethodSymbol(PRIVATE | STATIC | SYNTHETIC, methodName, mt, currClassSym);
         currClassSym.members().enter(ms);
 
         for (int i = 0; i < funcOp.parameters().size(); i++) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeReflectionSymbols.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeReflectionSymbols.java
@@ -25,7 +25,6 @@
 
 package jdk.incubator.code.internal;
 
-import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symtab;
@@ -48,10 +47,6 @@ public class CodeReflectionSymbols {
     public final MethodSymbol opParserFromString;
     public final MethodSymbol methodHandlesLookup;
     public final Type opType;
-    public final Type funcOpType;
-    public final Type dialectFactoryType;
-    public final Type javaOpType;
-    public final Symbol.VarSymbol javaDialectFactorySym;
 
     CodeReflectionSymbols(Context context) {
         Symtab syms = Symtab.instance(context);
@@ -62,7 +57,6 @@ public class CodeReflectionSymbols {
         quotableType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.Quotable");
         Type opInterpreterType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.interpreter.Interpreter");
         opType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.Op");
-        funcOpType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.core.CoreOp$FuncOp");
         opInterpreterInvoke = new MethodSymbol(PUBLIC | STATIC | VARARGS,
                 names.fromString("invoke"),
                 new MethodType(List.of(syms.methodHandleLookupType, opType, new ArrayType(syms.objectType, syms.arrayClass)), syms.objectType,
@@ -81,9 +75,5 @@ public class CodeReflectionSymbols {
                 syms.methodHandlesType.tsym);
         syms.synthesizeEmptyInterfaceIfMissing(quotedType);
         syms.synthesizeEmptyInterfaceIfMissing(quotableType);
-        dialectFactoryType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.DialectFactory");
-        javaOpType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.java.JavaOp");
-        javaDialectFactorySym = new Symbol.VarSymbol(PUBLIC | STATIC, names.fromString("DIALECT_FACTORY"),
-                dialectFactoryType, javaOpType.tsym);
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeReflectionSymbols.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeReflectionSymbols.java
@@ -49,12 +49,9 @@ public class CodeReflectionSymbols {
     public final MethodSymbol methodHandlesLookup;
     public final Type opType;
     public final Type funcOpType;
-    public final Type opFactoryType;
-    public final Type typeElementFactoryType;
+    public final Type dialectFactoryType;
     public final Type javaOpType;
-    public final Type coreTypeFactoryType;
-    public final Symbol.VarSymbol javaOpFactorySym;
-    public final Symbol.VarSymbol coreTypeFactorySym;
+    public final Symbol.VarSymbol javaDialectFactorySym;
 
     CodeReflectionSymbols(Context context) {
         Symtab syms = Symtab.instance(context);
@@ -84,13 +81,9 @@ public class CodeReflectionSymbols {
                 syms.methodHandlesType.tsym);
         syms.synthesizeEmptyInterfaceIfMissing(quotedType);
         syms.synthesizeEmptyInterfaceIfMissing(quotableType);
-        opFactoryType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.OpFactory");
-        typeElementFactoryType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.TypeElementFactory");
+        dialectFactoryType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.DialectFactory");
         javaOpType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.java.JavaOp");
-        coreTypeFactoryType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.core.CoreTypeFactory");
-        javaOpFactorySym = new Symbol.VarSymbol(PUBLIC | STATIC, names.fromString("FACTORY"), opFactoryType,
-                javaOpType.tsym);
-        coreTypeFactorySym = new Symbol.VarSymbol(PUBLIC | STATIC, names.fromString("CORE_TYPE_FACTORY"), typeElementFactoryType,
-                coreTypeFactoryType.tsym);
+        javaDialectFactorySym = new Symbol.VarSymbol(PUBLIC | STATIC, names.fromString("DIALECT_FACTORY"),
+                dialectFactoryType, javaOpType.tsym);
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -275,11 +275,9 @@ public class ReflectMethods extends TreeTranslator {
                         JCMethodInvocation lookup = make.App(make.Ident(crSyms.methodHandlesLookup), com.sun.tools.javac.util.List.nil());
                         interpreterArgs.append(lookup);
                         // Get the func operation
-                        JCFieldAccess opFactory = make.Select(make.Ident(crSyms.javaOpType.tsym),
-                                crSyms.javaOpFactorySym);
-                        JCFieldAccess typeFactory = make.Select(make.Ident(crSyms.coreTypeFactoryType.tsym),
-                                crSyms.coreTypeFactorySym);
-                        JCMethodInvocation op = make.App(opMethodId, com.sun.tools.javac.util.List.of(opFactory, typeFactory));
+                        JCFieldAccess dialectFactory = make.Select(make.Ident(crSyms.javaOpType.tsym),
+                                crSyms.javaDialectFactorySym);
+                        JCMethodInvocation op = make.App(opMethodId, com.sun.tools.javac.util.List.of(dialectFactory));
                         interpreterArgs.append(op);
                         // Append captured vars
                         ListBuffer<JCExpression> capturedArgs = quotedCapturedArgs(tree, bodyScanner);
@@ -413,7 +411,7 @@ public class ReflectMethods extends TreeTranslator {
     private JCMethodDecl opMethodDecl(Name methodName, CoreOp.FuncOp op, CodeModelStorageOption codeModelStorageOption) {
         switch (codeModelStorageOption) {
             case TEXT -> {
-                var paramTypes = com.sun.tools.javac.util.List.of(crSyms.opFactoryType, crSyms.typeElementFactoryType);
+                var paramTypes = com.sun.tools.javac.util.List.of(crSyms.dialectFactoryType);
                 var mt = new MethodType(paramTypes, crSyms.opType,
                         com.sun.tools.javac.util.List.nil(), syms.methodClass);
                 var ms = new MethodSymbol(PUBLIC | STATIC | SYNTHETIC, methodName, mt, currentClassSym);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -103,11 +103,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static com.sun.tools.javac.code.Flags.NOOUTERTHIS;
-import static com.sun.tools.javac.code.Flags.PARAMETER;
-import static com.sun.tools.javac.code.Flags.PUBLIC;
-import static com.sun.tools.javac.code.Flags.STATIC;
-import static com.sun.tools.javac.code.Flags.SYNTHETIC;
+import static com.sun.tools.javac.code.Flags.*;
 import static com.sun.tools.javac.code.Kinds.Kind.MTH;
 import static com.sun.tools.javac.code.Kinds.Kind.TYP;
 import static com.sun.tools.javac.code.Kinds.Kind.VAR;
@@ -412,7 +408,8 @@ public class ReflectMethods extends TreeTranslator {
             case TEXT -> {
                 var mt = new MethodType(com.sun.tools.javac.util.List.nil(), crSyms.opType,
                         com.sun.tools.javac.util.List.nil(), syms.methodClass);
-                var ms = new MethodSymbol(PUBLIC | STATIC | SYNTHETIC, methodName, mt, currentClassSym);
+                var ms = new MethodSymbol(PRIVATE | STATIC | SYNTHETIC, methodName, mt, currentClassSym);
+
                 currentClassSym.members().enter(ms);
                 var opFromStr = make.App(make.Ident(crSyms.opParserFromString),
                         com.sun.tools.javac.util.List.of(make.Literal(op.toText())));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
@@ -489,7 +489,7 @@ public final class Interpreter {
                                 }
                             }
 
-                            public Quoted __internal_quoted() {
+                            private Quoted __internal_quoted() {
                                 return quoted;
                             }
                         });

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
@@ -26,6 +26,7 @@
 package jdk.incubator.code.writer;
 
 import jdk.incubator.code.*;
+import jdk.incubator.code.dialect.DialectFactory;
 import jdk.incubator.code.dialect.OpFactory;
 import jdk.incubator.code.dialect.ExternalizableOp;
 import jdk.incubator.code.dialect.TypeElementFactory;
@@ -49,6 +50,12 @@ import static jdk.incubator.code.dialect.java.JavaType.*;
 public class OpBuilder {
 
     static final JavaType J_C_O_EXTERNALIZED_OP = type(ExternalizableOp.ExternalizedOp.class);
+
+    static final MethodRef DIALECT_FACTORY_OP_FACTORY = MethodRef.method(DialectFactory.class, "opFactory",
+            OpFactory.class);
+
+    static final MethodRef DIALECT_FACTORY_TYPE_ELEMENT_FACTORY = MethodRef.method(DialectFactory.class, "typeElementFactory",
+            TypeElementFactory.class);
 
     static final MethodRef OP_FACTORY_CONSTRUCT = MethodRef.method(OpFactory.class, "constructOp",
             Op.class, ExternalizableOp.ExternalizedOp.class);
@@ -113,8 +120,7 @@ public class OpBuilder {
             J_U_LIST);
 
     static final FunctionType BUILDER_F_TYPE = functionType(type(Op.class),
-            type(OpFactory.class),
-            type(TypeElementFactory.class));
+            type(DialectFactory.class));
 
 
     Map<Value, Value> valueMap;
@@ -126,6 +132,8 @@ public class OpBuilder {
     Map<TypeElement, Value> typeElementMap;
 
     Block.Builder builder;
+
+    Value dialectFactory;
 
     Value opFactory;
 
@@ -152,8 +160,9 @@ public class OpBuilder {
         Body.Builder body = Body.Builder.of(null, BUILDER_F_TYPE);
 
         builder = body.entryBlock();
-        opFactory = builder.parameters().get(0);
-        typeElementFactory = builder.parameters().get(1);
+        dialectFactory = builder.parameters().get(0);
+        opFactory = builder.op(invoke(DIALECT_FACTORY_OP_FACTORY, dialectFactory));
+        typeElementFactory = builder.op(invoke(DIALECT_FACTORY_TYPE_ELEMENT_FACTORY, dialectFactory));
 
         Value ancestorBody = builder.op(constant(type(Body.Builder.class), null));
         Value result = buildOp(ancestorBody, op);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/writer/OpBuilder.java
@@ -141,9 +141,14 @@ public class OpBuilder {
 
     /**
      * Transform the given code model to one that builds it.
+     * <p>
+     * This method initially applies the function {@code dialectFactoryF} to
+     * the block builder that is used to build resulting code model. The result
+     * is a dialect factory value which is subsequently used to build operations
+     * that construct type elements and operations present in the given code model.
      *
      * @param op the code model.
-     * @param dialectFactoryF a function that produces a value to a dialect factory instance.
+     * @param dialectFactoryF a function that builds code items to produce a dialect factory value.
      * @return the building code model.
      */
     public static FuncOp createBuilderFunction(Op op, Function<Block.Builder, Value> dialectFactoryF) {

--- a/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import jdk.incubator.code.dialect.DialectFactory;
+import jdk.incubator.code.dialect.java.JavaType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -121,7 +123,8 @@ public class TestCodeBuilder {
     }
 
     static void test(CoreOp.FuncOp fExpected) {
-        CoreOp.FuncOp fb = OpBuilder.createBuilderFunction(fExpected);
+        CoreOp.FuncOp fb = OpBuilder.createBuilderFunction(fExpected,
+                b -> b.parameter(JavaType.type(DialectFactory.class)));
         CoreOp.FuncOp fActual = (CoreOp.FuncOp) Interpreter.invoke(MethodHandles.lookup(),
                 fb, JavaOp.DIALECT_FACTORY);
         Assert.assertEquals(fActual.toText(), fExpected.toText());

--- a/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
@@ -123,7 +123,7 @@ public class TestCodeBuilder {
     static void test(CoreOp.FuncOp fExpected) {
         CoreOp.FuncOp fb = OpBuilder.createBuilderFunction(fExpected);
         CoreOp.FuncOp fActual = (CoreOp.FuncOp) Interpreter.invoke(MethodHandles.lookup(),
-                fb, JavaOp.FACTORY, CoreTypeFactory.CORE_TYPE_FACTORY);
+                fb, JavaOp.DIALECT_FACTORY);
         Assert.assertEquals(fActual.toText(), fExpected.toText());
     }
 


### PR DESCRIPTION
Group op factory and type element factory into dialect factory record.

The synthetic method added by javac to build a code model now has no parameters. The dialect factory, namely that for Java ops and type elements, is accessed from within the generated method body. This simplifies the connections between compiler/runtime and code reflection (see the reduction in `CodeReflectionSymbols.java` and `InnerClassLambdaMetafactory.java`).

The synthetic method's accessibility is now private, as is the synthetic method to access the quoted instance from a quotable lambda's functional interface implementation.

Further alignment of the factories and their use will occur in one or more subsequent PRs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/441/head:pull/441` \
`$ git checkout pull/441`

Update a local copy of the PR: \
`$ git checkout pull/441` \
`$ git pull https://git.openjdk.org/babylon.git pull/441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 441`

View PR using the GUI difftool: \
`$ git pr show -t 441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/441.diff">https://git.openjdk.org/babylon/pull/441.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/441#issuecomment-2977847019)
</details>
