### PR TITLE
Disallow `null` return expressions in quoted lambdas

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1403,6 +1403,9 @@ compiler.err.cant.infer.local.var.type=\
     cannot infer type for local variable {0}\n\
     ({1})
 
+compiler.err.bad.quoted.lambda.null.return=\
+    invalid ''null'' return expression in quoted lambda
+
 # 0: list of type
 compiler.err.cant.infer.quoted.lambda.return.type=\
     cannot infer return type for quoted lambda expression\n\

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -219,6 +219,7 @@ compiler.note.quoted.ir.dump                                  # code reflection
 compiler.err.quoted.method.inner.class                        # code reflection
 compiler.err.quoted.lambda.inner.class                        # code reflection
 compiler.err.quoted.mref.inner.class                          # code reflection
+compiler.err.bad.quoted.lambda.null.return                    # code reflection
 
 # this one needs a forged class file to be reproduced
 compiler.err.annotation.unrecognized.attribute.name

--- a/test/langtools/tools/javac/reflect/QuotedTest.java
+++ b/test/langtools/tools/javac/reflect/QuotedTest.java
@@ -33,6 +33,8 @@
 import jdk.incubator.code.Quoted;
 import jdk.incubator.code.CodeReflection;
 
+import java.util.List;
+
 public class QuotedTest {
     @IR("""
             func @"f" ()java.type:"void" -> {
@@ -185,5 +187,38 @@ public class QuotedTest {
             """)
     void captureField() {
         Quoted op = (int z) -> x + y + z;
+    }
+
+    @CodeReflection
+    @IR("""
+            func @"upwardNonDenotableReturn" (%0 : java.type:"QuotedTest")java.type:"void" -> {
+                %1 : java.type:"jdk.incubator.code.Quoted" = quoted ()java.type:"void" -> {
+                    %2 : func<java.type:"java.util.List<? extends java.io.Serializable>", java.type:"boolean", java.type:"java.util.List<java.lang.String>", java.type:"java.util.List<java.lang.Integer>"> = closure (%3 : java.type:"boolean", %4 : java.type:"java.util.List<java.lang.String>", %5 : java.type:"java.util.List<java.lang.Integer>")java.type:"java.util.List<? extends java.io.Serializable>" -> {
+                        %6 : Var<java.type:"boolean"> = var %3 @"cond";
+                        %7 : Var<java.type:"java.util.List<java.lang.String>"> = var %4 @"ls";
+                        %8 : Var<java.type:"java.util.List<java.lang.Integer>"> = var %5 @"li";
+                        %9 : java.type:"java.util.List<? extends java.io.Serializable>" = java.cexpression
+                            ()java.type:"boolean" -> {
+                                %10 : java.type:"boolean" = var.load %6;
+                                yield %10;
+                            }
+                            ()java.type:"java.util.List<? extends java.io.Serializable>" -> {
+                                %11 : java.type:"java.util.List<java.lang.String>" = var.load %7;
+                                yield %11;
+                            }
+                            ()java.type:"java.util.List<? extends java.io.Serializable>" -> {
+                                %12 : java.type:"java.util.List<java.lang.Integer>" = var.load %8;
+                                yield %12;
+                            };
+                        return %9;
+                    };
+                    yield %2;
+                };
+                %13 : Var<java.type:"jdk.incubator.code.Quoted"> = var %1 @"op";
+                return;
+            };
+            """)
+    void upwardNonDenotableReturn() {
+        Quoted op = (boolean cond, List<String> ls, List<Integer> li) -> cond ? ls : li;
     }
 }

--- a/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.java
+++ b/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.java
@@ -16,7 +16,7 @@ class TestNoCodeReflectionInInnerClasses {
         }
 
         void test3() {
-            Quoted q = () -> null;
+            Quoted q = () -> { };
         }
 
         void test4() {

--- a/test/langtools/tools/javac/reflect/quoted/TestAssignment.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestAssignment.java
@@ -62,4 +62,27 @@ class TestAssignment {
         Quoted fi_RetVRetS = (int i) -> { if (cond) return; else return ""; }; // error - only one branch returns
         Quoted fi_RetS = (int i) -> { if (cond) { return "2"; } }; // error - one return, but body completes normally
     }
+
+    void testBadNullReturn(boolean cond) {
+        Quoted fi_RetNullS = (int i) -> { return null; }; // error - null return - statement
+        Quoted fi_RetNullE = (int i) -> null; // error - null return - expression
+        Quoted fi_RetNullCondS = (int i) -> { return cond ? null : null; }; // error - null conditional return - statement
+        Quoted fi_RetNullCondE = (int i) -> cond ? null : null; // error - null conditional return - expression
+    }
+
+    void testBadLambdaReturn(boolean cond) {
+        Quoted fi_RetLambdaS = (int i) -> { return () -> {}; }; // error - lambda return - statement
+        Quoted fi_RetLambdaE = (int i) -> () -> {};; // error - lambda return - expression
+        Quoted fi_RetLambdaCondS = (int i) -> { return cond ? () -> {} : () -> {}; }; // error - lambda conditional return - statement
+        Quoted fi_RetLambdaCondE = (int i) -> cond ? () -> {} : () -> {}; // error - lambda conditional return - expression
+    }
+
+    void testBadMrefReturn(boolean cond) {
+        Quoted fi_RetMrefS = (int i) -> { return this::mr; }; // error - mref return - statement
+        Quoted fi_RetMrefE = (int i) -> this::mr;; // error - mref return - expression
+        Quoted fi_RetMrefCondS = (int i) -> { return cond ? this::mr : this::mr; }; // error - mref conditional return - statement
+        Quoted fi_RetMrefCondE = (int i) -> cond ? this::mr : this::mr; // error - mref conditional return - expression
+    }
+
+    void mr() { }
 }

--- a/test/langtools/tools/javac/reflect/quoted/TestAssignment.out
+++ b/test/langtools/tools/javac/reflect/quoted/TestAssignment.out
@@ -12,4 +12,20 @@ TestAssignment.java:57:29: compiler.err.quoted.lambda.must.be.explicit
 TestAssignment.java:58:29: compiler.err.quoted.lambda.must.be.explicit
 TestAssignment.java:62:41: compiler.err.cant.infer.quoted.lambda.return.type: void,java.lang.String
 TestAssignment.java:63:37: compiler.err.cant.infer.quoted.lambda.return.type: java.lang.String,void
-14 errors
+TestAssignment.java:67:50: compiler.err.bad.quoted.lambda.null.return
+TestAssignment.java:68:41: compiler.err.bad.quoted.lambda.null.return
+TestAssignment.java:69:59: compiler.err.bad.quoted.lambda.null.return
+TestAssignment.java:70:50: compiler.err.bad.quoted.lambda.null.return
+TestAssignment.java:74:52: compiler.err.unexpected.lambda
+TestAssignment.java:75:43: compiler.err.unexpected.lambda
+TestAssignment.java:76:63: compiler.err.unexpected.lambda
+TestAssignment.java:76:74: compiler.err.unexpected.lambda
+TestAssignment.java:77:54: compiler.err.unexpected.lambda
+TestAssignment.java:77:65: compiler.err.unexpected.lambda
+TestAssignment.java:81:50: compiler.err.unexpected.mref
+TestAssignment.java:82:41: compiler.err.unexpected.mref
+TestAssignment.java:83:61: compiler.err.unexpected.mref
+TestAssignment.java:83:72: compiler.err.unexpected.mref
+TestAssignment.java:84:52: compiler.err.unexpected.mref
+TestAssignment.java:84:63: compiler.err.unexpected.mref
+30 errors

--- a/test/langtools/tools/javac/reflect/quoted/TestGenericMethodCall.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestGenericMethodCall.java
@@ -63,5 +63,28 @@ public class TestGenericMethodCall {
         apply(Quoted.class, (int i) -> { if (cond) { return "2"; } }); // error - one return, but body completes normally
     }
 
+    void testBadNullReturn(boolean cond) {
+        apply(Quoted.class, (int i) -> { return null; }); // error - null return - statement
+        apply(Quoted.class, (int i) -> null); // error - null return - expression
+        apply(Quoted.class, (int i) -> { return cond ? null : null; }); // error - null conditional return - statement
+        apply(Quoted.class, (int i) -> cond ? null : null); // error - null conditional return - expression
+    }
+
+    void testBadLambdaReturn(boolean cond) {
+        apply(Quoted.class, (int i) -> { return () -> {}; }); // error - lambda return - statement
+        apply(Quoted.class, (int i) -> () -> {});; // error - lambda return - expression
+        apply(Quoted.class, (int i) -> { return cond ? () -> {} : () -> {}; }); // error - lambda conditional return - statement
+        apply(Quoted.class, (int i) -> cond ? () -> {} : () -> {}); // error - lambda conditional return - expression
+    }
+
+    void testBadMrefReturn(boolean cond) {
+        apply(Quoted.class, (int i) -> { return this::mr; }); // error - mref return - statement
+        apply(Quoted.class, (int i) -> this::mr); // error - mref return - expression
+        apply(Quoted.class, (int i) -> { return cond ? this::mr : this::mr; }); // error - mref conditional return - statement
+        apply(Quoted.class, (int i) -> cond ? this::mr : this::mr); // error - mref conditional return - expression
+    }
+
+    void mr() { }
+
     <Z> void apply(Class<Z> clazz, Z quoted) { }
 }

--- a/test/langtools/tools/javac/reflect/quoted/TestGenericMethodCall.out
+++ b/test/langtools/tools/javac/reflect/quoted/TestGenericMethodCall.out
@@ -12,4 +12,20 @@ TestGenericMethodCall.java:57:29: compiler.err.quoted.lambda.must.be.explicit
 TestGenericMethodCall.java:58:29: compiler.err.quoted.lambda.must.be.explicit
 TestGenericMethodCall.java:62:40: compiler.err.cant.infer.quoted.lambda.return.type: void,java.lang.String
 TestGenericMethodCall.java:63:40: compiler.err.cant.infer.quoted.lambda.return.type: java.lang.String,void
-14 errors
+TestGenericMethodCall.java:67:49: compiler.err.bad.quoted.lambda.null.return
+TestGenericMethodCall.java:68:40: compiler.err.bad.quoted.lambda.null.return
+TestGenericMethodCall.java:69:54: compiler.err.bad.quoted.lambda.null.return
+TestGenericMethodCall.java:70:45: compiler.err.bad.quoted.lambda.null.return
+TestGenericMethodCall.java:74:49: compiler.err.unexpected.lambda
+TestGenericMethodCall.java:75:40: compiler.err.unexpected.lambda
+TestGenericMethodCall.java:76:56: compiler.err.unexpected.lambda
+TestGenericMethodCall.java:76:67: compiler.err.unexpected.lambda
+TestGenericMethodCall.java:77:47: compiler.err.unexpected.lambda
+TestGenericMethodCall.java:77:58: compiler.err.unexpected.lambda
+TestGenericMethodCall.java:81:49: compiler.err.unexpected.mref
+TestGenericMethodCall.java:82:40: compiler.err.unexpected.mref
+TestGenericMethodCall.java:83:56: compiler.err.unexpected.mref
+TestGenericMethodCall.java:83:67: compiler.err.unexpected.mref
+TestGenericMethodCall.java:84:47: compiler.err.unexpected.mref
+TestGenericMethodCall.java:84:58: compiler.err.unexpected.mref
+30 errors

--- a/test/langtools/tools/javac/reflect/quoted/TestMethodCall.java
+++ b/test/langtools/tools/javac/reflect/quoted/TestMethodCall.java
@@ -63,5 +63,28 @@ public class TestMethodCall {
         apply((int i) -> { if (cond) { return "2"; } }); // error - one return, but body completes normally
     }
 
+    void testBadNullReturn(boolean cond) {
+        apply((int i) -> { return null; }); // error - null return - statement
+        apply((int i) -> null); // error - null return - expression
+        apply((int i) -> { return cond ? null : null; }); // error - null conditional return - statement
+        apply((int i) -> cond ? null : null); // error - null conditional return - expression
+    }
+
+    void testBadLambdaReturn(boolean cond) {
+        apply((int i) -> { return () -> {}; }); // error - lambda return - statement
+        apply((int i) -> () -> {});; // error - lambda return - expression
+        apply((int i) -> { return cond ? () -> {} : () -> {}; }); // error - lambda conditional return - statement
+        apply((int i) -> cond ? () -> {} : () -> {}); // error - lambda conditional return - expression
+    }
+
+    void testBadMrefReturn(boolean cond) {
+        apply((int i) -> { return this::mr; }); // error - mref return - statement
+        apply((int i) -> this::mr); // error - mref return - expression
+        apply((int i) -> { return cond ? this::mr : this::mr; }); // error - mref conditional return - statement
+        apply((int i) -> cond ? this::mr : this::mr); // error - mref conditional return - expression
+    }
+
+    void mr() { }
+
     void apply(Quoted quoted) { }
 }

--- a/test/langtools/tools/javac/reflect/quoted/TestMethodCall.out
+++ b/test/langtools/tools/javac/reflect/quoted/TestMethodCall.out
@@ -12,4 +12,20 @@ TestMethodCall.java:57:15: compiler.err.quoted.lambda.must.be.explicit
 TestMethodCall.java:58:15: compiler.err.quoted.lambda.must.be.explicit
 TestMethodCall.java:62:26: compiler.err.cant.infer.quoted.lambda.return.type: void,java.lang.String
 TestMethodCall.java:63:26: compiler.err.cant.infer.quoted.lambda.return.type: java.lang.String,void
-14 errors
+TestMethodCall.java:67:35: compiler.err.bad.quoted.lambda.null.return
+TestMethodCall.java:68:26: compiler.err.bad.quoted.lambda.null.return
+TestMethodCall.java:69:40: compiler.err.bad.quoted.lambda.null.return
+TestMethodCall.java:70:31: compiler.err.bad.quoted.lambda.null.return
+TestMethodCall.java:74:35: compiler.err.unexpected.lambda
+TestMethodCall.java:75:26: compiler.err.unexpected.lambda
+TestMethodCall.java:76:42: compiler.err.unexpected.lambda
+TestMethodCall.java:76:53: compiler.err.unexpected.lambda
+TestMethodCall.java:77:33: compiler.err.unexpected.lambda
+TestMethodCall.java:77:44: compiler.err.unexpected.lambda
+TestMethodCall.java:81:35: compiler.err.unexpected.mref
+TestMethodCall.java:82:26: compiler.err.unexpected.mref
+TestMethodCall.java:83:42: compiler.err.unexpected.mref
+TestMethodCall.java:83:53: compiler.err.unexpected.mref
+TestMethodCall.java:84:33: compiler.err.unexpected.mref
+TestMethodCall.java:84:44: compiler.err.unexpected.mref
+30 errors


### PR DESCRIPTION
Lambda expressions that are turned into a `Quoted` instance don't have an associated functional interface. Instead, they are type checked bottom-up (the parameter types in such lambdas must be explicit), and the return type is inferred from the various return expressions in the lambda body.

The aim of this patch is to establish a similar set of rules between quoted lambda return expressions and expressions that are allowed on the RHS of a `var`. More specifically, the RHS of a `var` is restricted as follows:

1. can't be `null`
2. can't be a "naked" array initializer, e.g. `{ 1, 2, 3 }`
3. can't be a poly expression (a lambda, or a method reference)

Now, (2) and (3) are already taken care of. (2) is not allowed in return context, and (3) is already rejected, given the body of the quoted lambda is attributed w/o a target type.

So this PR adds a check for (1), to reject `null` return expressions.

There are some other quality-of-life changes to make sure the compiler doesn't generate spurious diagnostics in case of errors.

I've beefed up the test a bit. First, I've added tests to make sure that invalid return expressions in quoted lambdas are correctly rejected, regardless of whether the quoted lambda appears in assignment vs. method vs. generic method context.

Secondly, I've added an IR test to make sure that the inferred return type of a quoted lambda is correctly upward-projected, to get rid of any non-denotable type that might arise in the inference process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/489/head:pull/489` \
`$ git checkout pull/489`

Update a local copy of the PR: \
`$ git checkout pull/489` \
`$ git pull https://git.openjdk.org/babylon.git pull/489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 489`

View PR using the GUI difftool: \
`$ git pr show -t 489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/489.diff">https://git.openjdk.org/babylon/pull/489.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/489#issuecomment-3048675012)
</details>
