### PR TITLE
Reduce Op writing to text methods.

### DIFF
--- a/hat/core/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/core/src/main/java/hat/backend/DebugBackend.java
@@ -82,7 +82,7 @@ public class DebugBackend extends BackendAdaptor {
                     }
                     computeContext.computeCallGraph.entrypoint.mh.invokeWithArguments(args);
                 } catch (Throwable e) {
-                    computeContext.computeCallGraph.entrypoint.lowered.op().writeTo(System.out);
+                    System.out.println(computeContext.computeCallGraph.entrypoint.lowered.op().toText());
                     throw new RuntimeException(e);
                 }
                 break;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -25,10 +25,6 @@
 
 package jdk.incubator.code;
 
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-
 import com.sun.tools.javac.api.JavacScope;
 import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
@@ -52,7 +48,6 @@ import javax.lang.model.element.Modifier;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.BiFunction;
 
@@ -462,24 +457,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         for (Body childBody : op.bodies()) {
             Body.capturedValues(capturedValues, bodyStack, childBody);
         }
-    }
-
-    /**
-     * Writes the textual form of this operation to the given output stream, using the UTF-8 character set.
-     *
-     * @param out the stream to write to.
-     */
-    public void writeTo(OutputStream out) {
-        writeTo(new OutputStreamWriter(out, StandardCharsets.UTF_8));
-    }
-
-    /**
-     * Writes the textual form of this operation to the given writer.
-     *
-     * @param w the writer to write to.
-     */
-    public void writeTo(Writer w) {
-        OpWriter.writeTo(w, this);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
@@ -25,15 +25,14 @@
 
 package jdk.incubator.code.extern;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UncheckedIOException;
-import java.io.Writer;
+import java.io.*;
+
 import jdk.incubator.code.*;
 import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.dialect.java.impl.JavaTypeUtils;
 
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -230,21 +229,13 @@ public final class OpWriter {
     }
 
     /**
-     * Writes a code model (an operation) to the character stream.
-     * <p>
-     * The character stream will be flushed after the model is writen.
+     * Writes a code model (an operation) to the output stream, using the UTF-8 character set.
      *
-     * @param w the character stream
+     * @param out the output stream
      * @param op the code model
      */
-    public static void writeTo(Writer w, Op op) {
-        OpWriter ow = new OpWriter(w);
-        ow.writeOp(op);
-        try {
-            w.flush();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    public static void writeTo(OutputStream out, Op op, Option... options) {
+        writeTo(new OutputStreamWriter(out, StandardCharsets.UTF_8), op, options);
     }
 
     /**
@@ -265,17 +256,6 @@ public final class OpWriter {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    /**
-     * Writes a code model (an operation) to a string.
-     *
-     * @param op the code model
-     */
-    public static String toText(Op op) {
-        StringWriter w = new StringWriter();
-        writeTo(w, op);
-        return w.toString();
     }
 
     /**

--- a/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
+++ b/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
@@ -264,7 +264,7 @@ public class CoreBinaryOpsTest {
                 return original; // already expected type
             }
             if (functionType.parameterTypes().stream().distinct().count() != 1) {
-                original.writeTo(System.err);
+                System.err.println(original.toText());
                 throw new IllegalArgumentException("Only FuncOps with exactly one distinct parameter type are supported");
             }
             // if the return type does not match the input types, we keep it

--- a/test/jdk/java/lang/reflect/code/TestArrayCreation.java
+++ b/test/jdk/java/lang/reflect/code/TestArrayCreation.java
@@ -49,7 +49,7 @@ public class TestArrayCreation {
     public void testf() {
         CoreOp.FuncOp f = getFuncOp("f");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f());
     }
@@ -63,7 +63,7 @@ public class TestArrayCreation {
     public void testf2() {
         CoreOp.FuncOp f = getFuncOp("f2");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f2());
     }
@@ -77,7 +77,7 @@ public class TestArrayCreation {
     public void testf3() {
         CoreOp.FuncOp f = getFuncOp("f3");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f3());
     }

--- a/test/jdk/java/lang/reflect/code/TestArrayTypes.java
+++ b/test/jdk/java/lang/reflect/code/TestArrayTypes.java
@@ -51,7 +51,7 @@ public class TestArrayTypes {
     public void testf() {
         CoreOp.FuncOp f = getFuncOp("f");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f());
     }
@@ -65,7 +65,7 @@ public class TestArrayTypes {
     public void testf2() {
         CoreOp.FuncOp f = getFuncOp("f2");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f2());
     }
@@ -79,7 +79,7 @@ public class TestArrayTypes {
     public void testf3() {
         CoreOp.FuncOp f = getFuncOp("f3");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), f3());
     }

--- a/test/jdk/java/lang/reflect/code/TestBinops.java
+++ b/test/jdk/java/lang/reflect/code/TestBinops.java
@@ -51,7 +51,7 @@ public class TestBinops {
     public void testNot() {
         CoreOp.FuncOp f = getFuncOp("not");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, true), not(true));
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, false), not(false));
@@ -66,7 +66,7 @@ public class TestBinops {
     public void testNeg() {
         CoreOp.FuncOp f = getFuncOp("neg");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 42), neg(42));
     }
@@ -80,7 +80,7 @@ public class TestBinops {
     public void testCompl() {
         CoreOp.FuncOp f = getFuncOp("compl");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 42), compl(42));
     }
@@ -94,7 +94,7 @@ public class TestBinops {
     public void testMod() {
         CoreOp.FuncOp f = getFuncOp("mod");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), mod(10, 3));
     }
@@ -108,7 +108,7 @@ public class TestBinops {
     public void testBitand() {
         CoreOp.FuncOp f = getFuncOp("bitand");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), bitand(10, 3));
     }
@@ -122,7 +122,7 @@ public class TestBinops {
     public void testBitor() {
         CoreOp.FuncOp f = getFuncOp("bitor");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), bitor(10, 3));
     }
@@ -136,7 +136,7 @@ public class TestBinops {
     public void testBitxor() {
         CoreOp.FuncOp f = getFuncOp("bitxor");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 10, 3), bitxor(10, 3));
     }
@@ -150,7 +150,7 @@ public class TestBinops {
     public void testBooland() {
         CoreOp.FuncOp f = getFuncOp("booland");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, true, false), booland(true, false));
     }
@@ -164,7 +164,7 @@ public class TestBinops {
     public void testBoolor() {
         CoreOp.FuncOp f = getFuncOp("boolor");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, false, true), boolor(false, true));
     }
@@ -178,7 +178,7 @@ public class TestBinops {
     public void testBoolxor() {
         CoreOp.FuncOp f = getFuncOp("boolxor");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, true, true), boolxor(true, true));
     }
@@ -192,7 +192,7 @@ public class TestBinops {
     public void testDoublemod() {
         CoreOp.FuncOp f = getFuncOp("doublemod");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 15.6, 2.1), doublemod(15.6, 2.1));
     }

--- a/test/jdk/java/lang/reflect/code/TestBlockOp.java
+++ b/test/jdk/java/lang/reflect/code/TestBlockOp.java
@@ -70,11 +70,11 @@ public class TestBlockOp {
     public void testf() {
         CoreOp.FuncOp f = getFuncOp("f");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f());
     }

--- a/test/jdk/java/lang/reflect/code/TestBreakContinue.java
+++ b/test/jdk/java/lang/reflect/code/TestBreakContinue.java
@@ -64,11 +64,11 @@ public class TestBreakContinue {
     public void testForLoopBreakContinue() {
         CoreOp.FuncOp f = getFuncOp("forLoopBreakContinue");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         IntUnaryOperator o = i -> {
             if (i <= 3) return -1;
@@ -108,11 +108,11 @@ public class TestBreakContinue {
     public void testNestedForLoopBreakContinue() {
         CoreOp.FuncOp f = getFuncOp("nestedForLoopBreakContinue");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int r = -1; r < 4; r++) {
             int fr = r;
@@ -156,11 +156,11 @@ public class TestBreakContinue {
     public void testForLoopLabeledBreakContinue() {
         CoreOp.FuncOp f = getFuncOp("forLoopLabeledBreakContinue");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int r = -1; r < 6; r++) {
             int fr = r;
@@ -206,11 +206,11 @@ public class TestBreakContinue {
     public void testBlockBreak() {
         CoreOp.FuncOp f = getFuncOp("blockBreak");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int i = 0; i < 7; i++) {
             int fi = i;

--- a/test/jdk/java/lang/reflect/code/TestClosureOps.java
+++ b/test/jdk/java/lang/reflect/code/TestClosureOps.java
@@ -37,6 +37,7 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.Quoted;
 import jdk.incubator.code.dialect.java.MethodRef;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import jdk.incubator.code.dialect.java.JavaType;
 import java.util.ArrayList;
@@ -98,7 +99,7 @@ public class TestClosureOps {
                     block.op(return_(or));
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -128,7 +129,7 @@ public class TestClosureOps {
                     block.op(return_(or));
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);

--- a/test/jdk/java/lang/reflect/code/TestConditionalExpression.java
+++ b/test/jdk/java/lang/reflect/code/TestConditionalExpression.java
@@ -50,11 +50,11 @@ public class TestConditionalExpression {
     public void testSimpleExpression() {
         CoreOp.FuncOp f = getFuncOp("simpleExpression");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, true, 1, 2), simpleExpression(true, 1, 2));
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, false, 1, 2), simpleExpression(false, 1, 2));

--- a/test/jdk/java/lang/reflect/code/TestConditionalOp.java
+++ b/test/jdk/java/lang/reflect/code/TestConditionalOp.java
@@ -28,6 +28,7 @@ import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import jdk.incubator.code.CodeReflection;
@@ -79,11 +80,11 @@ public class TestConditionalOp {
     public void testf() {
         CoreOp.FuncOp f = getFuncOp("f");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int i = 0; i < 8; i++) {
             boolean a = (i & 1) != 0;

--- a/test/jdk/java/lang/reflect/code/TestConstants.java
+++ b/test/jdk/java/lang/reflect/code/TestConstants.java
@@ -162,7 +162,7 @@ public class TestConstants {
         for (Method m : ms) {
             CoreOp.FuncOp f = Op.ofMethod(m).get();
 
-            f.writeTo(System.out);
+            System.out.println(f.toText());
 
             Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f), m.invoke(null));
         }
@@ -181,11 +181,11 @@ public class TestConstants {
     public void testCompareNull() {
         CoreOp.FuncOp f = getFuncOp("compareNull");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, (Object) null), compareNull(null));
     }

--- a/test/jdk/java/lang/reflect/code/TestDominate.java
+++ b/test/jdk/java/lang/reflect/code/TestDominate.java
@@ -31,6 +31,7 @@ import jdk.incubator.code.Block;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.java.JavaType;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -132,7 +133,7 @@ public class TestDominate {
             b1.op(CoreOp.return_());
         });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
         boolean[][] bvs = new boolean[][]{
                 {true, false, false, false, false, false},
                 {true, true, false, false, false, false},
@@ -213,7 +214,7 @@ public class TestDominate {
 
             b3.op(branch(b2.successor()));
         });
-        f.writeTo(System.out);
+        System.out.println(f.toText());
         Map<Block, Block> idoms = f.body().immediateDominators();
         System.out.println(idoms);
 
@@ -277,7 +278,7 @@ public class TestDominate {
             exit.op(CoreOp.return_());
         });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Map<Block, Block> idoms = f.body().immediateDominators();
         Node<String> domTree = buildDomTree(f.body().entryBlock(), idoms).transform(b -> Integer.toString(b.index()));

--- a/test/jdk/java/lang/reflect/code/TestEnhancedForOp.java
+++ b/test/jdk/java/lang/reflect/code/TestEnhancedForOp.java
@@ -65,11 +65,11 @@ public class TestEnhancedForOp {
     public void testf() {
         CoreOp.FuncOp f = getFuncOp("f");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f());
     }
@@ -88,11 +88,11 @@ public class TestEnhancedForOp {
     public void testArray() {
         CoreOp.FuncOp f = getFuncOp("array");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         int[] ia = new int[] {1, 2, 3, 4};
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, ia), array(ia));

--- a/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
+++ b/test/jdk/java/lang/reflect/code/TestExceptionRegionOps.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import jdk.incubator.code.dialect.java.JavaType;
 import java.util.ArrayList;
@@ -116,7 +117,7 @@ public class TestExceptionRegionOps {
                     });
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), f, c),
@@ -209,7 +210,7 @@ public class TestExceptionRegionOps {
                     });
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), f, c),
@@ -323,7 +324,7 @@ public class TestExceptionRegionOps {
                     });
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), f, c),
@@ -448,7 +449,7 @@ public class TestExceptionRegionOps {
                     });
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), f, c),

--- a/test/jdk/java/lang/reflect/code/TestForOp.java
+++ b/test/jdk/java/lang/reflect/code/TestForOp.java
@@ -55,11 +55,11 @@ public class TestForOp {
     public void testf() {
         CoreOp.FuncOp f = getFuncOp("f");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f());
     }
@@ -78,11 +78,11 @@ public class TestForOp {
     public void testf2() {
         CoreOp.FuncOp f = getFuncOp("f2");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f2());
     }
@@ -103,11 +103,11 @@ public class TestForOp {
     public void testf3() {
         CoreOp.FuncOp f = getFuncOp("f3");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), f3());
     }

--- a/test/jdk/java/lang/reflect/code/TestIfOp.java
+++ b/test/jdk/java/lang/reflect/code/TestIfOp.java
@@ -72,11 +72,11 @@ public class TestIfOp {
     public void testf() {
         CoreOp.FuncOp f = getFuncOp("f");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int i = 0; i < 6; i++) {
             Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, i), f(i));

--- a/test/jdk/java/lang/reflect/code/TestInline.java
+++ b/test/jdk/java/lang/reflect/code/TestInline.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import jdk.incubator.code.*;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import jdk.incubator.code.dialect.java.JavaType;
 import java.util.List;
@@ -59,7 +60,7 @@ public class TestInline {
                     Assert.assertEquals(fblock, cb);
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -87,7 +88,7 @@ public class TestInline {
                     fblock.op(return_(fblock.op(varLoad(v))));
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -103,9 +104,9 @@ public class TestInline {
             return a - b;
         };
         CoreOp.ClosureOp cop = (CoreOp.ClosureOp) q.op();
-        cop.writeTo(System.out);
+        System.out.println(cop.toText());
         CoreOp.ClosureOp lcop = cop.transform(CopyContext.create(), OpTransformer.LOWERING_TRANSFORMER);
-        lcop.writeTo(System.out);
+        System.out.println(lcop.toText());
 
         // functional type = (int)int
         CoreOp.FuncOp f = func("f", functionType(INT, INT))
@@ -117,7 +118,7 @@ public class TestInline {
                     var cb = fblock.inline(lcop, List.of(i, fortyTwo), Block.Builder.INLINE_RETURN);
                     Assert.assertNotEquals(fblock, cb);
                 });
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -132,9 +133,9 @@ public class TestInline {
             return a - b;
         };
         CoreOp.ClosureOp cop = (CoreOp.ClosureOp) q.op();
-        cop.writeTo(System.out);
+        System.out.println(cop.toText());
         CoreOp.ClosureOp lcop = cop.transform(CopyContext.create(), OpTransformer.LOWERING_TRANSFORMER);
-        lcop.writeTo(System.out);
+        System.out.println(lcop.toText());
 
         // functional type = (int)int
         CoreOp.FuncOp f = func("f", functionType(INT, INT))
@@ -152,7 +153,7 @@ public class TestInline {
 
                     cb.op(return_(cb.op(varLoad(v))));
                 });
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -167,7 +168,7 @@ public class TestInline {
             return a - b;
         };
         CoreOp.ClosureOp cop = (CoreOp.ClosureOp) q.op();
-        cop.writeTo(System.out);
+        System.out.println(cop.toText());
 
         CoreOp.FuncOp f = func("f", functionType(INT, INT))
                 .body(fblock -> {
@@ -178,10 +179,10 @@ public class TestInline {
                     var cb = fblock.inline(cop, List.of(i, fortyTwo), Block.Builder.INLINE_RETURN);
                     Assert.assertEquals(fblock, cb);
                 });
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -204,7 +205,7 @@ public class TestInline {
                     Assert.assertEquals(fblock, cb);
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int[] a = new int[1];
         Interpreter.invoke(MethodHandles.lookup(), f, a);

--- a/test/jdk/java/lang/reflect/code/TestInvokeSuper.java
+++ b/test/jdk/java/lang/reflect/code/TestInvokeSuper.java
@@ -66,7 +66,7 @@ public class TestInvokeSuper {
     public void testInvokeSuper() {
         CoreOp.FuncOp f = getFuncOp(B.class, "f");
         f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         for (boolean invokeClass : new boolean[] {true, false}) {
             B b = new B(invokeClass);

--- a/test/jdk/java/lang/reflect/code/TestLambdaOps.java
+++ b/test/jdk/java/lang/reflect/code/TestLambdaOps.java
@@ -38,6 +38,7 @@ import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
 import jdk.incubator.code.dialect.java.JavaOp.LambdaOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import jdk.incubator.code.CodeReflection;
@@ -100,7 +101,7 @@ public class TestLambdaOps {
                     block.op(return_(or));
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -135,7 +136,7 @@ public class TestLambdaOps {
                     block.op(return_(or));
                 });
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int ir = (int) Interpreter.invoke(MethodHandles.lookup(), f, 1);
         Assert.assertEquals(ir, 43);
@@ -175,14 +176,14 @@ public class TestLambdaOps {
     @Test
     public void testQuote() {
         FuncOp g = getFuncOp("quote");
-        g.writeTo(System.out);
+        System.out.println(g.toText());
 
         {
             QuotableIntSupplier op = (QuotableIntSupplier) Interpreter.invoke(MethodHandles.lookup(), g, 42);
             Assert.assertEquals(op.getAsInt(), 42);
 
             Quoted q = Op.ofQuotable(op).get();
-            q.op().writeTo(System.out);
+            System.out.println(q.op().toText());
             Assert.assertEquals(q.capturedValues().size(), 1);
             Assert.assertEquals(((Var<?>)q.capturedValues().values().iterator().next()).value(), 42);
 
@@ -200,7 +201,7 @@ public class TestLambdaOps {
             Assert.assertEquals(op.getAsInt(), 42);
 
             Quoted q = Op.ofQuotable(op).get();
-            q.op().writeTo(System.out);
+            System.out.println(q.op().toText());
             System.out.print(q.capturedValues().values());
             Assert.assertEquals(q.capturedValues().size(), 1);
             Assert.assertEquals(((Var<?>)q.capturedValues().values().iterator().next()).value(), 42);

--- a/test/jdk/java/lang/reflect/code/TestLinqUsingQuoted.java
+++ b/test/jdk/java/lang/reflect/code/TestLinqUsingQuoted.java
@@ -30,6 +30,7 @@ import jdk.incubator.code.Quoted;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.java.MethodRef;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.TypeElement;
@@ -251,12 +252,14 @@ public class TestLinqUsingQuoted {
                 // c -> c.contactName
                 .select((Customer c) -> c.contactName).elements();
 
-        qr.expression().writeTo(System.out);
+        Op op1 = qr.expression();
+        System.out.println(op1.toText());
 
         QueryResult qr2 = (QueryResult) Interpreter.invoke(MethodHandles.lookup(),
                 qr.expression(), qp.newQuery(JavaType.type(Customer.class)));
 
-        qr2.expression().writeTo(System.out);
+        Op op = qr2.expression();
+        System.out.println(op.toText());
 
         Assert.assertEquals(qr.expression().toText(), qr2.expression().toText());
     }

--- a/test/jdk/java/lang/reflect/code/TestLocalTransformationsAdaption.java
+++ b/test/jdk/java/lang/reflect/code/TestLocalTransformationsAdaption.java
@@ -93,10 +93,10 @@ public class TestLocalTransformationsAdaption {
     @Test
     public void testInvocation() {
         CoreOp.FuncOp f = getFuncOp("f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         int x = (int) Interpreter.invoke(MethodHandles.lookup(), f, 2);
         Assert.assertEquals(x, f(2));
@@ -112,7 +112,7 @@ public class TestLocalTransformationsAdaption {
     @Test
     public void testFuncEntryExit() {
         CoreOp.FuncOp f = getFuncOp("f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         AtomicBoolean first = new AtomicBoolean(true);
         CoreOp.FuncOp fc = f.transform((block, op) -> {
@@ -137,10 +137,10 @@ public class TestLocalTransformationsAdaption {
 
             return block;
         });
-        fc.writeTo(System.out);
+        System.out.println(fc.toText());
 
         fc = fc.transform(OpTransformer.LOWERING_TRANSFORMER);
-        fc.writeTo(System.out);
+        System.out.println(fc.toText());
 
         int x = (int) Interpreter.invoke(MethodHandles.lookup(), fc, 2);
         Assert.assertEquals(x, f(2));
@@ -170,7 +170,7 @@ public class TestLocalTransformationsAdaption {
     @Test
     public void testReplaceCall() {
         CoreOp.FuncOp f = getFuncOp("f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp fc = f.transform((block, op) -> {
             switch (op) {
@@ -189,10 +189,10 @@ public class TestLocalTransformationsAdaption {
             }
             return block;
         });
-        fc.writeTo(System.out);
+        System.out.println(fc.toText());
 
         fc = fc.transform(OpTransformer.LOWERING_TRANSFORMER);
-        fc.writeTo(System.out);
+        System.out.println(fc.toText());
 
         int x = (int) Interpreter.invoke(MethodHandles.lookup(), fc, 2);
         Assert.assertEquals(x, f(2));
@@ -202,7 +202,7 @@ public class TestLocalTransformationsAdaption {
     @Test
     public void testCallEntryExit() {
         CoreOp.FuncOp f = getFuncOp("f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp fc = f.transform((block, op) -> {
             switch (op) {
@@ -216,10 +216,10 @@ public class TestLocalTransformationsAdaption {
             }
             return block;
         });
-        fc.writeTo(System.out);
+        System.out.println(fc.toText());
 
         fc = fc.transform(OpTransformer.LOWERING_TRANSFORMER);
-        fc.writeTo(System.out);
+        System.out.println(fc.toText());
 
         int x = (int) Interpreter.invoke(MethodHandles.lookup(), fc, 2);
         Assert.assertEquals(x, f(2));

--- a/test/jdk/java/lang/reflect/code/TestPatterns.java
+++ b/test/jdk/java/lang/reflect/code/TestPatterns.java
@@ -34,6 +34,7 @@ import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import jdk.incubator.code.CodeReflection;
@@ -72,11 +73,11 @@ public class TestPatterns {
     public void testRecordPatterns() {
         CoreOp.FuncOp f = getFuncOp("recordPatterns");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         {
             Rectangle r = new Rectangle(
@@ -116,10 +117,10 @@ public class TestPatterns {
     void testRecordPattern2() {
 
         CoreOp.FuncOp f = getFuncOp("recordPatterns2");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Object[] objects = {new R(1), "str", null};
         for (Object o : objects) {

--- a/test/jdk/java/lang/reflect/code/TestPatterns2.java
+++ b/test/jdk/java/lang/reflect/code/TestPatterns2.java
@@ -29,10 +29,10 @@ public class TestPatterns2 {
     void test() {
 
         CoreOp.FuncOp f = getFuncOp("f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         R[] args = {new R(1), new R(2d)};
         for (R arg : args) {

--- a/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/java/lang/reflect/code/TestPrimitiveTypePatterns.java
@@ -144,10 +144,10 @@ public class TestPrimitiveTypePatterns {
     void testNarrowingPrimitiveAndWideningPrimitiveThatNeedCheck(JavaType sourceType, JavaType targetType, Object[] values) throws Throwable {
 
         var model = buildTypePatternModel(sourceType, targetType);
-        model.writeTo(System.out);
+        System.out.println(model.toText());
 
         var lmodel = model.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lmodel.writeTo(System.out);
+        System.out.println(lmodel.toText());
 
 
         var expectedConvMethod = conversionMethodRef(sourceType, targetType);
@@ -175,10 +175,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testIdentityPrimitive() {
         FuncOp f = getFuncOp("identityPrimitive");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Short.MAX_VALUE), true);
     }
@@ -191,10 +191,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testWideningNarrowingPrimitive() {
         FuncOp f = getFuncOp("wideningNarrowingPrimitive");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Byte.MAX_VALUE), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Byte.MIN_VALUE), false);
@@ -208,10 +208,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testBoxing() {
         FuncOp f = getFuncOp("boxing");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
@@ -225,10 +225,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testBoxingWideningReference() {
         FuncOp f = getFuncOp("boxingWideningReference");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
@@ -242,10 +242,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testNarrowingReferenceUnboxing() {
         FuncOp f = getFuncOp("narrowingReferenceUnboxing");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, 1), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, (short) 1), false);
@@ -259,10 +259,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testUnboxing() {
         FuncOp f = getFuncOp("unboxing");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
@@ -276,10 +276,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testUnboxingWideningPrimitive() {
         FuncOp f = getFuncOp("unboxingWideningPrimitive");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);
@@ -293,10 +293,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testWideningReference() {
         FuncOp f = getFuncOp("wideningReference");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, (Object) null), false);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, "str"), true);
@@ -310,10 +310,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testIdentityReference() {
         FuncOp f = getFuncOp("identityReference");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.MAX_VALUE), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.MIN_VALUE), true);
@@ -329,10 +329,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testNarrowingReference() {
         FuncOp f = getFuncOp("narrowingReference");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Float.MAX_VALUE), false);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), false);
@@ -348,10 +348,10 @@ public class TestPrimitiveTypePatterns {
     @Test
     void testWideningPrimitive() {
         FuncOp f = getFuncOp("wideningPrimitive");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE), true);
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE), true);

--- a/test/jdk/java/lang/reflect/code/TestRemoveFinalVars.java
+++ b/test/jdk/java/lang/reflect/code/TestRemoveFinalVars.java
@@ -36,18 +36,19 @@ public class TestRemoveFinalVars {
     @Test
     void test() {
         FuncOp f = getFuncOp(this.getClass(),"f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
         FuncOp lf = lower(f);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         FuncOp f2 = f.transform(TestRemoveFinalVars::rmFinalVars);
-        f2.writeTo(System.out);
+        System.out.println(f2.toText());
         FuncOp lf2 = lower(f2);
-        lf2.writeTo(System.out);
+        System.out.println(lf2.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), Interpreter.invoke(MethodHandles.lookup(), lf2));
 
-        SSA.transform(lower(f)).writeTo(System.out);
+        Op op = SSA.transform(lower(f));
+        System.out.println(op.toText());
     }
 
     static FuncOp lower(FuncOp funcOp) {

--- a/test/jdk/java/lang/reflect/code/TestSSA.java
+++ b/test/jdk/java/lang/reflect/code/TestSSA.java
@@ -154,13 +154,13 @@ public class TestSSA {
     }
 
     static CoreOp.FuncOp generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         lf = SSA.transform(lf);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
         return lf;
     }
 

--- a/test/jdk/java/lang/reflect/code/TestStringConcatTransform.java
+++ b/test/jdk/java/lang/reflect/code/TestStringConcatTransform.java
@@ -101,8 +101,8 @@ public class TestStringConcatTransform {
         CoreOp.FuncOp f_transformed = model.transform(new StringConcatTransformer());
         Object[] args = prepArgs(method);
 
-        model.writeTo(System.out);
-        f_transformed.writeTo(System.out);
+        System.out.println(model.toText());
+        System.out.println(f_transformed.toText());
 
         var interpreted = Interpreter.invoke(MethodHandles.lookup(), model, args);
         var transformed_interpreted = Interpreter.invoke(MethodHandles.lookup(), f_transformed, args);
@@ -181,7 +181,7 @@ public class TestStringConcatTransform {
     static CoreOp.FuncOp generateSSA(CoreOp.FuncOp f) {
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
         lf = SSA.transform(lf);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
         return lf;
     }
 

--- a/test/jdk/java/lang/reflect/code/TestTry.java
+++ b/test/jdk/java/lang/reflect/code/TestTry.java
@@ -34,6 +34,7 @@ import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import jdk.incubator.code.CodeReflection;
@@ -68,11 +69,11 @@ public class TestTry {
     public void testCatching() {
         CoreOp.FuncOp f = getFuncOp("catching");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -125,11 +126,11 @@ public class TestTry {
     public void testCatchThrowable() {
         CoreOp.FuncOp f = getFuncOp("catchThrowable");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -185,11 +186,11 @@ public class TestTry {
     public void testCatchNested() {
         CoreOp.FuncOp f = getFuncOp("catchNested");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),

--- a/test/jdk/java/lang/reflect/code/TestTryFinally.java
+++ b/test/jdk/java/lang/reflect/code/TestTryFinally.java
@@ -34,6 +34,7 @@ import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import jdk.incubator.code.CodeReflection;
@@ -66,11 +67,11 @@ public class TestTryFinally {
     public void testCatchFinally() {
         CoreOp.FuncOp f = getFuncOp("tryCatchFinally");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -102,11 +103,11 @@ public class TestTryFinally {
     public void testTryReturn() {
         CoreOp.FuncOp f = getFuncOp("tryReturn");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -138,11 +139,11 @@ public class TestTryFinally {
     public void testCatchThrow() {
         CoreOp.FuncOp f = getFuncOp("catchThrow");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -172,11 +173,11 @@ public class TestTryFinally {
     public void testFinallyReturn() {
         CoreOp.FuncOp f = getFuncOp("finallyReturn");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),

--- a/test/jdk/java/lang/reflect/code/TestTryNested.java
+++ b/test/jdk/java/lang/reflect/code/TestTryNested.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import jdk.incubator.code.CodeReflection;
@@ -86,11 +87,11 @@ public class TestTryNested {
     public void testCatchFinally() {
         CoreOp.FuncOp f = getFuncOp("tryCatchFinally");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int ra = -1; ra < 6; ra++) {
             int fra = ra;
@@ -145,11 +146,11 @@ public class TestTryNested {
     public void testCatchBreak() {
         CoreOp.FuncOp f = getFuncOp("tryCatchBreak");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int ra = -1; ra < 4; ra++) {
             int fra = ra;
@@ -213,11 +214,11 @@ public class TestTryNested {
     public void testCatchFinallyBreak() {
         CoreOp.FuncOp f = getFuncOp("tryCatchFinallyBreak");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int ra = -1; ra < 6; ra++) {
             int fra = ra;
@@ -264,11 +265,11 @@ public class TestTryNested {
     public void testTryForLoop() {
         CoreOp.FuncOp f = getFuncOp("tryForLoop");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -310,11 +311,11 @@ public class TestTryNested {
     public void testTryForLoopFinally() {
         CoreOp.FuncOp f = getFuncOp("tryForLoopFinally");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -362,11 +363,11 @@ public class TestTryNested {
     public void testTryLabeledForLoop() {
         CoreOp.FuncOp f = getFuncOp("tryLabeledForLoop");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Consumer<IntConsumer> test = testConsumer(
                 c -> Interpreter.invoke(MethodHandles.lookup(), lf, c),
@@ -401,11 +402,11 @@ public class TestTryNested {
     public void testTryLambda() {
         CoreOp.FuncOp f = getFuncOp("tryLambda");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         for (int ra = 0; ra < 2; ra++) {
             final int fra = ra;

--- a/test/jdk/java/lang/reflect/code/TestUninitializedVariable.java
+++ b/test/jdk/java/lang/reflect/code/TestUninitializedVariable.java
@@ -74,7 +74,7 @@ public class TestUninitializedVariable {
     @Test(dataProvider = "methods")
     public void testInterpret(String method) {
         CoreOp.FuncOp f = removeFirstStore(getFuncOp(method).transform(OpTransformer.LOWERING_TRANSFORMER));
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertThrows(Interpreter.InterpreterException.class, () -> Interpreter.invoke(MethodHandles.lookup(), f, 1));
     }
@@ -82,7 +82,7 @@ public class TestUninitializedVariable {
     @Test(dataProvider = "methods")
     public void testSSA(String method) {
         CoreOp.FuncOp f = removeFirstStore(getFuncOp(method).transform(OpTransformer.LOWERING_TRANSFORMER));
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertThrows(IllegalStateException.class, () -> SSA.transform(f));
     }

--- a/test/jdk/java/lang/reflect/code/TestUsesDependsOn.java
+++ b/test/jdk/java/lang/reflect/code/TestUsesDependsOn.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 
 import jdk.incubator.code.*;
 import jdk.incubator.code.extern.OpParser;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,7 @@ public class TestUsesDependsOn {
     @Test
     public void testUses() {
         Op f = OpParser.fromStringOfJavaCodeModel(OP);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Map<String, List<String>> uses = computeValueMap(f, Value::uses);
 

--- a/test/jdk/java/lang/reflect/code/TestWhileOp.java
+++ b/test/jdk/java/lang/reflect/code/TestWhileOp.java
@@ -55,11 +55,11 @@ public class TestWhileOp {
     public void testWhileLoop() {
         CoreOp.FuncOp f = getFuncOp("whileLoop");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), whileLoop());
     }
@@ -77,11 +77,11 @@ public class TestWhileOp {
     public void testDpWhileLoop() {
         CoreOp.FuncOp f = getFuncOp("doWhileLoop");
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), lf), doWhileLoop());
     }

--- a/test/jdk/java/lang/reflect/code/ad/TestForwardAutoDiff.java
+++ b/test/jdk/java/lang/reflect/code/ad/TestForwardAutoDiff.java
@@ -31,6 +31,7 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.analysis.SSA;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -52,10 +53,10 @@ public class TestForwardAutoDiff {
     @Test
     public void testExpression() throws Throwable {
         CoreOp.FuncOp f = getFuncOp("f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         f = SSA.transform(f);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 0.0, 1.0), f(0.0, 1.0));
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, PI_4, PI_4), f(PI_4, PI_4));
@@ -64,13 +65,13 @@ public class TestForwardAutoDiff {
         Block.Parameter y = f.body().entryBlock().parameters().get(1);
 
         CoreOp.FuncOp dff_dx = ExpressionElimination.eliminate(ForwardDifferentiation.partialDiff(f, x));
-        dff_dx.writeTo(System.out);
+        System.out.println(dff_dx.toText());
         MethodHandle dff_dx_mh = generate(dff_dx);
         Assert.assertEquals((double) dff_dx_mh.invoke(0.0, 1.0), df_dx(0.0, 1.0));
         Assert.assertEquals((double) dff_dx_mh.invoke(PI_4, PI_4), df_dx(PI_4, PI_4));
 
         CoreOp.FuncOp dff_dy = ExpressionElimination.eliminate(ForwardDifferentiation.partialDiff(f, y));
-        dff_dy.writeTo(System.out);
+        System.out.println(dff_dy.toText());
         MethodHandle dff_dy_mh = generate(dff_dy);
         Assert.assertEquals((double) dff_dy_mh.invoke(0.0, 1.0), df_dy(0.0, 1.0));
         Assert.assertEquals((double) dff_dy_mh.invoke(PI_4, PI_4), df_dy(PI_4, PI_4));
@@ -92,13 +93,13 @@ public class TestForwardAutoDiff {
     @Test
     public void testControlFlow() throws Throwable {
         CoreOp.FuncOp f = getFuncOp("fcf");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         f = SSA.transform(f);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 2.0, 6), fcf(2.0, 6));
         Assert.assertEquals(Interpreter.invoke(MethodHandles.lookup(), f, 2.0, 5), fcf(2.0, 5));
@@ -107,7 +108,7 @@ public class TestForwardAutoDiff {
         Block.Parameter x = f.body().entryBlock().parameters().get(0);
 
         CoreOp.FuncOp df_dx = ForwardDifferentiation.partialDiff(f, x);
-        df_dx.writeTo(System.out);
+        System.out.println(df_dx.toText());
         MethodHandle df_dx_mh = generate(df_dx);
 
         Assert.assertEquals((double) df_dx_mh.invoke(2.0, 6), dfcf_dx(2.0, 6));

--- a/test/jdk/java/lang/reflect/code/bytecode/TestArrayCreation.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestArrayCreation.java
@@ -28,6 +28,7 @@ import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -99,10 +100,10 @@ public class TestArrayCreation {
     }
 
     static MethodHandle generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestBytecode.java
@@ -646,7 +646,7 @@ public class TestBytecode {
                     .methods().stream().filter(m -> m.methodName().equalsString(d.testMethod().getName())).findAny().get(),
                     ClassPrinter.Verbosity.CRITICAL_ATTRIBUTES, System.out::print);
             System.out.println("Lift failed, compiled model:");
-            Op.ofMethod(d.testMethod).ifPresent(f -> f.writeTo(System.out));
+            Op.ofMethod(d.testMethod).ifPresent(f -> System.out.println(f.toText()));
             throw e;
         }
         try {
@@ -662,9 +662,9 @@ public class TestBytecode {
                 Assert.assertEquals(invokeAndConvert(flift, receiver1, args), d.testMethod.invoke(receiver2, args)));
         } catch (Throwable e) {
             System.out.println("Compiled model:");
-            Op.ofMethod(d.testMethod).ifPresent(f -> f.writeTo(System.out));
+            Op.ofMethod(d.testMethod).ifPresent(f -> System.out.println(f.toText()));
             System.out.println("Lifted model:");
-            flift.writeTo(System.out);
+            System.out.println(flift.toText());
             throw e;
         }
     }
@@ -717,8 +717,8 @@ public class TestBytecode {
                     Assert.assertEquals(mh.invokeWithArguments(argl), d.testMethod.invoke(receiver2, args));
             });
         } catch (Throwable e) {
-            func.writeTo(System.out);
-            lfunc.writeTo(System.out);
+            System.out.println(func.toText());
+            System.out.println(lfunc.toText());
             String methodName = d.testMethod().getName();
             for (var mm : CLASS_MODEL.methods()) {
                 if (mm.methodName().equalsString(methodName)

--- a/test/jdk/java/lang/reflect/code/bytecode/TestInvokeSuper.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestInvokeSuper.java
@@ -77,10 +77,10 @@ public class TestInvokeSuper {
     }
 
     static MethodHandle generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup().in(B.class), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestLiftCustomBytecode.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestLiftCustomBytecode.java
@@ -141,7 +141,7 @@ public class TestLiftCustomBytecode {
 
     static CoreOp.FuncOp getFuncOp(byte[] classdata, String method) {
         CoreOp.FuncOp flift = BytecodeLift.lift(classdata, method);
-        flift.writeTo(System.out);
+        System.out.println(flift.toText());
         return flift;
     }
 }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestLiftExample.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestLiftExample.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.bytecode.BytecodeLift;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
@@ -67,7 +68,7 @@ public class TestLiftExample {
         URL resource = TestLiftExample.class.getClassLoader().getResource(TestLiftExample.class.getName().replace('.', '/') + ".class");
         byte[] classdata = resource.openStream().readAllBytes();
         CoreOp.FuncOp flift = BytecodeLift.lift(classdata, "proxy");
-        flift.writeTo(System.out);
+        System.out.println(flift.toText());
 
         Function<Integer, Integer> f = i -> i;
         @SuppressWarnings("unchecked")

--- a/test/jdk/java/lang/reflect/code/bytecode/TestNestedCapturingLambda.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestNestedCapturingLambda.java
@@ -77,10 +77,10 @@ public class TestNestedCapturingLambda {
     }
 
     static MethodHandle generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestQuoted.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestQuoted.java
@@ -30,6 +30,7 @@ import jdk.incubator.code.Quoted;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 
@@ -55,11 +56,11 @@ public class TestQuoted {
     }
 
     static <O extends Op & Op.Invokable> MethodHandle generate(O f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         @SuppressWarnings("unchecked")
         O lf = (O) f.transform(CopyContext.create(), OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSlots.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSlots.java
@@ -28,6 +28,7 @@ import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -140,10 +141,10 @@ public class TestSlots {
     }
 
     static MethodHandle generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestSmallCorpus.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import java.io.StringWriter;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.Label;
@@ -175,11 +174,7 @@ public class TestSmallCorpus {
     }
 
     private static void printInColumns(CoreOp.FuncOp first, CoreOp.FuncOp second) {
-        StringWriter fw = new StringWriter();
-        first.writeTo(fw);
-        StringWriter sw = new StringWriter();
-        second.writeTo(sw);
-        printInColumns(fw.toString().lines().toList(), sw.toString().lines().toList());
+        printInColumns(first.toText().lines().toList(), second.toText().lines().toList());
     }
 
     private static void printInColumns(List<String> first, List<String> second) {

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTry.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTry.java
@@ -29,6 +29,7 @@ import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -258,10 +259,10 @@ public class TestTry {
     }
 
     static MethodHandle generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTryFinally.java
@@ -29,6 +29,7 @@ import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -194,10 +195,10 @@ public class TestTryFinally {
     }
 
     static MethodHandle generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestTryFinallyNested.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestTryFinallyNested.java
@@ -29,6 +29,7 @@ import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.interpreter.Interpreter;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -217,10 +218,10 @@ public class TestTryFinallyNested {
     }
 
     static MethodHandle generate(CoreOp.FuncOp f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         return BytecodeGenerator.generate(MethodHandles.lookup(), lf);
     }

--- a/test/jdk/java/lang/reflect/code/bytecode/TestVarArg.java
+++ b/test/jdk/java/lang/reflect/code/bytecode/TestVarArg.java
@@ -28,10 +28,10 @@ public class TestVarArg {
     @Test
     void test() throws Throwable {
         var f = getFuncOp("f");
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         var lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         var bytes = BytecodeGenerator.generateClassData(MethodHandles.lookup(), f);
         var classModel = ClassFile.of().parse(bytes);

--- a/test/jdk/java/lang/reflect/code/expression/TestExpressionElimination.java
+++ b/test/jdk/java/lang/reflect/code/expression/TestExpressionElimination.java
@@ -60,17 +60,17 @@ public class TestExpressionElimination {
     }
 
     static <T extends Op & Op.Invokable> T generateF(T f) {
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         @SuppressWarnings("unchecked")
         T lf = (T) f.transform(CopyContext.create(), OpTransformer.LOWERING_TRANSFORMER);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         lf = SSA.transform(lf);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         lf = ExpressionElimination.eliminate(lf);
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
         return lf;
     }
 }

--- a/test/jdk/java/lang/reflect/code/lower/CodeReflectionTester.java
+++ b/test/jdk/java/lang/reflect/code/lower/CodeReflectionTester.java
@@ -69,11 +69,11 @@ public class CodeReflectionTester {
 
     static CoreOp.FuncOp lower(CoreOp.FuncOp f, boolean ssa) {
         f = f.transform(OpTransformer.LOWERING_TRANSFORMER);
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         if (ssa) {
             f = SSA.transform(f);
-            f.writeTo(System.out);
+            System.out.println(f.toText());
         }
 
         return f;

--- a/test/jdk/java/lang/reflect/code/stream/TestStream.java
+++ b/test/jdk/java/lang/reflect/code/stream/TestStream.java
@@ -51,11 +51,11 @@ public class TestStream {
                 .filter((String s) -> s.length() < 10)
                 .forEach((String s) -> System.out.println(s));
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Interpreter.invoke(MethodHandles.lookup(), lf,
                 List.of(List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 100_000, 20)));
@@ -71,11 +71,11 @@ public class TestStream {
                 .filter((String s) -> s.length() < 10)
                 .collect(() -> new ArrayList<String>(), (List<String> l, String e) -> l.add(e));
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         List<Integer> source = List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 20);
 

--- a/test/jdk/java/lang/reflect/code/stream/TestStreamUsingQuotable.java
+++ b/test/jdk/java/lang/reflect/code/stream/TestStreamUsingQuotable.java
@@ -51,11 +51,11 @@ public class TestStreamUsingQuotable {
                 // Cannot use method reference since it captures the result of the expression "System.out"
                 .forEach(s -> System.out.println(s));
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         Interpreter.invoke(MethodHandles.lookup(), lf,
                 List.of(List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 100_000, 20)));
@@ -71,11 +71,11 @@ public class TestStreamUsingQuotable {
                 .filter(s -> s.length() < 10)
                 .collect(ArrayList::new, ArrayList::add);
 
-        f.writeTo(System.out);
+        System.out.println(f.toText());
 
         CoreOp.FuncOp lf = f.transform(OpTransformer.LOWERING_TRANSFORMER);
 
-        lf.writeTo(System.out);
+        System.out.println(lf.toText());
 
         List<Integer> source = List.of(1, 2, 3, 4, 5, 100_000_000, 10_000, 20);
 


### PR DESCRIPTION
Reduce the methods on op for writing to text down to one, `toText`. Ensure all other functionality is located on `OpWriter`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/488/head:pull/488` \
`$ git checkout pull/488`

Update a local copy of the PR: \
`$ git checkout pull/488` \
`$ git pull https://git.openjdk.org/babylon.git pull/488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 488`

View PR using the GUI difftool: \
`$ git pr show -t 488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/488.diff">https://git.openjdk.org/babylon/pull/488.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/488#issuecomment-3046723758)
</details>
