### PR TITLE
Move Block.Builder.inline to analysis package

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
@@ -9,6 +9,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import jdk.incubator.code.*;
 import jdk.incubator.code.analysis.NormalizeBlocksTransformer;
+import jdk.incubator.code.analysis.Inliner;
 import jdk.incubator.code.analysis.SSA;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.CoreType;
@@ -135,7 +136,7 @@ public final class OnnxTransformer {
                 if (doNotInline.contains(fo)) {
                     bb.context().mapValue(op.result(), bb.op(CoreOp.funcCall(fo, bb.context().getValues(op.operands()))));
                 } else {
-                    bb.inline(mapOrInline(fo, funcs, doNotInline), bb.context().getValues(io.operands()), (_, v) -> bb.context().mapValue(io.result(), v));
+                    Inliner.inline(bb, mapOrInline(fo, funcs, doNotInline), bb.context().getValues(io.operands()), (_, v) -> bb.context().mapValue(io.result(), v));
                 }
             } else {
                 bb.op(op);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -25,15 +25,8 @@
 
 package jdk.incubator.code;
 
-import jdk.incubator.code.dialect.core.CoreOp;
 import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static jdk.incubator.code.dialect.core.CoreOp.return_;
-import static jdk.incubator.code.dialect.core.CoreOp.branch;
 
 /**
  * A (basic) block containing an ordered sequence of operations, where the last operation is
@@ -310,7 +303,7 @@ public final class Block implements CodeElement<Block, Op> {
      * @apiNote A predecessor block may reference it successor block one or more times.
      */
     public List<Block.Reference> predecessorReferences() {
-        return predecessors.stream().flatMap(p -> successors().stream())
+        return predecessors.stream().flatMap(p -> p.successors().stream())
                 .filter(r -> r.targetBlock() == this)
                 .toList();
     }
@@ -325,8 +318,7 @@ public final class Block implements CodeElement<Block, Op> {
      * state that B is a successor block of A and A is a predecessor block of B.
      */
     public List<Reference> successors() {
-        Op lopr = ops.get(ops.size() - 1);
-        return lopr.successors();
+        return ops.getLast().successors();
     }
 
     /**
@@ -611,119 +603,6 @@ public final class Block implements CodeElement<Block, Op> {
             }
 
             return new Reference(Block.this, List.copyOf(args));
-        }
-
-        /**
-         * An inline consumer that inserts a return operation with a value, if non-null.
-         */
-        public static final BiConsumer<Block.Builder, Value> INLINE_RETURN = (block, value) -> {
-            block.op(value != null ? return_(value) : CoreOp.return_());
-        };
-
-        /**
-         * Inlines the invokable operation into this block and returns the block builder from which to
-         * continue building.
-         * <p>
-         * This method {@link #transformBody(Body, List, CopyContext, OpTransformer) transforms} the body of the
-         * invokable operation with the given arguments, a new context, and an operation transformer that
-         * replaces return operations by applying the given consumer to a block builder and a return value.
-         * <p>
-         * The operation transformer copies all operations except return operations whose nearest invokable operation
-         * ancestor is the given the invokable operation. When such a return operation is encountered, then on
-         * first encounter of its grandparent body a return block builder is computed and used for this return operation
-         * and encounters of subsequent return operations with the same grandparent body.
-         * <p>
-         * If the grandparent body has only one block then operation transformer's block builder is the return
-         * block builder. Otherwise, if the grandparent body has one or more blocks then the return block builder is
-         * created from the operation transformer's block builder. The created return block builder will have a block
-         * parameter whose type corresponds to the return type, or will have no parameter for void return.
-         * The computation finishes by applying the return block builder and a return value to the inlining consumer.
-         * If the grandparent body has only one block then the return value is the value mapped from the return
-         * operation's operand, or is null for void return. Otherwise, if the grandparent body has one or more blocks
-         * then the value is the block parameter of the created return block builder, or is null for void return.
-         * <p>
-         * For every encounter of a return operation the associated return block builder is compared against the
-         * operation transformer's block builder. If they are not equal then a branch operation is added to the
-         * operation transformer's block builder whose successor is the return block builder with a block argument
-         * that is the value mapped from the return operation's operand, or with no block argument for void return.
-         * @apiNote
-         * It is easier to inline an invokable op if its body is in lowered form (there are no operations in the blocks
-         * of the body that are lowerable). This ensures a single exit point can be created (paired with the single
-         * entry point). If there are one or more nested return operations, then there is unlikely to be a single exit.
-         * Transforming the model to create a single exit point while preserving nested structure is in general
-         * non-trivial and outside the scope of this method. In such cases the invokable operation can be transformed
-         * with a lowering transformation after which it can then be inlined.
-         *
-         * @param invokableOp the invokable operation
-         * @param args the arguments to map to the invokable operation's parameters
-         * @param inlineConsumer the consumer applied to process the return from the invokable operation.
-         *                       This is called once for each grandparent body of a return operation, with a block to
-         *                       build replacement operations and the return value, or null for void return.
-         * @return the block builder to continue building from
-         * @param <O> The invokable type
-         */
-        public <O extends Op & Op.Invokable> Block.Builder inline(O invokableOp, List<? extends Value> args,
-                                                                  BiConsumer<Block.Builder, Value> inlineConsumer) {
-            Map<Body, Block.Builder> returnBlocks = new HashMap<>();
-            // Create new context, ensuring inlining is isolated
-            transformBody(invokableOp.body(), args, CopyContext.create(), (block, op) -> {
-                // If the return operation is associated with the invokable operation
-                if (op instanceof CoreOp.ReturnOp rop && getNearestInvokeableAncestorOp(op) == invokableOp) {
-                    // Compute the return block
-                    Block.Builder returnBlock = returnBlocks.computeIfAbsent(rop.ancestorBody(), _body -> {
-                        Block.Builder rb;
-                        // If the body has one block we know there is just one return op declared, otherwise there may
-                        // one or more. If so, create a new block that joins all the returns.
-                        // Note: we could count all return op in a body to avoid creating a new block for a body
-                        // with two or more blocks with only one returnOp is declared.
-                        Value r;
-                        if (rop.ancestorBody().blocks().size() != 1) {
-                            List<TypeElement> param = rop.returnValue() != null
-                                    ? List.of(invokableOp.invokableType().returnType())
-                                    : List.of();
-                            rb = block.block(param);
-                            r = !param.isEmpty()
-                                    ? rb.parameters().get(0)
-                                    : null;
-                        } else {
-                            r = rop.returnValue() != null
-                                    ? block.context().getValue(rop.returnValue())
-                                    : null;
-                            rb = block;
-                        }
-
-                        // Inline the return
-                        inlineConsumer.accept(rb, r);
-
-                        return rb;
-                    });
-
-                    // Replace the return op with a branch to the return block, if needed
-                    if (!returnBlock.equals(block)) {
-                        // Replace return op with branch to return block, with given return value
-                        List<Value> arg = rop.returnValue() != null
-                                ? List.of(block.context().getValue(rop.returnValue()))
-                                : List.of();
-                        block.op(branch(returnBlock.successor(arg)));
-                    }
-
-                    return block;
-                }
-
-                block.op(op);
-                return block;
-            });
-
-
-            Builder builder = returnBlocks.get(invokableOp.body());
-            return builder != null ? builder : this;
-        }
-
-        private static Op getNearestInvokeableAncestorOp(Op op) {
-            do {
-                op = op.ancestorOp();
-            } while (!(op instanceof Op.Invokable));
-            return op;
         }
 
         /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Inliner.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Inliner.java
@@ -1,0 +1,135 @@
+package jdk.incubator.code.analysis;
+
+import jdk.incubator.code.*;
+import jdk.incubator.code.dialect.core.CoreOp;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static jdk.incubator.code.dialect.core.CoreOp.branch;
+import static jdk.incubator.code.dialect.core.CoreOp.return_;
+
+/**
+ * Functionality for inlining code.
+ */
+public final class Inliner {
+
+    private Inliner() {}
+
+    /**
+     * An inline consumer that inserts a return operation with a value, if non-null.
+     */
+    public static final BiConsumer<Block.Builder, Value> INLINE_RETURN = (block, value) -> {
+        block.op(value != null ? return_(value) : CoreOp.return_());
+    };
+
+    /**
+     * Inlines the invokable operation into the given block builder and returns the block builder from which to
+     * continue building.
+     * <p>
+     * This method {@link Block.Builder#transformBody(Body, List, CopyContext, OpTransformer) transforms} the
+     * body of the invokable operation with the given arguments, a new context, and an operation transformer that
+     * replaces return operations by applying the given consumer to a block builder and a return value.
+     * <p>
+     * The operation transformer copies all operations except return operations whose nearest invokable operation
+     * ancestor is the given the invokable operation. When such a return operation is encountered, then on
+     * first encounter of its grandparent body a return block builder is computed and used for this return operation
+     * and encounters of subsequent return operations with the same grandparent body.
+     * <p>
+     * If the grandparent body has only one block then operation transformer's block builder is the return
+     * block builder. Otherwise, if the grandparent body has one or more blocks then the return block builder is
+     * created from the operation transformer's block builder. The created return block builder will have a block
+     * parameter whose type corresponds to the return type, or will have no parameter for void return.
+     * The computation finishes by applying the return block builder and a return value to the inlining consumer.
+     * If the grandparent body has only one block then the return value is the value mapped from the return
+     * operation's operand, or is null for void return. Otherwise, if the grandparent body has one or more blocks
+     * then the value is the block parameter of the created return block builder, or is null for void return.
+     * <p>
+     * For every encounter of a return operation the associated return block builder is compared against the
+     * operation transformer's block builder. If they are not equal then a branch operation is added to the
+     * operation transformer's block builder whose successor is the return block builder with a block argument
+     * that is the value mapped from the return operation's operand, or with no block argument for void return.
+     * @apiNote
+     * It is easier to inline an invokable op if its body is in lowered form (there are no operations in the blocks
+     * of the body that are lowerable). This ensures a single exit point can be created (paired with the single
+     * entry point). If there are one or more nested return operations, then there is unlikely to be a single exit.
+     * Transforming the model to create a single exit point while preserving nested structure is in general
+     * non-trivial and outside the scope of this method. In such cases the invokable operation can be transformed
+     * with a lowering transformation after which it can then be inlined.
+     *
+     * @param _this the block builder
+     * @param invokableOp the invokable operation
+     * @param args the arguments to map to the invokable operation's parameters
+     * @param inlineConsumer the consumer applied to process the return from the invokable operation.
+     *                       This is called once for each grandparent body of a return operation, with a block to
+     *                       build replacement operations and the return value, or null for void return.
+     * @return the block builder to continue building from
+     * @param <O> The invokable type
+     */
+    public static <O extends Op & Op.Invokable>
+    Block.Builder inline(Block.Builder _this, O invokableOp, List<? extends Value> args,
+                         BiConsumer<Block.Builder, Value> inlineConsumer) {
+        Map<Body, Block.Builder> returnBlocks = new HashMap<>();
+        // Create new context, ensuring inlining is isolated
+        _this.transformBody(invokableOp.body(), args, CopyContext.create(), (block, op) -> {
+            // If the return operation is associated with the invokable operation
+            if (op instanceof CoreOp.ReturnOp rop && getNearestInvokeableAncestorOp(op) == invokableOp) {
+                // Compute the return block
+                Block.Builder returnBlock = returnBlocks.computeIfAbsent(rop.ancestorBody(), _body -> {
+                    Block.Builder rb;
+                    // If the body has one block we know there is just one return op declared, otherwise there may
+                    // one or more. If so, create a new block that joins all the returns.
+                    // Note: we could count all return op in a body to avoid creating a new block for a body
+                    // with two or more blocks with only one returnOp is declared.
+                    Value r;
+                    if (rop.ancestorBody().blocks().size() != 1) {
+                        List<TypeElement> param = rop.returnValue() != null
+                                ? List.of(invokableOp.invokableType().returnType())
+                                : List.of();
+                        rb = block.block(param);
+                        r = !param.isEmpty()
+                                ? rb.parameters().get(0)
+                                : null;
+                    } else {
+                        r = rop.returnValue() != null
+                                ? block.context().getValue(rop.returnValue())
+                                : null;
+                        rb = block;
+                    }
+
+                    // Inline the return
+                    inlineConsumer.accept(rb, r);
+
+                    return rb;
+                });
+
+                // Replace the return op with a branch to the return block, if needed
+                if (!returnBlock.equals(block)) {
+                    // Replace return op with branch to return block, with given return value
+                    List<Value> arg = rop.returnValue() != null
+                            ? List.of(block.context().getValue(rop.returnValue()))
+                            : List.of();
+                    block.op(branch(returnBlock.successor(arg)));
+                }
+
+                return block;
+            }
+
+            block.op(op);
+            return block;
+        });
+
+
+        Block.Builder builder = returnBlocks.get(invokableOp.body());
+        return builder != null ? builder : _this;
+    }
+
+    private static Op getNearestInvokeableAncestorOp(Op op) {
+        do {
+            op = op.ancestorOp();
+        } while (!(op instanceof Op.Invokable));
+        return op;
+    }
+}

--- a/test/jdk/java/lang/reflect/code/TestInline.java
+++ b/test/jdk/java/lang/reflect/code/TestInline.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.incubator.code.analysis.Inliner;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -56,7 +57,7 @@ public class TestInline {
 
                     Op.Result fortyTwo = fblock.op(constant(INT, 42));
 
-                    var cb = fblock.inline(cop, List.of(i, fortyTwo), Block.Builder.INLINE_RETURN);
+                    var cb = Inliner.inline(fblock, cop, List.of(i, fortyTwo), Inliner.INLINE_RETURN);
                     Assert.assertEquals(fblock, cb);
                 });
 
@@ -80,7 +81,7 @@ public class TestInline {
 
                     Op.Result v = fblock.op(var(fblock.op(constant(INT, 0))));
 
-                    var cb = fblock.inline(cop, List.of(i, fortyTwo), (b, value) -> {
+                    var cb = Inliner.inline(fblock, cop, List.of(i, fortyTwo), (b, value) -> {
                         b.op(varStore(v, value));
                     });
                     Assert.assertEquals(fblock, cb);
@@ -115,7 +116,7 @@ public class TestInline {
 
                     Op.Result fortyTwo = fblock.op(constant(INT, 42));
 
-                    var cb = fblock.inline(lcop, List.of(i, fortyTwo), Block.Builder.INLINE_RETURN);
+                    var cb = Inliner.inline(fblock, lcop, List.of(i, fortyTwo), Inliner.INLINE_RETURN);
                     Assert.assertNotEquals(fblock, cb);
                 });
         System.out.println(f.toText());
@@ -146,7 +147,7 @@ public class TestInline {
 
                     Op.Result v = fblock.op(var(fblock.op(constant(INT, 0))));
 
-                    var cb = fblock.inline(lcop, List.of(i, fortyTwo), (b, value) -> {
+                    var cb = Inliner.inline(fblock, lcop, List.of(i, fortyTwo), (b, value) -> {
                         b.op(varStore(v, value));
                     });
                     Assert.assertNotEquals(fblock, cb);
@@ -176,7 +177,7 @@ public class TestInline {
 
                     Op.Result fortyTwo = fblock.op(constant(INT, 42));
 
-                    var cb = fblock.inline(cop, List.of(i, fortyTwo), Block.Builder.INLINE_RETURN);
+                    var cb = Inliner.inline(fblock, cop, List.of(i, fortyTwo), Inliner.INLINE_RETURN);
                     Assert.assertEquals(fblock, cb);
                 });
         System.out.println(f.toText());
@@ -201,7 +202,7 @@ public class TestInline {
                 .body(fblock -> {
                     Block.Parameter a = fblock.parameters().get(0);
 
-                    var cb = fblock.inline(cop, List.of(a), Block.Builder.INLINE_RETURN);
+                    var cb = Inliner.inline(fblock, cop, List.of(a), Inliner.INLINE_RETURN);
                     Assert.assertEquals(fblock, cb);
                 });
 

--- a/test/jdk/java/lang/reflect/code/TestLinqUsingQuoted.java
+++ b/test/jdk/java/lang/reflect/code/TestLinqUsingQuoted.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.incubator.code.analysis.Inliner;
 import jdk.incubator.code.dialect.java.JavaOp;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -118,7 +119,7 @@ public class TestLinqUsingQuoted {
             FuncOp currentQueryExpression = expression();
             FuncOp nextQueryExpression = func("queryresult",
                     functionType(qp.queryResultType(), currentQueryExpression.invokableType().parameterTypes()))
-                    .body(b -> b.inline(currentQueryExpression, b.parameters(), (block, query) -> {
+                    .body(b -> Inliner.inline(b, currentQueryExpression, b.parameters(), (block, query) -> {
                         MethodRef md = method(qp.queryableType(), name, functionType(qp.queryResultType()));
                         Op.Result queryResult = block.op(JavaOp.invoke(md, query));
 

--- a/test/jdk/java/lang/reflect/code/linq/Queryable.java
+++ b/test/jdk/java/lang/reflect/code/linq/Queryable.java
@@ -22,6 +22,7 @@
  */
 
 import jdk.incubator.code.Op;
+import jdk.incubator.code.analysis.Inliner;
 import jdk.incubator.code.dialect.java.ClassType;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.MethodRef;
@@ -63,7 +64,7 @@ public interface Queryable<T> {
         JavaType queryableType = parameterized(Queryable.TYPE, elementType);
         FuncOp nextQueryExpression = func("query",
                 functionType(queryableType, queryExpression.invokableType().parameterTypes()))
-                .body(b -> b.inline(queryExpression, b.parameters(), (block, query) -> {
+                .body(b -> Inliner.inline(b, queryExpression, b.parameters(), (block, query) -> {
                     Op.Result fi = block.op(lambdaOp);
 
                     MethodRef md = method(Queryable.TYPE, methodName,
@@ -94,7 +95,7 @@ public interface Queryable<T> {
         JavaType queryResultType = parameterized(QueryResult.TYPE, resultType);
         FuncOp queryResultExpression = func("queryResult",
                 functionType(queryResultType, queryExpression.invokableType().parameterTypes()))
-                .body(b -> b.inline(queryExpression, b.parameters(), (block, query) -> {
+                .body(b -> Inliner.inline(b, queryExpression, b.parameters(), (block, query) -> {
                     MethodRef md = method(Queryable.TYPE, methodName,
                             functionType(QueryResult.TYPE));
                     Op.Result queryResult = block.op(JavaOp.invoke(queryResultType, md, query));

--- a/test/jdk/java/lang/reflect/code/stream/StreamFuser.java
+++ b/test/jdk/java/lang/reflect/code/stream/StreamFuser.java
@@ -22,6 +22,7 @@
  */
 
 import jdk.incubator.code.*;
+import jdk.incubator.code.analysis.Inliner;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.java.JavaOp;
@@ -141,11 +142,11 @@ public final class StreamFuser {
 
             StreamOp sop = streamOps.get(i);
             if (sop instanceof MapStreamOp) {
-                body.inline(sop.op(), List.of(element), (block, value) -> {
+                Inliner.inline(body, sop.op(), List.of(element), (block, value) -> {
                     fuseIntermediateOperation(i + 1, block, value, continueBlock, terminalConsumer);
                 });
             } else if (sop instanceof FilterStreamOp) {
-                body.inline(sop.op(), List.of(element), (block, p) -> {
+                Inliner.inline(body, sop.op(), List.of(element), (block, p) -> {
                     Block.Builder _if = block.block();
                     Block.Builder _else = continueBlock;
                     if (continueBlock == null) {
@@ -158,7 +159,7 @@ public final class StreamFuser {
                     fuseIntermediateOperation(i + 1, _if, element, _else, terminalConsumer);
                 });
             } else if (sop instanceof FlatMapStreamOp) {
-                body.inline(sop.op(), List.of(element), (block, iterable) -> {
+                Inliner.inline(body, sop.op(), List.of(element), (block, iterable) -> {
                     EnhancedForOp forOp = enhancedFor(block.parentBody(),
                             iterable.type(), ((ClassType) iterable.type()).typeArguments().get(0))
                             .expression(b -> {
@@ -192,7 +193,7 @@ public final class StreamFuser {
                         Op sourceLoop = loopSupplier.apply(b.parentBody(), source)
                                 .apply(loopBlock -> {
                                     fuseIntermediateOperations(loopBlock, (terminalBlock, resultValue) -> {
-                                        terminalBlock.inline(consumer, List.of(resultValue),
+                                        Inliner.inline(terminalBlock, consumer, List.of(resultValue),
                                                 (_, _) -> {
                                                 });
                                         terminalBlock.op(JavaOp.continue_());
@@ -218,11 +219,11 @@ public final class StreamFuser {
                     .body(b -> {
                         Value source = b.parameters().get(0);
 
-                        b.inline(supplier, List.of(), (block, collect) -> {
+                        Inliner.inline(b, supplier, List.of(), (block, collect) -> {
                             Op sourceLoop = loopSupplier.apply(block.parentBody(), source)
                                     .apply(loopBlock -> {
                                         fuseIntermediateOperations(loopBlock, (terminalBlock, resultValue) -> {
-                                            terminalBlock.inline(accumulator, List.of(collect, resultValue),
+                                            Inliner.inline(terminalBlock, accumulator, List.of(collect, resultValue),
                                                     (_, _) -> {
                                                     });
                                             terminalBlock.op(JavaOp.continue_());


### PR DESCRIPTION
Move the `Block.Builder.inline` method and dependent functionality to the class `Inliner` in the `analysis` package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/493/head:pull/493` \
`$ git checkout pull/493`

Update a local copy of the PR: \
`$ git checkout pull/493` \
`$ git pull https://git.openjdk.org/babylon.git pull/493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 493`

View PR using the GUI difftool: \
`$ git pr show -t 493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/493.diff">https://git.openjdk.org/babylon/pull/493.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/493#issuecomment-3059547483)
</details>
