### PR TITLE
renamed pom artifacts to align with docs and java @hat/bld

### DIFF
--- a/hat/backends/ffi/cuda/pom.xml
+++ b/hat/backends/ffi/cuda/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/backends/ffi/hip/pom.xml
+++ b/hat/backends/ffi/hip/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/backends/ffi/mock/pom.xml
+++ b/hat/backends/ffi/mock/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/backends/ffi/opencl/pom.xml
+++ b/hat/backends/ffi/opencl/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/backends/ffi/pom.xml
+++ b/hat/backends/ffi/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/backends/ffi/shared/pom.xml
+++ b/hat/backends/ffi/shared/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/backends/ffi/spirv/pom.xml
+++ b/hat/backends/ffi/spirv/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/backends/java/mt/pom.xml
+++ b/hat/backends/java/mt/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/backends/java/pom.xml
+++ b/hat/backends/java/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/backends/java/seq/pom.xml
+++ b/hat/backends/java/seq/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/backends/pom.xml
+++ b/hat/backends/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/core/pom.xml
+++ b/hat/core/pom.xml
@@ -26,7 +26,7 @@ questions.
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <groupId>oracle.code</groupId>
-    <artifactId>core</artifactId>
+    <artifactId>hat-core</artifactId>
     <version>1.0</version>
     <parent>
         <groupId>oracle.code</groupId>

--- a/hat/examples/blackscholes/pom.xml
+++ b/hat/examples/blackscholes/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/examples/experiments/pom.xml
+++ b/hat/examples/experiments/pom.xml
@@ -42,7 +42,7 @@ questions.
         <dependency>
             <groupId>oracle.code</groupId>
             <version>1.0</version>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
         </dependency>
         <dependency>
             <groupId>oracle.code</groupId>

--- a/hat/examples/heal/pom.xml
+++ b/hat/examples/heal/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/examples/life/pom.xml
+++ b/hat/examples/life/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/examples/mandel/pom.xml
+++ b/hat/examples/mandel/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/examples/nbody/pom.xml
+++ b/hat/examples/nbody/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/examples/pom.xml
+++ b/hat/examples/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/examples/shared/pom.xml
+++ b/hat/examples/shared/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/examples/squares/pom.xml
+++ b/hat/examples/squares/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/examples/violajones/pom.xml
+++ b/hat/examples/violajones/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/hat/bld.java
+++ b/hat/hat/bld.java
@@ -163,11 +163,11 @@ void main(String[] args) {
     var buildDir = Script.BuildDir.of(dir.path("build")).create();
 
     Artifacts.core = buildDir.mavenStyleBuild(
-          dir.existingDir("core"), "core-1.0.jar"
+          dir.existingDir("core"), "hat-core-1.0.jar"
     );
 
     Artifacts.tools = buildDir.mavenStyleBuild(
-          dir.existingDir("tools"), "tools-1.0.jar", Artifacts.core
+          dir.existingDir("tools"), "hat-tools-1.0.jar", Artifacts.core
     );
 
 
@@ -210,7 +210,7 @@ void main(String[] args) {
     Artifacts.wrap_shared = buildDir.mavenStyleBuild( wrapsDir.existingDir("shared"), "hat-wrap-shared-1.0.jar");
 
     if (Artifacts.jextracted_opencl != null){
-    Artifacts.wrap_opencl = buildDir.mavenStyleBuild( wrapsDir.dir("opencl"), "hat-opencl-1.0.jar", Artifacts.wrap_shared, Artifacts.core, Artifacts.jextracted_opencl);
+    Artifacts.wrap_opencl = buildDir.mavenStyleBuild( wrapsDir.dir("opencl"), "hat-wrap-opencl-1.0.jar", Artifacts.wrap_shared, Artifacts.core, Artifacts.jextracted_opencl);
 }
 // on jetson
 // ls extractions/opengl/src/main/java/opengl/glutKeyboardFunc*

--- a/hat/hat/run.java
+++ b/hat/hat/run.java
@@ -31,7 +31,7 @@ class Config{
      boolean verbose = false;
      boolean startOnFirstThread = false;
      boolean justShowCommandline = false;
-     String backendName = null;
+     String backendName =null;
      Script.JarFile backendJar= null;
      String exampleName = null;
      String examplePackageName = null;
@@ -42,7 +42,7 @@ class Config{
      List<String> appargs = new ArrayList<>();
      Config(Script.BuildDir buildDir,  String[] args){
 
-        classpath.add(buildDir.jarFile("core-1.0.jar"));
+        classpath.add(buildDir.jarFile("hat-core-1.0.jar"));
         classpath.add(buildDir.jarFile("hat-example-shared-1.0.jar"));
         for (int arg=0;arg<args.length;arg++){
             if (args[arg].startsWith("ffi-")) {
@@ -146,6 +146,8 @@ void main(String[] argv) {
       }else{
           var jextracted_opencl_jar = buildDir.jarFile("hat-jextracted-opencl-1.0.jar");
           var jextracted_opengl_jar = buildDir.jarFile("hat-jextracted-opengl-1.0.jar");
+//           jextracted_opencl_jar = buildDir.jarFile("hat-extraction-opencl-1.0.jar");
+ //          jextracted_opengl_jar = buildDir.jarFile("hat-extraction-opengl-1.0.jar");
           var wrap_shared_jar = buildDir.jarFile("hat-wrap-shared-1.0.jar");
           var wrap_opencl_jar = buildDir.jarFile("hat-wrap-opencl-1.0.jar");
           var wrap_opengl_jar = buildDir.jarFile("hat-wrap-opengl-1.0.jar");
@@ -160,10 +162,13 @@ void main(String[] argv) {
                      config.startOnFirstThread = true;
                   }
                   config.classpath.addAll(List.of(
+                          jextracted_opengl_jar,
+                          jextracted_opencl_jar,
                           wrap_shared_jar,
-                          wrap_opengl_jar, jextracted_opengl_jar,
-                          wrap_opencl_jar, jextracted_opencl_jar)
+                          wrap_opengl_jar,
+                          wrap_opencl_jar)
                   );
+                  config.classpath.forEach(c->println(c));
               }
               default -> {}
           }

--- a/hat/tools/pom.xml
+++ b/hat/tools/pom.xml
@@ -36,7 +36,7 @@ questions.
     <dependencies>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
     </dependencies>

--- a/hat/wraps/cuda/pom.xml
+++ b/hat/wraps/cuda/pom.xml
@@ -40,7 +40,7 @@ questions.
         </dependency>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/wraps/opencl/pom.xml
+++ b/hat/wraps/opencl/pom.xml
@@ -40,7 +40,7 @@ questions.
         </dependency>
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>

--- a/hat/wraps/opengl/pom.xml
+++ b/hat/wraps/opengl/pom.xml
@@ -42,7 +42,7 @@ questions.
 
         <dependency>
             <groupId>oracle.code</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>hat-core</artifactId>
             <version>1.0</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Make the pom artifact names align with the docs and `java @hat/bld` targets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/483/head:pull/483` \
`$ git checkout pull/483`

Update a local copy of the PR: \
`$ git checkout pull/483` \
`$ git pull https://git.openjdk.org/babylon.git pull/483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 483`

View PR using the GUI difftool: \
`$ git pr show -t 483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/483.diff">https://git.openjdk.org/babylon/pull/483.diff</a>

</details>
