### PR TITLE
Add back code for highlighting SSA id references

### DIFF
--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/FuncOpViewer.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/FuncOpViewer.java
@@ -45,22 +45,18 @@ public class FuncOpViewer extends JPanel {
     public FuncOpViewer(BabylonTextModel cr) {
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
         var font = new Font("Monospaced", Font.PLAIN, 14);
-        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
-
 
         var funcOpTextModelViewer = new FuncOpTextModelViewer(cr, font, false);
         var javaTextModelViewer = new JavaTextModelViewer(cr.javaTextModel, font, false);
-
         var gutter = new TextGutter(  funcOpTextModelViewer,javaTextModelViewer);
-       // add(funcOpTextModelViewer.scrollPane);
-        //add(gutter);
-        //add(javaTextModelViewer.scrollPane);
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         splitPane.setLeftComponent(funcOpTextModelViewer.scrollPane);
-        JSplitPane splitPane2 = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
-        splitPane2.setLeftComponent(gutter);
-        splitPane2.setRightComponent(javaTextModelViewer.scrollPane);
-        splitPane.setRightComponent(splitPane2);
+        JSplitPane rightSplitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+        rightSplitPane.setLeftComponent(gutter);
+        rightSplitPane.setRightComponent(javaTextModelViewer.scrollPane);
+        splitPane.setRightComponent(rightSplitPane);
         add(splitPane);
+
         // tell each about the other
         funcOpTextModelViewer.javaTextModelViewer = javaTextModelViewer;
         javaTextModelViewer.funcOpTextModelViewer = funcOpTextModelViewer;

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/TextViewer.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/TextViewer.java
@@ -68,11 +68,7 @@ public abstract class TextViewer {
                 // Plain text attributes changed, not relevant for this highlighter
             }
         });
-
-
     }
-
-
 
     public Element getElement(int offset) {
        return jtextPane.getStyledDocument().getCharacterElement(offset);
@@ -90,7 +86,6 @@ public abstract class TextViewer {
         }
     }
 
-
     public void highLightLines(LineCol first, LineCol last) {
         var highlighter = jtextPane.getHighlighter();
         try {
@@ -103,14 +98,7 @@ public abstract class TextViewer {
     public int getOffset(MouseEvent e) {
         return jtextPane.viewToModel2D(e.getPoint());
     }
-    public void highLight(int from, int to) {
-        var highlighter =  jtextPane.getHighlighter();
-        try {
-            highlighter.addHighlight(from,to, highlightPainter);
-        } catch (BadLocationException e) {
-            throw new IllegalStateException();
-        }
-    }
+
     public void highLight(Element element) {
         var highlighter =  jtextPane.getHighlighter();
         try {
@@ -118,6 +106,15 @@ public abstract class TextViewer {
         } catch (BadLocationException e) {
             throw new IllegalStateException();
         }
+    }
+
+    public int getLine(int offset) {
+       for (int l= 0; l < lines.size(); l++) {
+            if (lines.get(l).includes(offset)) {
+               return l+1;
+            }
+        }
+       return 0;
     }
 
     String setText(String text) {


### PR DESCRIPTION
Add back the code for highlighting ssaid refences to and from the current line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/505/head:pull/505` \
`$ git checkout pull/505`

Update a local copy of the PR: \
`$ git checkout pull/505` \
`$ git pull https://git.openjdk.org/babylon.git pull/505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 505`

View PR using the GUI difftool: \
`$ git pr show -t 505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/505.diff">https://git.openjdk.org/babylon/pull/505.diff</a>

</details>
