### PR TITLE
Remove Op::traverseOperands

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -385,30 +385,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Traverse the operands of this operation that are the results of prior operations, recursively.
-     * <p>
-     * Traversal is performed in pre-order, reporting the operation of each operand to the visitor.
-     *
-     * @param t   the traversing accumulator
-     * @param v   the visitor
-     * @param <T> accumulator type
-     * @return the traversing accumulator
-     * @apiNote A visitor that implements the abstract method of {@code OpVisitor} and does not override any
-     * other default method will only visit operations. As such a lambda expression or method reference
-     * may be used to visit operations.
-     */
-    public final <T> T traverseOperands(T t, BiFunction<T, Op, T> v) {
-        for (Value arg : operands()) {
-            if (arg instanceof Result or) {
-                t = v.apply(t, or.op);
-                t = or.op.traverseOperands(t, v);
-            }
-        }
-
-        return t;
-    }
-
-    /**
      * Computes values captured by this operation. A captured value is a value that dominates
      * this operation and is used by a descendant operation.
      * <p>

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
@@ -81,6 +81,7 @@ public sealed abstract class Value implements Comparable<Value>, CodeItem
      *
      * @return the values this value directly depends on, as an unmodifiable set.
      */
+    // @@@ Consider an additional method that returns a lazy stream of all dependent values, in order.
     public abstract Set<Value> dependsOn();
 
     /**
@@ -90,6 +91,7 @@ public sealed abstract class Value implements Comparable<Value>, CodeItem
      * @return the uses of this value, as an unmodifiable set.
      * @throws IllegalStateException if the declaring block is partially built
      */
+    // @@@ Consider an additional method that returns a lazy stream of all uses, in order.
     public Set<Op.Result> uses() {
         if (!isBound()) {
             throw new IllegalStateException("Users are partially constructed");

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Patterns.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Patterns.java
@@ -96,7 +96,11 @@ public final class Patterns {
         return op.result() != null && op.result().uses().isEmpty() && testPure.test(op);
     }
 
-    // @@@ this could be made generic with a method traversing backwards
+    // @@@ this could be made generic with a method traversing up the model tree,
+    // the challenge is controlling when to keep traversing or not, and it may make
+    // it more complex that just writing it like below for specific cases
+    // A better option may be to provide a lazy stream of the values that can be filtered
+    // similar to CodeElement::elements
     static void matchDependentDeadOps(Op op, Set<Op> deadOps, Predicate<Op> testPure) {
         for (Value arg : op.operands()) {
             if (arg instanceof Op.Result or) {


### PR DESCRIPTION
Remove `Op::traverseOperands`. Such traversal methods tend to be limited because it is not possible to control the traversal, and adding such facility will make the API more complex, likely more so that just writing the specific traversal method, since its only a few lines of code.

Evidence in other areas of the code base that traverses up the tree of values indicates this is so, since this method is not used. A better approach would to broaden the functionality of `Value::dependsOn`, adding another method that returns a lazy stream of all dependent values, in order.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/490/head:pull/490` \
`$ git checkout pull/490`

Update a local copy of the PR: \
`$ git checkout pull/490` \
`$ git pull https://git.openjdk.org/babylon.git pull/490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 490`

View PR using the GUI difftool: \
`$ git pr show -t 490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/490.diff">https://git.openjdk.org/babylon/pull/490.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/490#issuecomment-3053506798)
</details>
