### PR TITLE
[hat][cuda] 2D/3D NDrange supported for CUDA

### DIFF
--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
@@ -150,11 +150,7 @@ void CudaBackend::info() {
             ((totalGlobalMem > static_cast<unsigned long long>(4) * 1024 * 1024 * 1024L) ? "YES" : "NO") << std::endl;
 }
 
-
-
-
 PtxSource *CudaBackend::nvcc(const CudaSource *cudaSource) {
-  //std::cout << "inside nvcc" << std::endl;
     const uint64_t time = timeSinceEpochMillisec();
     const std::string ptxPath = tmpFileName(time, ".ptx");
     const std::string cudaPath = tmpFileName(time, ".cu");
@@ -194,16 +190,12 @@ CudaBackend::CudaModule *CudaBackend::compile(const PtxSource &ptxSource) {
 CudaBackend::CudaModule *CudaBackend::compile(const  PtxSource *ptx) {
 
     CUmodule module;
-     // std::cout << "inside compile" << std::endl;
-    // std::cout << "cuda " << cudaSource->text << std::endl;
     if (ptx->text != nullptr) {
-       // std::cout << "ptx " << ptx->text << std::endl;
         const Log *infLog = new Log(8192);
         const Log *errLog = new Log(8192);
         constexpr unsigned int optc = 5;
         const auto jitOptions = new CUjit_option[optc];
         auto jitOptVals = new void *[optc];
-
 
         jitOptions[0] = CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES;
         jitOptVals[0] = reinterpret_cast<void *>(infLog->len);

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
@@ -64,14 +64,9 @@ void CudaBackend::CudaQueue::computeStart(){
     release(); // also ;
 }
 
-
-
 void CudaBackend::CudaQueue::computeEnd(){
 
 }
-
-
-
 
 void CudaBackend::CudaQueue::release(){
 
@@ -107,7 +102,6 @@ void CudaBackend::CudaQueue::copyToDevice(Buffer *buffer) {
                     dynamic_cast<CudaQueue*>(backend->queue)->cuStream),
             .t="cuMemcpyHtoDAsync"
     }.report();
-
 }
 
 void CudaBackend::CudaQueue::copyFromDevice(Buffer *buffer) {
@@ -126,7 +120,6 @@ void CudaBackend::CudaQueue::copyFromDevice(Buffer *buffer) {
                   << std::endl;
     }
 
-
     WHERE{.f=__FILE__, .l=__LINE__,
             .e=cuMemcpyDtoHAsync(
                     cudaBuffer->bufferState->ptr,
@@ -138,32 +131,60 @@ void CudaBackend::CudaQueue::copyFromDevice(Buffer *buffer) {
 
 }
 
+// TODO: Improve heuristics to decide a better block size, if possible.
+// The following is just a rough number to fit into a modern NVIDIA GPU.
+int CudaBackend::CudaQueue::estimateThreadsPerBlock(int dimensions) {
+    switch (dimensions) {
+        case 1: return 256;
+        case 2: return 16;
+        case 3: return 16;
+        default: return 1;
+    }
+}
+
 void CudaBackend::CudaQueue::dispatch(KernelContext *kernelContext, CompilationUnit::Kernel *kernel) {
     const auto cudaKernel = dynamic_cast<CudaModule::CudaKernel *>(kernel);
 
-    const int range = kernelContext->maxX;
-    int rangediv1024 = range / 1024;
-    int rangemod1024 = range % 1024;
-    if (rangemod1024 > 0) {
-        rangediv1024++;
-    }
-// std::cout << "Running the kernel..." << std::endl;
-// std::cout << "   Requested range   = " << range << std::endl;
-// std::cout << "   Range mod 1024    = " << rangemod1024 << std::endl;
-// std::cout << "   Actual range 1024 = " << (rangediv1024 * 1024) << std::endl;
-//  auto status= static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cuStream));
+    const int threadsPerBlock = estimateThreadsPerBlock(kernelContext->dimensions);
 
-//  cudaBackend->cudaQueue.wait();
+    int blocksPerGridX = (kernelContext->maxX + threadsPerBlock - 1) / threadsPerBlock;
+    int blocksPerGridY = 1;
+    int blocksPerGridZ = 1;
+    int threadsPerBlockX = threadsPerBlock;
+    int threadsPerBlockY = 1;
+    int threadsPerBlockZ = 1;
+
+    if (kernelContext->dimensions > 1) {
+        blocksPerGridY = (kernelContext->maxY + threadsPerBlock - 1) / threadsPerBlock;
+        threadsPerBlockY = threadsPerBlock;
+    }
+    if (kernelContext->dimensions > 2) {
+        blocksPerGridZ = (kernelContext->maxZ + threadsPerBlock - 1) / threadsPerBlock;
+        threadsPerBlockZ = threadsPerBlock;
+    }
+
+    // Enable debug information with trace. Use HAT=TRACE
+    if (backend->config->trace) {
+        std::cout << "Dispatching the CUDA kernel" << std::endl;
+        std::cout << "   \\_ BlocksPerGrid  = [" << blocksPerGridX << "," << blocksPerGridY << "," << blocksPerGridZ << "]" << std::endl;
+        std::cout << "   \\_ ThreadsPerBlock  [" << threadsPerBlockX << "," << threadsPerBlockY << "," << threadsPerBlockZ << "]" << std::endl;
+    }
+
+    //  auto status= static_cast<CUresult>(cudaStreamSynchronize(cudaBackend->cudaQueue.cuStream));
+    //  cudaBackend->cudaQueue.wait();
+
     const std::thread::id thread_id = std::this_thread::get_id();
     if (thread_id != streamCreationThread){
         std::cout << "dispatch()  thread=" <<thread_id<< " != "<< streamCreationThread<< std::endl;
     }
 
-    const auto status = cuLaunchKernel(cudaKernel->function,
-                                 rangediv1024, 1, 1,
-                                 1024, 1, 1,
-                                 0, cuStream,
-                                 cudaKernel->argslist, nullptr);
+    const auto status = cuLaunchKernel(cudaKernel->function, //
+                                 blocksPerGridX, blocksPerGridY, blocksPerGridZ, //
+                                 threadsPerBlockX, threadsPerBlockY, threadsPerBlockZ, //
+                                 0, //
+                                 cuStream, //
+                                 cudaKernel->argslist, //
+                                 nullptr);
 
     WHERE{.f=__FILE__, .l=__LINE__, .e=status, .t="cuLaunchKernel"}.report();
 }

--- a/hat/backends/ffi/cuda/src/main/native/include/cuda_backend.h
+++ b/hat/backends/ffi/cuda/src/main/native/include/cuda_backend.h
@@ -113,10 +113,11 @@ class CudaQueue final : public Backend::Queue {
 
          void copyFromDevice(Buffer *buffer) override;
 
+        int estimateThreadsPerBlock(int dimensions);
+
         void dispatch(KernelContext *kernelContext, CompilationUnit::Kernel *kernel) override;
 
         ~CudaQueue() override;
-
 };
 
     class CudaBuffer final : public Buffer {


### PR DESCRIPTION
This PR extends the 2D and 3D NDRange developed for the OpenCL backend/runtime for CUDA devices. 
In addition, it improves the thread-block selection. 

The heuristic for thread-block selection here is quite simple (static decision based on the number of dimensions). However, in the future we can improve this. My goal with this PR is to showcase 2D and 2D ranges for CUDA compatible devices. 

How to test?

```bash
java @hat/run ffi-cuda matmul 1D

java @hat/run ffi-cuda matmul 2D

# Old examples should continue to work
java @hat/run ffi-cuda squares
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/504/head:pull/504` \
`$ git checkout pull/504`

Update a local copy of the PR: \
`$ git checkout pull/504` \
`$ git pull https://git.openjdk.org/babylon.git pull/504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 504`

View PR using the GUI difftool: \
`$ git pr show -t 504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/504.diff">https://git.openjdk.org/babylon/pull/504.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/504#issuecomment-3136083225)
</details>
