### PR TITLE
CodeElement ancestor functionality

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -89,7 +89,7 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public Op.Invokable invokableOperation() {
             if (declaringBlock().isEntryBlock() &&
-                    declaringBlock().ancestorBody().ancestorOp() instanceof Op.Invokable o) {
+                    declaringBlock().ancestorOp() instanceof Op.Invokable o) {
                 return o;
             } else {
                 return null;
@@ -453,7 +453,7 @@ public final class Block implements CodeElement<Block, Op> {
         while (domr != rb) {
             // @@@ What if body is isolated
 
-            b = rb.ancestorOp().ancestorBlock();
+            b = rb.ancestorBlock();
             // null when op is top-level (and its body is isolated), or not yet assigned to block
             if (b == null) {
                 return null;
@@ -720,7 +720,7 @@ public final class Block implements CodeElement<Block, Op> {
 
         private static Op getNearestInvokeableAncestorOp(Op op) {
             do {
-                op = op.ancestorBody().ancestorOp();
+                op = op.ancestorOp();
             } while (!(op instanceof Op.Invokable));
             return op;
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -89,7 +89,7 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public Op.Invokable invokableOperation() {
             if (declaringBlock().isEntryBlock() &&
-                    declaringBlock().parentBody().parentOp() instanceof Op.Invokable o) {
+                    declaringBlock().ancestorBody().ancestorOp() instanceof Op.Invokable o) {
                 return o;
             } else {
                 return null;
@@ -198,15 +198,6 @@ public final class Block implements CodeElement<Block, Op> {
         return parentBody;
     }
 
-    /**
-     * Returns this block's parent body.
-     *
-     * @return this block's parent body.
-     */
-    public Body parentBody() {
-        return parentBody;
-    }
-
     @Override
     public List<Op> children() {
         return ops();
@@ -255,28 +246,6 @@ public final class Block implements CodeElement<Block, Op> {
      */
     public List<TypeElement> parameterTypes() {
         return parameters.stream().map(Value::type).toList();
-    }
-
-    /**
-     * Finds the operation in this block that is the ancestor of the given operation.
-     *
-     * @param op the given operation.
-     * @return the operation in this block that is the ancestor of the given operation,
-     * otherwise {@code null}
-     */
-    public Op findAncestorOpInBlock(Op op) {
-        Objects.requireNonNull(op);
-
-        while (op != null && op.parentBlock() != this) {
-            Body encBody = op.ancestorBody();
-            if (encBody == null) {
-                return null;
-            }
-
-            op = encBody.parentOp();
-        }
-
-        return op;
     }
 
     /**
@@ -409,7 +378,7 @@ public final class Block implements CodeElement<Block, Op> {
      */
     // @@@ Should this be reversed and named dominates(Block b)
     public boolean isDominatedBy(Block dom) {
-        Block b = findBlockForDomBody(this, dom.parentBody());
+        Block b = findBlockForDomBody(this, dom.ancestorBody());
         if (b == null) {
             return false;
         }
@@ -420,13 +389,13 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         // The entry block in b's body dominates all other blocks in the body
-        Block entry = b.parentBody().entryBlock();
+        Block entry = b.ancestorBody().entryBlock();
         if (dom == entry) {
             return true;
         }
 
         // Traverse the immediate dominators until dom is reached or the entry block
-        Map<Block, Block> idoms = b.parentBody().immediateDominators();
+        Map<Block, Block> idoms = b.ancestorBody().immediateDominators();
         Block idom = idoms.get(b);
         while (idom != entry) {
             if (idom == dom) {
@@ -449,11 +418,11 @@ public final class Block implements CodeElement<Block, Op> {
      * @return the immediate dominator of this block, otherwise {@code null} if this block is the entry block.
      */
     public Block immediateDominator() {
-        if (this == parentBody().entryBlock()) {
+        if (this == ancestorBody().entryBlock()) {
             return null;
         }
 
-        Map<Block, Block> idoms = parentBody().immediateDominators();
+        Map<Block, Block> idoms = ancestorBody().immediateDominators();
         return idoms.get(this);
     }
 
@@ -468,11 +437,11 @@ public final class Block implements CodeElement<Block, Op> {
      * @return the immediate dominator of this block, otherwise {@code null} if this block is the entry block.
      */
     public Block immediatePostDominator() {
-        if (this == parentBody().entryBlock()) {
+        if (this == ancestorBody().entryBlock()) {
             return null;
         }
 
-        Map<Block, Block> ipdoms = parentBody().immediatePostDominators();
+        Map<Block, Block> ipdoms = ancestorBody().immediatePostDominators();
         Block ipdom = ipdoms.get(this);
         return ipdom == this ? Body.IPDOM_EXIT : ipdom;
     }
@@ -480,16 +449,16 @@ public final class Block implements CodeElement<Block, Op> {
     // @@@ isPostDominatedBy and immediatePostDominator
 
     private static Block findBlockForDomBody(Block b, final Body domr) {
-        Body rb = b.parentBody();
+        Body rb = b.ancestorBody();
         while (domr != rb) {
             // @@@ What if body is isolated
 
-            b = rb.parentOp().parentBlock();
+            b = rb.ancestorOp().ancestorBlock();
             // null when op is top-level (and its body is isolated), or not yet assigned to block
             if (b == null) {
                 return null;
             }
-            rb = b.parentBody();
+            rb = b.ancestorBody();
         }
         return b;
     }
@@ -751,7 +720,7 @@ public final class Block implements CodeElement<Block, Op> {
 
         private static Op getNearestInvokeableAncestorOp(Op op) {
             do {
-                op = op.ancestorBody().parentOp();
+                op = op.ancestorBody().ancestorOp();
             } while (!(op instanceof Op.Invokable));
             return op;
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -391,12 +391,10 @@ public final class Body implements CodeElement<Body, Block> {
 
     static boolean isDominatedBy(Body r, Body dom) {
         while (r != dom) {
-            Block eb = r.ancestorOp().ancestorBlock();
-            if (eb == null) {
+            r = r.ancestorBody();
+            if (r == null) {
                 return false;
             }
-
-            r = eb.ancestorBody();
         }
 
         return true;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -87,15 +87,6 @@ public final class Body implements CodeElement<Body, Block> {
         return parentOp;
     }
 
-    /**
-     * Returns this body's parent operation.
-     *
-     * @return the body's parent operation.
-     */
-    public Op parentOp() {
-        return parentOp;
-    }
-
     @Override
     public List<Block> children() {
         return blocks();
@@ -127,23 +118,6 @@ public final class Body implements CodeElement<Body, Block> {
     public FunctionType bodyType() {
         Block entryBlock = entryBlock();
         return CoreType.functionType(yieldType, entryBlock.parameterTypes());
-    }
-
-    /**
-     * Finds the block in this body that is the ancestor of the given block.
-     *
-     * @param b the given block.
-     * @return the block in this body that is the ancestor of the given block,
-     * otherwise {@code null}
-     */
-    public Block findAncestorBlockInBody(Block b) {
-        Objects.requireNonNull(b);
-
-        while (b != null && b.parentBody() != this) {
-            b = b.parentBody().parentOp().parentBlock();
-        }
-
-        return b;
     }
 
     /**
@@ -417,12 +391,12 @@ public final class Body implements CodeElement<Body, Block> {
 
     static boolean isDominatedBy(Body r, Body dom) {
         while (r != dom) {
-            Block eb = r.parentOp().parentBlock();
+            Block eb = r.ancestorOp().ancestorBlock();
             if (eb == null) {
                 return false;
             }
 
-            r = eb.parentBody();
+            r = eb.ancestorBody();
         }
 
         return true;
@@ -454,14 +428,14 @@ public final class Body implements CodeElement<Body, Block> {
                 }
 
                 for (Value a : op.operands()) {
-                    if (!bodyStack.contains(a.declaringBlock().parentBody())) {
+                    if (!bodyStack.contains(a.declaringBlock().ancestorBody())) {
                         capturedValues.add(a);
                     }
                 }
 
                 for (Block.Reference s : op.successors()) {
                     for (Value a : s.arguments()) {
-                        if (!bodyStack.contains(a.declaringBlock().parentBody())) {
+                        if (!bodyStack.contains(a.declaringBlock().ancestorBody())) {
                             capturedValues.add(a);
                         }
                     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
@@ -213,6 +213,22 @@ public sealed interface CodeElement<
     }
 
     /**
+     * Returns true if this element is the same as or an ancestor of the descendant element.
+     *
+     * @param descendant the descendant element.
+     * @return true if this element is the same as or an ancestor of the descendant element.
+     */
+    default boolean isAncestorOf(CodeElement<?, ?> descendant) {
+        Objects.requireNonNull(descendant);
+
+        CodeElement<?, ?> e = descendant;
+        while (e != null && e != this) {
+            e = e.parent();
+        }
+        return e != null;
+    }
+
+    /**
      * Finds the child element, of this element, both of which are ancestors of the given descendant element,
      * otherwise return {@code null} if this element is not an ancestor.
      *

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
@@ -26,6 +26,7 @@
 package jdk.incubator.code;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -33,8 +34,13 @@ import java.util.stream.Stream;
 /**
  * A code element, one of {@link Body body}, {@link Block block}, or {@link Op operation}.
  * <p>
- * A code element may have child code elements, and so on, to form a tree. A (root) code element and all its descendants
- * can be traversed.
+ * A code may have a parent code element. An unbound code element is an operation, an unbound operation, that has no
+ * parent block. An unbound operation may also be considered a root operation if never bound. A code element and all its
+ * ancestors can be traversed, up to and including the unbound or root operation.
+ * <p>
+ * A code element may have child code elements, and so on, to form a tree. An unbound or root operation and all its
+ * descendants can be traversed, down to and including operations with no children. Bodies and blocks have at least one
+ * child element.
  *
  * @param <E> the code element type
  * @param <C> the child code element type.
@@ -55,7 +61,7 @@ public sealed interface CodeElement<
         return Stream.of(Void.class).gather(() -> (_, _, downstream) -> traversePreOrder(downstream::push));
     }
 
-//    private boolean traversePreOrder(Gatherer.Downstream<? super CodeElement<?, ?>> v) {
+    //    private boolean traversePreOrder(Gatherer.Downstream<? super CodeElement<?, ?>> v) {
     private boolean traversePreOrder(Predicate<? super CodeElement<?, ?>> v) {
         if (!v.test(this)) {
             return false;
@@ -127,14 +133,105 @@ public sealed interface CodeElement<
     }
 
     /**
-     * Returns the parent code element.
-     * <p>
-     * If this element is an instance of {@code Op} then the parent may be {@code null}
-     * if operation is not assigned to a block.
+     * Returns the parent element, otherwise {@code null}
+     * if there is no parent.
      *
-     * @return the parent code element
+     * @return the parent code element.
+     * @throws IllegalStateException if this element is an operation whose parent block is unbuilt.
      */
     CodeElement<?, E> parent();
+
+    // Nearest ancestors
+
+    /**
+     * Finds the nearest ancestor operation, otherwise {@code null}
+     * if there is no nearest ancestor.
+     *
+     * @return the nearest ancestor operation.
+     * @throws IllegalStateException if an operation with unbuilt parent block is encountered.
+     */
+    default Op ancestorOp() {
+        return switch (this) {
+            // block -> body -> op~
+            case Block block -> block.parent().parent();
+            // body -> op~
+            case Body body -> body.parent();
+            // op -> block? -> body -> op~
+            case Op op -> {
+                // Throws ISE if op is not bound
+                Block parent = op.parent();
+                yield parent == null ? null : parent.parent().parent();
+            }
+        };
+    }
+
+    /**
+     * Finds the nearest ancestor body, otherwise {@code null}
+     * if there is no nearest ancestor.
+     *
+     * @return the nearest ancestor body.
+     * @throws IllegalStateException if an operation with unbuilt parent block is encountered.
+     */
+    default Body ancestorBody() {
+        return switch (this) {
+            // block -> body
+            case Block block -> block.parent();
+            // body -> op~ -> block? -> body
+            case Body body -> {
+                // Throws ISE if block is partially constructed
+                Block ancestor = body.parent().parent();
+                yield ancestor == null ? null : ancestor.parent();
+            }
+            // op~ -> block? -> body
+            case Op op -> {
+                // Throws ISE if op is not bound
+                Block parent = op.parent();
+                yield parent == null ? null : parent.parent();
+            }
+        };
+    }
+
+    /**
+     * Finds the nearest ancestor block, otherwise {@code null}
+     * if there is no nearest ancestor.
+     *
+     * @return the nearest ancestor block.
+     * @throws IllegalStateException if an operation with unbuilt parent block is encountered.
+     */
+    default Block ancestorBlock() {
+        return switch (this) {
+            // block -> body -> op~ -> block?
+            // Throws ISE if op is not bound
+            case Block block -> block.parent().parent().parent();
+            // body -> op~ -> block?
+            // Throws ISE if op is not bound
+            case Body body -> body.parent().parent();
+            // op~ -> block?
+            // Throws ISE if op is not bound
+            case Op op -> op.parent();
+        };
+    }
+
+    /**
+     * Finds the child element, of this element, both of which are ancestors of the given descendant element,
+     * otherwise return {@code null} if this element is not an ancestor.
+     *
+     * @param descendant the descendant element
+     * @return the child element that is an ancestor of the given descendant element
+     * @throws IllegalStateException if an operation with unbuilt parent block is encountered.
+     */
+    default C findChildAncestor(C descendant) {
+        Objects.requireNonNull(descendant);
+
+        CodeElement<?, ?> e = descendant;
+        while (e != null && e.parent() != this) {
+            e = e.parent();
+        }
+
+        @SuppressWarnings("unchecked")
+        C child = (C) e;
+        return child;
+    }
 
     /**
      * Returns the child code elements, as an unmodifiable list.
@@ -142,4 +239,9 @@ public sealed interface CodeElement<
      * @return the child code elements
      */
     List<C> children();
+
+    // Siblings
+    // Left, right
+
+    // Des
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -305,15 +305,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     @Override
     public final Block parent() {
-        return parentBlock();
-    }
-
-    /**
-     * Returns this operation's parent block, otherwise {@code null} if the operation is not assigned to a block.
-     *
-     * @return operation's parent block, or {@code null} if the operation is not assigned to a block.
-     */
-    public final Block parentBlock() {
         if (result == null) {
             return null;
         }
@@ -345,25 +336,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     public final Result result() {
         return result;
-    }
-
-
-    /**
-     * Returns this operation's nearest ancestor body (the parent body of this operation's parent block),
-     * otherwise {@code null} if the operation is not assigned to a block.
-     *
-     * @return operation's nearest ancestor body, or {@code null} if the operation is not assigned to a block.
-     */
-    public final Body ancestorBody() {
-        if (result == null) {
-            return null;
-        }
-
-        if (!result.block.isBound()) {
-            throw new IllegalStateException("Parent body is partially constructed");
-        }
-
-        return result.block.parentBody;
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
@@ -187,10 +187,10 @@ public final class Quoted {
                 throw invalidQuotedModel(funcOp);
             } else if (v.uses().size() == 1
                     && !(v.uses().iterator().next().op() instanceof CoreOp.VarOp vop && vop.result().uses().size() >= 1
-                    && vop.result().uses().stream().noneMatch(u -> u.op().parentBlock() == fblock))
+                    && vop.result().uses().stream().noneMatch(u -> u.op().ancestorBlock() == fblock))
                     && !operandsAndCaptures.contains(v)) {
                 throw invalidQuotedModel(funcOp);
-            } else if (v.uses().size() > 1 && v.uses().stream().anyMatch(u -> u.op().parentBlock() == fblock)) {
+            } else if (v.uses().size() > 1 && v.uses().stream().anyMatch(u -> u.op().ancestorBlock() == fblock)) {
                 throw invalidQuotedModel(funcOp);
             }
         };

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
@@ -167,16 +167,16 @@ public sealed abstract class Value implements Comparable<Value>, CodeItem
             }
         }
 
-        Body r1 = b1.parentBody();
-        Body r2 = b2.parentBody();
+        Body r1 = b1.ancestorBody();
+        Body r2 = b2.ancestorBody();
         if (r1 == r2) {
             // @@@ order should be defined by CFG and dominator relations
             List<Block> bs = r1.blocks();
             return Integer.compare(bs.indexOf(b1), bs.indexOf(b2));
         }
 
-        Op o1 = r1.parentOp();
-        Op o2 = r2.parentOp();
+        Op o1 = r1.ancestorOp();
+        Op o2 = r2.ancestorOp();
         if (o1 == o2) {
             List<Body> rs = o1.bodies();
             return Integer.compare(rs.indexOf(r1), rs.indexOf(r2));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Liveness.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Liveness.java
@@ -143,7 +143,7 @@ public class Liveness {
             for (Op.Result useOpr : value.uses()) {
                 Op useOp = useOpr.op();
                 // Find the operation in the current block
-                useOp = block.findAncestorOpInBlock(useOp);
+                useOp = block.findChildAncestor(useOp);
                 // Update if after
                 if (useOp != null && isBeforeInBlock(endOp, useOp)) {
                     endOp = useOp;
@@ -201,7 +201,7 @@ public class Liveness {
 
     void Compute_LiveSets_SSA_ByVar(Body CFG, Value v) {
         for (Op.Result use : v.uses()) {
-            Block B = CFG.findAncestorBlockInBody(use.declaringBlock());
+            Block B = CFG.findChildAncestor(use.declaringBlock());
             Up_and_Mark_Stack(B, v);
         }
     }
@@ -287,7 +287,7 @@ public class Liveness {
      * @return true if a value is last used by an operation
      */
     public boolean isLastUse(Value value, Op op) {
-        Block block = op.parentBlock();
+        Block block = op.ancestorBlock();
         BlockInfo liveness = getLiveness(block);
 
         // Value is used by some successor
@@ -318,11 +318,11 @@ public class Liveness {
             throw new IllegalArgumentException("This or the given operation is not assigned to a block");
         }
 
-        if (thisOp.parentBlock() != thatOp.parentBlock()) {
+        if (thisOp.ancestorBlock() != thatOp.ancestorBlock()) {
             throw new IllegalArgumentException("This and that operation are not assigned to the same blocks");
         }
 
-        List<Op> ops = thisOp.parentBlock().ops();
+        List<Op> ops = thisOp.ancestorBlock().ops();
         return ops.indexOf(thisOp) < ops.indexOf(thatOp);
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/SSACytron.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/SSACytron.java
@@ -309,7 +309,7 @@ final class SSACytron {
                 for (Block y : df.getOrDefault(x, Set.of())) {
                     if (hasAlready[y.index()] < iterCount) {
                         // Only add to the join points if y is dominated by the var's block
-                        if (y.isDominatedBy(v.parentBlock())) {
+                        if (y.isDominatedBy(v.ancestorBlock())) {
                             joinPoints.computeIfAbsent(y, _k -> new LinkedHashSet<>()).add(v);
                         }
                         hasAlready[y.index()] = iterCount;
@@ -334,7 +334,7 @@ final class SSACytron {
                     throw new IllegalStateException("Descendant variable store operation");
                 }
                 if (storeOp.varOp().ancestorBody() == r) {
-                    stores.computeIfAbsent(storeOp.varOp(), _v -> new LinkedHashSet<>()).add(storeOp.parentBlock());
+                    stores.computeIfAbsent(storeOp.varOp(), _v -> new LinkedHashSet<>()).add(storeOp.ancestorBlock());
                 }
             }
             return stores;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -55,7 +55,6 @@ import jdk.incubator.code.Value;
 import jdk.incubator.code.bytecode.impl.BranchCompactor;
 import jdk.incubator.code.bytecode.impl.LocalsCompactor;
 import jdk.incubator.code.dialect.core.CoreOp.*;
-import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.java.*;
 import jdk.incubator.code.extern.OpParser;
 import jdk.incubator.code.dialect.core.FunctionType;
@@ -425,7 +424,7 @@ public final class BytecodeGenerator {
         };
         // Pass over deferred operations
         while (canDefer(nextOp)) {
-            nextOp = nextOp.parentBlock().nextOp(nextOp);
+            nextOp = nextOp.ancestorBlock().nextOp(nextOp);
         }
         return isFirstOperand(nextOp, opr);
     }
@@ -440,7 +439,7 @@ public final class BytecodeGenerator {
         }
         Op.Result use = uses.iterator().next();
 
-        if (use.declaringBlock() != op.parentBlock()) {
+        if (use.declaringBlock() != op.ancestorBlock()) {
             return false;
         }
 
@@ -1072,7 +1071,7 @@ public final class BytecodeGenerator {
             return null;
         }
 
-        if (p.declaringBlock() != op.parentBlock()) {
+        if (p.declaringBlock() != op.ancestorBlock()) {
             return null;
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/SlotOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/SlotOp.java
@@ -119,7 +119,7 @@ sealed abstract class SlotOp extends Op {
 
         @Override
         public String toString() {
-            return "block_" + parentBlock().index() + " " + parentBlock().ops().indexOf(this) + ": #" + slot + " LOAD " + typeKind();
+            return "block_" + ancestorBlock().index() + " " + ancestorBlock().ops().indexOf(this) + ": #" + slot + " LOAD " + typeKind();
         }
     }
 
@@ -162,7 +162,7 @@ sealed abstract class SlotOp extends Op {
 
         @Override
         public String toString() {
-            return "block_" + parentBlock().index() + " " + parentBlock().ops().indexOf(this) + ": #" + slot + " STORE " + typeKind();
+            return "block_" + ancestorBlock().index() + " " + ancestorBlock().ops().indexOf(this) + ": #" + slot + " STORE " + typeKind();
         }
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/SlotToVarTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/SlotToVarTransformer.java
@@ -343,7 +343,7 @@ final class SlotToVarTransformer {
             tk = slotOp.typeKind();
             map = excMap;
             fwd = forward;
-            b = slotOp.parentBlock();
+            b = slotOp.ancestorBlock();
             ops = fwd ? b.ops() : b.ops().reversed();
             i = ops.indexOf(slotOp) + 1;
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/UnresolvedTypesTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/UnresolvedTypesTransformer.java
@@ -273,7 +273,7 @@ final class UnresolvedTypesTransformer {
             public void apply(Block.Builder block, Block b) {
                 if (block.isEntryBlock()) {
                     CopyContext cc = block.context();
-                    List<Block> sourceBlocks = b.parentBody().blocks();
+                    List<Block> sourceBlocks = b.ancestorBody().blocks();
 
                     // Override blocks with changed parameter types
                     for (int i = 1; i < sourceBlocks.size(); i++) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -2029,7 +2029,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             Value value = operands().get(0);
-            if (value instanceof Result r && r.op().ancestorBody().ancestorOp() instanceof LabeledOp lop) {
+            if (value instanceof Result r && r.op().ancestorOp() instanceof LabeledOp lop) {
                 return lop.target();
             } else {
                 throw new IllegalStateException("Bad label value: " + value + " " + ((Result) value).op());
@@ -2439,18 +2439,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         boolean ifExitFromSynchronized(JavaLabelOp lop) {
-            Op target = lop.target();
-            return target == this || ifAncestorOp(target, this);
-        }
-
-        static boolean ifAncestorOp(Op ancestor, Op op) {
-            while (op.ancestorBody() != null) {
-                op = op.ancestorBody().ancestorOp();
-                if (op == ancestor) {
-                    return true;
-                }
-            }
-            return false;
+            return lop.target().isAncestorOf(this);
         }
 
         @Override
@@ -3018,7 +3007,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         Block.Builder lower(Block.Builder b, Function<BranchTarget, Block.Builder> f) {
-            BranchTarget t = getBranchTarget(b.context(), ancestorBlock().ancestorBody());
+            BranchTarget t = getBranchTarget(b.context(), ancestorBody());
             if (t != null) {
                 b.op(branch(f.apply(t).successor()));
             } else {
@@ -4545,18 +4534,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         boolean ifExitFromTry(JavaLabelOp lop) {
-            Op target = lop.target();
-            return target == this || ifAncestorOp(target, this);
-        }
-
-        static boolean ifAncestorOp(Op ancestor, Op op) {
-            while (op.ancestorBody() != null) {
-                op = op.ancestorBody().ancestorOp();
-                if (op == ancestor) {
-                    return true;
-                }
-            }
-            return false;
+            return lop.target().isAncestorOf(this);
         }
 
         Block.Builder inlineFinalizer(Block.Builder block1, List<Block.Reference> tryHandlers, OpTransformer opT) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -2004,7 +2004,7 @@ public sealed abstract class JavaOp extends Op {
             Body b;
             do {
                 b = op.ancestorBody();
-                op = b.parentOp();
+                op = b.ancestorOp();
                 if (op == null) {
                     throw new IllegalStateException("No enclosing loop");
                 }
@@ -2029,7 +2029,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             Value value = operands().get(0);
-            if (value instanceof Result r && r.op().ancestorBody().parentOp() instanceof LabeledOp lop) {
+            if (value instanceof Result r && r.op().ancestorBody().ancestorOp() instanceof LabeledOp lop) {
                 return lop.target();
             } else {
                 throw new IllegalStateException("Bad label value: " + value + " " + ((Result) value).op());
@@ -2203,7 +2203,7 @@ public sealed abstract class JavaOp extends Op {
             Body b;
             do {
                 b = op.ancestorBody();
-                op = b.parentOp();
+                op = b.ancestorOp();
                 if (op == null) {
                     throw new IllegalStateException("No enclosing switch");
                 }
@@ -2445,7 +2445,7 @@ public sealed abstract class JavaOp extends Op {
 
         static boolean ifAncestorOp(Op ancestor, Op op) {
             while (op.ancestorBody() != null) {
-                op = op.ancestorBody().parentOp();
+                op = op.ancestorBody().ancestorOp();
                 if (op == ancestor) {
                     return true;
                 }
@@ -3018,7 +3018,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         Block.Builder lower(Block.Builder b, Function<BranchTarget, Block.Builder> f) {
-            BranchTarget t = getBranchTarget(b.context(), parentBlock().parentBody());
+            BranchTarget t = getBranchTarget(b.context(), ancestorBlock().ancestorBody());
             if (t != null) {
                 b.op(branch(f.apply(t).successor()));
             } else {
@@ -4551,7 +4551,7 @@ public sealed abstract class JavaOp extends Op {
 
         static boolean ifAncestorOp(Op ancestor, Op op) {
             while (op.ancestorBody() != null) {
-                op = op.ancestorBody().parentOp();
+                op = op.ancestorBody().ancestorOp();
                 if (op == ancestor) {
                     return true;
                 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
@@ -60,7 +60,7 @@ public final class OpWriter {
         }
 
         private String name(Block b) {
-            Block p = b.ancestorBody().ancestorOp().ancestorBlock();
+            Block p = b.ancestorBlock();
             return (p == null ? "block_" : name(p) + "_") + b.index();
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
@@ -60,7 +60,7 @@ public final class OpWriter {
         }
 
         private String name(Block b) {
-            Block p = b.parentBody().parentOp().parentBlock();
+            Block p = b.ancestorBody().ancestorOp().ancestorBlock();
             return (p == null ? "block_" : name(p) + "_") + b.index();
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
@@ -305,7 +305,7 @@ public final class Interpreter {
         // is the current context block's parent body
         BlockContext yieldContext = oc.stack.peek();
         assert yieldContext == null ||
-                yieldContext.b().parentBody() == entry.parentBody().parentOp().ancestorBody();
+                yieldContext.b().ancestorBody() == entry.ancestorBody().ancestorOp().ancestorBody();
 
         // Note that first block cannot have any successors so the queue will have at least one entry
         oc.stack.push(new BlockContext(entry, valuesAndArguments));
@@ -425,7 +425,7 @@ public final class Interpreter {
             // Find top-level op
             Op top = fco;
             while (top.ancestorBody() != null) {
-                top = top.ancestorBody().parentOp();
+                top = top.ancestorBody().ancestorOp();
             }
 
             // Ensure top-level op is a module and function name

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
@@ -305,7 +305,7 @@ public final class Interpreter {
         // is the current context block's parent body
         BlockContext yieldContext = oc.stack.peek();
         assert yieldContext == null ||
-                yieldContext.b().ancestorBody() == entry.ancestorBody().ancestorOp().ancestorBody();
+                yieldContext.b().ancestorBody() == entry.ancestorBody().ancestorBody();
 
         // Note that first block cannot have any successors so the queue will have at least one entry
         oc.stack.push(new BlockContext(entry, valuesAndArguments));
@@ -425,7 +425,7 @@ public final class Interpreter {
             // Find top-level op
             Op top = fco;
             while (top.ancestorBody() != null) {
-                top = top.ancestorBody().ancestorOp();
+                top = top.ancestorOp();
             }
 
             // Ensure top-level op is a module and function name

--- a/test/jdk/java/lang/reflect/code/TestBlockIndexes.java
+++ b/test/jdk/java/lang/reflect/code/TestBlockIndexes.java
@@ -74,7 +74,7 @@ public class TestBlockIndexes {
 
     static void assertBlockIndexes(CoreOp.FuncOp f) {
         for (Block b : f.body().blocks()) {
-            Assert.assertEquals(b.index(), b.parentBody().blocks().indexOf(b));
+            Assert.assertEquals(b.index(), b.ancestorBody().blocks().indexOf(b));
         }
     }
 

--- a/test/jdk/java/lang/reflect/code/TestBuild.java
+++ b/test/jdk/java/lang/reflect/code/TestBuild.java
@@ -139,7 +139,7 @@ public class TestBuild {
         Assert.assertThrows(IllegalStateException.class, a::declaringBlock);
         Assert.assertThrows(IllegalStateException.class, result::declaringBlock);
         // Access to parent block/body of operation result before they are constructed
-        Assert.assertThrows(IllegalStateException.class, result.op()::parentBlock);
+        Assert.assertThrows(IllegalStateException.class, result.op()::ancestorBlock);
         Assert.assertThrows(IllegalStateException.class, result.op()::ancestorBody);
         // Access to set of users before constructed
         Assert.assertThrows(IllegalStateException.class, a::uses);
@@ -150,7 +150,7 @@ public class TestBuild {
 
         Assert.assertNotNull(a.declaringBlock());
         Assert.assertNotNull(result.declaringBlock());
-        Assert.assertNotNull(result.op().parentBlock());
+        Assert.assertNotNull(result.op().ancestorBlock());
         Assert.assertNotNull(result.op().ancestorBody());
         Assert.assertNotNull(a.uses());
     }

--- a/test/jdk/java/lang/reflect/code/TestClosureOps.java
+++ b/test/jdk/java/lang/reflect/code/TestClosureOps.java
@@ -138,7 +138,7 @@ public class TestClosureOps {
     public void testQuotableModel() {
         Quoted quoted = () -> {};
         Op qop = quoted.op();
-        Op top = qop.ancestorBody().ancestorOp().ancestorBody().ancestorOp();
+        Op top = qop.ancestorOp().ancestorOp();
         Assert.assertTrue(top instanceof CoreOp.FuncOp);
 
         CoreOp.FuncOp fop = (CoreOp.FuncOp) top;

--- a/test/jdk/java/lang/reflect/code/TestClosureOps.java
+++ b/test/jdk/java/lang/reflect/code/TestClosureOps.java
@@ -138,7 +138,7 @@ public class TestClosureOps {
     public void testQuotableModel() {
         Quoted quoted = () -> {};
         Op qop = quoted.op();
-        Op top = qop.ancestorBody().parentOp().ancestorBody().parentOp();
+        Op top = qop.ancestorBody().ancestorOp().ancestorBody().ancestorOp();
         Assert.assertTrue(top instanceof CoreOp.FuncOp);
 
         CoreOp.FuncOp fop = (CoreOp.FuncOp) top;

--- a/test/jdk/java/lang/reflect/code/TestLambdaOps.java
+++ b/test/jdk/java/lang/reflect/code/TestLambdaOps.java
@@ -155,7 +155,7 @@ public class TestLambdaOps {
     public void testQuotableModel() {
         Quotable quotable = (Runnable & Quotable) () -> {};
         Op qop = Op.ofQuotable(quotable).get().op();
-        Op top = qop.ancestorBody().parentOp().ancestorBody().parentOp();
+        Op top = qop.ancestorBody().ancestorOp().ancestorBody().ancestorOp();
         Assert.assertTrue(top instanceof CoreOp.FuncOp);
 
         CoreOp.FuncOp fop = (CoreOp.FuncOp) top;

--- a/test/jdk/java/lang/reflect/code/TestLambdaOps.java
+++ b/test/jdk/java/lang/reflect/code/TestLambdaOps.java
@@ -155,7 +155,7 @@ public class TestLambdaOps {
     public void testQuotableModel() {
         Quotable quotable = (Runnable & Quotable) () -> {};
         Op qop = Op.ofQuotable(quotable).get().op();
-        Op top = qop.ancestorBody().ancestorOp().ancestorBody().ancestorOp();
+        Op top = qop.ancestorOp().ancestorOp();
         Assert.assertTrue(top instanceof CoreOp.FuncOp);
 
         CoreOp.FuncOp fop = (CoreOp.FuncOp) top;

--- a/test/jdk/java/lang/reflect/code/TestLiveness.java
+++ b/test/jdk/java/lang/reflect/code/TestLiveness.java
@@ -282,7 +282,7 @@ public class TestLiveness {
 
         return op.traverse(new HashMap<>(),
                 CodeElement.blockVisitor((m, b) -> {
-                    if (b.ancestorBody().ancestorOp() == op) {
+                    if (b.ancestorOp() == op) {
                         Liveness.BlockInfo lbi = l.getLiveness(b);
                         m.put(blockMap.get(b),
                                 List.of(
@@ -297,7 +297,7 @@ public class TestLiveness {
     static Map<Block, Integer> blockNameMapping(Op top) {
         AtomicInteger i = new AtomicInteger();
         return top.traverse(new HashMap<>(), CodeElement.blockVisitor((m, b) -> {
-            if (b.ancestorBody().ancestorOp() != top) {
+            if (b.ancestorOp() != top) {
                 return m;
             }
 

--- a/test/jdk/java/lang/reflect/code/TestLiveness.java
+++ b/test/jdk/java/lang/reflect/code/TestLiveness.java
@@ -282,7 +282,7 @@ public class TestLiveness {
 
         return op.traverse(new HashMap<>(),
                 CodeElement.blockVisitor((m, b) -> {
-                    if (b.parentBody().parentOp() == op) {
+                    if (b.ancestorBody().ancestorOp() == op) {
                         Liveness.BlockInfo lbi = l.getLiveness(b);
                         m.put(blockMap.get(b),
                                 List.of(
@@ -297,7 +297,7 @@ public class TestLiveness {
     static Map<Block, Integer> blockNameMapping(Op top) {
         AtomicInteger i = new AtomicInteger();
         return top.traverse(new HashMap<>(), CodeElement.blockVisitor((m, b) -> {
-            if (b.parentBody().parentOp() != top) {
+            if (b.ancestorBody().ancestorOp() != top) {
                 return m;
             }
 

--- a/test/jdk/java/lang/reflect/code/TestLocalTransformationsAdaption.java
+++ b/test/jdk/java/lang/reflect/code/TestLocalTransformationsAdaption.java
@@ -161,7 +161,7 @@ public class TestLocalTransformationsAdaption {
 
     static Op getNearestInvokeableAncestorOp(Op op) {
         do {
-            op = op.ancestorBody().parentOp();
+            op = op.ancestorBody().ancestorOp();
         } while (!(op instanceof Op.Invokable));
         return op;
     }

--- a/test/jdk/java/lang/reflect/code/TestLocalTransformationsAdaption.java
+++ b/test/jdk/java/lang/reflect/code/TestLocalTransformationsAdaption.java
@@ -161,7 +161,7 @@ public class TestLocalTransformationsAdaption {
 
     static Op getNearestInvokeableAncestorOp(Op op) {
         do {
-            op = op.ancestorBody().ancestorOp();
+            op = op.ancestorOp();
         } while (!(op instanceof Op.Invokable));
         return op;
     }

--- a/test/jdk/java/lang/reflect/code/TestQuoteOp.java
+++ b/test/jdk/java/lang/reflect/code/TestQuoteOp.java
@@ -86,8 +86,8 @@ public class TestQuoteOp {
         // access FuncOp created by javac
         Quoted quoted = Op.ofQuotable(q).orElseThrow();
         Op op = quoted.op();
-        CoreOp.QuotedOp qop = ((CoreOp.QuotedOp) op.ancestorBody().ancestorOp());
-        CoreOp.FuncOp fop = ((CoreOp.FuncOp) qop.ancestorBody().ancestorOp());
+        CoreOp.QuotedOp qop = ((CoreOp.QuotedOp) op.ancestorOp());
+        CoreOp.FuncOp fop = ((CoreOp.FuncOp) qop.ancestorOp());
 
         Object[] args = {this, 111};
         Quoted quoted2 = Quoted.quotedOp(fop, args);

--- a/test/jdk/java/lang/reflect/code/TestQuoteOp.java
+++ b/test/jdk/java/lang/reflect/code/TestQuoteOp.java
@@ -86,8 +86,8 @@ public class TestQuoteOp {
         // access FuncOp created by javac
         Quoted quoted = Op.ofQuotable(q).orElseThrow();
         Op op = quoted.op();
-        CoreOp.QuotedOp qop = ((CoreOp.QuotedOp) op.ancestorBody().parentOp());
-        CoreOp.FuncOp fop = ((CoreOp.FuncOp) qop.ancestorBody().parentOp());
+        CoreOp.QuotedOp qop = ((CoreOp.QuotedOp) op.ancestorBody().ancestorOp());
+        CoreOp.FuncOp fop = ((CoreOp.FuncOp) qop.ancestorBody().ancestorOp());
 
         Object[] args = {this, 111};
         Quoted quoted2 = Quoted.quotedOp(fop, args);

--- a/test/jdk/java/lang/reflect/code/anf/AnfTransformer.java
+++ b/test/jdk/java/lang/reflect/code/anf/AnfTransformer.java
@@ -52,7 +52,7 @@ public class AnfTransformer {
 
         var builderEntry = outerBodyBuilder.entryBlock();
 
-        var selfRefP = builderEntry.parameter(((CoreOp.FuncOp) b.parentOp()).invokableType());
+        var selfRefP = builderEntry.parameter(((CoreOp.FuncOp) b.ancestorOp()).invokableType());
         funMap.put(entry, selfRefP);
 
         for (Block.Parameter p : entry.parameters()) {

--- a/test/jdk/java/lang/reflect/code/bytecode/Verifier.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/Verifier.java
@@ -121,7 +121,7 @@ public final class Verifier {
             // Verify operands declaration dominannce
             for (var v : op.operands()) {
                 if (!op.result().isDominatedBy(v)) {
-                    error("%s %s operand %s is not dominated by its declaration in %s", op.parentBlock(), op, v, v.declaringBlock());
+                    error("%s %s operand %s is not dominated by its declaration in %s", op.ancestorBlock(), op, v, v.declaringBlock());
                 }
             }
 
@@ -154,7 +154,7 @@ public final class Verifier {
                 Block tb = r.targetBlock();
                 for (int i = 0; i < args.size(); i++) {
                     if (!isAssignable(params.get(i).type(), args.get(i), tb, b)) {
-                        error("%s %s %s is not assignable from %s", op.parentBlock(), op, params.get(i).type(), args.get(i).type());
+                        error("%s %s %s is not assignable from %s", op.ancestorBlock(), op, params.get(i).type(), args.get(i).type());
                     }
                 }
             }
@@ -201,9 +201,9 @@ public final class Verifier {
             var mt = MethodRef.toNominalDescriptor(op.opType()).resolveConstantDesc(lookup).erase();
             CLASS_INVOKABLE_LEAF_OPS.getDeclaredMethod(opName, mt.parameterArray());
         } catch (NoSuchMethodException nsme) {
-            error("%s %s of type %s is not supported", op.parentBlock(), op, op.opType());
+            error("%s %s of type %s is not supported", op.ancestorBlock(), op, op.opType());
         } catch (ReflectiveOperationException roe) {
-            error("%s %s %s",  op.parentBlock(), op, roe.getMessage());
+            error("%s %s %s",  op.ancestorBlock(), op, roe.getMessage());
         }
     }
 


### PR DESCRIPTION
Declare common ancestor methods on `CodeElement`.

This enables more uniform traversal up the tree of code elements and querying of ancestors.