### PR TITLE
[hat][cuda] Add check errors for all CUDA calls

### DIFF
--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
@@ -115,14 +115,6 @@ CudaBackend::~CudaBackend() {
     }.report();
 }
 
-#define CUDA_CHECK(err, functionName) { \
-    WHERE{.f =__FILE__, \
-          .l=__LINE__, \
-          .e = err, \
-          .t = functionName \
-      }.report(); \
-}
-
 void CudaBackend::info() {
     char name[100];
     CUDA_CHECK(cuDeviceGetName(name, sizeof(name), device), "cuDeviceGetName");

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
@@ -79,40 +79,20 @@ CudaBackend::CudaBackend(int configBits)
     int deviceCount = 0;
 
     if (initStatus == CUDA_SUCCESS) {
-        WHERE{
-            .f = __FILE__, .l = __LINE__,
-            .e = cuDeviceGetCount(&deviceCount),
-            .t = "cuDeviceGetCount"
-        }.report();
+        CUDA_CHECK(cuDeviceGetCount(&deviceCount), "cuDeviceGetCount");
         std::cout << "CudaBackend device count = " << deviceCount << std::endl;
-        WHERE{
-            .f = __FILE__, .l = __LINE__,
-            .e = cuDeviceGet(&device, 0),
-            .t = "cuDeviceGet"
-        }.report();
-        WHERE{
-            .f = __FILE__, .l = __LINE__,
-            .e = cuCtxCreate(&context, 0, device),
-            .t = "cuCtxCreate"
-        }.report();
+        CUDA_CHECK(cuDeviceGet(&device, 0), "cuDeviceGet");
+        CUDA_CHECK(cuCtxCreate(&context, 0, device), "cuCtxCreate");
         std::cout << "CudaBackend context created ok (id=" << context << ")" << std::endl;
         dynamic_cast<CudaQueue *>(queue)->init();
     } else {
-        WHERE{
-            .f = __FILE__, .l = __LINE__,
-            .e = initStatus,
-            "cuInit() failed we seem to have the runtime library but no device"
-        }.report();
+        CUDA_CHECK(initStatus, "cuInit() failed we seem to have the runtime library but no device");
     }
 }
 
 CudaBackend::~CudaBackend() {
     std::cout << "freeing context" << std::endl;
-    WHERE{
-        .f = __FILE__, .l = __LINE__,
-        .e = cuCtxDestroy(context),
-        .t = "cuCtxDestroy"
-    }.report();
+    CUDA_CHECK(cuCtxDestroy(context), "cuCtxDestroy");
 }
 
 void CudaBackend::info() {
@@ -211,11 +191,8 @@ CudaBackend::CudaModule *CudaBackend::compile(const  PtxSource *ptx) {
         jitOptions[4] = CU_JIT_GENERATE_LINE_INFO;
         jitOptVals[4] = reinterpret_cast<void *>(1);
 
-        WHERE{
-            .f = __FILE__, .l = __LINE__,
-            .e = cuModuleLoadDataEx(&module, ptx->text, optc, jitOptions, (void **) jitOptVals),
-            .t = "cuModuleLoadDataEx"
-        }.report();
+        CUDA_CHECK(cuModuleLoadDataEx(&module, ptx->text, optc, jitOptions, (void **) jitOptVals), "cuModuleLoadDataEx");
+
         if (*infLog->text!='\0'){
            std::cout << "> PTX JIT inflog:" << std::endl << infLog->text << std::endl;
         }

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_buffer.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_buffer.cpp
@@ -38,11 +38,8 @@ CudaBackend::CudaBuffer::CudaBuffer(Backend *backend,  BufferState *bufferState)
     if (cudaBackend->config->traceCalls) {
         std::cout << "CudaBuffer()" << std::endl;
     }
+    CUDA_CHECK(cuMemAlloc(&devicePtr, static_cast<size_t>(bufferState->length)), "cuMemAlloc");
 
-    WHERE{.f=__FILE__, .l=__LINE__,
-          .e=cuMemAlloc(&devicePtr, static_cast<size_t>(bufferState->length)),
-          .t="cuMemAlloc"
-    }.report();
     if (cudaBackend->config->traceCalls) {
         std::cout << "devptr=" << std::hex<<  static_cast<long>(devicePtr) << "stream=" <<dynamic_cast<CudaQueue *>(backend->queue)->cuStream <<std::dec <<std::endl;
     }
@@ -54,15 +51,11 @@ CudaBackend::CudaBuffer::~CudaBuffer() {
     const auto cudaBackend = dynamic_cast<CudaBackend*>(backend);
     if (cudaBackend->config->traceCalls) {
         const std::thread::id thread_id = std::this_thread::get_id();
-
         std::cout << "~CudaBuffer()"<< "devptr =" << std::hex << (long) devicePtr << std::dec
                 << " thread=" <<thread_id
         <<std::endl;
     }
-    WHERE{.f=__FILE__, .l=__LINE__,
-            .e=cuMemFree(devicePtr),
-            .t="cuMemFree"
-    }.report();
+    CUDA_CHECK(cuMemFree(devicePtr), "cuMemFree");
     bufferState->vendorPtr= nullptr;
 }
 

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_buffer.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_buffer.cpp
@@ -40,8 +40,8 @@ CudaBackend::CudaBuffer::CudaBuffer(Backend *backend,  BufferState *bufferState)
     }
 
     WHERE{.f=__FILE__, .l=__LINE__,
-            .e=cuMemAlloc(&devicePtr, static_cast<size_t>(bufferState->length)),
-            .t="cuMemAlloc"
+          .e=cuMemAlloc(&devicePtr, static_cast<size_t>(bufferState->length)),
+          .t="cuMemAlloc"
     }.report();
     if (cudaBackend->config->traceCalls) {
         std::cout << "devptr=" << std::hex<<  static_cast<long>(devicePtr) << "stream=" <<dynamic_cast<CudaQueue *>(backend->queue)->cuStream <<std::dec <<std::endl;

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_module.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_module.cpp
@@ -46,12 +46,8 @@ CudaBackend::CudaModule::CudaKernel *CudaBackend::CudaModule::getCudaKernel(char
 }
 CudaBackend::CudaModule::CudaKernel *CudaBackend::CudaModule::getCudaKernel(int nameLen, char *name) {
     CUfunction function;
-    WHERE{.f=__FILE__, .l=__LINE__,
-          .e=cuModuleGetFunction(&function, module, name),
-          .t="cuModuleGetFunction"
-    }.report();
+    CUDA_CHECK(cuModuleGetFunction(&function, module, name), "cuModuleGetFunction");
     return new CudaKernel(this,name, function);
-
 }
 
 bool CudaBackend::CudaModule::programOK() {

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
@@ -52,36 +52,25 @@ void CudaBackend::CudaQueue::init(){
     }
 
 void CudaBackend::CudaQueue::wait(){
-    WHERE{.f=__FILE__, .l=__LINE__,
-          .e=cuStreamSynchronize(cuStream),
-          .t= "cuStreamSynchronize"
-    }.report();
+    CUDA_CHECK(cuStreamSynchronize(cuStream), "cuStreamSynchronize");
 }
 
 
-void CudaBackend::CudaQueue::computeStart(){
+void CudaBackend::CudaQueue::computeStart() {
     wait(); // should be no-op
     release(); // also ;
 }
 
-
-
-void CudaBackend::CudaQueue::computeEnd(){
+void CudaBackend::CudaQueue::computeEnd() {
 
 }
 
-
-
-
-void CudaBackend::CudaQueue::release(){
+void CudaBackend::CudaQueue::release() {
 
 }
 
-CudaBackend::CudaQueue::~CudaQueue(){
-    WHERE{.f=__FILE__, .l=__LINE__,
-            .e=cuStreamDestroy(cuStream),
-            .t= "cuStreamDestroy"
-    }.report();
+CudaBackend::CudaQueue::~CudaQueue() {
+    CUDA_CHECK(cuStreamDestroy(cuStream), "cuStreamDestroy");
 }
 
 void CudaBackend::CudaQueue::copyToDevice(Buffer *buffer) {
@@ -99,15 +88,11 @@ void CudaBackend::CudaQueue::copyToDevice(Buffer *buffer) {
                 << " thread=" <<thread_id
                   << std::endl;
     }
-    WHERE{.f=__FILE__, .l=__LINE__,
-            .e=cuMemcpyHtoDAsync(
-                    cudaBuffer->devicePtr,
+
+    CUDA_CHECK(cuMemcpyHtoDAsync(cudaBuffer->devicePtr,
                     cudaBuffer->bufferState->ptr,
                     cudaBuffer->bufferState->length,
-                    dynamic_cast<CudaQueue*>(backend->queue)->cuStream),
-            .t="cuMemcpyHtoDAsync"
-    }.report();
-
+                    dynamic_cast<CudaQueue*>(backend->queue)->cuStream), "cuMemcpyHtoDAsync");
 }
 
 void CudaBackend::CudaQueue::copyFromDevice(Buffer *buffer) {
@@ -126,15 +111,11 @@ void CudaBackend::CudaQueue::copyFromDevice(Buffer *buffer) {
                   << std::endl;
     }
 
-
-    WHERE{.f=__FILE__, .l=__LINE__,
-            .e=cuMemcpyDtoHAsync(
-                    cudaBuffer->bufferState->ptr,
-                    cudaBuffer->devicePtr,
-                    cudaBuffer->bufferState->length,
-                                 dynamic_cast<CudaQueue*>(backend->queue)->cuStream),
-            .t="cuMemcpyDtoHAsync"
-    }.report();
+    CUDA_CHECK(cuMemcpyDtoHAsync(cudaBuffer->bufferState->ptr,
+                                cudaBuffer->devicePtr,
+                                cudaBuffer->bufferState->length,
+                                dynamic_cast<CudaQueue*>(backend->queue)->cuStream),
+                                "cuMemcpyDtoHAsync");
 
 }
 
@@ -165,5 +146,5 @@ void CudaBackend::CudaQueue::dispatch(KernelContext *kernelContext, CompilationU
                                  0, cuStream,
                                  cudaKernel->argslist, nullptr);
 
-    WHERE{.f=__FILE__, .l=__LINE__, .e=status, .t="cuLaunchKernel"}.report();
+    CUDA_CHECK(status, "cuLaunchKernel");
 }

--- a/hat/backends/ffi/cuda/src/main/native/include/cuda_backend.h
+++ b/hat/backends/ffi/cuda/src/main/native/include/cuda_backend.h
@@ -62,10 +62,8 @@ struct WHERE{
     int l;
     cudaError_enum e;
     const char* t;
-    void report() const{
-        if (e == CUDA_SUCCESS){
-           // std::cout << t << "  OK at " << f << " line " << l << std::endl;
-        }else {
+    void report() const {
+        if (e != CUDA_SUCCESS){
             const char *buf;
             cuGetErrorName(e, &buf);
             std::cerr << t << " CUDA error = " << e << " " << buf <<std::endl<< "      " << f << " line " << l << std::endl;
@@ -73,6 +71,14 @@ struct WHERE{
         }
     }
 };
+
+#define CUDA_CHECK(err, functionName) { \
+    WHERE{.f =__FILE__, \
+          .l=__LINE__, \
+          .e = err, \
+          .t = functionName \
+         }.report(); \
+}
 
 class PtxSource final : public Text  {
 public:


### PR DESCRIPTION
This PR just calls a new macro to insert an error check for all the CUDA calls. 
The macro makes use of an existing struct. 

How to check:

```bash
./build/cuda_info
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/508/head:pull/508` \
`$ git checkout pull/508`

Update a local copy of the PR: \
`$ git checkout pull/508` \
`$ git pull https://git.openjdk.org/babylon.git pull/508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 508`

View PR using the GUI difftool: \
`$ git pr show -t 508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/508.diff">https://git.openjdk.org/babylon/pull/508.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/508#issuecomment-3139074151)
</details>
