### PR TITLE
Remove export of package from java.base.

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -163,8 +163,6 @@ module java.base {
         jdk.jlink,   // participates in preview features
         jdk.jshell, // participates in preview features
         jdk.incubator.code; // participates in preview features
-    exports jdk.internal.classfile.impl to
-        jdk.incubator.code;
     exports jdk.internal.access to
         java.desktop,
         java.logging,

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BranchCompactor.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BranchCompactor.java
@@ -24,8 +24,6 @@
  */
 package jdk.incubator.code.bytecode;
 
-import jdk.internal.classfile.impl.BytecodeHelpers;
-
 import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeTransform;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeHelpers.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeHelpers.java
@@ -1,0 +1,16 @@
+package jdk.incubator.code.bytecode;
+
+import java.lang.classfile.Opcode;
+
+final class BytecodeHelpers {
+
+    // Copied from java.base/jdk.internal.classfile.impl.BytecodeHelpers
+    // to avoid export of package from java.base to jdk.incubator.code
+
+    static boolean isUnconditionalBranch(Opcode opcode) {
+        return switch (opcode) {
+            case GOTO, ATHROW, GOTO_W, LOOKUPSWITCH, TABLESWITCH -> true;
+            default -> opcode.kind() == Opcode.Kind.RETURN;
+        };
+    }
+}

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeLift.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeLift.java
@@ -28,7 +28,6 @@ package jdk.incubator.code.bytecode;
 import jdk.incubator.code.dialect.core.FunctionType;
 import jdk.incubator.code.dialect.core.VarType;
 import jdk.incubator.code.dialect.java.*;
-import jdk.internal.classfile.impl.BytecodeHelpers;
 
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;


### PR DESCRIPTION
Remove export of `java.base/jdk.internal.classfile.impl` to `jdk.incubator.code`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/447/head:pull/447` \
`$ git checkout pull/447`

Update a local copy of the PR: \
`$ git checkout pull/447` \
`$ git pull https://git.openjdk.org/babylon.git pull/447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 447`

View PR using the GUI difftool: \
`$ git pr show -t 447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/447.diff">https://git.openjdk.org/babylon/pull/447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/447#issuecomment-2981812935)
</details>
