### PR TITLE
Transformation API changes

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
@@ -572,7 +572,7 @@ public final class TritonTransformer {
                     }
 
                     // Transform kernel body
-                    fblock.transformBody(kernel.body(), args, (kblock, op) -> {
+                    fblock.body(kernel.body(), args, (kblock, op) -> {
                         return transformToTritonOperation(kblock, op, valueTypeMap, opData, fsymTable);
                     });
                 });
@@ -743,7 +743,7 @@ public final class TritonTransformer {
                     }
 
                     // Transform the Java for body into the SCF for body
-                    builder.transformBody(body, List.of(), (block, op) -> {
+                    builder.body(body, List.of(), (block, op) -> {
                         // Yield iter values
                         if (op instanceof JavaOp.ContinueOp) {
                             // Replace with yield of loaded vars

--- a/hat/core/src/main/java/hat/OpsAndTypes.java
+++ b/hat/core/src/main/java/hat/OpsAndTypes.java
@@ -112,7 +112,7 @@ public class OpsAndTypes {
     public static <T extends MappableIface> CoreOp.FuncOp transformInvokesToPtrs(MethodHandles.Lookup lookup,
                                                                                  CoreOp.FuncOp ssaForm, FunctionType functionType) {
         return CoreOp.func(ssaForm.funcName(), functionType).body(funcBlock -> {
-            funcBlock.transformBody(ssaForm.body(), funcBlock.parameters(), (builder, op) -> {
+            funcBlock.body(ssaForm.body(), funcBlock.parameters(), (builder, op) -> {
                 /*
                    We are looking for
                       interface Iface extends Buffer // or Buffer.StructChild

--- a/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
+++ b/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
@@ -134,7 +134,7 @@ public class LayoutExample {
         var builder= CoreOp.func(f.funcName(), functionType);
 
         var funcOp = builder.body(funcBlock -> {
-            funcBlock.transformBody(f.body(), funcBlock.parameters(), (b, op) -> {
+            funcBlock.body(f.body(), funcBlock.parameters(), (b, op) -> {
                 if (op instanceof JavaOp.InvokeOp invokeOp
                         && invokeOp.hasReceiver()
                         && invokeOp.operands().getFirst() instanceof Value receiver) {

--- a/hat/examples/experiments/src/main/java/experiments/RawLayout.java
+++ b/hat/examples/experiments/src/main/java/experiments/RawLayout.java
@@ -155,7 +155,7 @@ public class RawLayout {
                 transformStructClassToPtr(l, f.invokableType().returnType()),
                 pTypes);
         return CoreOp.func(f.funcName(), functionType).body(funcBlock -> {
-            funcBlock.transformBody(f.body(), funcBlock.parameters(), (b, op) -> {
+            funcBlock.body(f.body(), funcBlock.parameters(), (b, op) -> {
                 if (op instanceof JavaOp.InvokeOp iop && iop.hasReceiver()) {
                     Value receiver = iop.operands().getFirst();
                     if (structClass(l, receiver.type()) instanceof Class<?> _) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -606,11 +606,14 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Transforms a body starting from this block builder, using a given operation transformer.
+         * Transforms a body starting from this block builder, using an operation transformer.
          * <p>
          * This method first rebinds this builder with a child context created from
-         * this builder's context and the given operation transformer, and then using the rebound
-         * builder {@link #body(Body, List) transforms} the body with the given values.
+         * this builder's context and the given operation transformer, and then
+         * transforms the body using the operation transformer by
+         * {@link OpTransformer#acceptBody(Builder, Body, List) accepting}
+         * the rebound builder, the body, and the values.
+         *
          * @apiNote
          * Creation of a child context ensures block and value mappings produced by
          * the transformation do not affect this builder's context.
@@ -618,19 +621,24 @@ public final class Block implements CodeElement<Block, Op> {
          * @param body the body to transform
          * @param values the output values to map to the input parameters of the body's entry block
          * @param ot the operation transformer
-         * @see #body(Body, List)
+         * @see OpTransformer#acceptBody(Builder, Body, List)
          */
         public void body(Body body, List<? extends Value> values,
                          OpTransformer ot) {
-            rebind(CopyContext.create(cc), ot).body(body, values);
+            check();
+
+            ot.acceptBody(rebind(CopyContext.create(cc), ot), body, values);
         }
 
         /**
          * Transforms a body starting from this block builder, using a given operation transformer.
          * <p>
          * This method first rebinds this builder with the given context
-         * and the given operation transformer, and then using the rebound
-         * builder {@link #body(Body, List) transforms} the body with the given values.
+         * and the given operation transformer, and then
+         * transforms the body using the operation transformer by
+         * {@link OpTransformer#acceptBody(Builder, Body, List) accepting}
+         * the rebound builder, the body, and the values.
+         *
          * @apiNote
          * The passing of a context can ensure block and value mappings produced by
          * the transformation do not affect this builder's context.
@@ -639,27 +647,13 @@ public final class Block implements CodeElement<Block, Op> {
          * @param values the output values to map to the input parameters of the body's entry block
          * @param cc the copy context
          * @param ot the operation transformer
-         * @see #body(Body, List)
+         * @see OpTransformer#acceptBody(Builder, Body, List)
          */
         public void body(Body body, List<? extends Value> values,
                          CopyContext cc, OpTransformer ot) {
-            rebind(cc, ot).body(body, values);
-        }
-
-        /**
-         * Transforms a body starting from this builder.
-         * <p>
-         * This builder's operation transformer transforms the body by
-         * {@link OpTransformer#acceptBody(Builder, Body, List)} accepting
-         * this builder, the body, and the values.
-         *
-         * @param body the body to transform
-         * @param values the output values to map to the input parameters of the body's entry block
-         */
-        public void body(Body body, List<? extends Value> values) {
             check();
 
-            ot.acceptBody(this, body, values);
+            ot.acceptBody(rebind(cc, ot), body, values);
         }
 
         /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -606,87 +606,70 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Transforms a body into this block, with this block builder's context.
+         * Transforms a body starting from this block builder, using a given operation transformer.
+         * <p>
+         * This method first rebinds this builder with a child context created from
+         * this builder's context and the given operation transformer, and then using the rebound
+         * builder {@link #body(Body, List) transforms} the body with the given values.
+         * @apiNote
+         * Creation of a child context ensures block and value mappings produced by
+         * the transformation do not affect this builder's context.
          *
-         * @param bodyToTransform the body to transform
-         * @param args        the list of output values to map to the input parameters of the body's entry block
-         * @param ot          the operation transformer
-         * @see #transformBody(Body, List, CopyContext, OpTransformer)
+         * @param body the body to transform
+         * @param values the output values to map to the input parameters of the body's entry block
+         * @param ot the operation transformer
+         * @see #body(Body, List)
          */
-        public void transformBody(Body bodyToTransform, List<? extends Value> args,
-                                  OpTransformer ot) {
-            transformBody(bodyToTransform, args, cc, ot);
+        public void body(Body body, List<? extends Value> values,
+                         OpTransformer ot) {
+            rebind(CopyContext.create(cc), ot).body(body, values);
         }
 
         /**
-         * Transforms a body into this block.
+         * Transforms a body starting from this block builder, using a given operation transformer.
          * <p>
-         * First, a new context is created from the given context and that new context is used to map values and
-         * blocks.
-         * <p>
-         * Second, the entry block is mapped to this block builder rebound with the given operation transformer and
-         * copy context, the input block parameters of the body's entry block are mapped to the given arguments.
-         * <p>
-         * Third, for each input block in the body (except the entry block) an output block builder is created with
-         * equivalent parameters as the input block and with the given operation transformer and copy context.
-         * The input block parameters are mapped to the output block parameters, and the input block is mapped to the
-         * output block builder.
-         * <p>
-         * Fourth, for each input block in the body (in order) the input block's operations are transformed
-         * by applying the output block builder and input block to the given operation transformer.
-         * <p>
-         * When the parent body is built any empty non-entry blocks that have no successors will be removed.
+         * This method first rebinds this builder with the given context
+         * and the given operation transformer, and then using the rebound
+         * builder {@link #body(Body, List) transforms} the body with the given values.
+         * @apiNote
+         * The passing of a context can ensure block and value mappings produced by
+         * the transformation do not affect this builder's context.
          *
-         * @param bodyToTransform the body to transform
-         * @param args            the list of output values to map to the input parameters of the body's entry block
-         * @param cc              the copy context, for values captured in the body
-         * @param ot              the operation transformer
+         * @param body the body to transform
+         * @param values the output values to map to the input parameters of the body's entry block
+         * @param cc the copy context
+         * @param ot the operation transformer
+         * @see #body(Body, List)
          */
-        public void transformBody(Body bodyToTransform, List<? extends Value> args,
-                                  CopyContext cc, OpTransformer ot) {
+        public void body(Body body, List<? extends Value> values,
+                         CopyContext cc, OpTransformer ot) {
+            rebind(cc, ot).body(body, values);
+        }
+
+        /**
+         * Transforms a body starting from this builder.
+         * <p>
+         * This builder's operation transformer transforms the body by
+         * {@link OpTransformer#acceptBody(Builder, Body, List)} accepting
+         * this builder, the body, and the values.
+         *
+         * @param body the body to transform
+         * @param values the output values to map to the input parameters of the body's entry block
+         */
+        public void body(Body body, List<? extends Value> values) {
             check();
 
-            // @@@ This might be a new context e.g., when transforming a body
-            cc = CopyContext.create(cc);
-
-            Block entryBlockToTransform  = bodyToTransform.entryBlock();
-            List<Block> blocksToTransform = bodyToTransform.blocks();
-
-            // Map entry block
-            // Rebind this block builder to the created context and transformer
-            Block.Builder startingBlock = rebind(cc, ot);
-            cc.mapBlock(entryBlockToTransform, startingBlock);
-            cc.mapValues(entryBlockToTransform.parameters(), args);
-
-            // Map subsequent blocks up front, for forward referencing successors
-            for (int i = 1; i < blocksToTransform.size(); i++) {
-                Block blockToTransform = blocksToTransform.get(i);
-                if (cc.getBlock(blockToTransform) != null) {
-                    throw new IllegalStateException("Block is already transformed");
-                }
-
-                // Create block and map block
-                Block.Builder transformedBlock = startingBlock.block(List.of());
-                for (Block.Parameter ba : blockToTransform.parameters()) {
-                    transformedBlock.parameter(ba.type());
-                }
-                cc.mapBlock(blockToTransform, transformedBlock);
-                cc.mapValues(blockToTransform.parameters(), transformedBlock.parameters());
-            }
-
-            for (Block blockToTransform : blocksToTransform) {
-                ot.apply(cc.getBlock(blockToTransform), blockToTransform);
-            }
+            ot.acceptBody(this, body, values);
         }
 
         /**
-         * Appends an operation to this block.
+         * Appends an operation to this block builder, first transforming the operation if bound.
          * <p>
          * If the operation is not bound to a block, then the operation is appended and bound to this block.
          * Otherwise, if the operation is bound, the operation is first
          * {@link Op#transform(CopyContext, OpTransformer) transformed} with this builder's context and
-         * operation transformer, the unbound transformed operation is appended, and the operation's result is mapped
-         * to the transformed operation's result (using the builder's context).
+         * operation transformer, the resulting unbound transformed operation is appended, and the
+         * operation's result mapped to the transformed operation's result, using the builder's context.
          * <p>
          * If the unbound operation (transformed, or otherwise) is structurally invalid then an
          * {@code IllegalStateException} is thrown. An unbound operation is structurally invalid if:

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -692,9 +692,12 @@ public final class Body implements CodeElement<Body, Block> {
                 ? ancestorBlockBuilder.parentBody() : null;
         Builder bodyBuilder = Builder.of(ancestorBodyBuilder,
                 bodyType(),
-                cc, ot);
+                // Create child context for mapped code items contained in this body
+                // thereby not polluting the given context
+                CopyContext.create(cc), ot);
 
-        bodyBuilder.entryBlock.body(this, bodyBuilder.entryBlock.parameters(), ot);
+        // Transform body starting from the entry block builder
+        ot.acceptBody(bodyBuilder.entryBlock, this, bodyBuilder.entryBlock.parameters());
         return bodyBuilder;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -677,9 +677,9 @@ public final class Body implements CodeElement<Body, Block> {
      * Transforms this body.
      * <p>
      * A new body builder is created with the same function type as this body.
-     * Then, this body is {@link Block.Builder#transformBody(Body, java.util.List, CopyContext, OpTransformer) transformed}
-     * into the body builder's entry block builder with the given copy context, operation transformer, and values
-     * that are the entry block's parameters.
+     * Then, this body is {@link Block.Builder#body(Body, java.util.List, CopyContext, OpTransformer) transformed}
+     * into the body builder's entry block builder with the given copy context, operation transformer, and arguments
+     * that are the entry block builder's parameters.
      *
      * @param cc the copy context
      * @param ot the operation transformer
@@ -690,17 +690,12 @@ public final class Body implements CodeElement<Body, Block> {
                 ? cc.getBlock(ancestorBody.entryBlock()) : null;
         Builder ancestorBodyBuilder = ancestorBlockBuilder != null
                 ? ancestorBlockBuilder.parentBody() : null;
-        Builder body = Builder.of(ancestorBodyBuilder,
-                // Create function type with just the return type and add parameters afterward
-                CoreType.functionType(yieldType),
+        Builder bodyBuilder = Builder.of(ancestorBodyBuilder,
+                bodyType(),
                 cc, ot);
 
-        for (Block.Parameter p : entryBlock().parameters()) {
-            body.entryBlock.parameter(p.type());
-        }
-
-        body.entryBlock.transformBody(this, body.entryBlock.parameters(), cc, ot);
-        return body;
+        bodyBuilder.entryBlock.body(this, bodyBuilder.entryBlock.parameters(), ot);
+        return bodyBuilder;
     }
 
     // Sort blocks in reverse post order

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/OpTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/OpTransformer.java
@@ -148,7 +148,6 @@ public interface OpTransformer {
      * @param op    the operation to transform.
      * @return      the block builder to append to for subsequent operations.
      */
-    // @@@ Change to acceptOp
     Block.Builder acceptOp(Block.Builder block, Op op);
 
     default OpTransformer compose(OpTransformer before) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Inliner.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/Inliner.java
@@ -29,7 +29,7 @@ public final class Inliner {
      * Inlines the invokable operation into the given block builder and returns the block builder from which to
      * continue building.
      * <p>
-     * This method {@link Block.Builder#transformBody(Body, List, CopyContext, OpTransformer) transforms} the
+     * This method {@link Block.Builder#body(Body, List, CopyContext, OpTransformer) transforms} the
      * body of the invokable operation with the given arguments, a new context, and an operation transformer that
      * replaces return operations by applying the given consumer to a block builder and a return value.
      * <p>
@@ -73,7 +73,7 @@ public final class Inliner {
                          BiConsumer<Block.Builder, Value> inlineConsumer) {
         Map<Body, Block.Builder> returnBlocks = new HashMap<>();
         // Create new context, ensuring inlining is isolated
-        _this.transformBody(invokableOp.body(), args, CopyContext.create(), (block, op) -> {
+        _this.body(invokableOp.body(), args, CopyContext.create(), (block, op) -> {
             // If the return operation is associated with the invokable operation
             if (op instanceof CoreOp.ReturnOp rop && getNearestInvokeableAncestorOp(op) == invokableOp) {
                 // Compute the return block

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/NormalizeBlocksTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/NormalizeBlocksTransformer.java
@@ -61,15 +61,15 @@ public final class NormalizeBlocksTransformer implements OpTransformer {
     ;
 
     @Override
-    public void apply(Block.Builder block, Block b) {
+    public void acceptBlock(Block.Builder block, Block b) {
         // Ignore merged block
         if (!mergedBlocks.contains(b)) {
-            OpTransformer.super.apply(block, b);
+            OpTransformer.super.acceptBlock(block, b);
         }
     }
 
     @Override
-    public Block.Builder apply(Block.Builder b, Op op) {
+    public Block.Builder acceptOp(Block.Builder b, Op op) {
         if (op instanceof CoreOp.BranchOp bop &&
                 bop.branch().targetBlock().predecessors().size() == 1) {
             // Merge the successor's target block with this block, and so on
@@ -164,6 +164,6 @@ public final class NormalizeBlocksTransformer implements OpTransformer {
         }
 
         // Check if subsequent successor block can be normalized
-        apply(b, successor.terminatingOp());
+        acceptOp(b, successor.terminatingOp());
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/SSABraun.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/SSABraun.java
@@ -224,7 +224,7 @@ final class SSABraun implements OpTransformer {
     }
 
     @Override
-    public Block.Builder apply(Block.Builder block, Op op) {
+    public Block.Builder acceptOp(Block.Builder block, Op op) {
         Block originalBlock = op.ancestorBlock();
         CopyContext context = block.context();
         switch (op) {
@@ -256,7 +256,7 @@ final class SSABraun implements OpTransformer {
     }
 
     @Override
-    public void apply(Block.Builder block, Block b) {
+    public void acceptBlock(Block.Builder block, Block b) {
         // add the required additional parameters to this block
         boolean isEntry = b.isEntryBlock();
         for (Phi phi : this.additionalParameters.getOrDefault(b, List.of())) {
@@ -272,7 +272,7 @@ final class SSABraun implements OpTransformer {
         }
 
         // actually visit ops in this block
-        OpTransformer.super.apply(block, b);
+        OpTransformer.super.acceptBlock(block, b);
     }
 
     sealed interface Val {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/StringConcatTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/StringConcatTransformer.java
@@ -44,7 +44,7 @@ public final class StringConcatTransformer implements OpTransformer {
     public StringConcatTransformer() {}
 
     @Override
-    public Block.Builder apply(Block.Builder block, Op op) {
+    public Block.Builder acceptOp(Block.Builder block, Op op) {
         switch (op) {
             case JavaOp.ConcatOp cz when isRootConcat(cz) -> {
                 // Create a string builder and build by traversing tree of operands

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/UnresolvedTypesTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/UnresolvedTypesTransformer.java
@@ -270,7 +270,7 @@ final class UnresolvedTypesTransformer {
     private OpTransformer blockParamTypesTransformer() {
         return new OpTransformer() {
             @Override
-            public void apply(Block.Builder block, Block b) {
+            public void acceptBlock(Block.Builder block, Block b) {
                 if (block.isEntryBlock()) {
                     CopyContext cc = block.context();
                     List<Block> sourceBlocks = b.ancestorBody().blocks();
@@ -289,11 +289,11 @@ final class UnresolvedTypesTransformer {
                     }
 
                 }
-                OpTransformer.super.apply(block, b);
+                OpTransformer.super.acceptBlock(block, b);
             }
 
             @Override
-            public Block.Builder apply(Block.Builder block, Op op) {
+            public Block.Builder acceptOp(Block.Builder block, Op op) {
                 block.op(op);
                 return block;
             }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -2268,7 +2268,7 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder exit = b.block();
             setBranchTarget(b.context(), this, new BranchTarget(exit, null));
 
-            b.transformBody(body, List.of(), opT.andThen((block, op) -> {
+            b.body(body, List.of(), opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     block.op(branch(exit.successor()));
                 } else {
@@ -2384,7 +2384,7 @@ public sealed abstract class JavaOp extends Op {
                 }
             });
 
-            syncRegionEnter.transformBody(blockBody, List.of(), syncExitTransformer.andThen((block, op) -> {
+            syncRegionEnter.body(blockBody, List.of(), syncExitTransformer.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     // Monitor exit
                     block.op(monitorExit(monitorTarget));
@@ -2421,7 +2421,7 @@ public sealed abstract class JavaOp extends Op {
 
         Block.Builder lowerExpr(Block.Builder b, OpTransformer opT) {
             Block.Builder exprExit = b.block(expr.bodyType().returnType());
-            b.transformBody(expr, List.of(), opT.andThen((block, op) -> {
+            b.body(expr, List.of(), opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value monitorTarget = block.context().getValue(yop.yieldValue());
                     block.op(branch(exprExit.successor(monitorTarget)));
@@ -2510,7 +2510,7 @@ public sealed abstract class JavaOp extends Op {
             setBranchTarget(b.context(), this, new BranchTarget(exit, null));
 
             AtomicBoolean first = new AtomicBoolean();
-            b.transformBody(body, List.of(), opT.andThen((block, op) -> {
+            b.body(body, List.of(), opT.andThen((block, op) -> {
                 // Drop first operation that corresponds to the label
                 if (!first.get()) {
                     first.set(true);
@@ -2723,7 +2723,7 @@ public sealed abstract class JavaOp extends Op {
                     action = builders.get(i + 1);
                     Block.Builder next = builders.get(i + 2);
 
-                    pred.transformBody(predBody, List.of(), opT.andThen((block, op) -> {
+                    pred.body(predBody, List.of(), opT.andThen((block, op) -> {
                         if (op instanceof CoreOp.YieldOp yo) {
                             block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                                     action.successor(), next.successor()));
@@ -2737,7 +2737,7 @@ public sealed abstract class JavaOp extends Op {
                     }));
                 }
 
-                action.transformBody(actionBody, List.of(), opT.andThen((block, op) -> {
+                action.body(actionBody, List.of(), opT.andThen((block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.successor()));
                     } else {
@@ -2843,7 +2843,7 @@ public sealed abstract class JavaOp extends Op {
                     Block.Builder statement = blocks.get(i + 1);
                     boolean isLastLabel = i == blocks.size() - 2;
                     Block.Builder nextLabel = isLastLabel ? null : blocks.get(i + 2);
-                    curr.transformBody(bodies().get(i), List.of(selectorExpression), opT.andThen((block, op) -> {
+                    curr.body(bodies().get(i), List.of(selectorExpression), opT.andThen((block, op) -> {
                         switch (op) {
                             case CoreOp.YieldOp _ when isLastLabel && this instanceof SwitchExpressionOp -> {
                                 block.op(branch(statement.successor()));
@@ -2859,7 +2859,7 @@ public sealed abstract class JavaOp extends Op {
                         return block;
                     }));
                 } else { // statement body
-                    curr.transformBody(bodies().get(i), blocks.get(i).parameters(), opT.andThen((block, op) -> {
+                    curr.body(bodies().get(i), blocks.get(i).parameters(), opT.andThen((block, op) -> {
                         switch (op) {
                             case CoreOp.YieldOp _ when this instanceof SwitchStatementOp -> block.op(branch(exit.successor()));
                             case CoreOp.YieldOp yop when this instanceof SwitchExpressionOp -> block.op(branch(exit.successor(block.context().getValue(yop.yieldValue()))));
@@ -3201,7 +3201,7 @@ public sealed abstract class JavaOp extends Op {
             List<Value> initValues = new ArrayList<>();
             // @@@ Init body has one yield operation yielding
             //  void, a single variable, or a tuple of one or more variables
-            b.transformBody(init, List.of(), opT.andThen((block, op) -> {
+            b.body(init, List.of(), opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.TupleOp) {
                     // Drop Tuple if a yielded
                     boolean isResult = op.result().uses().size() == 1 &&
@@ -3231,7 +3231,7 @@ public sealed abstract class JavaOp extends Op {
                 return block;
             }));
 
-            header.transformBody(cond, initValues, opT.andThen((block, op) -> {
+            header.body(cond, initValues, opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.successor(), exit.successor()));
@@ -3246,7 +3246,7 @@ public sealed abstract class JavaOp extends Op {
 
             setBranchTarget(b.context(), this, new BranchTarget(exit, update));
 
-            body.transformBody(this.body, initValues, opT.andThen((block, op) -> {
+            body.body(this.body, initValues, opT.andThen((block, op) -> {
                 // @@@ Composition of lowerable ops
                 if (op instanceof Lowerable lop) {
                     block = lop.lower(block, opT);
@@ -3256,7 +3256,7 @@ public sealed abstract class JavaOp extends Op {
                 return block;
             }));
 
-            update.transformBody(this.update, initValues, opT.andThen((block, op) -> {
+            update.body(this.update, initValues, opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     block.op(branch(header.successor()));
                 } else {
@@ -3441,7 +3441,7 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder body = b.block();
             Block.Builder exit = b.block();
 
-            b.transformBody(expression, List.of(), opT.andThen((block, op) -> {
+            b.body(expression, List.of(), opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value loopSource = block.context().getValue(yop.yieldValue());
                     block.op(branch(preHeader.successor(loopSource)));
@@ -3465,7 +3465,7 @@ public sealed abstract class JavaOp extends Op {
                 Value e = init.op(arrayLoadOp(array, i));
                 List<Value> initValues = new ArrayList<>();
                 // @@@ Init body has one yield operation yielding a single variable
-                init.transformBody(this.init, List.of(e), (block, op) -> {
+                init.body(this.init, List.of(e), (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
                         block.op(branch(body.successor()));
@@ -3479,7 +3479,7 @@ public sealed abstract class JavaOp extends Op {
                 Block.Builder update = b.block();
                 setBranchTarget(b.context(), this, new BranchTarget(exit, update));
 
-                body.transformBody(this.body, initValues, opT.andThen((block, op) -> {
+                body.body(this.body, initValues, opT.andThen((block, op) -> {
                     // @@@ Composition of lowerable ops
                     if (op instanceof Lowerable lop) {
                         block = lop.lower(block, opT);
@@ -3501,7 +3501,7 @@ public sealed abstract class JavaOp extends Op {
 
                 Value e = init.op(invoke(elementType, ITERATOR_NEXT, iterator));
                 List<Value> initValues = new ArrayList<>();
-                init.transformBody(this.init, List.of(e), opT.andThen((block, op) -> {
+                init.body(this.init, List.of(e), opT.andThen((block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
                         block.op(branch(body.successor()));
@@ -3514,7 +3514,7 @@ public sealed abstract class JavaOp extends Op {
 
                 setBranchTarget(b.context(), this, new BranchTarget(exit, header));
 
-                body.transformBody(this.body, initValues, opT.andThen((block, op) -> {
+                body.body(this.body, initValues, opT.andThen((block, op) -> {
                     // @@@ Composition of lowerable ops
                     if (op instanceof Lowerable lop) {
                         block = lop.lower(block, opT);
@@ -3642,7 +3642,7 @@ public sealed abstract class JavaOp extends Op {
 
             b.op(branch(header.successor()));
 
-            header.transformBody(predicateBody(), List.of(), opT.andThen((block, op) -> {
+            header.body(predicateBody(), List.of(), opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.successor(), exit.successor()));
@@ -3657,7 +3657,7 @@ public sealed abstract class JavaOp extends Op {
 
             setBranchTarget(b.context(), this, new BranchTarget(exit, header));
 
-            body.transformBody(loopBody(), List.of(), opT.andThen((block, op) -> {
+            body.body(loopBody(), List.of(), opT.andThen((block, op) -> {
                 // @@@ Composition of lowerable ops
                 if (op instanceof Lowerable lop) {
                     block = lop.lower(block, opT);
@@ -3786,7 +3786,7 @@ public sealed abstract class JavaOp extends Op {
 
             setBranchTarget(b.context(), this, new BranchTarget(exit, header));
 
-            body.transformBody(loopBody(), List.of(), opT.andThen((block, op) -> {
+            body.body(loopBody(), List.of(), opT.andThen((block, op) -> {
                 // @@@ Composition of lowerable ops
                 if (op instanceof Lowerable lop) {
                     block = lop.lower(block, opT);
@@ -3796,7 +3796,7 @@ public sealed abstract class JavaOp extends Op {
                 return block;
             }));
 
-            header.transformBody(predicateBody(), List.of(), opT.andThen((block, op) -> {
+            header.body(predicateBody(), List.of(), opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.successor(), exit.successor()));
@@ -3903,10 +3903,10 @@ public sealed abstract class JavaOp extends Op {
 
                 Body fromPred = bodies.get(i);
                 if (i == 0) {
-                    startBlock.transformBody(fromPred, List.of(), opt);
+                    startBlock.body(fromPred, List.of(), opt);
                 } else {
                     pred = startBlock.block(fromPred.bodyType().parameterTypes());
-                    pred.transformBody(fromPred, pred.parameters(), opT.andThen(opt));
+                    pred.body(fromPred, pred.parameters(), opT.andThen(opt));
                 }
             }
 
@@ -4094,7 +4094,7 @@ public sealed abstract class JavaOp extends Op {
             setBranchTarget(b.context(), this, new BranchTarget(exit, null));
 
             List<Block.Builder> builders = List.of(b.block(), b.block());
-            b.transformBody(bodies.get(0), List.of(), opT.andThen((block, op) -> {
+            b.body(bodies.get(0), List.of(), opT.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             builders.get(0).successor(), builders.get(1).successor()));
@@ -4108,7 +4108,7 @@ public sealed abstract class JavaOp extends Op {
             }));
 
             for (int i = 0; i < 2; i++) {
-                builders.get(i).transformBody(bodies.get(i + 1), List.of(), opT.andThen((block, op) -> {
+                builders.get(i).body(bodies.get(i + 1), List.of(), opT.andThen((block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         block.op(branch(exit.successor(block.context().getValue(yop.yieldValue()))));
                     } else if (op instanceof Lowerable lop) {
@@ -4341,7 +4341,7 @@ public sealed abstract class JavaOp extends Op {
 
             // Simple case with no catch and finally bodies
             if (catchers.isEmpty() && finalizer == null) {
-                b.transformBody(body, List.of(), (block, op) -> {
+                b.body(body, List.of(), (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.successor()));
                     } else {
@@ -4403,7 +4403,7 @@ public sealed abstract class JavaOp extends Op {
             }
             // Inline the try body
             AtomicBoolean hasTryRegionExit = new AtomicBoolean();
-            tryRegionEnter.transformBody(body, List.of(), tryExitTransformer.andThen((block, op) -> {
+            tryRegionEnter.body(body, List.of(), tryExitTransformer.andThen((block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     hasTryRegionExit.set(true);
                     block.op(branch(tryRegionExit.successor()));
@@ -4456,7 +4456,7 @@ public sealed abstract class JavaOp extends Op {
                     });
                     // Inline the catch body
                     AtomicBoolean hasCatchRegionExit = new AtomicBoolean();
-                    catchRegionEnter.transformBody(catcherBody, List.of(t), catchExitTransformer.andThen((block, op) -> {
+                    catchRegionEnter.body(catcherBody, List.of(t), catchExitTransformer.andThen((block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
                             hasCatchRegionExit.set(true);
                             block.op(branch(catchRegionExit.successor()));
@@ -4478,7 +4478,7 @@ public sealed abstract class JavaOp extends Op {
                     }
                 } else {
                     // Inline the catch body
-                    catcher.transformBody(catcherBody, List.of(t), opT.andThen((block, op) -> {
+                    catcher.body(catcherBody, List.of(t), opT.andThen((block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
                             block.op(branch(exit.successor()));
                         } else {
@@ -4496,7 +4496,7 @@ public sealed abstract class JavaOp extends Op {
 
             if (finalizer != null && hasTryRegionExit.get()) {
                 // Inline the finally body
-                finallyEnter.transformBody(finalizer, List.of(), opT.andThen((block, op) -> {
+                finallyEnter.body(finalizer, List.of(), opT.andThen((block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.successor()));
                     } else {
@@ -4516,7 +4516,7 @@ public sealed abstract class JavaOp extends Op {
                 // Create the throwable argument
                 Block.Parameter t = catcherFinally.parameter(type(Throwable.class));
 
-                catcherFinally.transformBody(finalizer, List.of(), opT.andThen((block, op) -> {
+                catcherFinally.body(finalizer, List.of(), opT.andThen((block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(throw_(t));
                     } else {
@@ -4545,7 +4545,7 @@ public sealed abstract class JavaOp extends Op {
             block1.op(exceptionRegionExit(finallyEnter.successor(), tryHandlers));
 
             // Inline the finally body
-            finallyEnter.transformBody(finalizer, List.of(), opT.andThen((block2, op2) -> {
+            finallyEnter.body(finalizer, List.of(), opT.andThen((block2, op2) -> {
                 if (op2 instanceof CoreOp.YieldOp) {
                     block2.op(branch(finallyExit.successor()));
                 } else {
@@ -4883,7 +4883,7 @@ public sealed abstract class JavaOp extends Op {
 
                 // Match block
                 // Lower match body and pass true
-                endMatchBlock.transformBody(match, patternValues, opT.andThen((block, op) -> {
+                endMatchBlock.body(match, patternValues, opT.andThen((block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(endBlock.successor(
                                 block.op(constant(BOOLEAN, true)))));

--- a/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
+++ b/test/jdk/java/lang/reflect/code/CoreBinaryOpsTest.java
@@ -272,7 +272,7 @@ public class CoreBinaryOpsTest {
                     ? type
                     : functionType.returnType();
             return CoreOp.func(original.funcName(), CoreType.functionType(retType, type, type))
-                    .body(builder -> builder.transformBody(original.body(), builder.parameters(), OpTransformer.COPYING_TRANSFORMER)
+                    .body(builder -> builder.body(original.body(), builder.parameters(), OpTransformer.COPYING_TRANSFORMER)
                     );
         }
 

--- a/test/jdk/java/lang/reflect/code/TestVarOp.java
+++ b/test/jdk/java/lang/reflect/code/TestVarOp.java
@@ -57,7 +57,7 @@ public class TestVarOp {
         CoreOp.FuncOp f = getFuncOp("f");
         CoreOp.FuncOp ft = CoreOp.func("f", CoreType.functionType(JavaType.J_L_OBJECT, JavaType.type(CharSequence.class)))
                 .body(fb -> {
-                    fb.transformBody(f.body(), fb.parameters(), OpTransformer.COPYING_TRANSFORMER);
+                    fb.body(f.body(), fb.parameters(), OpTransformer.COPYING_TRANSFORMER);
                 });
 
         List<CoreOp.VarOp> vops = ft.elements()


### PR DESCRIPTION
Move transformation of a `Body` starting at a `Block.Builder` to `OpTransformer`, which now has three methods, default method `acceptBody` calls default method `acceptBlock`, which in turn calls abstract method `acceptOp`.

Simplify the body accepting methods on `Block.Builder` which now defer to `OpTransformer.acceptBody`. Those methods are responsible for rebinding the `Block.Builder` and passing the rebound result to `acceptBody`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/494/head:pull/494` \
`$ git checkout pull/494`

Update a local copy of the PR: \
`$ git checkout pull/494` \
`$ git pull https://git.openjdk.org/babylon.git pull/494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 494`

View PR using the GUI difftool: \
`$ git pr show -t 494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/494.diff">https://git.openjdk.org/babylon/pull/494.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/494#issuecomment-3141563179)
</details>
