### PR TITLE
Added a Java code builder 

### DIFF
--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -327,10 +327,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
     @Override
     public T funcCall(CodeBuilderContext buildContext, FuncCallOpWrapper funcCallOpWrapper) {
-        var functionCallName = funcCallOpWrapper.funcName();
-
-
-        identifier(funcCallOpWrapper.funcName());
+          identifier(funcCallOpWrapper.funcName());
         paren(_ -> {
             commaSeparated(funcCallOpWrapper.operands(), (e) -> {
                 if (e instanceof Op.Result r) {

--- a/hat/intellij/.idea/compiler.xml
+++ b/hat/intellij/.idea/compiler.xml
@@ -15,8 +15,8 @@
       <module name="example_mandel" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
       <module name="example_nbody" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
       <module name="example_violajones" options="--add-modules=jdk.incubator.code,java.desktop,java.xml --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
-      <module name="glwrap" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
       <module name="hat" options="--add-modules=jdk.incubator.code,java.compiler,java.xml --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
+      <module name="tools" options="--add-modules=jdk.incubator.code,java.desktop --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports=java.base/jdk.internal=ALL-UNNAMED" />
     </option>
   </component>
 </project>

--- a/hat/intellij/backend_jextracted_opencl.iml
+++ b/hat/intellij/backend_jextracted_opencl.iml
@@ -10,12 +10,10 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="core" />
     <orderEntry type="module" module-name="backend_jextracted_shared" />
-    <orderEntry type="module" module-name="clwrap" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opencl-1.0.jar!/" />
-          <root url="jar://$MODULE_DIR$/../build/extraction-opencl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opencl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/hat/intellij/example_nbody.iml
+++ b/hat/intellij/example_nbody.iml
@@ -5,7 +5,6 @@
     <content url="file://$MODULE_DIR$/../examples/nbody">
       <sourceFolder url="file://$MODULE_DIR$/../examples/nbody/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../examples/nbody/src/main/resources" type="java-resource" />
-      <!--<excludeFolder url="file://$MODULE_DIR$/../examples/nbody/src/main/java/nbody" />-->
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -17,8 +16,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opencl-1.0.jar!/" />
-          <root url="jar://$MODULE_DIR$/../build/extraction-opencl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opencl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
@@ -27,8 +25,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opengl-1.0.jar!/" />
-          <root url="jar://$MODULE_DIR$/../build/extraction-opengl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opengl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/hat/intellij/wrap_opencl.iml
+++ b/hat/intellij/wrap_opencl.iml
@@ -9,16 +9,15 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="wrap_shared" />
-    <orderEntry type="module" module-name="core" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opencl-1.0.jar!/" />
-          <root url="jar://$MODULE_DIR$/../build/extraction-opencl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opencl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module" module-name="core" />
   </component>
 </module>

--- a/hat/intellij/wrap_opengl.iml
+++ b/hat/intellij/wrap_opengl.iml
@@ -5,7 +5,6 @@
     <content url="file://$MODULE_DIR$/../wraps/opengl">
       <sourceFolder url="file://$MODULE_DIR$/../wraps/opengl/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../wraps/opengl/src/main/resources" type="java-resource" />
-      <!--<excludeFolder url="file://$MODULE_DIR$/../wraps/opengl/src/main/java/wrap/glwrap" />-->
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -13,8 +12,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-jextracted-opengl-1.0.jar!/" />
-          <root url="jar://$MODULE_DIR$/../build/extraction-opengl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opengl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/hat/tools/src/main/java/hat/codebuilders/OpCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/codebuilders/OpCodeBuilder.java
@@ -22,10 +22,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package hat.opcodebuilders;
+package hat.codebuilders;
 
-
-import hat.codebuilders.CodeBuilder;
 
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;

--- a/hat/tools/src/main/java/hat/codebuilders/StyledOpCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/codebuilders/StyledOpCodeBuilder.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package hat.opcodebuilders;
+package hat.codebuilders;
 
 
 import jdk.incubator.code.TypeElement;


### PR DESCRIPTION
I have some tooling to visualize code models when converted to C99, I figured we should have one that converts bacl to java source. 

So fernflowery style. 

This is not in core but in the news tools project (where I plan on adding some of the more useful tools I have collected)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/487/head:pull/487` \
`$ git checkout pull/487`

Update a local copy of the PR: \
`$ git checkout pull/487` \
`$ git pull https://git.openjdk.org/babylon.git pull/487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 487`

View PR using the GUI difftool: \
`$ git pr show -t 487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/487.diff">https://git.openjdk.org/babylon/pull/487.diff</a>

</details>
