### PR TITLE
Cleanup compiler code gen

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
@@ -149,7 +149,8 @@ public final class Quoted {
     }
 
     // Extract the quoted operation from funcOp and maps the operands and captured values to the runtime values
-    public static Quoted quotedOp(CoreOp.FuncOp funcOp, Object[] args) {
+    // @@@ Add List<Object> accepting method, varargs array defers to it
+    public static Quoted quotedOp(CoreOp.FuncOp funcOp, Object... args) {
 
         if (funcOp.body().blocks().size() != 1) {
             throw invalidQuotedModel(funcOp);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeReflectionSymbols.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/CodeReflectionSymbols.java
@@ -47,10 +47,9 @@ public class CodeReflectionSymbols {
     public final Type quotedType;
     public final Type quotableType;
     public final Type codeReflectionType;
-    public final MethodSymbol opInterpreterInvoke;
-    public final MethodSymbol opParserFromString;
-    public final MethodSymbol methodHandlesLookup;
     public final Type opType;
+    public final Type funcOpType;
+    public final MethodSymbol quotedQuotedOp;
 
     CodeReflectionSymbols(Context context) {
         Symtab syms = Symtab.instance(context);
@@ -59,24 +58,13 @@ public class CodeReflectionSymbols {
         codeReflectionType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.CodeReflection");
         quotedType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.Quoted");
         quotableType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.Quotable");
-        Type opInterpreterType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.interpreter.Interpreter");
         opType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.Op");
-        opInterpreterInvoke = new MethodSymbol(PUBLIC | STATIC | VARARGS,
-                names.fromString("invoke"),
-                new MethodType(List.of(syms.methodHandleLookupType, opType, new ArrayType(syms.objectType, syms.arrayClass)), syms.objectType,
+        funcOpType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.dialect.core.CoreOp$FuncOp");
+        quotedQuotedOp = new MethodSymbol(PUBLIC | STATIC | VARARGS,
+                names.fromString("quotedOp"),
+                new MethodType(List.of(funcOpType, new ArrayType(syms.objectType, syms.arrayClass)), quotedType,
                         List.nil(), syms.methodClass),
-                opInterpreterType.tsym);
-        Type opParserType = syms.enterClass(jdk_incubator_code, "jdk.incubator.code.extern.OpParser");
-        opParserFromString = new MethodSymbol(PUBLIC | STATIC,
-                names.fromString("fromStringOfJavaCodeModel"),
-                new MethodType(List.of(syms.stringType), opType,
-                        List.nil(), syms.methodClass),
-                opParserType.tsym);
-        methodHandlesLookup = new MethodSymbol(PUBLIC | STATIC,
-                names.fromString("lookup"),
-                new MethodType(List.nil(), syms.methodHandleLookupType,
-                        List.nil(), syms.methodClass),
-                syms.methodHandlesType.tsym);
+                quotedType.tsym);
         syms.synthesizeEmptyInterfaceIfMissing(quotedType);
         syms.synthesizeEmptyInterfaceIfMissing(quotableType);
     }


### PR DESCRIPTION
Remove option for storing the model as text now the alternative is stable (retain the enum option for when we experiment with further kinds of encoding).

Change the code extracting the Quoted instance from a structurally quoted lambda to not use the interpreter to produce the quoted instance.