### PR TITLE
Move verifier into bytecode tests

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
@@ -693,7 +693,7 @@ public final class Interpreter {
         }
     }
 
-    public static MethodType resolveToMethodType(MethodHandles.Lookup l, FunctionType ft) {
+    static MethodType resolveToMethodType(MethodHandles.Lookup l, FunctionType ft) {
         try {
             return MethodRef.toNominalDescriptor(ft).resolveConstantDesc(l);
         } catch (ReflectiveOperationException e) {
@@ -701,7 +701,7 @@ public final class Interpreter {
         }
     }
 
-    public static Class<?> resolveToClass(MethodHandles.Lookup l, TypeElement d) {
+    static Class<?> resolveToClass(MethodHandles.Lookup l, TypeElement d) {
         try {
             if (d instanceof JavaType jt) {
                 return (Class<?>)jt.erasure().resolve(l);

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -33,7 +33,6 @@ import java.lang.classfile.instruction.*;
 import java.lang.invoke.MethodHandles;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.bytecode.BytecodeLift;
-import jdk.incubator.code.interpreter.Verifier;
 import jdk.incubator.code.dialect.core.CoreOp;
 import java.net.URI;
 import java.nio.file.FileSystem;


### PR DESCRIPTION
Move verifier from public API into bytecode tests, some aspects of this may come back in the form of structural validation when building a model, specifically value use requires declaration dominates and arity block reference arguments matches the target block parameters.   
