### PR TITLE
Missed a project rename in hat/bld.java

### DIFF
--- a/hat/hat/bld.java
+++ b/hat/hat/bld.java
@@ -277,17 +277,17 @@ if (Artifacts.extraction_opengl != null
             jextractedBackendsDir.existingDir("shared"), "hat-backend-jextracted-shared-1.0.jar", Artifacts.core
     );
 
-    if (Artifacts.jextracted_opencl != null && jextractedBackendsDir.optionalDir("opencl") instanceof Script.DirEntry jextractedBackendDir) {
+    if (Artifacts.extraction_opencl != null && jextractedBackendsDir.optionalDir("opencl") instanceof Script.DirEntry jextractedBackendDir) {
         Artifacts.backend_jextracted_opencl = buildDir.mavenStyleBuild(
                 jextractedBackendDir, "hat-backend-jextracted-" + jextractedBackendDir.fileName() + "-1.0.jar",
-                Artifacts.core, Artifacts.jextracted_opencl, Artifacts.backend_jextracted_shared
+                Artifacts.core, Artifacts.extraction_opencl, Artifacts.backend_jextracted_shared
         );
     }
 
-    if (Artifacts.jextracted_cuda != null && jextractedBackendsDir.optionalDir("cuda") instanceof Script.DirEntry jextractedBackendDir) {
+    if (Artifacts.extraction_cuda != null && jextractedBackendsDir.optionalDir("cuda") instanceof Script.DirEntry jextractedBackendDir) {
         Artifacts.backend_jextracted_cuda = buildDir.mavenStyleBuild(
                 jextractedBackendDir, "hat-backend-jextracted-" + jextractedBackendDir.fileName() + "-1.0.jar",
-                Artifacts.core, Artifacts.jextracted_cuda, Artifacts.backend_jextracted_shared
+                Artifacts.core, Artifacts.extraction_cuda, Artifacts.backend_jextracted_shared
         );
     }
 


### PR DESCRIPTION
Whoops.  I missed the rename of extraction artifacts in bld.java

This is the fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/485/head:pull/485` \
`$ git checkout pull/485`

Update a local copy of the PR: \
`$ git checkout pull/485` \
`$ git pull https://git.openjdk.org/babylon.git pull/485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 485`

View PR using the GUI difftool: \
`$ git pr show -t 485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/485.diff">https://git.openjdk.org/babylon/pull/485.diff</a>

</details>
