### PR TITLE
Enhance JavaType::type to deal with inner classes

### DIFF
--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -399,4 +399,42 @@ public class TestJavaType {
     private static JavaType typeFromFlatString(String desc) {
         return JavaTypeUtils.toJavaType(JavaTypeUtils.parseExternalTypeString(desc));
     }
+
+    static class InnerTypes {
+
+        class Member { }
+
+        static class Nested { }
+
+        void m() {
+            class Local_I_M { }
+        }
+
+        static void s_m() {
+            class Local_S_M { }
+        }
+
+        InnerTypes() {
+            class Local_C { }
+        }
+    }
+
+    @Test
+    public void testInnerTypes() throws ReflectiveOperationException {
+        var innertypes = JavaType.type(InnerTypes.class);
+        var member = (ClassType)JavaType.type(InnerTypes.Member.class);
+        Assert.assertEquals(member.enclosingType().get(), innertypes);
+
+        var nested = (ClassType)JavaType.type(InnerTypes.Nested.class);
+        Assert.assertTrue(nested.enclosingType().isEmpty());
+
+        var local_s_m = (ClassType)JavaType.type(Class.forName("TestJavaType$InnerTypes$1Local_S_M"));
+        Assert.assertTrue(local_s_m.enclosingType().isEmpty());
+
+        var local_i_m = (ClassType)JavaType.type(Class.forName("TestJavaType$InnerTypes$1Local_I_M"));
+        Assert.assertEquals(local_i_m.enclosingType().get(), innertypes);
+
+        var local_c = (ClassType)JavaType.type(Class.forName("TestJavaType$InnerTypes$1Local_C"));
+        Assert.assertEquals(local_c.enclosingType().get(), innertypes);
+    }
 }

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -402,7 +402,13 @@ public class TestJavaType {
 
     static class InnerTypes {
 
-        class Member { }
+        class Member {
+            class One {
+                class Two {
+                    class Three { }
+                }
+            }
+        }
 
         static class Nested { }
 
@@ -424,6 +430,18 @@ public class TestJavaType {
         var innertypes = JavaType.type(InnerTypes.class);
         var member = (ClassType)JavaType.type(InnerTypes.Member.class);
         Assert.assertEquals(member.enclosingType().get(), innertypes);
+
+        var memberOne = (ClassType)JavaType.type(InnerTypes.Member.One.class);
+        Assert.assertEquals(memberOne.enclosingType().get(), member);
+        Assert.assertEquals(memberOne.toClassName(), InnerTypes.Member.One.class.getName());
+
+        var memberTwo = (ClassType)JavaType.type(InnerTypes.Member.One.Two.class);
+        Assert.assertEquals(memberTwo.enclosingType().get(), memberOne);
+        Assert.assertEquals(memberTwo.toClassName(), InnerTypes.Member.One.Two.class.getName());
+
+        var memberThree = (ClassType)JavaType.type(InnerTypes.Member.One.Two.Three.class);
+        Assert.assertEquals(memberThree.enclosingType().get(), memberTwo);
+        Assert.assertEquals(memberThree.toClassName(), InnerTypes.Member.One.Two.Three.class.getName());
 
         var nested = (ClassType)JavaType.type(InnerTypes.Nested.class);
         Assert.assertTrue(nested.enclosingType().isEmpty());


### PR DESCRIPTION
In some cases, the `JavaType::type(Type)` factory loses information about enclosing/enclosed type.
This is due to the fact that, when the type in question contains some generic parameterization, the enclosing/enclosed relationship is reified in the `ParameterizedType` class.
However, if the type is non-generic, it is modelled as a simple `Class` -- and the enclosing/enclosed relationship is lost.

This PR enhances the factory to recover the enclosing type using the reflective information available:
* the class is a non-static member class. The enclosing type is the class in which the class is declared
* the class is a local class, defined in a method `m`. If `m` is non-static, the enclosing type is the class declaring `m`
* the class is a local class, defined in a constructor of class `C`. The enclosing type is `C`
* otherwise, there's no enclosing type.

Note that there are some [known pathological cases](https://bugs.openjdk.org/browse/JDK-8162500) where the enclosing class information cannot be reconstructed from the information we have available in the bytecode, but this should not be a big issue for the time being.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [f9c613b4](https://git.openjdk.org/babylon/pull/443/files/f9c613b456270f51b82413f53dbc9172fb745ba9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/443/head:pull/443` \
`$ git checkout pull/443`

Update a local copy of the PR: \
`$ git checkout pull/443` \
`$ git pull https://git.openjdk.org/babylon.git pull/443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 443`

View PR using the GUI difftool: \
`$ git pr show -t 443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/443.diff">https://git.openjdk.org/babylon/pull/443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/443#issuecomment-2980725262)
</details>
