### PR TITLE
Move annotation processing support to a different module

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -162,7 +162,8 @@ module java.base {
         jdk.jfr, // participates in preview features
         jdk.jlink,   // participates in preview features
         jdk.jshell, // participates in preview features
-        jdk.incubator.code; // participates in preview features
+        jdk.incubator.code, // participates in preview features
+        jdk.incubator.code.proc; // participates in preview features
     exports jdk.internal.access to
         java.desktop,
         java.logging,

--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -239,17 +239,19 @@ module jdk.compiler {
         jdk.javadoc,
         jdk.jshell,
         jdk.internal.md,
-        jdk.incubator.code;
+        jdk.incubator.code.proc;
     exports com.sun.tools.javac.resources to
         jdk.jshell;
     exports com.sun.tools.javac.code to
         jdk.javadoc,
         jdk.jshell,
-        jdk.incubator.code;
+        jdk.incubator.code,
+        jdk.incubator.code.proc;
     exports com.sun.tools.javac.comp to
         jdk.javadoc,
         jdk.jshell,
-        jdk.incubator.code;
+        jdk.incubator.code,
+        jdk.incubator.code.proc;
     exports com.sun.tools.javac.file to
         jdk.jdeps,
         jdk.javadoc;
@@ -262,7 +264,7 @@ module jdk.compiler {
         jdk.incubator.code;
     exports com.sun.tools.javac.model to
         jdk.javadoc,
-        jdk.incubator.code;
+        jdk.incubator.code.proc;
     exports com.sun.tools.javac.parser to
         jdk.jshell,
         jdk.internal.md;
@@ -273,15 +275,17 @@ module jdk.compiler {
         jdk.javadoc,
         jdk.jshell,
         jdk.internal.md,
-        jdk.incubator.code;
+        jdk.incubator.code,
+        jdk.incubator.code.proc;
     exports com.sun.tools.javac.util to
         jdk.jdeps,
         jdk.javadoc,
         jdk.jshell,
         jdk.internal.md,
-        jdk.incubator.code;
+        jdk.incubator.code,
+        jdk.incubator.code.proc;
     exports com.sun.tools.javac.processing to
-        jdk.incubator.code;
+        jdk.incubator.code.proc;
 
     uses javax.annotation.processing.Processor;
     uses com.sun.source.util.Plugin;

--- a/src/jdk.incubator.code.proc/share/classes/jdk/incubator/code/proc/CodeModelElements.java
+++ b/src/jdk.incubator.code.proc/share/classes/jdk/incubator/code/proc/CodeModelElements.java
@@ -1,0 +1,78 @@
+package jdk.incubator.code.proc;
+
+import com.sun.tools.javac.api.JavacScope;
+import com.sun.tools.javac.api.JavacTrees;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.comp.Attr;
+import com.sun.tools.javac.model.JavacElements;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
+import jdk.incubator.code.internal.ReflectMethods;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import java.util.Optional;
+
+/**
+ * Utility methods for extracting code models from program elements.
+ */
+public class CodeModelElements {
+
+    final ReflectMethods reflectMethods;
+    final Attr attr;
+    final JavacElements elements;
+    final JavacTrees trees;
+    final TreeMaker make;
+
+    CodeModelElements(ProcessingEnvironment processingEnvironment) {
+        Context context = ((JavacProcessingEnvironment)processingEnvironment).getContext();
+        reflectMethods = ReflectMethods.instance(context);
+        attr = Attr.instance(context);
+        elements = JavacElements.instance(context);
+        trees = JavacTrees.instance(context);
+        make = TreeMaker.instance(context);
+    }
+    /**
+     * Returns the code model of provided executable element (if any).
+     * <p>
+     * If the executable element has a code model then it will be an instance of
+     * {@code java.lang.reflect.code.op.CoreOps.FuncOp}.
+     * Note: due to circular dependencies we cannot refer to the type explicitly.
+     *
+     * @implSpec The default implementation unconditionally returns an empty optional.
+     * @param e the executable element.
+     * @return the code model of the provided executable element (if any).
+     */
+    public Optional<FuncOp> createCodeModel(ExecutableElement e) {
+        if (e.getModifiers().contains(Modifier.ABSTRACT) ||
+                e.getModifiers().contains(Modifier.NATIVE)) {
+            return Optional.empty();
+        }
+
+        try {
+            JCMethodDecl methodTree = (JCMethodDecl)elements.getTree(e);
+            JavacScope scope = trees.getScope(trees.getPath(e));
+            ClassSymbol enclosingClass = (ClassSymbol) scope.getEnclosingClass();
+            FuncOp op = attr.runWithAttributedMethod(scope.getEnv(), methodTree,
+                    attribBlock -> reflectMethods.getMethodBody(enclosingClass, methodTree, attribBlock, make));
+            return Optional.of(op);
+        } catch (RuntimeException ex) {  // ReflectMethods.UnsupportedASTException
+            // some other error occurred when attempting to attribute the method
+            // @@@ better report of error
+            ex.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * {@return a new instance of {@code CodeModelElements} for the provided processing environment}
+     * @param processingEnvironment the annotation processing environment
+     */
+    public static CodeModelElements of(ProcessingEnvironment processingEnvironment) {
+        return new CodeModelElements(processingEnvironment);
+    }
+}

--- a/src/jdk.incubator.code.proc/share/classes/module-info.java
+++ b/src/jdk.incubator.code.proc/share/classes/module-info.java
@@ -31,23 +31,12 @@
  * @moduleGraph
  */
 
-import jdk.incubator.code.internal.ReflectMethods;
 import jdk.internal.javac.ParticipatesInPreview;
 
 @ParticipatesInPreview
-module jdk.incubator.code {
-    requires jdk.compiler;
+module jdk.incubator.code.proc {
+    requires transitive jdk.compiler;
+    requires transitive jdk.incubator.code;
 
-    exports jdk.incubator.code;
-    exports jdk.incubator.code.extern;
-    exports jdk.incubator.code.dialect.core;
-    exports jdk.incubator.code.dialect.java;
-    exports jdk.incubator.code.analysis;
-    exports jdk.incubator.code.bytecode;
-    exports jdk.incubator.code.interpreter;
-
-    exports jdk.incubator.code.internal to jdk.incubator.code.proc;
-
-    provides com.sun.tools.javac.comp.CodeReflectionTransformer with
-            ReflectMethods.Provider;
+    exports jdk.incubator.code.proc;
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -29,26 +29,13 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
-import com.sun.tools.javac.api.JavacScope;
-import com.sun.tools.javac.api.JavacTrees;
-import com.sun.tools.javac.code.Symbol.ClassSymbol;
-import com.sun.tools.javac.comp.Attr;
-import com.sun.tools.javac.model.JavacElements;
-import com.sun.tools.javac.processing.JavacProcessingEnvironment;
-import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
-import com.sun.tools.javac.tree.TreeMaker;
-import com.sun.tools.javac.util.Context;
 import jdk.incubator.code.dialect.core.CoreType;
-import jdk.incubator.code.internal.ReflectMethods;
 import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
 import jdk.incubator.code.dialect.core.FunctionType;
 import jdk.incubator.code.dialect.java.MethodRef;
 import jdk.incubator.code.extern.OpWriter;
 import jdk.internal.access.SharedSecrets;
 
-import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -566,45 +553,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
             return Optional.of(funcOp);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Returns the code model of provided executable element (if any).
-     * <p>
-     * If the executable element has a code model then it will be an instance of
-     * {@code java.lang.reflect.code.op.CoreOps.FuncOp}.
-     * Note: due to circular dependencies we cannot refer to the type explicitly.
-     *
-     * @implSpec The default implementation unconditionally returns an empty optional.
-     * @param e the executable element.
-     * @return the code model of the provided executable element (if any).
-     * @since 99
-     */
-    public static Optional<FuncOp> ofElement(ProcessingEnvironment processingEnvironment, ExecutableElement e) {
-        if (e.getModifiers().contains(Modifier.ABSTRACT) ||
-                e.getModifiers().contains(Modifier.NATIVE)) {
-            return Optional.empty();
-        }
-
-        Context context = ((JavacProcessingEnvironment)processingEnvironment).getContext();
-        ReflectMethods reflectMethods = ReflectMethods.instance(context);
-        Attr attr = Attr.instance(context);
-        JavacElements elements = JavacElements.instance(context);
-        JavacTrees javacTrees = JavacTrees.instance(context);
-        TreeMaker make = TreeMaker.instance(context);
-        try {
-            JCMethodDecl methodTree = (JCMethodDecl)elements.getTree(e);
-            JavacScope scope = javacTrees.getScope(javacTrees.getPath(e));
-            ClassSymbol enclosingClass = (ClassSymbol) scope.getEnclosingClass();
-            FuncOp op = attr.runWithAttributedMethod(scope.getEnv(), methodTree,
-                    attribBlock -> reflectMethods.getMethodBody(enclosingClass, methodTree, attribBlock, make));
-            return Optional.of(op);
-        } catch (RuntimeException ex) {  // ReflectMethods.UnsupportedASTException
-            // some other error occurred when attempting to attribute the method
-            // @@@ better report of error
-            ex.printStackTrace();
-            return Optional.empty();
         }
     }
 }

--- a/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
+++ b/test/langtools/tools/javac/reflect/TestIRFromAnnotation.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @modules jdk.incubator.code
+ * @modules jdk.incubator.code jdk.incubator.code.proc
  * @enablePreview
  * @library ../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -41,6 +41,8 @@ import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.extern.OpParser;
 import jdk.incubator.code.extern.OpWriter;
+import jdk.incubator.code.proc.CodeModelElements;
+
 import java.nio.charset.Charset;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -150,7 +152,7 @@ public class TestIRFromAnnotation {
                     if (ir == null) {
                         return null; // skip
                     }
-                    Optional<FuncOp> body = Op.ofElement(processingEnv, e);
+                    Optional<FuncOp> body = CodeModelElements.of(processingEnv).createCodeModel(e);
                     if (!body.isPresent()) {
                         throw new AssertionError(String.format("No body found in method %s annotated with @IR",
                                 toMethodString(e)));


### PR DESCRIPTION
This PR moves the ability to crete a code model from an executable element to a different incubating module (`jdk.incubator.code.proc`). This allows to ger rid of the transitive require of `jdk.compiler` from `jdk.incubator.code`.

