### PR TITLE
Sadly opengl wrap had hardcoded package name this is fixed now

### DIFF
--- a/hat/wraps/opengl/src/main/java/wrap/opengl/GLWindow.java
+++ b/hat/wraps/opengl/src/main/java/wrap/opengl/GLWindow.java
@@ -192,8 +192,8 @@ public abstract class GLWindow implements ArenaHolder {
     }
     public GLWindow bindEvents(){
         return bindEvents(
-                "wrap.glwrap.GLCallbackEventHandler",
-                "wrap.glwrap.GLFuncEventHandler"
+                "wrap.opengl.GLCallbackEventHandler",
+                "wrap.opengl.GLFuncEventHandler"
         );
     }
 
@@ -219,6 +219,7 @@ public abstract class GLWindow implements ArenaHolder {
     }
 
     public void mainLoop() {
+       // glutDisplayFunc(null);
         glutMainLoop();
     }
 


### PR DESCRIPTION
Extracted OpenGL used by wrap_opengl differs between linux anbd mac. We need to 'exclude' one source file when we build each.  
The wrapper code was trying to do this reflectively.  Sadly it had hardcoded expected path for classes to look for. 

This broke when I moved the classes from 'wrap.glwrap' to 'wrap.opengl' to be consistent with other projects. 

This PR fixes this.

This comment is way larger than the fix ;)