### PR TITLE
Add line number gutter to op viewer

### DIFF
--- a/hat/tools/src/main/java/hat/tools/textmodel/terminal/CodeModelFormatter.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/terminal/CodeModelFormatter.java
@@ -1,8 +1,29 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package hat.tools.textmodel.terminal;
 
-import hat.KernelContext;
-import hat.buffer.S32Array;
-import hat.ifacemapper.MappableIface;
 import hat.tools.textmodel.BabylonTextModel;
 import hat.tools.textmodel.JavaTextModel;
 import hat.tools.textmodel.tokens.At;

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/AbstractTextModelViewer.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/AbstractTextModelViewer.java
@@ -144,7 +144,6 @@ public class AbstractTextModelViewer extends TextViewer {
                         case BabylonTextModel.BabylonLocationAttribute _ -> babylonLocationAttribute;
                         case BabylonTextModel.BabylonNamedAttribute _ -> babylonNamedAttribute;
                         case JavaTextModel.JavaType _, BabylonTextModel.BabylonTypeAttribute _ -> type;
-                        //      case BabylonTextModel.BabylonRefAttribute _ -> babylonRefAttribute;
                         case BabylonTextModel.BabylonSSADef _ -> babylonSSADef;
                         case BabylonTextModel.BabylonSSARef _ -> babylonSSARef;
                         case BabylonTextModel.BabylonOp _ -> babylonOp;

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/FuncOpViewer.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/FuncOpViewer.java
@@ -24,18 +24,13 @@
  */
 package hat.tools.textmodel.ui;
 
-import hat.KernelContext;
-import hat.buffer.S32Array;
-import hat.buffer.S32Array2D;
-import jdk.incubator.code.Op;
-import jdk.incubator.code.dialect.core.CoreOp;
 import hat.tools.textmodel.BabylonTextModel;
 import hat.tools.textmodel.TextModel;
+import jdk.incubator.code.dialect.core.CoreOp;
 
 import javax.swing.BoxLayout;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
-import javax.swing.JSplitPane;
 import javax.swing.JTextPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.Element;
@@ -46,7 +41,6 @@ import java.awt.Graphics2D;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -67,7 +61,7 @@ public class FuncOpViewer extends JPanel {
             public void paintComponent(Graphics g) {
                 super.paintComponent(g);
                 Graphics2D g2d = (Graphics2D) g;
-// So we can overlay with arrows for
+                // So we can overlay with arrows for
                 // Draw Text
                 //  g2d.drawString("This is my custom Panel!",10,20);
             }
@@ -153,15 +147,16 @@ public class FuncOpViewer extends JPanel {
     }
 
     public FuncOpViewer(BabylonTextModel cr) {
-        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
-        splitPane.setOneTouchExpandable(true);
-        splitPane.setResizeWeight(0.5);
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
-        var font = new Font("Monospaced", Font.PLAIN, 16);
+        var font = new Font("Monospaced", Font.PLAIN, 14);
+
         var funcOpTextModelViewer = new FuncOpTextModelViewer(cr, font, false);
         var javaTextModelViewer = new JavaTextModelViewer(cr.javaTextModel, font, false);
-        splitPane.add(funcOpTextModelViewer.scrollPane);
-        splitPane.add(javaTextModelViewer.scrollPane);
+
+        var gutter = new TextGutter(  funcOpTextModelViewer,javaTextModelViewer);
+        add(funcOpTextModelViewer.scrollPane);
+        add(gutter);
+        add(javaTextModelViewer.scrollPane);
         // tell each about the other
         funcOpTextModelViewer.javaTextModelViewer = javaTextModelViewer;
         javaTextModelViewer.funcOpTextModelViewer = funcOpTextModelViewer;
@@ -191,19 +186,18 @@ public class FuncOpViewer extends JPanel {
         });
 
         javaTextModelViewer.highLightLines(cr.babylonLocationAttributes.getFirst(), cr.babylonLocationAttributes.getLast());
-        add(splitPane);
     }
 
     public static void launch(BabylonTextModel crDoc) {
-        SwingUtilities.invokeLater(() -> {
-            var viewer = new FuncOpViewer(crDoc);
-            var frame = new JFrame();
-            frame.setLayout(new BorderLayout());
-            frame.getContentPane().add(viewer);
-            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-            frame.pack();
-            frame.setVisible(true);
-        });
+            SwingUtilities.invokeLater(() -> {
+                var viewer = new FuncOpViewer(crDoc);
+                var frame = new JFrame();
+                frame.setLayout(new BorderLayout());
+                frame.getContentPane().add(viewer);
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.pack();
+                frame.setVisible(true);
+            });
 
     }
 

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/TextGutter.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/TextGutter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.tools.textmodel.ui;
+
+import javax.swing.JComponent;
+import javax.swing.JViewport;
+import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.MatteBorder;
+import javax.swing.text.Element;
+import javax.swing.text.Utilities;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+
+public class TextGutter extends JComponent {
+    private final static Border OUTER = new MatteBorder(0, 0, 0, 2, Color.GRAY);
+    private final AbstractTextModelViewer lhs;
+    private final AbstractTextModelViewer rhs;
+    private final Color currentLineForeground;
+    private final FontMetrics fontMetrics;
+    private final int colWidth;
+    private final Dimension size;
+
+    @Override
+    public Dimension getMinimumSize() {
+        return size;
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return size;
+    }
+
+    public TextGutter(AbstractTextModelViewer lhs, AbstractTextModelViewer rhs) {
+        this.lhs = lhs;
+        this.rhs = rhs;
+        setFont(this.lhs.jtextPane.getFont());
+        setBorder(new CompoundBorder(OUTER, new EmptyBorder(0, 5, 0, 5)));
+        this.fontMetrics = getFontMetrics(getFont());
+        Insets insets = getInsets();
+        colWidth = fontMetrics.charWidth('0') * 4; // for digits either side
+        size = new Dimension(insets.left + insets.right + colWidth * 2, 1000 * fontMetrics.getHeight());
+        this.currentLineForeground = Color.RED;
+        this.lhs.jtextPane.addCaretListener(_ -> repaint());
+        this.rhs.jtextPane.addCaretListener(_ -> repaint());
+        this.lhs.scrollPane.getViewport().addChangeListener(_->repaint());
+        this.rhs.scrollPane.getViewport().addChangeListener(_->repaint());
+
+    }
+
+    void paintNumbers(Graphics g, AbstractTextModelViewer tv, int col) {
+        var viewPort = tv.scrollPane.getViewport();
+        var viewportPosition = viewPort.getViewPosition();
+        int rowStartOffset = tv.jtextPane.viewToModel(new Point(0, viewportPosition.y));
+        int endOffset = tv.jtextPane.viewToModel(new Point(0, viewportPosition.y + viewPort.getHeight()));
+        Element root = tv.jtextPane.getDocument().getDefaultRootElement();
+        while (rowStartOffset <= endOffset) {
+            try {
+                int caretPosition = tv.jtextPane.getCaretPosition();
+                g.setColor(root.getElementIndex(rowStartOffset) == root.getElementIndex(caretPosition)
+                        ? currentLineForeground
+                        : getForeground());
+                int index = root.getElementIndex(rowStartOffset);
+                String lineNumber = (root.getElement(index).getStartOffset() == rowStartOffset) ? Integer.toString(index + 1) : "";
+                int width = fontMetrics.stringWidth(lineNumber);
+                Rectangle r = tv.jtextPane.modelToView(rowStartOffset);
+                int x = this.getInsets().left + ((col == 0) ? 0 : colWidth * 2 - width);
+                int y = r.y + r.height - fontMetrics.getDescent() - viewportPosition.y;
+                g.drawString(lineNumber, x, y);
+                rowStartOffset = Utilities.getRowEnd(tv.jtextPane, rowStartOffset) + 1;
+            } catch (Exception e) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        paintNumbers(g, lhs, 0);
+        paintNumbers(g, rhs, 1);
+    }
+
+}


### PR DESCRIPTION
Added line number back to the op viewer tool.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/499/head:pull/499` \
`$ git checkout pull/499`

Update a local copy of the PR: \
`$ git checkout pull/499` \
`$ git pull https://git.openjdk.org/babylon.git pull/499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 499`

View PR using the GUI difftool: \
`$ git pr show -t 499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/499.diff">https://git.openjdk.org/babylon/pull/499.diff</a>

</details>
