### PR TITLE
Added example-experiments to hat/bld and maven poms"

### DIFF
--- a/hat/examples/experiments/pom.xml
+++ b/hat/examples/experiments/pom.xml
@@ -35,7 +35,7 @@ questions.
     <parent>
         <groupId>oracle.code</groupId>
         <version>1.0</version>
-        <artifactId>hat.examples</artifactId>
+        <artifactId>hat-examples</artifactId>
     </parent>
 
     <dependencies>
@@ -43,6 +43,16 @@ questions.
             <groupId>oracle.code</groupId>
             <version>1.0</version>
             <artifactId>core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <version>1.0</version>
+            <artifactId>hat-backend-ffi-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <version>1.0</version>
+            <artifactId>hat-backend-ffi-opencl</artifactId>
         </dependency>
     </dependencies>
 

--- a/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
+++ b/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
@@ -437,7 +437,6 @@ public class LayoutExample {
         }
     }
 
-    @OpFactory.OpDeclaration(PtrToMember.NAME)
     public static final class PtrStoreValue extends Op {
         public static final String NAME = "ptr.store.value";
 

--- a/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
@@ -24,7 +24,7 @@
  */
 package experiments;
 
-import hat.backend.codebuilders.C99HATComputeBuilder;
+import hat.codebuilders.C99HATComputeBuilder;
 import hat.optools.FuncOpWrapper;
 import hat.optools.OpWrapper;
 
@@ -69,12 +69,12 @@ public class QuotedTest {
                     CoreOp.ClosureOp closure = CoreOp.closure(block.parentBody(), functionType(INT, INT))
                             .body(cblock -> {
                                 Block.Parameter ci = cblock.parameters().get(0);
-                                cblock.op(_return(cblock.op(add(i, ci))));
+                                cblock.op(return_(cblock.op(add(i, ci))));
                             });
                     Op.Result c = block.op(closure);
                     Op.Result fortyTwo = block.op(constant(INT, 42));
                     Op.Result or = block.op(closureCall(c, fortyTwo));
-                    block.op(_return(or));
+                    block.op(return_(or));
                 });
 
         f.writeTo(System.out);

--- a/hat/examples/pom.xml
+++ b/hat/examples/pom.xml
@@ -48,7 +48,7 @@ questions.
         <module>violajones</module>
         <module>squares</module>
         <module>life</module>
-        <!--<module>experiments</module>-->
+        <module>experiments</module>
     </modules>
     <profiles>
         <profile>

--- a/hat/hat/bld.java
+++ b/hat/hat/bld.java
@@ -305,22 +305,22 @@ if (Artifacts.jextracted_opengl != null
             examplesDir.existingDir("shared"), "hat-example-shared-1.0.jar", Artifacts.core
     );
 
-    Stream.of(
-            "blackscholes",
-                    "squares"
-            )
+    Stream.of( "blackscholes", "squares")
             .parallel()
             .map(examplesDir::existingDir)
             .forEach(exampleDir->buildDir.mavenStyleBuild(
                 exampleDir, "hat-example-"+exampleDir.fileName()+"-1.0.jar", Artifacts.core
             ));
 
-    Stream.of(
-                    "heal",
-                    "life",
-                    "mandel",
-                    "violajones"
-            )
+    Stream.of( "experiments")   // this has hardcoded references to opencl backend
+            .parallel()
+            .map(examplesDir::existingDir)
+            .forEach(exampleDir->buildDir.mavenStyleBuild(
+                exampleDir, "hat-example-"+exampleDir.fileName()+"-1.0.jar",
+              Artifacts.core, Artifacts.backend_ffi_shared, Artifacts.backend_ffi_opencl
+            ));
+
+    Stream.of( "heal", "life", "mandel", "violajones")   // these require example_shared ui stuff
             .parallel()
             .map(examplesDir::existingDir)
             .forEach(exampleDir->buildDir.mavenStyleBuild(


### PR DESCRIPTION
Added the experiments dir to build system. Both the maven and hat/bld versions

Note : recent changes have broken nbody (opengl wrapper) looking at it now

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/481/head:pull/481` \
`$ git checkout pull/481`

Update a local copy of the PR: \
`$ git checkout pull/481` \
`$ git pull https://git.openjdk.org/babylon.git pull/481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 481`

View PR using the GUI difftool: \
`$ git pr show -t 481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/481.diff">https://git.openjdk.org/babylon/pull/481.diff</a>

</details>
