### PR TITLE
[hat][opencl] Check errors macro added

### DIFF
--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_buffer.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_buffer.cpp
@@ -36,10 +36,7 @@ OpenCLBackend::OpenCLBuffer::OpenCLBuffer(Backend *backend, BufferState *bufferS
         bufferState->ptr,
         &status);
 
-    if (status != CL_SUCCESS) {
-        std::cerr << errorMsg(status) << std::endl;
-        exit(1);
-    }
+    OPENCL_CHECK(status, "clCreateBuffer");
     bufferState->vendorPtr =  static_cast<void *>(this);
 }
 

--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_info.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_info.cpp
@@ -29,22 +29,27 @@ template<typename T>
 static T info(cl_device_id device_id, cl_device_info device_info){
     T v;
     cl_int status = clGetDeviceInfo(device_id, device_info, sizeof(T), &v, nullptr);
+    OPENCL_CHECK(status, "clGetDeviceInfo");
     return v;
 }
 
 static char *strInfo(cl_device_id device_id, cl_device_info device_info){
     size_t sz;
     cl_int  status = clGetDeviceInfo(device_id, device_info, 0, nullptr,  &sz);
+    OPENCL_CHECK(status, "clGetDeviceInfo");
     auto ptr = new char[sz+1];
     status = clGetDeviceInfo(device_id, device_info, sz, ptr,nullptr);
+    OPENCL_CHECK(status, "clGetDeviceInfo");
     return ptr;
 }
 
 static char *strInfo(cl_platform_id platform_id, cl_platform_info platform_info){
     size_t sz;
     cl_int  status = clGetPlatformInfo(platform_id, platform_info, 0, nullptr,  &sz);
+    OPENCL_CHECK(status, "clGetPlatformInfo");
     char *ptr = new char[sz+1];
     status = clGetPlatformInfo(platform_id, platform_info, sz, ptr,nullptr);
+    OPENCL_CHECK(status, "clGetPlatformInfo");
     return ptr;
 }
 
@@ -110,28 +115,27 @@ PlatformInfo::~PlatformInfo(){
 
 void OpenCLBackend::info() {
     const PlatformInfo platformInfo(this);
-    std::cerr << "platform{" <<std::endl;
-    std::cerr << "   CL_PLATFORM_VENDOR..\"" << platformInfo.vendorName <<"\""<<std::endl;
-    std::cerr << "   CL_PLATFORM_VERSION.\"" << platformInfo.versionName <<"\""<<std::endl;
-    std::cerr << "   CL_PLATFORM_NAME....\"" << platformInfo.name <<"\""<<std::endl;
-    std::cerr << "         CL_DEVICE_TYPE..................... " <<  platformInfo.deviceInfo.deviceTypeStr << " "<<  platformInfo.deviceInfo.deviceType<<std::endl;
-    std::cerr << "         CL_DEVICE_MAX_COMPUTE_UNITS........ " <<  platformInfo.deviceInfo.maxComputeUnits<<std::endl;
+    std::cerr << "platform{" << std::endl;
+    std::cerr << "   CL_PLATFORM_VENDOR..\"" << platformInfo.vendorName <<"\""<< std::endl;
+    std::cerr << "   CL_PLATFORM_VERSION.\"" << platformInfo.versionName <<"\"" <<std::endl;
+    std::cerr << "   CL_PLATFORM_NAME....\"" << platformInfo.name <<"\""<< std::endl;
+    std::cerr << "         CL_DEVICE_TYPE..................... " <<  platformInfo.deviceInfo.deviceTypeStr << " "<<  platformInfo.deviceInfo.deviceType << std::endl;
+    std::cerr << "         CL_DEVICE_MAX_COMPUTE_UNITS........ " <<  platformInfo.deviceInfo.maxComputeUnits << std::endl;
     std::cerr << "         CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS. " <<  platformInfo.deviceInfo.maxWorkItemDimensions << " {";
     for (unsigned dimIdx = 0; dimIdx <  platformInfo.deviceInfo.maxWorkItemDimensions; dimIdx++) {
         std::cerr<<  platformInfo.deviceInfo.maxWorkItemSizes[dimIdx] << " ";
     }
-    std::cerr<< "}"<<std::endl;
-    std::cerr <<  "         CL_DEVICE_MAX_WORK_GROUP_SIZE...... "<<  platformInfo.deviceInfo.maxWorkGroupSize<<std::endl;
-    std::cerr <<  "         CL_DEVICE_MAX_MEM_ALLOC_SIZE....... "<<  platformInfo.deviceInfo.maxMemAllocSize<<std::endl;
-    std::cerr <<  "         CL_DEVICE_GLOBAL_MEM_SIZE.......... "<<  platformInfo.deviceInfo.globalMemSize<<std::endl;
-    std::cerr <<  "         CL_DEVICE_LOCAL_MEM_SIZE........... "<<  platformInfo.deviceInfo.localMemSize<<std::endl;
-    std::cerr <<  "         CL_DEVICE_PROFILE.................. "<<  platformInfo.deviceInfo.profile<<std::endl;
-    std::cerr <<  "         CL_DEVICE_VERSION.................. "<<  platformInfo.deviceInfo.deviceVersion<<std::endl;
-    std::cerr <<  "         CL_DRIVER_VERSION.................. "<<  platformInfo.deviceInfo.driverVersion<<std::endl;
-    std::cerr <<  "         CL_DEVICE_OPENCL_C_VERSION......... "<<  platformInfo.deviceInfo.cVersion<<std::endl;
-    std::cerr <<  "         CL_DEVICE_NAME..................... "<<  platformInfo.deviceInfo.name<<std::endl;
-    std::cerr <<  "         CL_DEVICE_EXTENSIONS............... "<<  platformInfo.deviceInfo.extensions<<std::endl;
-    std::cerr <<  "         CL_DEVICE_BUILT_IN_KERNELS......... "<<  platformInfo.deviceInfo.builtInKernels<<std::endl;
-    std::cerr <<  "}"<<std::endl;
+    std::cerr<< "}" << std::endl;
+    std::cerr <<  "         CL_DEVICE_MAX_WORK_GROUP_SIZE...... "<<  platformInfo.deviceInfo.maxWorkGroupSize << std::endl;
+    std::cerr <<  "         CL_DEVICE_MAX_MEM_ALLOC_SIZE....... "<<  platformInfo.deviceInfo.maxMemAllocSize << std::endl;
+    std::cerr <<  "         CL_DEVICE_GLOBAL_MEM_SIZE.......... "<<  platformInfo.deviceInfo.globalMemSize << std::endl;
+    std::cerr <<  "         CL_DEVICE_LOCAL_MEM_SIZE........... "<<  platformInfo.deviceInfo.localMemSize << std::endl;
+    std::cerr <<  "         CL_DEVICE_PROFILE.................. "<<  platformInfo.deviceInfo.profile << std::endl;
+    std::cerr <<  "         CL_DEVICE_VERSION.................. "<<  platformInfo.deviceInfo.deviceVersion << std::endl;
+    std::cerr <<  "         CL_DRIVER_VERSION.................. "<<  platformInfo.deviceInfo.driverVersion <<std::endl;
+    std::cerr <<  "         CL_DEVICE_OPENCL_C_VERSION......... "<<  platformInfo.deviceInfo.cVersion << std::endl;
+    std::cerr <<  "         CL_DEVICE_NAME..................... "<<  platformInfo.deviceInfo.name << std::endl;
+    std::cerr <<  "         CL_DEVICE_EXTENSIONS............... "<<  platformInfo.deviceInfo.extensions << std::endl;
+    std::cerr <<  "         CL_DEVICE_BUILT_IN_KERNELS......... "<<  platformInfo.deviceInfo.builtInKernels << std::endl;
+    std::cerr <<  "}" << std::endl;
 }
-

--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_kernel.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_kernel.cpp
@@ -24,15 +24,15 @@
  */
 #include "opencl_backend.h"
 
-OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLKernel(Backend::CompilationUnit *compilationUnit, char* name, cl_kernel kernel)
-    : Kernel(compilationUnit, name), kernel(kernel){
+OpenCLBackend::OpenCLProgram::OpenCLKernel::OpenCLKernel(CompilationUnit *compilationUnit, char* name, cl_kernel kernel)
+    : Kernel(compilationUnit, name), kernel(kernel) {
 }
 
 OpenCLBackend::OpenCLProgram::OpenCLKernel::~OpenCLKernel() {
-    clReleaseKernel(kernel);
+    OPENCL_CHECK(clReleaseKernel(kernel), "clReleaseKernel");
 }
 
-bool OpenCLBackend::OpenCLProgram::OpenCLKernel::setArg(KernelArg *arg, Buffer *buffer){
+bool OpenCLBackend::OpenCLProgram::OpenCLKernel::setArg(KernelArg *arg, Buffer *buffer) {
     const auto * openCLBuffer = dynamic_cast<OpenCLBuffer *>(buffer);
     const cl_int status = clSetKernelArg(kernel, arg->idx, sizeof(cl_mem), &openCLBuffer->clMem);
     if (status != CL_SUCCESS) {
@@ -43,7 +43,7 @@ bool OpenCLBackend::OpenCLProgram::OpenCLKernel::setArg(KernelArg *arg, Buffer *
 }
 
 bool OpenCLBackend::OpenCLProgram::OpenCLKernel::setArg(KernelArg *arg) {
-    const cl_int status = clSetKernelArg(kernel, arg->idx, arg->size(), (void *) &arg->value);
+    const cl_int status = clSetKernelArg(kernel, arg->idx, arg->size(), &arg->value);
     if (status != CL_SUCCESS) {
         std::cerr << errorMsg(status) << std::endl;
         return false;

--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_program.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_program.cpp
@@ -30,16 +30,14 @@ OpenCLBackend::OpenCLProgram::OpenCLProgram(Backend *backend,  char *src, char *
 }
 
 OpenCLBackend::OpenCLProgram::~OpenCLProgram() {
-    clReleaseProgram(program);
+    OPENCL_CHECK(clReleaseProgram(program), "clReleaseProgram");
 }
 
  Backend::CompilationUnit::Kernel *OpenCLBackend::OpenCLProgram::getKernel(int nameLen, char *name) {
     cl_int status;
     cl_kernel kernel = clCreateKernel(program, name, &status);
-    if (status != CL_SUCCESS){
-       std::cerr << "Failed to get kernel "<<name<<" "<<errorMsg(status)<<std::endl;
-    }
-    return new OpenCLKernel(this,name, kernel);
+    OPENCL_CHECK(status, "clCreateKernel");
+    return new OpenCLKernel(this, name, kernel);
 }
 OpenCLBackend::OpenCLProgram::OpenCLKernel *OpenCLBackend::OpenCLProgram::getOpenCLKernel(int len, char *name) {
    return dynamic_cast<OpenCLKernel *>(getKernel(len, name));
@@ -48,5 +46,3 @@ OpenCLBackend::OpenCLProgram::OpenCLKernel *OpenCLBackend::OpenCLProgram::getOpe
 OpenCLBackend::OpenCLProgram::OpenCLKernel *OpenCLBackend::OpenCLProgram::getOpenCLKernel(char *name) {
    return getOpenCLKernel(strlen(name), name);
 }
-
-

--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
@@ -28,37 +28,45 @@ While based on OpenCL's event list, I think we need to use a MOD eventMax queue.
 
 So
 */
- OpenCLBackend::OpenCLQueue::OpenCLQueue(Backend *backend)
+OpenCLBackend::OpenCLQueue::OpenCLQueue(Backend *backend)
     : ProfilableQueue(backend, 10000),
       command_queue(),
-      events(new cl_event[eventMax]){
- }
+      events(new cl_event[eventMax]) {
+}
 
- cl_event *OpenCLBackend::OpenCLQueue::eventListPtr() const {
+cl_event *OpenCLBackend::OpenCLQueue::eventListPtr() const {
     return (eventc == 0) ? nullptr : events;
- }
- cl_event *OpenCLBackend::OpenCLQueue::nextEventPtr() const {
+}
+
+cl_event *OpenCLBackend::OpenCLQueue::nextEventPtr() const {
     return &events[eventc];
- }
+}
 
 void OpenCLBackend::OpenCLQueue::showEvents(const int width) {
-    constexpr int  SAMPLE_TYPES=4;
+    constexpr int SAMPLE_TYPES = 4;
     auto *samples = new cl_ulong[SAMPLE_TYPES * eventc]; // queued, submit, start, end, complete
     int sample = 0;
-    cl_ulong min=CL_LONG_MAX;
-    cl_ulong max=CL_LONG_MIN;
+    cl_ulong min = CL_LONG_MAX;
+    cl_ulong max = CL_LONG_MIN;
 
     for (int event = 0; event < eventc; event++) {
         for (int type = 0; type < SAMPLE_TYPES; type++) {
-            cl_profiling_info profiling_info_arr[]={CL_PROFILING_COMMAND_QUEUED,CL_PROFILING_COMMAND_SUBMIT,CL_PROFILING_COMMAND_START,CL_PROFILING_COMMAND_END};
-            if ((clGetEventProfilingInfo(events[event], profiling_info_arr[type], sizeof(samples[sample]), &samples[sample], NULL)) !=
+            cl_profiling_info profiling_info_arr[] = {
+                CL_PROFILING_COMMAND_QUEUED,CL_PROFILING_COMMAND_SUBMIT,CL_PROFILING_COMMAND_START,
+                CL_PROFILING_COMMAND_END
+            };
+            if ((clGetEventProfilingInfo(events[event], profiling_info_arr[type], sizeof(samples[sample]),
+                                         &samples[sample], NULL)) !=
                 CL_SUCCESS) {
-                const char* profiling_info_name_arr[]={"CL_PROFILING_COMMAND_QUEUED","CL_PROFILING_COMMAND_SUBMIT","CL_PROFILING_COMMAND_START","CL_PROFILING_COMMAND_END" };
+                const char *profiling_info_name_arr[] = {
+                    "CL_PROFILING_COMMAND_QUEUED", "CL_PROFILING_COMMAND_SUBMIT", "CL_PROFILING_COMMAND_START",
+                    "CL_PROFILING_COMMAND_END"
+                };
                 std::cerr << "failed to get profile info " << profiling_info_name_arr[type] << std::endl;
             }
             if (sample == 0) {
-                if (type == 0){
-                   min = max = samples[sample];
+                if (type == 0) {
+                    min = max = samples[sample];
                 }
             } else {
                 if (samples[sample] < min) {
@@ -73,52 +81,50 @@ void OpenCLBackend::OpenCLQueue::showEvents(const int width) {
     }
     sample = 0;
     const cl_ulong range = (max - min);
-    const cl_ulong scale = range / width;  // range per char
-    std::cout << "Range: " <<min<< "-" <<max<< "("<< range << "ns)"
-        <<  "  (" << scale << "ns) per char"
-        << " +:submitted, .:started, =:end  "<< std::endl;
+    const cl_ulong scale = range / width; // range per char
+    std::cout << "Range: " << min << "-" << max << "(" << range << "ns)"
+            << "  (" << scale << "ns) per char"
+            << " +:submitted, .:started, =:end  " << std::endl;
 
     for (int event = 0; event < eventc; event++) {
-      /*  cl_command_type command_type;
-        clGetEventInfo(events[event],CL_EVENT_COMMAND_TYPE,sizeof(command_type), &command_type, nullptr);
-        switch (command_type){
-          case CL_COMMAND_MARKER:         std::cout <<   "marker "; break;
-          case CL_COMMAND_USER:           std::cout <<   "  user "; break;
-          case CL_COMMAND_NDRANGE_KERNEL: std::cout <<   "kernel "; break;
-          case CL_COMMAND_READ_BUFFER:    std::cout <<   "  read "; break;
-          case CL_COMMAND_WRITE_BUFFER:   std::cout <<   " write "; break;
-          default: std::cout <<                          " other "; break;
-        } */
+        /*  cl_command_type command_type;
+          clGetEventInfo(events[event],CL_EVENT_COMMAND_TYPE,sizeof(command_type), &command_type, nullptr);
+          switch (command_type){
+            case CL_COMMAND_MARKER:         std::cout <<   "marker "; break;
+            case CL_COMMAND_USER:           std::cout <<   "  user "; break;
+            case CL_COMMAND_NDRANGE_KERNEL: std::cout <<   "kernel "; break;
+            case CL_COMMAND_READ_BUFFER:    std::cout <<   "  read "; break;
+            case CL_COMMAND_WRITE_BUFFER:   std::cout <<   " write "; break;
+            default: std::cout <<                          " other "; break;
+          } */
         const int bits = eventInfoBits[event];
-        if ((bits&CopyToDeviceBits)==CopyToDeviceBits){
-           std::cout <<   "  write "<<(bits&0xffff)<<" " ;
+        if ((bits & CopyToDeviceBits) == CopyToDeviceBits) {
+            std::cout << "  write " << (bits & 0xffff) << " ";
         }
-        if ((bits&CopyFromDeviceBits)==CopyFromDeviceBits){
-           std::cout <<   "   read "<<(bits&0xffff)<<" ";
+        if ((bits & CopyFromDeviceBits) == CopyFromDeviceBits) {
+            std::cout << "   read " << (bits & 0xffff) << " ";
         }
-        if ((bits&StartComputeBits)==StartComputeBits){
-           std::cout <<   "  start    ";
+        if ((bits & StartComputeBits) == StartComputeBits) {
+            std::cout << "  start    ";
         }
-        if ((bits&EndComputeBits)==EndComputeBits){
-           std::cout <<   "    end    ";
+        if ((bits & EndComputeBits) == EndComputeBits) {
+            std::cout << "    end    ";
         }
-        if ((bits&NDRangeBits)==NDRangeBits){
-           std::cout <<   " kernel    ";
+        if ((bits & NDRangeBits) == NDRangeBits) {
+            std::cout << " kernel    ";
         }
-        if ((bits&EnterKernelDispatchBits)==EnterKernelDispatchBits){
-           if ((bits&HasConstCharPtrArgBits)==HasConstCharPtrArgBits){
-               std::cout<< eventInfoConstCharPtrArgs[event]<<std::endl;
-           }
-           std::cout <<   "  enter{   ";
-
+        if ((bits & EnterKernelDispatchBits) == EnterKernelDispatchBits) {
+            if ((bits & HasConstCharPtrArgBits) == HasConstCharPtrArgBits) {
+                std::cout << eventInfoConstCharPtrArgs[event] << std::endl;
+            }
+            std::cout << "  enter{   ";
         }
-        if ((bits&LeaveKernelDispatchBits)==LeaveKernelDispatchBits){
-          // std::cout <<   "  leave    ";
-            if ((bits&HasConstCharPtrArgBits)==HasConstCharPtrArgBits){
-                          std::cout<< eventInfoConstCharPtrArgs[event] <<std::endl;
-                      }
-                          std::cout <<   " }leave    ";
-
+        if ((bits & LeaveKernelDispatchBits) == LeaveKernelDispatchBits) {
+            // std::cout <<   "  leave    ";
+            if ((bits & HasConstCharPtrArgBits) == HasConstCharPtrArgBits) {
+                std::cout << eventInfoConstCharPtrArgs[event] << std::endl;
+            }
+            std::cout << " }leave    ";
         }
 
 
@@ -127,14 +133,14 @@ void OpenCLBackend::OpenCLQueue::showEvents(const int width) {
         const cl_ulong start = (samples[sample++] - min) / scale;
         const cl_ulong end = (samples[sample++] - min) / scale;
 
-        std::cout << std::setw(20)<< (queue-end) << "(ns) ";
+        std::cout << std::setw(20) << (queue - end) << "(ns) ";
         for (int c = 0; c < width; c++) {
             char ch = ' ';
-            if (c >= queue && c<=submit) {
+            if (c >= queue && c <= submit) {
                 ch = '+';
-            }else if (c>submit && c<start){
+            } else if (c > submit && c < start) {
                 ch = '.';
-            }else if (c>=start && c<end){
+            } else if (c >= start && c < end) {
                 ch = '=';
             }
             std::cout << ch;
@@ -143,106 +149,98 @@ void OpenCLBackend::OpenCLQueue::showEvents(const int width) {
     }
     delete[] samples;
 }
-void OpenCLBackend::OpenCLQueue::wait(){
-    if (eventc > 0){
-       cl_int status = clWaitForEvents(eventc, events);
-       if (status != CL_SUCCESS) {
-          std::cerr << "failed clWaitForEvents" << OpenCLBackend::errorMsg(status) << std::endl;
-          exit(1);
-       }
-    }
- }
-// void clCallback(void *){
-  //    std::cerr<<"start of compute"<<std::endl;
-// }
 
-  void OpenCLBackend::OpenCLQueue::marker(int bits){
-      cl_int status = clEnqueueMarkerWithWaitList(
-          command_queue,
-          this->eventc,
-          this->eventListPtr(),
-          this->nextEventPtr()
-          );
-        if (status != CL_SUCCESS){
-             std::cerr << "failed to clEnqueueMarkerWithWaitList "<<errorMsg(status)<< std::endl;
-             std::exit(1);
-         }
-      inc(bits);
-  }
-    void OpenCLBackend::OpenCLQueue::marker(int bits, const char* arg){
+void OpenCLBackend::OpenCLQueue::wait() {
+    if (eventc > 0) {
+        OPENCL_CHECK(clWaitForEvents(eventc, events), "clWaitForEvents");
+    }
+}
+
+void OpenCLBackend::OpenCLQueue::marker(int bits) {
     cl_int status = clEnqueueMarkerWithWaitList(
         command_queue,
-        this->eventc, this->eventListPtr(),this->nextEventPtr()
-        );
-          if (status != CL_SUCCESS){
-               std::cerr << "failed to clEnqueueMarkerWithWaitList "<<errorMsg(status)<< std::endl;
-               std::exit(1);
-           }
-        inc(bits, arg);
+        this->eventc,
+        this->eventListPtr(),
+        this->nextEventPtr()
+    );
+    if (status != CL_SUCCESS) {
+        std::cerr << "failed to clEnqueueMarkerWithWaitList " << errorMsg(status) << std::endl;
+        std::exit(1);
     }
+    inc(bits);
+}
+
+void OpenCLBackend::OpenCLQueue::marker(int bits, const char *arg) {
+    OPENCL_CHECK(clEnqueueMarkerWithWaitList(
+                     command_queue,
+                     this->eventc,
+                     this->eventListPtr(),
+                     this->nextEventPtr()),
+                 "clEnqueueMarkerWithWaitList");
+
+    inc(bits, arg);
+}
 
 
- void OpenCLBackend::OpenCLQueue::computeStart(){
-   wait(); // should be no-op
-   release(); // also ;
-   marker(StartComputeBits);
- }
+void OpenCLBackend::OpenCLQueue::computeStart() {
+    wait(); // should be no-op
+    release(); // also ;
+    marker(StartComputeBits);
+}
 
- void OpenCLBackend::OpenCLQueue::computeEnd(){
-   marker(EndComputeBits);
- }
+void OpenCLBackend::OpenCLQueue::computeEnd() {
+    marker(EndComputeBits);
+}
 
- void OpenCLBackend::OpenCLQueue::inc(const int bits){
-    if (eventc+1 >= eventMax){
-       std::cerr << "OpenCLBackend::OpenCLQueue event list overflowed!!" << std::endl;
-    }else{
-        eventInfoBits[eventc]=bits;
+void OpenCLBackend::OpenCLQueue::inc(const int bits) {
+    if (eventc + 1 >= eventMax) {
+        std::cerr << "OpenCLBackend::OpenCLQueue event list overflowed!!" << std::endl;
+    } else {
+        eventInfoBits[eventc] = bits;
     }
     eventc++;
- }
+}
 
-void OpenCLBackend::OpenCLQueue::inc(const int bits, const char *arg){
-     if (eventc+1 >= eventMax){
+void OpenCLBackend::OpenCLQueue::inc(const int bits, const char *arg) {
+    if (eventc + 1 >= eventMax) {
         std::cerr << "OpenCLBackend::OpenCLQueue event list overflowed!!" << std::endl;
-     }else{
-         eventInfoBits[eventc]=bits|HasConstCharPtrArgBits;
-         eventInfoConstCharPtrArgs[eventc]=arg;
-     }
-     eventc++;
- }
+    } else {
+        eventInfoBits[eventc] = bits | HasConstCharPtrArgBits;
+        eventInfoConstCharPtrArgs[eventc] = arg;
+    }
+    eventc++;
+}
 
- void OpenCLBackend::OpenCLQueue::markAsEndComputeAndInc(){
-     inc(EndComputeBits);
- }
- void OpenCLBackend::OpenCLQueue::markAsStartComputeAndInc(){
-     inc(StartComputeBits);
- }
+void OpenCLBackend::OpenCLQueue::markAsEndComputeAndInc() {
+    inc(EndComputeBits);
+}
 
- void OpenCLBackend::OpenCLQueue::markAsEnterKernelDispatchAndInc(){
-     inc(EnterKernelDispatchBits);
- }
- void OpenCLBackend::OpenCLQueue::markAsLeaveKernelDispatchAndInc(){
-     inc(LeaveKernelDispatchBits);
- }
+void OpenCLBackend::OpenCLQueue::markAsStartComputeAndInc() {
+    inc(StartComputeBits);
+}
 
- void OpenCLBackend::OpenCLQueue::release(){
-     cl_int status = CL_SUCCESS;
-     for (int i = 0; i < eventc; i++) {
-         status = clReleaseEvent(events[i]);
-         if (status != CL_SUCCESS) {
-             std::cerr << OpenCLBackend::errorMsg(status) << std::endl;
-             exit(1);
-         }
-     }
-     eventc = 0;
- }
+void OpenCLBackend::OpenCLQueue::markAsEnterKernelDispatchAndInc() {
+    inc(EnterKernelDispatchBits);
+}
 
- OpenCLBackend::OpenCLQueue::~OpenCLQueue(){
-     clReleaseCommandQueue(command_queue);
-     delete []events;
- }
+void OpenCLBackend::OpenCLQueue::markAsLeaveKernelDispatchAndInc() {
+    inc(LeaveKernelDispatchBits);
+}
 
-void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend::CompilationUnit::Kernel *kernel){
+void OpenCLBackend::OpenCLQueue::release() {
+    // TODO: possible check ALL events before return from the macro
+    for (int i = 0; i < eventc; i++) {
+        OPENCL_CHECK(clReleaseEvent(events[i]), "clReleaseEvent");
+    }
+    eventc = 0;
+}
+
+OpenCLBackend::OpenCLQueue::~OpenCLQueue() {
+    OPENCL_CHECK(clReleaseCommandQueue(command_queue), "clReleaseCommandQueue");
+    delete []events;
+}
+
+void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend::CompilationUnit::Kernel *kernel) {
     size_t numDimensions = kernelContext->dimensions;
 
     size_t global_work_size[]{
@@ -265,55 +263,47 @@ void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend:
     inc(NDRangeBits);
     // markAsNDRangeAndInc();
 
-    if (status != CL_SUCCESS) {
-        std::cerr << errorMsg(status) << std::endl;
-        exit(1);
-    }
+    OPENCL_CHECK(status, "clEnqueueNDRangeKernel");
     if (backend->config->trace | backend->config->traceEnqueues) {
-        std::cout << "enqueued kernel dispatch \"" << kernel->name << "\" globalSize=" << kernelContext->maxX << std::endl;
+        std::cout << "enqueued kernel dispatch \"" << kernel->name << "\" globalSize=" << kernelContext->maxX <<
+                std::endl;
     }
 }
 
-void OpenCLBackend::OpenCLQueue::copyToDevice(Backend::Buffer *buffer) {
-
+void OpenCLBackend::OpenCLQueue::copyToDevice(Buffer *buffer) {
     auto openclBuffer = dynamic_cast<OpenCLBuffer *>(buffer);
     cl_int status = clEnqueueWriteBuffer(
-            command_queue,
-            openclBuffer->clMem,
-            CL_FALSE,
-            0,
-            buffer->bufferState->length,
-            buffer->bufferState->ptr,
-            eventc,
-            eventListPtr(),
-            nextEventPtr()
+        command_queue,
+        openclBuffer->clMem,
+        CL_FALSE,
+        0,
+        buffer->bufferState->length,
+        buffer->bufferState->ptr,
+        eventc,
+        eventListPtr(),
+        nextEventPtr()
     );
 
-    if (status != CL_SUCCESS) {
-        std::cerr << OpenCLBackend::errorMsg(status) << std::endl;
-        exit(1);
-    }
+    OPENCL_CHECK(status, "clEnqueueWriteBuffer");
+
     inc(CopyToDeviceBits);
-  //  markAsCopyToDeviceAndInc();
+    //  markAsCopyToDeviceAndInc();
 }
 
-void  OpenCLBackend::OpenCLQueue::copyFromDevice(Backend::Buffer *buffer) {
+void OpenCLBackend::OpenCLQueue::copyFromDevice(Buffer *buffer) {
     auto openclBuffer = dynamic_cast<OpenCLBuffer *>(buffer);
     cl_int status = clEnqueueReadBuffer(
-            command_queue,
-            openclBuffer->clMem,
-            CL_FALSE,
-            0,
-            buffer->bufferState->length,
-            buffer->bufferState->ptr,
-            eventc,
-            eventListPtr(),
-            nextEventPtr()
+        command_queue,
+        openclBuffer->clMem,
+        CL_FALSE,
+        0,
+        buffer->bufferState->length,
+        buffer->bufferState->ptr,
+        eventc,
+        eventListPtr(),
+        nextEventPtr()
     );
-    if (status != CL_SUCCESS) {
-        std::cerr << OpenCLBackend::errorMsg(status) << std::endl;
-        exit(1);
-    }
+    OPENCL_CHECK(status, "clEnqueueReadBuffer");
     inc(CopyFromDeviceBits);
     //markAsCopyFromDeviceAndInc();
 }

--- a/hat/backends/ffi/opencl/src/main/native/cpp/squares.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/squares.cpp
@@ -121,10 +121,10 @@ int main(int argc, char **argv) {
             {.idx = 0, .variant = '&',.value = {.buffer ={.memorySegment = static_cast<void *>(kernelContextWithBufferState), .sizeInBytes = sizeof(KernelContextWithBufferState), .access = RO_BYTE}}},
             {.idx = 1, .variant = '&',.value = {.buffer ={.memorySegment = static_cast<void *>(s32Array1024WithBufferState), .sizeInBytes = sizeof(S32Array1024WithBufferState), .access = RW_BYTE}}}
     }};
+
     const auto kernel = program->getOpenCLKernel((char*)"squareKernel");
-    kernel->ndrange( reinterpret_cast<ArgArray_s *>(&args2Array));
+    kernel->ndrange(&args2Array);
     for (int i=0; i < s32Array1024WithBufferState->length; i++){
         std::cout << i << " array[" << i << "]=" << s32Array1024WithBufferState->array[i] << std::endl;
     }
 }
-

--- a/hat/backends/ffi/opencl/src/main/native/include/opencl_backend.h
+++ b/hat/backends/ffi/opencl/src/main/native/include/opencl_backend.h
@@ -26,7 +26,7 @@
 // The following looks like it is not used (at least to CLION) but it is. ;) don't remove
 #define CL_TARGET_OPENCL_VERSION 120
 #ifdef __APPLE__
-   #include <opencl/opencl.h>
+#include <opencl/opencl.h>
 #else
 #include <CL/cl.h>
 #include <malloc.h>
@@ -47,9 +47,9 @@ public:
     ~OpenCLSource() override = default;
 };
 
-extern void __checkOpenclErrors(cl_int status, const char *file, const int line);
+extern void __checkOpenclErrors(cl_int status, const char *functionName, const char *file, const int line);
 
-#define checkOpenCLErrors(err)  __checkOpenclErrors (err, __FILE__, __LINE__)
+#define OPENCL_CHECK(err, functionName) __checkOpenclErrors (err, functionName, __FILE__, __LINE__)
 
 class OpenCLBackend final : public Backend {
 public:


### PR DESCRIPTION
This PR adds a new macro for controlling OpenCL errors.

Notes: At the moment, the macro exits the VM if an error is encountered. In long run, what we should do is to return a state to the Java side. Thus the Java/HAT runtime can control what to do with the exception. 

The state can be common for all backends, at least at a high-level. Then each backend can have its own list of error status.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/510/head:pull/510` \
`$ git checkout pull/510`

Update a local copy of the PR: \
`$ git checkout pull/510` \
`$ git pull https://git.openjdk.org/babylon.git pull/510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 510`

View PR using the GUI difftool: \
`$ git pr show -t 510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/510.diff">https://git.openjdk.org/babylon/pull/510.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/510#issuecomment-3144577695)
</details>
