### PR TITLE
Block.Reference implements CodeItem

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -113,7 +113,7 @@ public final class Block implements CodeElement<Block, Op> {
      * When control is passed from a block to a successor block the values of the block reference's arguments are
      * assigned, in order, to the successor block's parameters.
      */
-    public static final class Reference {
+    public static final class Reference implements CodeItem {
         final Block target;
         final List<Value> arguments;
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeItem.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeItem.java
@@ -30,6 +30,6 @@ package jdk.incubator.code;
  * @sealedGraph
  */
 public sealed interface CodeItem
-        permits CodeElement, Value, TypeElement {
+        permits CodeElement, Value, TypeElement, Block.Reference {
     // @@@ Common functionality between elements and values?
 }


### PR DESCRIPTION
`Block.Reference` implements `CodeItem`, thereby all items in a code model share the same top type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/478/head:pull/478` \
`$ git checkout pull/478`

Update a local copy of the PR: \
`$ git checkout pull/478` \
`$ git pull https://git.openjdk.org/babylon.git pull/478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 478`

View PR using the GUI difftool: \
`$ git pr show -t 478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/478.diff">https://git.openjdk.org/babylon/pull/478.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/478#issuecomment-3032942362)
</details>
