### PR TITLE
Simplify OpFactory

### DIFF
--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/proto/OnnxModelTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/proto/OnnxModelTest.java
@@ -135,7 +135,8 @@ public class OnnxModelTest {
         };
     }
 
-    static final OpFactory ONNX_OP_FACTORY = OpFactory.OP_FACTORY.get(ExplicitOnnxOps.class).andThen(OpFactory.OP_FACTORY.get(OnnxOps.class));
+    static final OpFactory ONNX_OP_FACTORY = OpFactoryHelper.OP_FACTORY.get(ExplicitOnnxOps.class)
+            .andThen(OpFactoryHelper.OP_FACTORY.get(OnnxOps.class));
 
     static final Map<String, OnnxOp.OnnxSchema> ONNX_SCHEMA_REGISTRY = collectSchemas(ExplicitOnnxOps.class, OnnxOps.class);
 

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/proto/OpFactoryHelper.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/proto/OpFactoryHelper.java
@@ -1,0 +1,136 @@
+package oracle.code.onnx.proto;
+
+import jdk.incubator.code.Op;
+import jdk.incubator.code.extern.ExternalizedOp;
+import jdk.incubator.code.extern.OpFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class OpFactoryHelper {
+
+    /**
+     * A class value for lazily computing an operation factory for {@link Op operation} classes
+     * annotated with {@link OpFactory.OpDeclaration} and enclosed within a given class to compute over.
+     * <p>
+     * Each enclosed class annotated with {@code OpDeclaration} must declare a public static method named {@code create}
+     * with one parameter type of {@link ExternalizedOp} and return type that is the concrete class type.
+     * Alternatively, the concrete class must declare public constructor with one parameter type of
+     * {@link ExternalizedOp}.
+     */
+    static final ClassValue<OpFactory> OP_FACTORY = new ClassValue<>() {
+        @Override
+        protected OpFactory computeValue(Class<?> c) {
+            // @@@ See https://bugs.openjdk.org/browse/JDK-8321207
+            final Map<String, Class<? extends Op>> opMapping = createOpMapping(c);
+
+            return def -> {
+                var opClass = opMapping.get(def.name());
+                if (opClass == null) {
+                    return null;
+                }
+
+                Op op = constructOp(opClass, def);
+                // Set location if available
+                if (op != null && def.location() != null) {
+                    op.setLocation(def.location());
+                }
+                return op;
+            };
+        }
+    };
+
+    private static Map<String, Class<? extends Op>> createOpMapping(Class<?> opClasses) {
+        Map<String, Class<? extends Op>> mapping = new HashMap<>();
+        for (Class<?> opClass : opClasses.getNestMembers()) {
+            if (opClass.isAnnotationPresent(OpFactory.OpDeclaration.class)) {
+                if (!Modifier.isPublic(opClass.getModifiers())) {
+                    throw new InternalError("Operation class not public: " + opClass.getName());
+                }
+
+                if (!Op.class.isAssignableFrom(opClass)) {
+                    throw new InternalError("Operation class is not assignable to Op: " + opClass);
+                }
+
+                MethodHandle handle = getOpConstructorMethodHandle(opClass);
+                if (handle == null) {
+                    throw new InternalError("Operation constructor for operation class not found: " + opClass.getName());
+                }
+
+                if (!Op.class.isAssignableFrom(handle.type().returnType())) {
+                    throw new InternalError("Operation constructor does not return an Op: " + handle);
+                }
+
+                String opName = opClass.getAnnotation(OpFactory.OpDeclaration.class).value();
+                @SuppressWarnings("unchecked")
+                var opClassCast = (Class<Op>) opClass;
+                mapping.put(opName, opClassCast);
+            }
+        }
+        return mapping;
+    }
+
+    private static MethodHandle getOpConstructorMethodHandle(Class<?> opClass) {
+        Method method = null;
+        try {
+            method = opClass.getMethod("create", ExternalizedOp.class);
+        } catch (NoSuchMethodException e) {
+        }
+
+        if (method != null) {
+            if (!Modifier.isStatic(method.getModifiers())) {
+                throw new InternalError("Operation constructor is not a static method: " + method);
+            }
+
+            try {
+                return MethodHandles.publicLookup().unreflect(method);
+            } catch (IllegalAccessException e) {
+                throw new InternalError("Inaccessible operation constructor for operation: " +
+                        method);
+            }
+        }
+
+        Constructor<?> constructor;
+        try {
+            constructor = opClass.getConstructor(ExternalizedOp.class);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+
+        try {
+            return MethodHandles.publicLookup().unreflectConstructor(constructor);
+        } catch (IllegalAccessException e) {
+            throw new InternalError("Inaccessible operation constructor for operation: " +
+                    constructor);
+        }
+    }
+
+    private static Op constructOp(Class<? extends Op> opClass, ExternalizedOp opDef) {
+        class Enclosed {
+            private static final ClassValue<Function<ExternalizedOp, Op>> OP_CONSTRUCTOR = new ClassValue<>() {
+                @Override
+                protected Function<ExternalizedOp, Op> computeValue(Class<?> opClass) {
+                    final MethodHandle opConstructorMH = getOpConstructorMethodHandle(opClass);
+                    assert opConstructorMH != null;
+
+                    return operationDefinition -> {
+                        try {
+                            return (Op) opConstructorMH.invoke(operationDefinition);
+                        } catch (RuntimeException | Error e) {
+                            throw e;
+                        } catch (Throwable t) {
+                            throw new RuntimeException(t);
+                        }
+                    };
+                }
+            };
+        }
+        return Enclosed.OP_CONSTRUCTOR.get(opClass).apply(opDef);
+    }
+}

--- a/cr-examples/triton/src/main/java/oracle/code/triton/OpFactoryHelper.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/OpFactoryHelper.java
@@ -1,0 +1,136 @@
+package oracle.code.triton;
+
+import jdk.incubator.code.Op;
+import jdk.incubator.code.extern.ExternalizedOp;
+import jdk.incubator.code.extern.OpFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class OpFactoryHelper {
+
+    /**
+     * A class value for lazily computing an operation factory for {@link Op operation} classes
+     * annotated with {@link OpFactory.OpDeclaration} and enclosed within a given class to compute over.
+     * <p>
+     * Each enclosed class annotated with {@code OpDeclaration} must declare a public static method named {@code create}
+     * with one parameter type of {@link ExternalizedOp} and return type that is the concrete class type.
+     * Alternatively, the concrete class must declare public constructor with one parameter type of
+     * {@link ExternalizedOp}.
+     */
+    static final ClassValue<OpFactory> OP_FACTORY = new ClassValue<>() {
+        @Override
+        protected OpFactory computeValue(Class<?> c) {
+            // @@@ See https://bugs.openjdk.org/browse/JDK-8321207
+            final Map<String, Class<? extends Op>> opMapping = createOpMapping(c);
+
+            return def -> {
+                var opClass = opMapping.get(def.name());
+                if (opClass == null) {
+                    return null;
+                }
+
+                Op op = constructOp(opClass, def);
+                // Set location if available
+                if (op != null && def.location() != null) {
+                    op.setLocation(def.location());
+                }
+                return op;
+            };
+        }
+    };
+
+    private static Map<String, Class<? extends Op>> createOpMapping(Class<?> opClasses) {
+        Map<String, Class<? extends Op>> mapping = new HashMap<>();
+        for (Class<?> opClass : opClasses.getNestMembers()) {
+            if (opClass.isAnnotationPresent(OpFactory.OpDeclaration.class)) {
+                if (!Modifier.isPublic(opClass.getModifiers())) {
+                    throw new InternalError("Operation class not public: " + opClass.getName());
+                }
+
+                if (!Op.class.isAssignableFrom(opClass)) {
+                    throw new InternalError("Operation class is not assignable to Op: " + opClass);
+                }
+
+                MethodHandle handle = getOpConstructorMethodHandle(opClass);
+                if (handle == null) {
+                    throw new InternalError("Operation constructor for operation class not found: " + opClass.getName());
+                }
+
+                if (!Op.class.isAssignableFrom(handle.type().returnType())) {
+                    throw new InternalError("Operation constructor does not return an Op: " + handle);
+                }
+
+                String opName = opClass.getAnnotation(OpFactory.OpDeclaration.class).value();
+                @SuppressWarnings("unchecked")
+                var opClassCast = (Class<Op>) opClass;
+                mapping.put(opName, opClassCast);
+            }
+        }
+        return mapping;
+    }
+
+    private static MethodHandle getOpConstructorMethodHandle(Class<?> opClass) {
+        Method method = null;
+        try {
+            method = opClass.getMethod("create", ExternalizedOp.class);
+        } catch (NoSuchMethodException e) {
+        }
+
+        if (method != null) {
+            if (!Modifier.isStatic(method.getModifiers())) {
+                throw new InternalError("Operation constructor is not a static method: " + method);
+            }
+
+            try {
+                return MethodHandles.publicLookup().unreflect(method);
+            } catch (IllegalAccessException e) {
+                throw new InternalError("Inaccessible operation constructor for operation: " +
+                        method);
+            }
+        }
+
+        Constructor<?> constructor;
+        try {
+            constructor = opClass.getConstructor(ExternalizedOp.class);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+
+        try {
+            return MethodHandles.publicLookup().unreflectConstructor(constructor);
+        } catch (IllegalAccessException e) {
+            throw new InternalError("Inaccessible operation constructor for operation: " +
+                    constructor);
+        }
+    }
+
+    private static Op constructOp(Class<? extends Op> opClass, ExternalizedOp opDef) {
+        class Enclosed {
+            private static final ClassValue<Function<ExternalizedOp, Op>> OP_CONSTRUCTOR = new ClassValue<>() {
+                @Override
+                protected Function<ExternalizedOp, Op> computeValue(Class<?> opClass) {
+                    final MethodHandle opConstructorMH = getOpConstructorMethodHandle(opClass);
+                    assert opConstructorMH != null;
+
+                    return operationDefinition -> {
+                        try {
+                            return (Op) opConstructorMH.invoke(operationDefinition);
+                        } catch (RuntimeException | Error e) {
+                            throw e;
+                        } catch (Throwable t) {
+                            throw new RuntimeException(t);
+                        }
+                    };
+                }
+            };
+        }
+        return Enclosed.OP_CONSTRUCTOR.get(opClass).apply(opDef);
+    }
+}

--- a/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
@@ -162,7 +162,7 @@ public class SCFOps {
     }
 
 
-    public static final OpFactory OP_FACTORY = OpFactory.OP_FACTORY.get(SCFOps.class);
+    public static final OpFactory OP_FACTORY = OpFactoryHelper.OP_FACTORY.get(SCFOps.class);
 
     static public YieldOp yield_(Value... values) {
         return yield_(List.of(values));

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -818,7 +818,7 @@ public class TritonOps {
 
     // Operation and type factories
 
-    static final OpFactory OP_FACTORY = OpFactory.OP_FACTORY.get(TritonOps.class);
+    static final OpFactory OP_FACTORY = OpFactoryHelper.OP_FACTORY.get(TritonOps.class);
 
     static final TypeElementFactory TRITON_TYPE_FACTORY = new TypeElementFactory() {
         @Override

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTestOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTestOps.java
@@ -62,7 +62,7 @@ public class TritonTestOps {
     }
 
 
-    public static final OpFactory FACTORY = OpFactory.OP_FACTORY.get(TritonTestOps.class);
+    public static final OpFactory FACTORY = OpFactoryHelper.OP_FACTORY.get(TritonTestOps.class);
 
     public static ConsumeOp consume(Value... operands) {
         return consume(List.of(operands));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpFactory.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpFactory.java
@@ -29,15 +29,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import jdk.incubator.code.Op;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 
 /**
  * An operation factory for constructing an {@link Op operation} from its
@@ -64,37 +56,6 @@ public interface OpFactory {
     }
 
     /**
-     * A class value for lazily computing an operation factory for {@link Op operation} classes
-     * annotated with {@link OpDeclaration} and enclosed within a given class to compute over.
-     * <p>
-     * Each enclosed class annotated with {@code OpDeclaration} must declare a public static method named {@code create}
-     * with one parameter type of {@link ExternalizedOp} and return type that is the concrete class type.
-     * Alternatively, the concrete class must declare public constructor with one parameter type of
-     * {@link ExternalizedOp}.
-     */
-    ClassValue<OpFactory> OP_FACTORY = new ClassValue<>() {
-        @Override
-        protected OpFactory computeValue(Class<?> c) {
-            // @@@ See https://bugs.openjdk.org/browse/JDK-8321207
-            final Map<String, Class<? extends Op>> opMapping = createOpMapping(c);
-
-            return def -> {
-                var opClass = opMapping.get(def.name());
-                if (opClass == null) {
-                    return null;
-                }
-
-                Op op = constructOp(opClass, def);
-                // Set location if available
-                if (op != null && def.location() != null) {
-                    op.setLocation(def.location());
-                }
-                return op;
-            };
-        }
-    };
-
-    /**
      * Constructs an {@link Op operation} from its external content.
      * <p>
      * If there is no mapping from the operation's name to a concrete
@@ -112,7 +73,7 @@ public interface OpFactory {
      * class of an {@code Op} then this method throws UnsupportedOperationException.
      *
      * @param def the operation's external content
-     * @return the operation, otherwise null
+     * @return the operation
      * @throws UnsupportedOperationException if there is no mapping from the operation's
      *                                       name to a concrete class of an {@code Op}
      */
@@ -126,7 +87,7 @@ public interface OpFactory {
     }
 
     /**
-     * Compose this operation factory with another operation factory.
+     * Composes this operation factory with another operation factory.
      * <p>
      * If there is no mapping in this operation factory then the result
      * of the other operation factory is returned.
@@ -139,94 +100,6 @@ public interface OpFactory {
             Op op = constructOp(def);
             return op != null ? op : after.constructOp(def);
         };
-    }
-
-    private static Map<String, Class<? extends Op>> createOpMapping(Class<?> opClasses) {
-        Map<String, Class<? extends Op>> mapping = new HashMap<>();
-        for (Class<?> opClass : opClasses.getNestMembers()) {
-            if (opClass.isAnnotationPresent(OpDeclaration.class)) {
-                if (!Modifier.isPublic(opClass.getModifiers())) {
-                    throw new InternalError("Operation class not public: " + opClass.getName());
-                }
-
-                if (!Op.class.isAssignableFrom(opClass)) {
-                    throw new InternalError("Operation class is not assignable to Op: " + opClass);
-                }
-
-                MethodHandle handle = getOpConstructorMethodHandle(opClass);
-                if (handle == null) {
-                    throw new InternalError("Operation constructor for operation class not found: " + opClass.getName());
-                }
-
-                if (!Op.class.isAssignableFrom(handle.type().returnType())) {
-                    throw new InternalError("Operation constructor does not return an Op: " + handle);
-                }
-
-                String opName = opClass.getAnnotation(OpDeclaration.class).value();
-                @SuppressWarnings("unchecked")
-                var opClassCast = (Class<Op>) opClass;
-                mapping.put(opName, opClassCast);
-            }
-        }
-        return mapping;
-    }
-
-    private static MethodHandle getOpConstructorMethodHandle(Class<?> opClass) {
-        Method method = null;
-        try {
-            method = opClass.getMethod("create", ExternalizedOp.class);
-        } catch (NoSuchMethodException e) {
-        }
-
-        if (method != null) {
-            if (!Modifier.isStatic(method.getModifiers())) {
-                throw new InternalError("Operation constructor is not a static method: " + method);
-            }
-
-            try {
-                return MethodHandles.publicLookup().unreflect(method);
-            } catch (IllegalAccessException e) {
-                throw new InternalError("Inaccessible operation constructor for operation: " +
-                        method);
-            }
-        }
-
-        Constructor<?> constructor;
-        try {
-            constructor = opClass.getConstructor(ExternalizedOp.class);
-        } catch (NoSuchMethodException e) {
-            return null;
-        }
-
-        try {
-            return MethodHandles.publicLookup().unreflectConstructor(constructor);
-        } catch (IllegalAccessException e) {
-            throw new InternalError("Inaccessible operation constructor for operation: " +
-                    constructor);
-        }
-    }
-
-    private static Op constructOp(Class<? extends Op> opClass, ExternalizedOp opDef) {
-        class Enclosed {
-            private static final ClassValue<Function<ExternalizedOp, Op>> OP_CONSTRUCTOR = new ClassValue<>() {
-                @Override
-                protected Function<ExternalizedOp, Op> computeValue(Class<?> opClass) {
-                    final MethodHandle opConstructorMH = getOpConstructorMethodHandle(opClass);
-                    assert opConstructorMH != null;
-
-                    return operationDefinition -> {
-                        try {
-                            return (Op) opConstructorMH.invoke(operationDefinition);
-                        } catch (RuntimeException | Error e) {
-                            throw e;
-                        } catch (Throwable t) {
-                            throw new RuntimeException(t);
-                        }
-                    };
-                }
-            };
-        }
-        return Enclosed.OP_CONSTRUCTOR.get(opClass).apply(opDef);
     }
 
 //    // Uncomment the following and execute like as follows to generate a factory method


### PR DESCRIPTION
Remove functionality from `OpFactory` to compute an op factory from annotated op classes. Functionality is cloned in example Triton and ONNX code as an `OpFacotyrHelper` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/470/head:pull/470` \
`$ git checkout pull/470`

Update a local copy of the PR: \
`$ git checkout pull/470` \
`$ git pull https://git.openjdk.org/babylon.git pull/470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 470`

View PR using the GUI difftool: \
`$ git pr show -t 470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/470.diff">https://git.openjdk.org/babylon/pull/470.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/470#issuecomment-3014243182)
</details>
