### PR TITLE
Issue errors when quotable constructs are found inside inner classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4277,6 +4277,18 @@ compiler.err.enclosing.class.type.non.denotable=\
 # Diagnostics for code reflection
 ########################################
 
+# 0: symbol
+compiler.err.quoted.method.inner.class=\
+    unsupported quoted method in inner class {0}
+
+# 0: symbol
+compiler.err.quoted.lambda.inner.class=\
+    unsupported quoted lambda in inner class {0}
+
+# 0: symbol
+compiler.err.quoted.mref.inner.class=\
+    unsupported quoted method reference in inner class {0}
+
 compiler.misc.feature.reflect.methods=\
     code reflection
 
@@ -4285,15 +4297,7 @@ compiler.note.method.ir.dump=\
     code reflection enabled for method {0}.{1}\n\
     {2}
 
-# 0: symbol, 1: symbol, 2: string
-compiler.note.method.ir.skip=\
-    unsupported code reflection node {2} found in method {0}.{1}
-
 # 0: string
 compiler.note.quoted.ir.dump=\
     code reflection enabled for method quoted lambda\n\
     {0}
-
-# 0: string
-compiler.note.quoted.ir.skip=\
-    unsupported code reflection node {0} found in quoted lambda

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -213,11 +213,12 @@ compiler.err.preview.without.source.or.release
 compiler.misc.illegal.signature                               # the compiler can now detect more non-denotable types before class writing
 compiler.misc.feature.reflect.methods                         # code reflection
 compiler.note.method.ir.dump                                  # code reflection
-compiler.note.method.ir.skip                                  # code reflection
 compiler.err.cant.infer.quoted.lambda.return.type             # code reflection
 compiler.err.quoted.lambda.must.be.explicit                   # code reflection
 compiler.note.quoted.ir.dump                                  # code reflection
-compiler.note.quoted.ir.skip                                  # code reflection
+compiler.err.quoted.method.inner.class                        # code reflection
+compiler.err.quoted.lambda.inner.class                        # code reflection
+compiler.err.quoted.mref.inner.class                          # code reflection
 
 # this one needs a forged class file to be reproduced
 compiler.err.annotation.unrecognized.attribute.name

--- a/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.java
+++ b/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.java
@@ -1,0 +1,26 @@
+/*
+ * @test /nodynamiccopyright/
+ * @modules jdk.incubator.code
+ * @compile/fail/ref=TestNoCodeReflectionInInnerClasses.out -XDrawDiagnostics TestNoCodeReflectionInInnerClasses.java
+ */
+
+import jdk.incubator.code.*;
+
+class TestNoCodeReflectionInInnerClasses {
+    class Inner {
+        @CodeReflection
+        public void test1() { }
+
+        void test2() {
+            Quotable q = (Runnable & Quotable) () -> { };
+        }
+
+        void test3() {
+            Quoted q = () -> null;
+        }
+
+        void test4() {
+            Quotable q = (Runnable & Quotable) this::test2;
+        }
+    }
+}

--- a/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
+++ b/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
@@ -1,0 +1,7 @@
+- compiler.warn.incubating.modules: jdk.incubator.code
+TestNoCodeReflectionInInnerClasses.java:12:21: compiler.err.quoted.method.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:15:48: compiler.err.quoted.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:19:24: compiler.err.quoted.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:23:48: compiler.err.quoted.mref.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+4 errors
+1 warning

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuotable.java
@@ -137,19 +137,20 @@ public class TestCaptureQuotable {
         }
     }
 
+    static class Context {
+        final int x;
+
+        Context(int x) {
+            this.x = x;
+        }
+
+        Quotable quotable() {
+            return (Quotable & IntUnaryOperator) y -> x + y;
+        }
+    }
+
     @Test(dataProvider = "ints")
     public void testCaptureIntField(int x) {
-        class Context {
-            final int x;
-
-            Context(int x) {
-                this.x = x;
-            }
-
-            Quotable quotable() {
-                return (Quotable & IntUnaryOperator) y -> x + y;
-            }
-        }
         Context context = new Context(x);
         Quotable quotable = context.quotable();
         Quoted quoted = Op.ofQuotable(quotable).get();

--- a/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestCaptureQuoted.java
@@ -56,19 +56,20 @@ public class TestCaptureQuoted {
         assertEquals(res, x + 1);
     }
 
+    static class Context {
+        final int x;
+
+        Context(int x) {
+            this.x = x;
+        }
+
+        Quoted quoted() {
+            return (int y) -> x + y;
+        }
+    }
+
     @Test(dataProvider = "ints")
     public void testCaptureIntField(int x) {
-        class Context {
-            final int x;
-
-            Context(int x) {
-                this.x = x;
-            }
-
-            Quoted quoted() {
-                return (int y) -> x + y;
-            }
-        }
         Context context = new Context(x);
         Quoted quoted = context.quoted();
         assertEquals(quoted.capturedValues().size(), 1);


### PR DESCRIPTION
This PR adds check in `ReflectMethods` to issue errors when quotable methods, lambdas, method references are found inside an inner class. This includes member inner classes, local and anonymous inner classes, but static inner classes (sometimes referred to as *nested classes*) are ok.

The issue is that if we allowed code reflection in these places, we would need to come up with uniform treatment for compiler-generated captured symbols.
Currently `ReflectMethods` just allows method in an inner class to refer to a variable or a method in the enclosing class freely. While this is correct from a source code perspective, by the time we translate to bytecode, such references are no longer possible, and are typically mediated by compiler-generated symbols such as `this$0`.

So, instead of generating a code model that might be unreliable, it is better, for now, to just disallow such cases.

In principle, we should just "skip over" code elements we cannot support, and generate bytecode as usual. Indeed this is where I started, but then I realized that the support for lambda conversion into `Quoted` does not make sense unless we enable code reflection (as there's no real functional interface target we can use there). For this reason, an error is generated instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/486/head:pull/486` \
`$ git checkout pull/486`

Update a local copy of the PR: \
`$ git checkout pull/486` \
`$ git pull https://git.openjdk.org/babylon.git pull/486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 486`

View PR using the GUI difftool: \
`$ git pr show -t 486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/486.diff">https://git.openjdk.org/babylon/pull/486.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/486#issuecomment-3045554706)
</details>
