### PR TITLE
Move certain classes into non-exportable packages

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -51,6 +51,8 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.Quotable;
 import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
+import jdk.incubator.code.bytecode.impl.BranchCompactor;
+import jdk.incubator.code.bytecode.impl.LocalsCompactor;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.CoreOp.*;
 import jdk.incubator.code.dialect.java.*;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeLift.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeLift.java
@@ -25,6 +25,7 @@
 
 package jdk.incubator.code.bytecode;
 
+import jdk.incubator.code.bytecode.impl.BytecodeHelpers;
 import jdk.incubator.code.dialect.core.FunctionType;
 import jdk.incubator.code.dialect.core.VarType;
 import jdk.incubator.code.dialect.java.*;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/BranchCompactor.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/BranchCompactor.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.incubator.code.bytecode;
+package jdk.incubator.code.bytecode.impl;
 
 import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.CodeElement;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/BytecodeHelpers.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/BytecodeHelpers.java
@@ -1,13 +1,13 @@
-package jdk.incubator.code.bytecode;
+package jdk.incubator.code.bytecode.impl;
 
 import java.lang.classfile.Opcode;
 
-final class BytecodeHelpers {
+public final class BytecodeHelpers {
 
     // Copied from java.base/jdk.internal.classfile.impl.BytecodeHelpers
     // to avoid export of package from java.base to jdk.incubator.code
 
-    static boolean isUnconditionalBranch(Opcode opcode) {
+    public static boolean isUnconditionalBranch(Opcode opcode) {
         return switch (opcode) {
             case GOTO, ATHROW, GOTO_W, LOOKUPSWITCH, TABLESWITCH -> true;
             default -> opcode.kind() == Opcode.Kind.RETURN;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LocalsCompactor.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LocalsCompactor.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.incubator.code.bytecode;
+package jdk.incubator.code.bytecode.impl;
 
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassTransform;

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBranchCompactor.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBranchCompactor.java
@@ -28,7 +28,7 @@ import jdk.internal.classfile.components.ClassPrinter;
 import static java.lang.classfile.Opcode.*;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
-import jdk.incubator.code.bytecode.BranchCompactor;
+import jdk.incubator.code.bytecode.impl.BranchCompactor;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
  * @test
  * @modules jdk.incubator.code
  * @modules java.base/jdk.internal.classfile.components
+ * @modules jdk.incubator.code/jdk.incubator.code.bytecode.impl
  * @enablePreview
  * @run testng TestBranchCompactor
  */


### PR DESCRIPTION
Move certain classes in the bytecode package to a non-exportable packages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/449/head:pull/449` \
`$ git checkout pull/449`

Update a local copy of the PR: \
`$ git checkout pull/449` \
`$ git pull https://git.openjdk.org/babylon.git pull/449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 449`

View PR using the GUI difftool: \
`$ git pr show -t 449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/449.diff">https://git.openjdk.org/babylon/pull/449.diff</a>

</details>
