### PR TITLE
Adjust factory constants

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -887,7 +887,7 @@ public class TritonOps {
 
     // Triton types then Java types
     static final TypeElementFactory TRITON_JAVA_TYPE_FACTORY =
-            TRITON_TYPE_FACTORY.andThen(JavaOp.JAVA_TYPE_FACTORY);
+            TRITON_TYPE_FACTORY.andThen(JavaType.JAVA_ONLY_TYPE_FACTORY);
 
     // Triton types then Java types, combined with core types
     static final TypeElementFactory TYPE_FACTORY =
@@ -896,7 +896,7 @@ public class TritonOps {
     public static final DialectFactory DIALECT_FACTORY = new DialectFactory(
             OP_FACTORY.andThen(ArithMathOps.OP_FACTORY)
                     .andThen(SCFOps.OP_FACTORY)
-                    .andThen(JavaOp.OP_FACTORY),
+                    .andThen(JavaOp.JAVA_OP_FACTORY),
             TYPE_FACTORY
     );
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -1349,7 +1349,7 @@ public sealed abstract class CoreOp extends ExternalizableOp {
     /**
      * An operation factory for core operations.
      */
-    public static final OpFactory OP_FACTORY = OpFactory.OP_FACTORY.get(CoreOp.class);
+    public static final OpFactory CORE_OP_FACTORY = OpFactory.OP_FACTORY.get(CoreOp.class);
 
     /**
      * Creates a function operation builder

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -28,11 +28,9 @@ package jdk.incubator.code.dialect.java;
 import java.lang.constant.ClassDesc;
 import jdk.incubator.code.*;
 import jdk.incubator.code.extern.DialectFactory;
-import jdk.incubator.code.extern.TypeElementFactory;
 import jdk.incubator.code.dialect.core.*;
 import jdk.incubator.code.extern.ExternalizableOp;
 import jdk.incubator.code.extern.OpFactory;
-import jdk.incubator.code.dialect.java.impl.JavaTypeUtils;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -5291,29 +5289,9 @@ public sealed abstract class JavaOp extends ExternalizableOp {
     }
 
     /**
-     * An operation factory for Java operations.
+     * An operation factory for core operations composed with Java operations.
      */
-    public static OpFactory JAVA_OP_FACTORY = OpFactory.OP_FACTORY.get(JavaOp.class);
-
-    /**
-     * A type element factory for Java type elements.
-     */
-    public static final TypeElementFactory JAVA_TYPE_FACTORY = tree -> switch (JavaTypeUtils.Kind.of(tree)) {
-        case INFLATED_TYPE -> JavaTypeUtils.toJavaType(tree);
-        case INFLATED_REF -> JavaTypeUtils.toJavaRef(tree);
-        default -> throw new UnsupportedOperationException("Unsupported: " + tree);
-    };
-
-    /**
-     * An operation factory for core and Java operations.
-     */
-    public static final OpFactory OP_FACTORY = CoreOp.OP_FACTORY.andThen(JAVA_OP_FACTORY);
-
-    /**
-     * A type element factory for core type and Java type elements, where the core type elements can refer to
-     * Java type elements.
-     */
-    public static final TypeElementFactory TYPE_FACTORY = CoreType.coreTypeFactory(JAVA_TYPE_FACTORY);
+    public static final OpFactory JAVA_OP_FACTORY = CoreOp.CORE_OP_FACTORY.andThen(OpFactory.OP_FACTORY.get(JavaOp.class));
 
     /**
      * A Java dialect factory, for constructing core and Java operations and constructing
@@ -5321,8 +5299,8 @@ public sealed abstract class JavaOp extends ExternalizableOp {
      * type elements.
      */
     public static final DialectFactory DIALECT_FACTORY = new DialectFactory(
-            OP_FACTORY,
-            TYPE_FACTORY);
+            JAVA_OP_FACTORY,
+            JAVA_TYPE_FACTORY);
 
     /**
      * Creates a lambda operation.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5298,7 +5298,7 @@ public sealed abstract class JavaOp extends ExternalizableOp {
      * core type and Java type elements, where the core type elements can refer to Java
      * type elements.
      */
-    public static final DialectFactory DIALECT_FACTORY = new DialectFactory(
+    public static final DialectFactory JAVA_DIALECT_FACTORY = new DialectFactory(
             JAVA_OP_FACTORY,
             JAVA_TYPE_FACTORY);
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaType.java
@@ -31,8 +31,11 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.*;
 
+import jdk.incubator.code.dialect.core.CoreType;
+import jdk.incubator.code.dialect.java.impl.JavaTypeUtils;
 import jdk.incubator.code.extern.ExternalizableTypeElement;
 import jdk.incubator.code.dialect.java.WildcardType.BoundKind;
+import jdk.incubator.code.extern.TypeElementFactory;
 
 import java.util.List;
 import java.util.Objects;
@@ -182,6 +185,21 @@ public sealed interface JavaType extends ExternalizableTypeElement
     JavaType erasure();
 
     // Factories
+
+    /**
+     * A type element factory for Java type elements that is not composed with any other type element factory.
+     */
+    TypeElementFactory JAVA_ONLY_TYPE_FACTORY = tree -> switch (JavaTypeUtils.Kind.of(tree)) {
+        case INFLATED_TYPE -> JavaTypeUtils.toJavaType(tree);
+        case INFLATED_REF -> JavaTypeUtils.toJavaRef(tree);
+        default -> throw new UnsupportedOperationException("Unsupported: " + tree);
+    };
+
+    /**
+     * A type element factory for core type elements composed with Java type elements, where the core type elements can
+     * refer to Java type elements.
+     */
+    TypeElementFactory JAVA_TYPE_FACTORY = CoreType.coreTypeFactory(JAVA_ONLY_TYPE_FACTORY);
 
     /**
      * Constructs a Java type from a reflective type mirror.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpParser.java
@@ -168,7 +168,7 @@ public final class OpParser {
      * Parse a Java code model, modeling a method body or quoted lambda body, from
      * its serialized textual form obtained from an input string.
      * <p>
-     * This method uses the Java {@link JavaOp#DIALECT_FACTORY dialect factory}
+     * This method uses the Java {@link JavaOp#JAVA_DIALECT_FACTORY dialect factory}
      * for construction of operations and type elements.
      *
      * @param in the input string
@@ -179,7 +179,7 @@ public final class OpParser {
     public static Op fromStringOfJavaCodeModel(String in) {
         // @@@ Used produce code models stored as text in the class file,
         // can eventually be removed as storing text is now a backup option.
-        Op op = fromString(JavaOp.DIALECT_FACTORY, in).get(0);
+        Op op = fromString(JavaOp.JAVA_DIALECT_FACTORY, in).get(0);
         if (!(op instanceof CoreOp.FuncOp)) {
             throw new IllegalArgumentException("Op is not a FuncOp: " + op);
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -421,7 +421,7 @@ public class ReflectMethods extends TreeTranslator {
                 // using the builder API and public APIs
                 var opBuilder = OpBuilder.createBuilderFunction(op,
                         b -> b.op(JavaOp.fieldLoad(
-                                FieldRef.field(JavaOp.class, "DIALECT_FACTORY", DialectFactory.class))));
+                                FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))));
                 var cmToASTTransformer = new CodeModelToAST(make, names, syms, resolve, types, typeEnvs.get(currentClassSym));
                 yield cmToASTTransformer.transformFuncOpToAST(opBuilder, ms);
             }

--- a/test/jdk/java/lang/reflect/code/TestCopy.java
+++ b/test/jdk/java/lang/reflect/code/TestCopy.java
@@ -62,7 +62,7 @@ public class TestCopy {
         CoreOp.FuncOp f = getFuncOp("f");
 
         ExternalizableOp.ExternalizedOp odef = ExternalizableOp.ExternalizedOp.externalizeOp(CopyContext.create(), f);
-        Op copy = CoreOp.OP_FACTORY.constructOp(odef);
+        Op copy = CoreOp.CORE_OP_FACTORY.constructOp(odef);
 
         Assert.assertEquals(f.toText(), copy.toText());
     }

--- a/test/jdk/java/lang/reflect/code/TestLiveness.java
+++ b/test/jdk/java/lang/reflect/code/TestLiveness.java
@@ -56,7 +56,7 @@ public class TestLiveness {
 
     @Test
     public void testF() {
-        Op op = OpParser.fromString(JavaOp.DIALECT_FACTORY, F).getFirst();
+        Op op = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, F).getFirst();
 
         var actual = liveness(op);
         var expected = Map.of(
@@ -88,7 +88,7 @@ public class TestLiveness {
 
     @Test
     public void testIfElse() {
-        Op op = OpParser.fromString(JavaOp.DIALECT_FACTORY, IF_ELSE).getFirst();
+        Op op = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, IF_ELSE).getFirst();
 
         var actual = liveness(op);
         var expected = Map.of(
@@ -126,7 +126,7 @@ public class TestLiveness {
 
     @Test
     public void testLoop() {
-        Op op = OpParser.fromString(JavaOp.DIALECT_FACTORY, LOOP).getFirst();
+        Op op = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, LOOP).getFirst();
 
         var actual = liveness(op);
         var expected = Map.of(
@@ -195,7 +195,7 @@ public class TestLiveness {
 
     @Test
     public void testIfElseNested() {
-        Op op = OpParser.fromString(JavaOp.DIALECT_FACTORY, IF_ELSE_NESTED).getFirst();
+        Op op = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, IF_ELSE_NESTED).getFirst();
 
         var actual = liveness(op);
         var expected = Map.of(
@@ -256,7 +256,7 @@ public class TestLiveness {
 
     @Test
     public void testLoopNested() {
-        Op op = OpParser.fromString(JavaOp.DIALECT_FACTORY, LOOP_NESTED).getFirst();
+        Op op = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, LOOP_NESTED).getFirst();
 
         var actual = liveness(op);
         var expected = Map.of(

--- a/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
+++ b/test/jdk/java/lang/reflect/code/TestNormalizeBlocksTransformer.java
@@ -264,7 +264,7 @@ public class TestNormalizeBlocksTransformer {
     }
 
     static Object[] parse(String... models) {
-        return Stream.of(models).map(s -> OpParser.fromString(JavaOp.DIALECT_FACTORY, s).getFirst())
+        return Stream.of(models).map(s -> OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, s).getFirst())
                 .toArray(Object[]::new);
     }
 

--- a/test/jdk/java/lang/reflect/code/TestVarOp.java
+++ b/test/jdk/java/lang/reflect/code/TestVarOp.java
@@ -83,7 +83,7 @@ public class TestVarOp {
             return block;
         });
 
-        Op op = OpParser.fromString(JavaOp.DIALECT_FACTORY, f.toText()).get(0);
+        Op op = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, f.toText()).get(0);
         boolean allNullNames = op.elements()
                 .flatMap(ce -> ce instanceof CoreOp.VarOp vop ? Stream.of(vop) : null)
                 .allMatch(CoreOp.VarOp::isUnnamedVariable);

--- a/test/jdk/java/lang/reflect/code/location/TestLocation.java
+++ b/test/jdk/java/lang/reflect/code/location/TestLocation.java
@@ -91,7 +91,7 @@ public class TestLocation {
         StringWriter w = new StringWriter();
         OpWriter.writeTo(w, f, OpWriter.LocationOption.DROP_LOCATION);
         String tfText = w.toString();
-        CoreOp.FuncOp tf = (CoreOp.FuncOp) OpParser.fromString(JavaOp.DIALECT_FACTORY, tfText).getFirst();
+        CoreOp.FuncOp tf = (CoreOp.FuncOp) OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, tfText).getFirst();
         testNoLocations(tf);
     }
 

--- a/test/jdk/java/lang/reflect/code/lower/CodeReflectionTester.java
+++ b/test/jdk/java/lang/reflect/code/lower/CodeReflectionTester.java
@@ -88,7 +88,7 @@ public class CodeReflectionTester {
     static String canonicalizeModel(Member m, String d) {
         Op o;
         try {
-            o = OpParser.fromString(JavaOp.DIALECT_FACTORY, d).get(0);
+            o = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, d).get(0);
         } catch (Exception e) {
             throw new IllegalStateException(m.toString(), e);
         }

--- a/test/jdk/java/lang/reflect/code/parser/TestParse.java
+++ b/test/jdk/java/lang/reflect/code/parser/TestParse.java
@@ -79,7 +79,7 @@ public class TestParse {
                     block.op(_return(or));
                 });
 
-        List<Op> ops = OpParser.fromString(JavaOp.DIALECT_FACTORY, f.toText());
+        List<Op> ops = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, f.toText());
         assertTextEquals(f, ops.get(0));
     }
 
@@ -96,8 +96,8 @@ public class TestParse {
             """;
     @Test
     void testParseNamedBody() {
-        Op opE = OpParser.fromString(JavaOp.DIALECT_FACTORY, NAMED_BODY).get(0);
-        Op opA = OpParser.fromString(JavaOp.DIALECT_FACTORY, opE.toText()).get(0);
+        Op opE = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, NAMED_BODY).get(0);
+        Op opA = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, opE.toText()).get(0);
         assertTextEquals(opA, opE);
     }
 
@@ -110,8 +110,8 @@ public class TestParse {
             """;
     @Test
     void testEscapedString() {
-        Op opE = OpParser.fromString(JavaOp.DIALECT_FACTORY, ESCAPED_STRING).get(0);
-        Op opA = OpParser.fromString(JavaOp.DIALECT_FACTORY, opE.toText()).get(0);
+        Op opE = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, ESCAPED_STRING).get(0);
+        Op opA = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, opE.toText()).get(0);
         assertTextEquals(opA, opE);
 
         CoreOp.ConstantOp cop = (CoreOp.ConstantOp) opE.bodies().get(0).entryBlock().firstOp();

--- a/test/jdk/java/lang/reflect/code/pe/CodeReflectionTester.java
+++ b/test/jdk/java/lang/reflect/code/pe/CodeReflectionTester.java
@@ -129,7 +129,7 @@ public class CodeReflectionTester {
     static String canonicalizeModel(Member m, String d) {
         Op o;
         try {
-            o = OpParser.fromString(JavaOp.DIALECT_FACTORY, d).get(0);
+            o = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, d).get(0);
         } catch (Exception e) {
             throw new IllegalStateException(m.toString(), e);
         }

--- a/test/jdk/java/lang/reflect/code/type/TestJavaType.java
+++ b/test/jdk/java/lang/reflect/code/type/TestJavaType.java
@@ -173,7 +173,7 @@ public class TestJavaType {
     public void testTypeRoundTrip(Type type) throws ReflectiveOperationException {
         JavaType javaType = JavaType.type(type);
         Assert.assertEquals(type, javaType.resolve(MethodHandles.lookup()));
-        Assert.assertEquals(javaType, JavaOp.JAVA_TYPE_FACTORY.constructType(javaType.externalize()));
+        Assert.assertEquals(javaType, JavaType.JAVA_ONLY_TYPE_FACTORY.constructType(javaType.externalize()));
     }
 
     @Test(dataProvider = "types")

--- a/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestCodeBuilder.java
@@ -125,7 +125,7 @@ public class TestCodeBuilder {
         CoreOp.FuncOp fb = OpBuilder.createBuilderFunction(fExpected,
                 b -> b.parameter(JavaType.type(DialectFactory.class)));
         CoreOp.FuncOp fActual = (CoreOp.FuncOp) Interpreter.invoke(MethodHandles.lookup(),
-                fb, JavaOp.DIALECT_FACTORY);
+                fb, JavaOp.JAVA_DIALECT_FACTORY);
         Assert.assertEquals(fActual.toText(), fExpected.toText());
     }
 

--- a/test/langtools/tools/javac/reflect/CodeReflectionTester.java
+++ b/test/langtools/tools/javac/reflect/CodeReflectionTester.java
@@ -130,7 +130,7 @@ public class CodeReflectionTester {
     static String canonicalizeModel(Member m, String d) {
         Op o;
         try {
-            o = OpParser.fromString(JavaOp.DIALECT_FACTORY, d).get(0);
+            o = OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, d).get(0);
         } catch (Exception e) {
             throw new IllegalStateException(m.toString(), e);
         }

--- a/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
+++ b/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
@@ -179,7 +179,7 @@ public class TestIRFromAnnotation {
 
     // parses, and then serializes, dropping location information
     static String canonicalizeModel(String d) {
-        return serialize(OpParser.fromString(JavaOp.DIALECT_FACTORY, d).get(0));
+        return serialize(OpParser.fromString(JavaOp.JAVA_DIALECT_FACTORY, d).get(0));
     }
 
     // serializes, dropping location information


### PR DESCRIPTION
Move and rename various op, type element, and dialect factory constants.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/460/head:pull/460` \
`$ git checkout pull/460`

Update a local copy of the PR: \
`$ git checkout pull/460` \
`$ git pull https://git.openjdk.org/babylon.git pull/460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 460`

View PR using the GUI difftool: \
`$ git pr show -t 460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/460.diff">https://git.openjdk.org/babylon/pull/460.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/460#issuecomment-2998172029)
</details>
