### PR TITLE
After previous linux (clang tidy) changes, mac c++ wanted a few tweaks

### DIFF
--- a/hat/backends/ffi/shared/cpp/fsutil.cpp
+++ b/hat/backends/ffi/shared/cpp/fsutil.cpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <mutex>
 #include <iostream>
+#include <sstream>
 #include <fstream>
 #include <dirent.h>
 #include <unistd.h>

--- a/hat/backends/ffi/shared/include/schema.h
+++ b/hat/backends/ffi/shared/include/schema.h
@@ -173,7 +173,7 @@ struct Schema {
             : Node(nullptr, "Schema") {
         }
 
-        virtual SchemaNode *parse(SchemaCursor *cursor);
+        SchemaNode *parse(SchemaCursor *cursor) override;
 
         ~SchemaNode() override = default;
     };


### PR DESCRIPTION
Mac c++/clang compiler fussed over lack of <sstream> and inconsistant use of 'override'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/452/head:pull/452` \
`$ git checkout pull/452`

Update a local copy of the PR: \
`$ git checkout pull/452` \
`$ git pull https://git.openjdk.org/babylon.git pull/452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 452`

View PR using the GUI difftool: \
`$ git pr show -t 452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/452.diff">https://git.openjdk.org/babylon/pull/452.diff</a>

</details>
