### PR TITLE
Add SSA id dependency viewer tool + DotViewer infra

### DIFF
--- a/hat/tools/src/main/java/hat/tools/jdot/DotBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/jdot/DotBuilder.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.tools.jdot;
+import java.util.function.Consumer;
+
+public class DotBuilder<T extends DotBuilder<T>> {
+    Consumer<String> consumer;
+    T self(){
+        return (T) this;
+    }
+    public DotBuilder(Consumer<String> consumer) {
+        this.consumer = consumer;
+    }
+
+    public T accept(String s) {
+        consumer.accept(s);
+        return self();
+    }
+
+    public T  digraph(String name, Consumer<T> consumer) {
+        accept("strict").space().accept("digraph").space().accept(name).obrace().nl();
+        consumer.accept(self());
+        return nl().cbrace().nl();
+    }
+
+    public T obrace() {
+        return accept("{");
+    }
+
+    public T cbrace() {
+        return accept("}");
+    }
+
+    public  T osbrace() {
+        return accept("[");
+    }
+
+    public T csbrace() {
+        return accept("]");
+    }
+
+    public T space() {
+        return accept(" ");
+    }
+
+    public T nl() {
+        return accept("\n");
+    }
+
+    public  T semicolon() {
+        return accept(";");
+    }
+
+    public T equals() {
+        return accept("=");
+    }
+
+    public T arrow() {
+        return accept("->");
+    }
+
+    public T nodeShape(String shape) {
+        return accept("node").space().osbrace().assign("shape", shape).csbrace().semicolon();
+    }
+
+    public T assign(String name, String value) {
+        return accept(name).equals().dquote(value);
+    }
+    public T label(String value) {
+        return assign("label", value);
+    }
+    public T record(String nodeName, String labelValue) {
+        return node(nodeName, _->sbrace(_->label(labelValue)));
+    }
+
+    T dquote(String s) {
+        int portIndex= s.indexOf(":");
+        if (portIndex != -1) {
+            String nodeName = s.substring(0, portIndex);
+            String port = s.substring( portIndex);
+            return accept("\"").accept(nodeName).accept("\"").accept(port);
+        }else {
+            return accept("\"").accept(s).accept("\"");
+        }
+    }
+
+    public T node(String name, Consumer<T> consumer) {
+        dquote(name);
+        consumer.accept(self());
+        return semicolon().nl();
+    }
+
+    public T edge(String fromNodeName, String toNodeName) {
+        return dquote(fromNodeName).arrow().dquote(toNodeName).semicolon().nl();
+    }
+
+    public T sbrace(Consumer<T> consumer) {
+        osbrace();
+        consumer.accept(self());
+        return csbrace();
+    }
+    public static class StringDotBuilder extends DotBuilder<StringDotBuilder> {
+            public StringDotBuilder(Consumer<String> consumer) {
+            super(consumer);
+        }
+    }
+    public static String dotDigraph(String name, Consumer<StringDotBuilder> consumer) {
+        StringBuilder sb = new StringBuilder();
+         var db = new StringDotBuilder(sb::append);
+         db.digraph(name, consumer);
+         return sb.toString();
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/jdot/ui/JDot.java
+++ b/hat/tools/src/main/java/hat/tools/jdot/ui/JDot.java
@@ -1,0 +1,712 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.tools.jdot.ui;
+
+import hat.tools.jdot.DotBuilder;
+import hat.tools.json.Json;
+import hat.tools.json.JsonArray;
+import hat.tools.json.JsonNumber;
+import hat.tools.json.JsonObject;
+import hat.tools.json.JsonString;
+import hat.tools.json.JsonValue;
+
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.font.TextAttribute;
+import java.awt.geom.CubicCurve2D;
+import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.geom.RectangularShape;
+import java.awt.geom.RoundRectangle2D;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class JDot {
+    public static final String FloatRegex = "([0-9]+|[0-9]*\\.[0-9]*)"; // not completely foolproof but seems to work for  json0 DOT
+    public static final String FloatPointRegex = FloatRegex + "," + FloatRegex;
+    public static final Pattern RectRegex = Pattern.compile(FloatPointRegex + "," + FloatPointRegex);
+    public static final Pattern PointRegex = Pattern.compile(FloatPointRegex);
+
+    public static class JsonQuery {
+        public static JsonValue query(JsonValue jsonValue, String path) {
+            return jsonValue instanceof JsonObject jsonObject && jsonObject.members().get(path) instanceof JsonValue v ? v : null;
+        }
+
+        public static String str(JsonValue jsonValue, String path) {
+            return query(jsonValue, path) instanceof JsonString jsonString ? jsonString.value() : null;
+        }
+
+        public static Number num(JsonValue jsonValue, String path) {
+            return (query(jsonValue, path) instanceof JsonNumber jsonNumber) ? jsonNumber.toNumber() : null;
+        }
+
+        public static Float floatOr(JsonValue jsonValue, String path, float defaultValue) {
+            return JsonQuery.num(jsonValue, path) instanceof JsonNumber n ? n.toNumber().floatValue() : defaultValue;
+        }
+
+        public static Float floatStrOr(JsonValue jsonValue, String path, float defaultValue) {
+            return JsonQuery.str(jsonValue, path) instanceof String s ? Float.parseFloat(s) : defaultValue;
+        }
+
+        public static List<JsonValue> arr(JsonValue jsonValue, String path) {
+            return (jsonValue instanceof JsonObject jsonObject
+                    && jsonObject.members().get(path) instanceof JsonArray jsonArray) ? jsonArray.values() : null;
+        }
+
+        public static Number obj(JsonValue jsonValue, String path) {
+            return (jsonValue instanceof JsonObject jsonObject
+                    && jsonObject.members().get(path) instanceof JsonNumber jsonNumber) ? jsonNumber.toNumber() : null;
+        }
+
+        public static Color colorOr(JsonValue jsonValue, String path, Color defaultColor) {
+            return JsonQuery.str(jsonValue, path) instanceof String s ? Color.getColor(s) : defaultColor;
+        }
+
+    }
+
+    public interface Label {
+        String value();
+    }
+
+    public static class SimpleLabel implements Label {
+        public String value;
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        SimpleLabel(String value) {
+            this.value = value;
+        }
+    }
+
+
+    abstract static class Renderable {
+        final JsonValue jsonValue;
+        public Color color;
+        public Color fillColor;
+        public Color fontColor;
+        final int id;
+
+
+        public abstract void render(Graphics2D g2d);
+
+        Renderable(JsonValue jsonValue) {
+            this.jsonValue = jsonValue;
+            this.id = JsonQuery.num(jsonValue, "_gvid").intValue();
+            this.color = JsonQuery.colorOr(jsonValue, "color", Color.BLACK);
+            this.fillColor = JsonQuery.colorOr(jsonValue, "fillcolor", Color.WHITE);
+            this.fontColor = JsonQuery.colorOr(jsonValue, "fontcolor", Color.BLACK);
+        }
+    }
+
+    abstract static class RenderableShape<T extends Shape> extends Renderable {
+        final String name;
+        final float width;
+        final float height;
+        T shape;
+
+        Label label;
+
+        RenderableShape(JsonValue jsonValue) {
+            super(jsonValue);
+            this.name = JsonQuery.str(jsonValue, "name");
+            // for reasons inexplicable.  width and height are inches so need to be *72 or *60 ?
+            this.height = JsonQuery.floatStrOr(jsonValue, "height", 0f) * 60;
+            this.width = JsonQuery.floatStrOr(jsonValue, "width", 0f) * 60;
+        }
+    }
+
+    static class Line extends RenderableShape<Line2D.Float> {
+        Line(JsonValue jsonValue, Point2D.Float start, Point2D.Float end) {
+            super(jsonValue);
+            shape = new Line2D.Float(start, end);
+        }
+
+        public void render(Graphics2D g2d) {
+            g2d.setColor(color);
+            g2d.draw(this.shape);
+        }
+    }
+
+    abstract static class TextBox<T extends RectangularShape> extends RenderableShape<T> {
+
+        TextBox(JsonValue jsonValue) {
+            super(jsonValue);
+        }
+
+        @Override
+        public void render(Graphics2D g2d) {
+            g2d.setColor(this.fillColor);
+            g2d.fill(this.shape);
+            g2d.setColor(this.color);
+            g2d.draw(this.shape);
+            g2d.setColor(this.fontColor);
+            FontMetrics metrics = g2d.getFontMetrics(g2d.getFont());
+            float xStr = (float) this.shape.getCenterX() - ((float) metrics.stringWidth(label.value()) / 2);
+            float yStr = (float) this.shape.getCenterY() - ((float) metrics.getHeight() / 2) + metrics.getAscent();
+            g2d.drawString(label.value(), xStr, yStr);
+        }
+    }
+
+    static class RoundedTextBox extends TextBox<RoundRectangle2D.Float> {
+        RoundedTextBox(JsonValue jsonValue, List<Point2D.Float> points) {
+            super(jsonValue); // we need the name
+            this.shape = new RoundRectangle2D.Float(
+                    points.getFirst().x - width / 2,
+                    points.getFirst().y - height / 2,
+                    width, height,
+                    20,
+                    20);
+            this.label = new SimpleLabel(name);
+        }
+
+    }
+
+    abstract static class SquareTextBox extends TextBox<Rectangle2D.Float> {
+        SquareTextBox(JsonValue jsonValue, Point2D.Float[] points, SimpleLabel label) {
+            super(jsonValue);
+            this.shape = new Rectangle2D.Float(points[0].x, points[0].y, points[1].x - points[0].x, points[1].y - points[0].y);
+            this.label = label;
+        }
+    }
+
+    abstract static class RecordShape<T extends RectangularShape> extends RenderableShape<T> {
+
+        /*
+                           " One | Two "                    [One|Two]
+                           " One | Two | Three "            [One|Two|Three]
+                           " One | Two | Three | Four "     [One|Two|Three|Four]
+                                                            +---+-------+----+
+                                                            |   | Two   |    |
+                           " One |{ Two | Three }| Four "   |One+-------+Four+
+                                                            |   | Three |    |
+                                                            +---+-------+----+
+        */
+        private final RecordLabel recordLabel;
+
+        public static class RecordLabel implements Label {
+            public static class Box implements Label {
+                public static class Port {
+                    String name = "";
+
+                    void append(char ch) {
+                        name += ch;
+                    }
+                }
+
+                public Box parent;
+                public boolean v;
+                public Port port;
+                private String value;
+
+                @Override
+                public String value() {
+                    return value;
+                }
+
+                Rectangle2D.Float rect;
+
+                public Box(Box parent, boolean v, Rectangle2D.Float rect) {
+                    this.parent = parent;
+                    this.v = v;
+                    this.rect = rect;
+                    this.value = "";
+                    this.port = null;
+                }
+
+                @Override
+                public String toString() {
+                    return (v ? "V" : "H") + "Box " + (port == null ? "" : "<" + port.name + ">") + value + " " +
+                            "x1=" + rect.getMinX() + " y1=" + rect.getMinY() + "x2=" + rect.getMaxX() + " y2=" + rect.getMaxY() + " w=" + rect.getWidth() + " h=" + rect.getHeight();
+                }
+
+                public void append(char ch) {
+                    value += ch;
+                }
+
+                public void portAppend(char ch) {
+                    port.name += ch;
+                }
+            }
+
+            private final String value;
+
+            @Override
+            public String value() {
+                return value;
+            }
+
+            List<Box> boxes = new ArrayList<>();
+
+            RecordLabel(String value,
+                        List<Rectangle2D.Float> rects) {
+                this.value = value;
+                // this.points = points;
+                int boxIdx = 0;
+
+                /*
+                 *  <name> port
+                 *  | is  used to separate record 'boxes'
+                 *                            +---------------------+
+                 *  |here|there|everywhere -> |here|there|everywhere|
+                 *                            +---------------------+
+                 *  {} used (with bar) to change dir
+                 *                            +---------------+
+                 *                            |    |there     |
+                 *  |here|{there|everywhere}  |here+----------+
+                 *                            |    |everywhere|
+                 *                            +---------------+
+                 */
+
+                int len = value.length();
+                enum STATE {
+                    NORMAL,
+                    INPORT,
+                    ESCAPING,
+                    ERR
+                }
+                STATE state = STATE.NORMAL;
+                boxes.add(new Box(null, false, rects.get(boxIdx++)));
+                boolean v = false;
+                for (int idx = 0; idx < len && state != STATE.ERR; idx++) {
+                    char ch = value.charAt(idx);
+
+                    switch (state) {
+                        case NORMAL -> {
+                            switch (ch) {
+                                case '\\' -> state = STATE.ESCAPING;
+                                case '<' -> {
+                                    if (boxes.getLast().port == null) {
+                                        state = STATE.INPORT;
+                                        boxes.getLast().port = new Box.Port();
+                                    } else {
+                                        state = STATE.ERR;
+                                        System.out.println("one port per box!");
+                                    }
+                                }
+                                case '|' -> {
+                                    if ((idx + 1 < len) && (value.charAt(idx + 1) == '{')) {
+                                        v = !v;
+                                        idx++;
+                                    }
+                                    this.boxes.add(new Box(this.boxes.getLast(), v, rects.get(boxIdx++)));
+                                }
+                                case '{' -> {
+                                    v = !v;
+                                    this.boxes.add(new Box(this.boxes.getLast(), v, rects.get(boxIdx++)));
+                                }
+                                case '}' -> v = !v;
+                                default -> boxes.getLast().append(ch);
+
+                            }
+                        }
+                        case INPORT -> {
+                            switch (ch) {
+                                case '>' -> state = STATE.NORMAL;
+                                default -> {
+                                    if (Character.isAlphabetic(ch) || Character.isDigit(ch)) {
+                                        boxes.getLast().port.append(ch);
+                                    } else {
+                                        state = STATE.ERR;
+                                        System.out.println("invalid char '" + ch + "' in port");
+                                    }
+                                }
+                            }
+                        }
+                        case ESCAPING -> {
+                            boxes.getLast().append(ch);
+                            state = STATE.NORMAL;
+                        }
+                    }
+                }
+                if (state == STATE.ERR) {
+                    throw new IllegalStateException("err!");
+                }
+            }
+
+
+            @Override
+            public String toString() {
+                StringBuilder sb = new StringBuilder();
+                boxes.forEach(b -> sb.append("    ").append(b).append('\n'));
+                sb.append("}").append('\n');
+                return sb.toString();
+            }
+        }
+
+        public RecordShape(JsonValue jsonValue, List<Rectangle2D.Float> rects) {
+            super(jsonValue);
+            this.recordLabel = new RecordLabel(JsonQuery.str(jsonValue, "label"), rects);
+        }
+
+        @Override
+        public void render(Graphics2D g2d) {
+            Map<TextAttribute, Object> attributes = new HashMap<>();
+            // The Text was too close to the edge of the box, so this hack rescales the font 96% so we can avoid the edges.
+            var currentFont = g2d.getFont();
+            attributes.put(TextAttribute.FAMILY, currentFont.getFamily());
+            attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_SEMIBOLD);
+            attributes.put(TextAttribute.SIZE, (int) (currentFont.getSize() * .96));
+            var myFont = Font.getFont(attributes);
+            g2d.setFont(myFont);
+            FontMetrics metrics = g2d.getFontMetrics(g2d.getFont());
+            // These are the boxes that comprise the record
+            recordLabel.boxes.forEach(box -> {
+                g2d.setColor(this.fillColor);
+                g2d.fill(box.rect);
+                g2d.setColor(this.color);
+                g2d.draw(box.rect);
+                g2d.setColor(this.fontColor);
+                Rectangle2D stringBounds = metrics.getStringBounds(box.value(), g2d);
+                g2d.drawString(box.value(), (float) (box.rect.getCenterX() - stringBounds.getCenterX()), (float) (box.rect.getCenterY() - stringBounds.getCenterY()));
+
+            });
+            //g2d.setColor(Color.RED); //useful for debugging
+            //g2d.fill(this.shape);
+
+            //switch back to the original sized font
+            g2d.setFont(currentFont);
+        }
+    }
+
+    static Rectangle2D.Float sqRect(List<Point2D.Float> points) {
+        return new Rectangle2D.Float(points.getFirst().x - 1, points.getFirst().y - 1, 2f, 2f);
+    }
+
+    static RoundRectangle2D.Float roundRect(List<Point2D.Float> points, float radius) {
+        var sqr = sqRect(points);
+        return new RoundRectangle2D.Float(sqr.x, sqr.y, sqr.width, sqr.height, radius, radius);
+    }
+
+    static class RoundedRecordShape extends RecordShape<RoundRectangle2D.Float> {
+        public RoundedRecordShape(JsonValue jsonValue, List<Point2D.Float> points, List<Rectangle2D.Float> rects) {
+            super(jsonValue, rects);
+            this.shape = roundRect(points, 20f);
+        }
+    }
+
+    static class SqRecordShape extends RecordShape<Rectangle2D.Float> {
+        public SqRecordShape(JsonValue jsonValue, List<Point2D.Float> points, List<Rectangle2D.Float> rects) {
+            super(jsonValue, rects);
+            this.shape = sqRect(points);
+        }
+    }
+
+    static class Curve extends Renderable {
+        List<Point2D.Float> pos;
+        List<Shape> shapesToDraw = new ArrayList<>();
+        List<Shape> tailShapesToFill = new ArrayList<>();
+        List<Shape> headShapesToFill = new ArrayList<>();
+        Line2D.Float headLine;
+        Line2D.Float tailLine;
+        Path2D.Float tailPath;
+        long head;
+        long tail;
+        float weight;
+        char posType;
+
+        /*
+         * From the DOT docs.
+         * spline = (endp)? (startp)? point (triple)+
+         * and triple = point point point
+         * and endp = "e,%f,%f"
+         * and startp = "s,%f,%f"
+         * If a spline has points p₁ p₂ p₃ ... pₙ, (n = 1 (mod 3)), the points correspond to the
+         * control points of a cubic B-spline from p₁ to pₙ. If startp is given, it touches one node
+         * of the edge, and the arrowhead goes from p₁ to startp. If startp is not given, p₁ touches a node.
+         *  Similarly for pₙ and endp.
+         */
+
+        public Curve(JsonValue jasonValue, char posType, List<Point2D.Float> pos) {
+                    /*
+                     https://stackoverflow.com/questions/71744148/graphviz-dot-output-what-are-the-4-6-pos-coordinates-for-an-edge
+                     https://forum.graphviz.org/t/fun-with-edges/888/4
+                     https://stackoverflow.com/questions/3162645/convert-a-quadratic-bezier-to-a-cubic-one
+                     https://stackoverflow.com/questions/65410883/bezier-curve-forcing-a-curve-of-4-points-to-pass-through-control-points-in-3d
+                    */
+
+            super(jasonValue);
+            this.head = JsonQuery.obj(jsonValue, "head").longValue();
+            this.tail = JsonQuery.obj(jsonValue, "tail").longValue();
+            this.weight = JsonQuery.floatOr(jsonValue, "weight", 0f);
+            this.posType = posType;
+            this.pos = pos;
+            if (this.posType == 'e') {
+                /*
+                 * triple = (point point point)
+                 * curve = (endp/pos[0])? (startp/pos[1])? point/pos[2] triple+
+                 */
+
+                this.headLine = new Line2D.Float(pos.get(1).x, pos.get(1).y, pos.get(2).x, pos.get(2).y);
+
+                int n = this.pos.size();
+                for (int posIdx = 1; posIdx < (n - 1); posIdx += 3) {
+                    this.shapesToDraw.add(
+                            new CubicCurve2D.Float(
+                                    this.pos.get(posIdx).x,
+                                    this.pos.get(posIdx).y,
+                                    this.pos.get(posIdx + 1).x,
+                                    this.pos.get(posIdx + 1).y,
+                                    this.pos.get(posIdx + 2).x,
+                                    this.pos.get(posIdx + 2).y,
+                                    this.pos.get(posIdx + 3).x,
+                                    this.pos.get(posIdx + 3).y));
+                }
+                this.tailLine = new Line2D.Float(this.pos.get(n - 1).x, this.pos.get(n - 1).y, this.pos.getFirst().x, this.pos.getFirst().y);
+                float hypot = (float) Math.hypot(this.tailLine.x1 - this.tailLine.x2, this.tailLine.y1 - this.tailLine.y2);
+                this.tailPath = new Path2D.Float();
+                tailPath.moveTo(hypot / 2, 0);
+                tailPath.lineTo(0, hypot);
+                tailPath.lineTo(-hypot / 2, 0);
+                tailPath.closePath();
+                this.tailShapesToFill.add(tailPath);
+            } else {
+                throw new IllegalStateException("no support for " + posType);
+            }
+        }
+
+        @Override
+        public void render(Graphics2D g2d) {
+            g2d.setColor(color);
+            shapesToDraw.forEach(g2d::draw);
+            // we create our own g2d copy
+            // Translate to the end of the tail
+            // Rotate perpendicular to the tail line segment
+            final Graphics2D tail2d = (Graphics2D) g2d.create();
+
+            tail2d.translate(tailLine.x1, tailLine.y1);
+            tail2d.rotate(-Math.atan2(tailLine.x2 - tailLine.x1, tailLine.y2 - tailLine.y1));
+            tailShapesToFill.forEach(tail2d::fill);
+            // we create our own g2d copy
+            // Translate to the end of the head
+            // Rotate perpendicular to the head line segment
+            final Graphics2D head2d = (Graphics2D) g2d.create();
+            head2d.translate(headLine.x1, headLine.y1);
+            head2d.rotate(-Math.atan2(headLine.x2 - headLine.x1, headLine.y2 - headLine.y1));
+            headShapesToFill.forEach(head2d::fill);
+        }
+    }
+
+
+    double scale = 1;
+
+    public JScrollPane pane;
+
+    JComponent viewer;
+
+    final JsonValue jsonValue;
+    final Rectangle2D.Float bounds;
+
+
+    public JDot(JsonValue jsonValue) {
+        this.jsonValue = jsonValue;
+        String bb = JsonQuery.str(jsonValue, "bb");
+        this.bounds = RectRegex.matcher(bb) instanceof Matcher m && m.matches() && m.groupCount() == 4
+                ? new Rectangle2D.Float(Float.parseFloat(m.group(1)), Float.parseFloat(m.group(2)),
+                Float.parseFloat(m.group(3)), Float.parseFloat(m.group(4)))
+                : null;
+
+        List<Renderable> renderables = new ArrayList<>();
+
+
+        JsonQuery.arr(jsonValue, "edges").forEach(edgeJsonValue -> {
+            var posStr = JsonQuery.str(edgeJsonValue, "pos");
+
+            var points = Arrays.stream(posStr.substring(2).split(" "))
+                    .map(s -> (PointRegex.matcher(s) instanceof Matcher m && m.matches() && m.groupCount() == 2)
+                            ? new Point2D.Float(Float.parseFloat(m.group(1)), bounds.height - Float.parseFloat(m.group(2)))
+                            : null).toList();
+            var curve = new Curve(edgeJsonValue, posStr.charAt(0), points);
+            renderables.add(curve);
+        });
+        JsonQuery.arr(jsonValue, "objects").forEach(objectJsonValue -> {
+            var shape = JsonQuery.str(objectJsonValue, "shape");
+            var posStr = JsonQuery.str(objectJsonValue, "pos");
+            var points = Arrays.stream(posStr.split(" "))
+                    .map(s -> (PointRegex.matcher(s) instanceof Matcher m && m.matches() && m.groupCount() == 2)
+                            ? new Point2D.Float(Float.parseFloat(m.group(1)), bounds.height - Float.parseFloat(m.group(2)))
+                            : null).toList();
+
+            if (shape != null && shape.equals("record")) {
+                var rectString = JsonQuery.str(objectJsonValue, "rects").split(" ");
+                var recordRects = Arrays.stream(rectString).map(s -> {
+                    if (RectRegex.matcher(s) instanceof Matcher m && m.matches() && m.groupCount() == 4) {
+                        var x1 = Float.parseFloat(m.group(1));
+                        var y1 = bounds.height - Float.parseFloat(m.group(4));
+                        var x2 = Float.parseFloat(m.group(3));
+                        var y2 = bounds.height - Float.parseFloat(m.group(2));
+                        return new Rectangle2D.Float(x1, y1, x2 - x1, y2 - y1);
+                    } else {
+                        return null;
+                    }
+                }).toList();
+                renderables.add(new RoundedRecordShape(objectJsonValue, points, recordRects));
+            } else {
+                renderables.add(new RoundedTextBox(objectJsonValue, points));
+            }
+        });
+
+        this.viewer =
+                new JComponent() {
+                    @Override
+                    public void paintComponent(Graphics g1d) {
+                        super.paintComponent(g1d);
+                        if (g1d instanceof Graphics2D g2d) {
+                            g2d.scale(scale, scale);
+                            g2d.setRenderingHints(new RenderingHints(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON));
+                            renderables.forEach(e -> e.render(g2d));
+                        }
+                    }
+                };
+
+        viewer.addMouseListener(
+                new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        // System.out.println(e.getPoint());
+                        // synchronized (doorBell) {
+                        //   doorBell.notify();
+                        // }
+                    }
+                });
+        viewer.addMouseWheelListener(
+                e -> {
+                    scale *= (e.getWheelRotation() < 0) ? 1.01 : 1 / 1.01;
+                    viewer.repaint();
+                });
+
+        this.pane = new JScrollPane(this.viewer);
+        pane.setPreferredSize(new Dimension((int) (bounds.width * scale), (int) (bounds.height * scale)));
+    }
+
+    static JsonValue dotToJson(Path dotFile) {
+        final Path dotExecutable =
+                Stream.of(
+                                System.getProperty("DOT_PATH"),
+                                "/usr/bin/dot",
+                                "/opt/homebrew/bin/dot"
+                        )
+                        .filter(Objects::nonNull) // incase we hve no var
+                        .map(Path::of)
+                        .filter(Files::isExecutable)
+                        .findFirst()
+                        .orElse(null);
+        try {
+            Process process = new ProcessBuilder()
+                    .command(dotExecutable.toString(), "-Tjson0", dotFile.toString())
+                   // .redirectErrorStream(true)
+                    .start();
+
+            String jsonText = String.join("\n", new BufferedReader(new InputStreamReader(process.getInputStream())).readAllLines());
+
+            process.waitFor();
+
+              boolean success = (process.exitValue() == 0);
+            if (!success) {
+                throw new RuntimeException("DOT  exited with code " + process.exitValue());
+            }
+            return Json.parse(jsonText);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static JsonValue dotToJson(String dotText) {
+        try {
+            Path tmp = Files.createTempFile("", ".dot");
+            tmp.toFile().deleteOnExit();
+            Files.writeString(tmp, dotText);
+            return dotToJson(tmp);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public JDot(Path dotFile) {
+        this(dotToJson(dotFile));
+    }
+
+    public JDot(String dotText) {
+        this(dotToJson(dotText));
+    }
+
+    public static void main(String[] args) throws IOException {
+        SwingUtilities.invokeLater(() -> {
+            JDot jDot = new JDot(DotBuilder.dotDigraph("cmake",db->db
+                            .assign("rankdir", "RL")
+                            .nodeShape("record")
+                            .record("backend-ffi-opencl", "backend|{ffi|extracted}|opencl")
+                            .record("backend-ffi-shared", "backend|ffi|<in>shared")
+                            .record("backend-ffi", "backend|ffi")
+                            .record("core",  "core")
+                            .record("cmake-info-opencl", "<in>cmake|info|opencl")
+                            .edge("backend-ffi-opencl","backend-ffi-shared:se")
+                            .edge("backend-ffi-shared","backend-ffi:n")
+                            .edge("backend-ffi","core:s")
+                            .edge("backend-ffi-opencl","cmake-info-opencl:ne")
+                    ));
+            var frame = new JFrame();
+            frame.setLayout(new BorderLayout());
+            frame.getContentPane().add(jDot.pane);
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.pack();
+            frame.setVisible(true);
+        });
+    }
+
+}

--- a/hat/tools/src/main/java/hat/tools/json/Json.java
+++ b/hat/tools/src/main/java/hat/tools/json/Json.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.tools.json;
+
+
+import hat.tools.json.impl.JsonParser;
+import hat.tools.json.impl.Utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * This class provides static methods for producing and manipulating a {@link JsonValue}.
+ * <p>
+ * {@link #parse(String)} and {@link #parse(char[])} produce a {@code JsonValue}
+ * by parsing data adhering to the JSON syntax defined in RFC 8259.
+ * <p>
+ * {@link #toDisplayString(JsonValue)} is a formatter that produces a
+ * representation of the JSON value suitable for display.
+ * <p>
+ * {@link #fromUntyped(Object)} and {@link #toUntyped(JsonValue)} provide a conversion
+ * between {@code JsonValue} and an untyped object.
+ *
+ * @spec https://datatracker.ietf.org/doc/html/rfc8259 RFC 8259: The JavaScript
+ *      Object Notation (JSON) Data Interchange Format
+ * @since 99
+ */
+public final class Json {
+
+    /**
+     * Parses and creates a {@code JsonValue} from the given JSON document.
+     * If parsing succeeds, it guarantees that the input document conforms to
+     * the JSON syntax. If the document contains any JSON Object that has
+     * duplicate names, a {@code JsonParseException} is thrown.
+     * <p>
+     * {@code JsonValue}s created by this method produce their String and underlying
+     * value representation lazily.
+     * <p>
+     * {@code JsonObject}s preserve the order of their members declared in and parsed from
+     * the JSON document.
+     *
+     * @param in the input JSON document as {@code String}. Non-null.
+     * @throws JsonParseException if the input JSON document does not conform
+     *      to the JSON document format or a JSON object containing
+     *      duplicate names is encountered.
+     * @throws NullPointerException if {@code in} is {@code null}
+     * @return the parsed {@code JsonValue}
+     */
+    public static JsonValue parse(String in) {
+        Objects.requireNonNull(in);
+        return new JsonParser(in.toCharArray()).parseRoot();
+    }
+
+    /**
+     * Parses and creates a {@code JsonValue} from the given JSON document.
+     * If parsing succeeds, it guarantees that the input document conforms to
+     * the JSON syntax. If the document contains any JSON Object that has
+     * duplicate names, a {@code JsonParseException} is thrown.
+     * <p>
+     * {@code JsonValue}s created by this method produce their String and underlying
+     * value representation lazily.
+     * <p>
+     * {@code JsonObject}s preserve the order of their members declared in and parsed from
+     * the JSON document.
+     *
+     * @param in the input JSON document as {@code char[]}. Non-null.
+     * @throws JsonParseException if the input JSON document does not conform
+     *      to the JSON document format or a JSON object containing
+     *      duplicate names is encountered.
+     * @throws NullPointerException if {@code in} is {@code null}
+     * @return the parsed {@code JsonValue}
+     */
+    public static JsonValue parse(char[] in) {
+        Objects.requireNonNull(in);
+        return new JsonParser(Arrays.copyOf(in, in.length)).parseRoot();
+    }
+
+    /**
+     * {@return a {@code JsonValue} created from the given {@code src} object}
+     * The mapping from an untyped {@code src} object to a {@code JsonValue}
+     * follows the table below.
+     * <table class="striped">
+     * <caption>Untyped to JsonValue mapping</caption>
+     * <thead>
+     *    <tr>
+     *       <th scope="col" class="TableHeadingColor">Untyped Object</th>
+     *       <th scope="col" class="TableHeadingColor">JsonValue</th>
+     *    </tr>
+     * </thead>
+     * <tbody>
+     * <tr>
+     *     <th>{@code List<Object>}</th>
+     *     <th>{@code JsonArray}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code Boolean}</th>
+     *     <th>{@code JsonBoolean}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code `null`}</th>
+     *     <th>{@code JsonNull}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code Number*}</th>
+     *     <th>{@code JsonNumber}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code Map<String, Object>}</th>
+     *     <th>{@code JsonObject}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code String}</th>
+     *     <th>{@code JsonString}</th>
+     * </tr>
+     * </tbody>
+     * </table>
+     *
+     * <i><sup>*</sup>The supported {@code Number} subclasses are: {@code Byte},
+     * {@code Short}, {@code Integer}, {@code Long}, {@code Float},
+     * {@code Double}, {@code BigInteger}, and {@code BigDecimal}.</i>
+     *
+     * <p>If {@code src} is an instance of {@code JsonValue}, it is returned as is.
+     * If {@code src} contains a circular reference, {@code IllegalArgumentException}
+     * will be thrown. For example, the following code throws an exception,
+     * {@snippet lang=java:
+     *     var map = new HashMap<String, Object>();
+     *     map.put("foo", false);
+     *     map.put("bar", map);
+     *     Json.fromUntyped(map);
+     * }
+     *
+     * @param src the data to produce the {@code JsonValue} from. May be null.
+     * @throws IllegalArgumentException if {@code src} cannot be converted
+     *      to {@code JsonValue} or contains a circular reference.
+     * @see #toUntyped(JsonValue)
+     */
+    public static JsonValue fromUntyped(Object src) {
+        return fromUntyped(src, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    static JsonValue fromUntyped(Object src, Set<Object> identitySet) {
+        return switch (src) {
+            // Structural: JSON object, JSON array
+            case Map<?, ?> map -> {
+                if (!identitySet.add(map)) {
+                    throw new IllegalArgumentException("Circular reference detected");
+                }
+                Map<String, JsonValue> m = LinkedHashMap.newLinkedHashMap(map.size());
+                for (Map.Entry<?, ?> entry : new LinkedHashMap<>(map).entrySet()) {
+                    if (!(entry.getKey() instanceof String strKey)) {
+                        throw new IllegalArgumentException("Key is not a String: " + entry.getKey());
+                    } else {
+                        var unescapedKey = Utils.unescape(
+                                strKey.toCharArray(), 0, strKey.length());
+                        if (m.containsKey(unescapedKey)) {
+                            throw new IllegalArgumentException(
+                                    "Duplicate member name: '%s'".formatted(unescapedKey));
+                        } else {
+                            m.put(unescapedKey, Json.fromUntyped(entry.getValue(), identitySet));
+                        }
+                    }
+                }
+                // Bypasses defensive copy in JsonObject.of(m)
+                yield Utils.objectOf(m);
+            }
+            case List<?> list -> {
+                if (!identitySet.add(list)) {
+                    throw new IllegalArgumentException("Circular reference detected");
+                }
+                List<JsonValue> l = new ArrayList<>(list.size());
+                for (Object o : list) {
+                    l.add(Json.fromUntyped(o, identitySet));
+                }
+                // Bypasses defensive copy in JsonArray.of(l)
+                yield Utils.arrayOf(l);
+            }
+            // JSON primitives
+            case String str -> JsonString.of(str);
+            case Boolean bool -> JsonBoolean.of(bool);
+            case Byte b -> JsonNumber.of(b);
+            case Integer i -> JsonNumber.of(i);
+            case Long l -> JsonNumber.of(l);
+            case Short s -> JsonNumber.of(s);
+            case Float f -> JsonNumber.of(f);
+            case Double d -> JsonNumber.of(d);
+            case BigInteger bi -> JsonNumber.of(bi);
+            case BigDecimal bd -> JsonNumber.of(bd);
+            case null -> JsonNull.of();
+            // JsonValue
+            case JsonValue jv -> jv;
+            default -> throw new IllegalArgumentException("Type not recognized.");
+        };
+    }
+
+    /**
+     * {@return an {@code Object} created from the given {@code src}
+     * {@code JsonValue}} The mapping from a {@code JsonValue} to an
+     * untyped {@code src} object follows the table below.
+     * <table class="striped">
+     * <caption>JsonValue to Untyped mapping</caption>
+     * <thead>
+     *    <tr>
+     *       <th scope="col" class="TableHeadingColor">JsonValue</th>
+     *       <th scope="col" class="TableHeadingColor">Untyped Object</th>
+     *    </tr>
+     * </thead>
+     * <tbody>
+     * <tr>
+     *     <th>{@code JsonArray}</th>
+     *     <th>{@code List<Object>}(unmodifiable)</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code JsonBoolean}</th>
+     *     <th>{@code Boolean}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code JsonNull}</th>
+     *     <th>{@code `null`}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code JsonNumber}</th>
+     *     <th>{@code Number}</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code JsonObject}</th>
+     *     <th>{@code Map<String, Object>}(unmodifiable)</th>
+     * </tr>
+     * <tr>
+     *     <th>{@code JsonString}</th>
+     *     <th>{@code String}</th>
+     * </tr>
+     * </tbody>
+     * </table>
+     *
+     * <p>
+     * A {@code JsonObject} in {@code src} is converted to a {@code Map} whose
+     * entries occur in the same order as the {@code JsonObject}'s members.
+     *
+     * @param src the {@code JsonValue} to convert to untyped. Non-null.
+     * @throws NullPointerException if {@code src} is {@code null}
+     * @see #fromUntyped(Object)
+     */
+    public static Object toUntyped(JsonValue src) {
+        Objects.requireNonNull(src);
+        return switch (src) {
+            case JsonObject jo -> jo.members().entrySet().stream()
+                    .collect(LinkedHashMap::new, // to allow `null` value
+                            (m, e) -> m.put(e.getKey(), Json.toUntyped(e.getValue())),
+                            HashMap::putAll);
+            case JsonArray ja -> ja.values().stream()
+                    .map(Json::toUntyped)
+                    .toList();
+            case JsonBoolean jb -> jb.value();
+            case JsonNull _ -> null;
+            case JsonNumber n -> n.toNumber();
+            case JsonString js -> js.value();
+        };
+    }
+
+    /**
+     * {@return the String representation of the given {@code JsonValue} that conforms
+     * to the JSON syntax} As opposed to the compact output returned by {@link
+     * JsonValue#toString()}, this method returns a JSON string that is better
+     * suited for display.
+     *
+     * @param value the {@code JsonValue} to create the display string from. Non-null.
+     * @throws NullPointerException if {@code value} is {@code null}
+     * @see JsonValue#toString()
+     */
+    public static String toDisplayString(JsonValue value) {
+        Objects.requireNonNull(value);
+        return toDisplayString(value, 0 , false);
+    }
+
+    private static String toDisplayString(JsonValue jv, int indent, boolean isField) {
+        return switch (jv) {
+            case JsonObject jo -> toDisplayString(jo, indent, isField);
+            case JsonArray ja -> toDisplayString(ja, indent, isField);
+            default -> " ".repeat(isField ? 1 : indent) + jv;
+        };
+    }
+
+    private static String toDisplayString(JsonObject jo, int indent, boolean isField) {
+        var prefix = " ".repeat(indent);
+        var s = new StringBuilder(isField ? " " : prefix);
+        if (jo.members().isEmpty()) {
+            s.append("{}");
+        } else {
+            s.append("{\n");
+            jo.members().forEach((name, valu) -> {
+                if (valu instanceof JsonValue val) {
+                    s.append(prefix)
+                            .append(" ".repeat(INDENT))
+                            .append("\"")
+                            .append(name)
+                            .append("\":")
+                            .append(Json.toDisplayString(val, indent + INDENT, true))
+                            .append(",\n");
+                } else {
+                    throw new InternalError("type mismatch");
+                }
+            });
+            s.setLength(s.length() - 2); // trim final comma
+            s.append("\n").append(prefix).append("}");
+        }
+        return s.toString();
+    }
+
+    private static String toDisplayString(JsonArray ja, int indent, boolean isField) {
+        var prefix = " ".repeat(indent);
+        var s = new StringBuilder(isField ? " " : prefix);
+        if (ja.values().isEmpty()) {
+            s.append("[]");
+        } else {
+            s.append("[\n");
+            for (JsonValue v: ja.values()) {
+                if (v instanceof JsonValue jv) {
+                    s.append(Json.toDisplayString(jv,indent + INDENT, false)).append(",\n");
+                } else {
+                    throw new InternalError("type mismatch");
+                }
+            }
+            s.setLength(s.length() - 2); // trim final comma/newline
+            s.append("\n").append(prefix).append("]");
+        }
+        return s.toString();
+    }
+
+    // default indentation for display string
+    private static final int INDENT = 2;
+
+    // no instantiation is allowed for this class
+    private Json() {}
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonArray.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonArray.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+
+import hat.tools.json.impl.JsonArrayImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The interface that represents JSON array.
+ * <p>
+ * A {@code JsonArray} can be produced by {@link Json#parse(String)}.
+ * <p> Alternatively, {@link #of(List)} can be used to obtain a {@code JsonArray}.
+ *
+ * @since 99
+ */
+public non-sealed interface JsonArray extends JsonValue {
+
+    /**
+     * {@return an unmodifiable list of the {@code JsonValue} elements in
+     * this {@code JsonArray}}
+     */
+    List<JsonValue> values();
+
+    /**
+     * {@return the {@code JsonArray} created from the given
+     * list of {@code JsonValue}s}
+     *
+     * @param src the list of {@code JsonValue}s. Non-null.
+     * @throws NullPointerException if {@code src} is {@code null}, or contains
+     *      any values that are {@code null}
+     */
+    static JsonArray of(List<? extends JsonValue> src) {
+        var values = new ArrayList<JsonValue>(src); // implicit null check
+        if (values.contains(null)) {
+            throw new NullPointerException("src contains null value(s)");
+        }
+        return new JsonArrayImpl(values);
+    }
+
+    /**
+     * {@return {@code true} if the given object is also a {@code JsonArray}
+     * and the two {@code JsonArray}s represent the same elements} Two
+     * {@code JsonArray}s {@code ja1} and {@code ja2} represent the same
+     * elements if {@code ja1.values().equals(ja2.values())}.
+     *
+     * @see #values()
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * {@return the hash code value for this {@code JsonArray}} The hash code of a
+     * {@code JsonArray} is calculated by {@code Objects.hash(JsonArray.values()}.
+     * Thus, for two {@code JsonArray}s {@code ja1} and {@code ja2},
+     * {@code ja1.equals(ja2)} implies that {@code ja1.hashCode() == ja2.hashCode()}
+     * as required by the general contract of {@link Object#hashCode}.
+     *
+     * @see #values()
+     */
+    @Override
+    int hashCode();
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonBoolean.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonBoolean.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+
+import hat.tools.json.impl.JsonBooleanImpl;
+
+/**
+ * The interface that represents JSON boolean.
+ * <p>
+ * A {@code JsonBoolean} can be produced by {@link Json#parse(String)}.
+ * <p> Alternatively, {@link #of(boolean)} can be used to
+ * obtain a {@code JsonBoolean}.
+ *
+ * @since 99
+ */
+public non-sealed interface JsonBoolean extends JsonValue {
+
+    /**
+     * {@return the {@code boolean} value represented by this
+     * {@code JsonBoolean}}
+     */
+    boolean value();
+
+    /**
+     * {@return the {@code JsonBoolean} created from the given
+     * {@code boolean}}
+     *
+     * @param src the given {@code boolean}.
+     */
+    static JsonBoolean of(boolean src) {
+        return src ? JsonBooleanImpl.TRUE : JsonBooleanImpl.FALSE;
+    }
+
+    /**
+     * {@return {@code true} if the given object is also a {@code JsonBoolean}
+     * and the two {@code JsonBoolean}s represent the same boolean value} Two
+     * {@code JsonBoolean}s {@code jb1} and {@code jb2} represent the same
+     * boolean values if {@code jb1.value().equals(jb2.value())}.
+     *
+     * @see #value()
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * {@return the hash code value for this {@code JsonBoolean}} The hash code value
+     * of a {@code JsonBoolean} is defined to be the hash code of {@code JsonBoolean}'s
+     * {@link #value()}. Thus, for two {@code JsonBooleans}s {@code jb1} and {@code jb2},
+     * {@code jb1.equals(jb2)} implies that {@code jb1.hashCode() == jb2.hashCode()}
+     * as required by the general contract of {@link Object#hashCode}.
+     *
+     * @see #value()
+     */
+    @Override
+    int hashCode();
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonNull.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonNull.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+
+import hat.tools.json.impl.JsonNullImpl;
+
+/**
+ * The interface that represents JSON null.
+ * <p>
+ * A {@code JsonNull} can be produced by {@link Json#parse(String)}.
+ * <p> Alternatively, {@link #of()} can be used to obtain a {@code JsonNull}.
+ *
+ * @since 99
+ */
+public non-sealed interface JsonNull extends JsonValue {
+
+    /**
+     * {@return the {@code JsonNull} that represents a "null" JSON value}
+     */
+    static JsonNull of() {
+        return JsonNullImpl.NULL;
+    }
+
+    /**
+     * {@return true if the given {@code obj} is a {@code JsonNull}}
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * {@return the hash code value of this {@code JsonNull}}
+     */
+    @Override
+    int hashCode();
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonNumber.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonNumber.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+
+import hat.tools.json.impl.JsonNumberImpl;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * The interface that represents JSON number, an arbitrary-precision
+ * number represented in base 10 using decimal digits.
+ * <p>
+ * A {@code JsonNumber} can be produced by {@link Json#parse(String)}.
+ * Alternatively, {@link #of(double)} and its overloads can be used to obtain
+ * a {@code JsonNumber} from a {@code Number}.
+ * When a JSON number is parsed, a {@code JsonNumber} object is created
+ * as long as the parsed value adheres to the JSON number
+ * <a href="https://datatracker.ietf.org/doc/html/rfc8259#section-6">
+ * syntax</a>. The value of the {@code JsonNumber}
+ * can be retrieved from {@link #toString()} as the string representation
+ * from which the JSON number is originally parsed, with
+ * {@link #toNumber()} as a {@code Number} instance, or with
+ * {@link #toBigDecimal()}.
+ *
+ * @spec https://datatracker.ietf.org/doc/html/rfc8259#section-6 RFC 8259:
+ *      The JavaScript Object Notation (JSON) Data Interchange Format - Numbers
+ * @since 99
+ */
+public non-sealed interface JsonNumber extends JsonValue {
+
+    /**
+     * {@return the {@code Number} parsed or translated from the
+     * {@link #toString string representation} of this {@code JsonNumber}}
+     * <p>
+     * This method operates on the string representation and depending on that
+     * representation computes and returns an instance of {@code Long}, {@code BigInteger},
+     * {@code Double}, or {@code BigDecimal}.
+     * <p>
+     * If the string representation is the decimal string representation of
+     * a {@code long} value, parsable by {@link Long#parseLong(String)},
+     * then that {@code long} value is returned in its boxed form as {@code Long}.
+     * Otherwise, if the string representation is the decimal string representation of a
+     * {@code BigInteger}, translatable by {@link BigInteger#BigInteger(String)},
+     * then that {@code BigInteger} is returned.
+     * Otherwise, if the string representation is the decimal string representation of
+     * a {@code double} value, parsable by {@link Double#parseDouble(String)},
+     * and the {@code double} value is not {@link Double#isInfinite() infinite}, then that
+     * {@code double} value is returned in its boxed form as {@code Double}.
+     * Otherwise, and in all other cases, the string representation is the decimal string
+     * representation of a {@code BigDecimal}, translatable by
+     * {@link BigDecimal#BigDecimal(String)}, and that {@code BigDecimal} is
+     * returned.
+     * <p>
+     * The computation may not preserve all information in the string representation.
+     * In all of the above cases one or more leading zero digits are not preserved.
+     * In the third case, returning {@code Double}, decimal to binary conversion may lose
+     * decimal precision, and will not preserve one or more trailing zero digits in the fraction
+     * part.
+     *
+     * @apiNote
+     * Pattern matching can be used to match against {@code Long},
+     * {@code Double}, {@code BigInteger}, or {@code BigDecimal} reference
+     * types. For example:
+     * {@snippet lang=java:
+     * switch(jsonNumber.toNumber()) {
+     *     case Long l -> { ... }
+     *     case Double d -> { ... }
+     *     case BigInteger bi -> { ... }
+     *     case BigDecimal bd -> { ... }
+     *     default -> { } // should not happen
+     * }
+     *}
+     * @throws NumberFormatException if the {@code Number} cannot be parsed or translated from the string representation
+     * @see #toBigDecimal()
+     * @see #toString()
+     */
+    Number toNumber();
+
+    /**
+     * {@return the {@code BigDecimal} translated from the
+     * {@link #toString string representation} of this {@code JsonNumber}}
+     * <p>
+     * The string representation is the decimal string representation of a
+     * {@code BigDecimal}, translatable by {@link BigDecimal#BigDecimal(String)},
+     * and that {@code BigDecimal} is returned.
+     * <p>
+     * The translation may not preserve all information in the string representation.
+     * The sign is not preserved for the decimal string representation {@code -0.0}. One or more
+     * leading zero digits are not preserved.
+     *
+     * @throws NumberFormatException if the {@code BigDecimal} cannot be translated from the string representation
+     */
+    BigDecimal toBigDecimal();
+
+    /**
+     * Creates a JSON number whose string representation is the
+     * decimal string representation of the given {@code double} value,
+     * produced by applying the value to {@link Double#toString(double)}.
+     *
+     * @param num the given {@code double} value.
+     * @return a JSON number created from a {@code double} value
+     * @throws IllegalArgumentException if the given {@code double} value
+     * is {@link Double#isNaN() NaN} or is {@link Double#isInfinite() infinite}.
+     */
+    static JsonNumber of(double num) {
+        // non-integral types
+        return new JsonNumberImpl(num);
+    }
+
+    /**
+     * Creates a JSON number whose string representation is the
+     * decimal string representation of the given {@code long} value,
+     * produced by applying the value to {@link Long#toString(long)}.
+     *
+     * @param num the given {@code long} value.
+     * @return a JSON number created from a {@code long} value
+     */
+    static JsonNumber of(long num) {
+        // integral types
+        return new JsonNumberImpl(num);
+    }
+
+    /**
+     * Creates a JSON number whose string representation is the
+     * string representation of the given {@code BigInteger} value.
+     *
+     * @param num the given {@code BigInteger} value.
+     * @return a JSON number created from a {@code BigInteger} value
+     */
+    static JsonNumber of(BigInteger num) {
+        return new JsonNumberImpl(num);
+    }
+
+    /**
+     * Creates a JSON number whose string representation is the
+     * string representation of the given {@code BigDecimal} value.
+     *
+     * @param num the given {@code BigDecimal} value.
+     * @return a JSON number created from a {@code BigDecimal} value
+     */
+    static JsonNumber of(BigDecimal num) {
+        return new JsonNumberImpl(num);
+    }
+
+    /**
+     * {@return the decimal string representation of this {@code JsonNumber}}
+     *
+     * If this {@code JsonNumber} is created by parsing a JSON number in a JSON document,
+     * it preserves the string representation in the document, regardless of its
+     * precision or range. For example, a JSON number like
+     * {@code 3.141592653589793238462643383279} in the JSON document will be
+     * returned exactly as it appears.
+     * If this {@code JsonNumber} is created via one of the factory methods,
+     * such as {@link JsonNumber#of(double)}, then the string representation is
+     * specified by the factory method.
+     */
+    @Override
+    String toString();
+
+    /**
+     * {@return true if the given {@code obj} is equal to this {@code JsonNumber}}
+     * The comparison is based on the string representation of this {@code JsonNumber},
+     * ignoring the case.
+     *
+     * @see #toString()
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * {@return the hash code value of this {@code JsonNumber}} The returned hash code
+     * is calculated based on the string representation of this {@code JsonNumber},
+     * ignoring the case.
+     *
+     * @see #toString()
+     */
+    @Override
+    int hashCode();
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonObject.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonObject.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+
+import hat.tools.json.impl.JsonObjectImpl;
+import hat.tools.json.impl.Utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The interface that represents JSON object.
+ * <p>
+ * A {@code JsonObject} can be produced by a {@link Json#parse(String)}.
+ * <p> Alternatively, {@link #of(Map)} can be used to obtain a {@code JsonObject}.
+ * Implementations of {@code JsonObject} cannot be created from sources that
+ * contain duplicate member names. If duplicate names appear during
+ * a {@link Json#parse(String)}, a {@code JsonParseException} is thrown.
+ *
+ * @since 99
+ */
+public non-sealed interface JsonObject extends JsonValue {
+
+    /**
+     * {@return an unmodifiable map of the {@code String} to {@code JsonValue}
+     * members in this {@code JsonObject}}
+     */
+    Map<String, JsonValue> members();
+
+    /**
+     * {@return the {@code JsonObject} created from the given
+     * map of {@code String} to {@code JsonValue}s}
+     *
+     * The {@code JsonObject}'s members occur in the same order as the given
+     * map's entries.
+     * <p>
+     * If a key in the provided {@code map} contains escape characters, they are
+     * unescaped before being added to the resulting {@code JsonObject}. If multiple
+     * keys unescape to the same value, an {@code IllegalArgumentException} is thrown.
+     *
+     * @param map the map of {@code JsonValue}s. Non-null.
+     * @throws IllegalArgumentException if {@code map} contains multiple keys
+     *      that unescape to the same value
+     * @throws NullPointerException if {@code map} is {@code null}, contains
+     *      any keys that are {@code null}, or contains any values that are {@code null}
+     */
+    static JsonObject of(Map<String, ? extends JsonValue> map) {
+        Map<String, JsonValue> ret = new LinkedHashMap<>(map.size()); // implicit NPE on map
+        for (var e : map.entrySet()) {
+            var key = e.getKey();
+            // Implicit NPE on key
+            var unescapedKey = Utils.unescape(key.toCharArray(), 0, key.length());
+            var val = e.getValue();
+            if (ret.containsKey(unescapedKey)) {
+                throw new IllegalArgumentException(
+                        "Multiple keys unescape to the same value: '%s'".formatted(unescapedKey));
+            } else {
+                ret.put(unescapedKey, Objects.requireNonNull(val));
+            }
+        }
+        return new JsonObjectImpl(ret);
+    }
+
+    /**
+     * {@return {@code true} if the given object is also a {@code JsonObject}
+     * and the two {@code JsonObject}s represent the same mappings} Two
+     * {@code JsonObject}s {@code jo1} and {@code jo2} represent the same
+     * mappings if {@code jo1.members().equals(jo2.members())}.
+     *
+     * @see #members()
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * {@return the hash code value for this {@code JsonObject}} The hash code value
+     * of a {@code JsonObject} is defined to be the hash code of {@code JsonObject}'s
+     * {@link #members()} value. Thus, for two {@code JsonObject}s {@code jo1} and {@code jo2},
+     * {@code jo1.equals(jo2)} implies that {@code jo1.hashCode() == jo2.hashCode()}
+     * as required by the general contract of {@link Object#hashCode}.
+     *
+     * @see #members()
+     */
+    @Override
+    int hashCode();
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonParseException.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonParseException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+import java.io.Serial;
+
+/**
+ * Signals that an error has been detected while parsing the
+ * JSON document.
+ *
+ * @since 99
+ */
+public class JsonParseException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 7022545379651073390L;
+
+    /**
+     * Position of the error row in the document
+     * @serial
+     */
+    private final int row;
+
+    /**
+     * Position of the error column in the document
+     * @serial
+     */
+    private final int col;
+
+    /**
+     * Constructs a JsonParseException with the specified detail message.
+     * @param message the detail message
+     * @param row the row of the error on parsing the document
+     * @param col the column of the error on parsing the document
+     */
+    public JsonParseException(String message, int row, int col) {
+        super(message);
+        this.row = row;
+        this.col = col;
+    }
+
+    /**
+     * {@return the row of the error on parsing the document}
+     */
+    public int getErrorRow() {
+        return row;
+    }
+
+    /**
+     * {@return the column of the error on parsing the document}
+     */
+    public int getErrorColumn() {
+        return col;
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonString.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonString.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+
+import hat.tools.json.impl.JsonStringImpl;
+
+import java.util.Objects;
+
+/**
+ * The interface that represents JSON string. Any character may be escaped,
+ * see the JSON string <a href="https://datatracker.ietf.org/doc/html/rfc8259#section-6">
+ * syntax</a> for the full list of two-character sequence escapes as well as
+ * the characters that must be escaped.
+ * <p>
+ * A {@code JsonString} can be produced by a {@link Json#parse(String)}.
+ * <p> Alternatively, {@link #of(String)} can be used to obtain a {@code JsonString}
+ * from a {@code String}.
+ *
+ * @spec https://datatracker.ietf.org/doc/html/rfc8259#section-7 RFC 8259:
+ *      The JavaScript Object Notation (JSON) Data Interchange Format - Strings
+ * @since 99
+ */
+public non-sealed interface JsonString extends JsonValue {
+
+    /**
+     * {@return the {@code JsonString} created from the given
+     * {@code String}}
+     *
+     * @param src the given {@code String}. Non-null.
+     * @throws IllegalArgumentException if the given {@code src} is
+     *          not a valid JSON string.
+     * @throws NullPointerException if {@code src} is {@code null}
+     */
+    static JsonString of(String src) {
+        Objects.requireNonNull(src);
+        return new JsonStringImpl(src);
+    }
+
+    /**
+     * {@return the {@code String} value represented by this {@code JsonString}}
+     * Any escaped characters in the original JSON string are converted to their
+     * unescaped form in the returned {@code String}.
+     *
+     * @see #toString()
+     */
+    String value();
+
+    /**
+     * {@return the {@code String} value represented by this {@code JsonString}
+     * surrounded by quotation marks} Any escaped characters in the original JSON
+     * string are converted to their unescaped form in the returned {@code String}.
+     *
+     * @see #value()
+     */
+    @Override
+    String toString();
+
+    /**
+     * {@return true if the given {@code obj} is equal to this {@code JsonString}}
+     * Two {@code JsonString}s {@code js1} and {@code js2} represent the same value
+     * if {@code js1.value().equals(js2.value())}.
+     *
+     * @see #value()
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * {@return the hash code value of this {@code JsonString}} The hash code of a
+     * {@code JsonString} is calculated by {@code Objects.hash(JsonString.value())}.
+     *
+     * @see #value()
+     */
+    @Override
+    int hashCode();
+}

--- a/hat/tools/src/main/java/hat/tools/json/JsonValue.java
+++ b/hat/tools/src/main/java/hat/tools/json/JsonValue.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json;
+
+/**
+ * The interface that represents a JSON value.
+ * <p>
+ * Instances of {@code JsonValue} are immutable and thread safe.
+ * <p>
+ * A {@code JsonValue} can be produced by {@link Json#parse(String)} or {@link
+ * Json#fromUntyped(Object)}. See {@link #toString()}  for converting a {@code
+ * JsonValue} to its corresponding JSON String. For example,
+ * {@snippet lang=java:
+ *     List<Object> values = Arrays.asList("foo", true, 25);
+ *     JsonValue json = Json.fromUntyped(values);
+ *     json.toString(); // returns "[\"foo\",true,25]"
+ * }
+ *
+ * A class implementing a non-sealed {@code JsonValue} sub-interface must adhere
+ * to the following:
+ * <ul>
+ * <li>The class's implementations of {@code equals}, {@code hashCode},
+ * and {@code toString} compute their results solely from the values
+ * of the class's instance fields (and the members of the objects they
+ * reference), not from the instance's identity.</li>
+ * <li>The class's methods treat instances as <em>freely substitutable</em>
+ * when equal, meaning that interchanging any two instances {@code x} and
+ * {@code y} that are equal according to {@code equals()} produces no
+ * visible change in the behavior of the class's methods.</li>
+ * <li>The class performs no synchronization using an instance's monitor.</li>
+ * <li>The class does not provide any instance creation mechanism that promises
+ * a unique identity on each method call&mdash;in particular, any factory
+ * method's contract must allow for the possibility that if two independently-produced
+ * instances are equal according to {@code equals()}, they may also be
+ * equal according to {@code ==}.</li>
+ * </ul>
+ * <p>
+ * Users of {@code JsonValue} instances should ensure the following:
+ * <ul>
+ * <li> When two instances of {@code JsonValue} are equal (according to {@code equals()}), users
+ * should not attempt to distinguish between their identities, whether directly via reference
+ * equality or indirectly via an appeal to synchronization, identity hashing,
+ * serialization, or any other identity-sensitive mechanism.</li>
+ * <li> Synchronization on instances of {@code JsonValue} is strongly discouraged,
+ * because the programmer cannot guarantee exclusive ownership of the
+ * associated monitor.</li>
+ * </ul>
+ *
+ * @since 99
+ */
+public sealed interface JsonValue
+        permits JsonString, JsonNumber, JsonObject, JsonArray, JsonBoolean, JsonNull {
+
+    /**
+     * {@return the String representation of this {@code JsonValue} that conforms
+     * to the JSON syntax} If this {@code JsonValue} is created by parsing a
+     * JSON document, it preserves the text representation of the corresponding
+     * JSON element, except that the returned string does not contain any white
+     * spaces or newlines to produce a compact representation.
+     * For a String representation suitable for display, use
+     * {@link Json#toDisplayString(JsonValue)}.
+     *
+     * @see Json#toDisplayString(JsonValue)
+     */
+    String toString();
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/JsonArrayImpl.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/JsonArrayImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonArray;
+import hat.tools.json.JsonValue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * JsonArray implementation class
+ */
+public final class JsonArrayImpl implements JsonArray {
+
+    private final List<JsonValue> theValues;
+
+    public JsonArrayImpl(List<JsonValue> from) {
+        theValues = from;
+    }
+
+    @Override
+    public List<JsonValue> values() {
+        return Collections.unmodifiableList(theValues);
+    }
+
+    @Override
+    public String toString() {
+        var s = new StringBuilder("[");
+        for (JsonValue v: values()) {
+            s.append(v.toString()).append(",");
+        }
+        if (!values().isEmpty()) {
+            s.setLength(s.length() - 1); // trim final comma
+        }
+        return s.append("]").toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof JsonArray oja &&
+                Objects.equals(values(), oja.values());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(values());
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/JsonBooleanImpl.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/JsonBooleanImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonBoolean;
+
+import java.util.Objects;
+
+/**
+ * JsonBoolean implementation class
+ */
+public final class JsonBooleanImpl implements JsonBoolean {
+
+    private final Boolean theBoolean;
+
+    public static final JsonBooleanImpl TRUE = new JsonBooleanImpl(true);
+    public static final JsonBooleanImpl FALSE = new JsonBooleanImpl(false);
+
+    private JsonBooleanImpl(Boolean bool) {
+        theBoolean = bool;
+    }
+
+    @Override
+    public boolean value() {
+        return theBoolean;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof JsonBoolean ojb &&
+                Objects.equals(value(), ojb.value());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value());
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/JsonNullImpl.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/JsonNullImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonNull;
+
+import java.util.Objects;
+
+/**
+ * JsonNull implementation class
+ */
+public final class JsonNullImpl implements JsonNull {
+
+    public static final JsonNullImpl NULL = new JsonNullImpl();
+    private static final String VALUE = "null";
+    private static final int HASH = Objects.hash(VALUE);
+
+    private JsonNullImpl() {}
+
+    @Override
+    public String toString() {
+        return VALUE;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof JsonNull;
+    }
+
+    @Override
+    public int hashCode() {
+        return HASH;
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/JsonNumberImpl.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/JsonNumberImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonNumber;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Locale;
+
+/**
+ * JsonNumber implementation class
+ */
+public final class JsonNumberImpl implements JsonNumber {
+
+    private final char[] doc;
+    private final int startOffset;
+    private final int endOffset;
+    private Number theNumber;
+
+    public JsonNumberImpl(Number num) {
+        if (num == null ||
+            num instanceof Double d && (d.isNaN() || d.isInfinite())) {
+            throw new IllegalArgumentException("Not a valid JSON number");
+        }
+        theNumber = num;
+        // unused
+        startOffset = -1;
+        endOffset = -1;
+        doc = null;
+    }
+
+    public JsonNumberImpl(char[] doc, int start, int end) {
+        this.doc = doc;
+        startOffset = start;
+        endOffset = end;
+    }
+
+    @Override
+    public Number toNumber() {
+        var n = theNumber;
+        if (n == null) {
+            n = theNumber = computeNumber();
+        }
+        return n;
+    }
+
+    private Number computeNumber() {
+        var str = toString();
+        // Check if integral (Java literal format)
+        boolean integerOnly = true;
+        for (int index = 0; index < str.length(); index++) {
+            char c = str.charAt(index);
+            if (c == '.' || c == 'e' || c == 'E') {
+                integerOnly = false;
+                break;
+            }
+        }
+        if (integerOnly) {
+            try {
+                return Long.parseLong(str);
+            } catch (NumberFormatException _) {
+                return new BigInteger(str);
+            }
+        } else {
+            var db = Double.parseDouble(str);
+            if (Double.isInfinite(db)) {
+                return toBigDecimal();
+            } else {
+                return db;
+            }
+        }
+    }
+
+    @Override
+    public BigDecimal toBigDecimal() {
+        return new BigDecimal(toString());
+    }
+
+    @Override
+    public String toString() {
+        return new String(doc, startOffset, endOffset - startOffset);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof JsonNumber ojn &&
+                toString().compareToIgnoreCase(ojn.toString()) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().toLowerCase(Locale.ROOT).hashCode();
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/JsonObjectImpl.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/JsonObjectImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonObject;
+import hat.tools.json.JsonValue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * JsonObject implementation class
+ */
+public final class JsonObjectImpl implements JsonObject {
+
+    private final Map<String, JsonValue> theMembers;
+
+    public JsonObjectImpl(Map<String, JsonValue> map) {
+        theMembers = map;
+    }
+
+    @Override
+    public Map<String, JsonValue> members() {
+        return Collections.unmodifiableMap(theMembers);
+    }
+
+    @Override
+    public String toString() {
+        var s = new StringBuilder("{");
+        for (Map.Entry<String, JsonValue> kv: members().entrySet()) {
+            s.append("\"").append(kv.getKey()).append("\":")
+             .append(kv.getValue().toString())
+             .append(",");
+        }
+        if (!members().isEmpty()) {
+            s.setLength(s.length() - 1); // trim final comma
+        }
+        return s.append("}").toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof JsonObject ojo &&
+                Objects.equals(members(), ojo.members());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(members());
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/JsonParser.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/JsonParser.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonArray;
+import hat.tools.json.JsonObject;
+import hat.tools.json.JsonParseException;
+import hat.tools.json.JsonString;
+import hat.tools.json.JsonValue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Parses a JSON Document char[] into a tree of JsonValues. JsonObject and JsonArray
+ * nodes create their data structures which maintain the connection to children.
+ * JsonNumber and JsonString contain only a start and end offset, which
+ * are used to lazily procure their underlying value/string on demand. Singletons
+ * are used for JsonBoolean and JsonNull.
+ */
+public final class JsonParser {
+
+    // Access to the underlying JSON contents
+    private final char[] doc;
+    // Current offset during parsing
+    private int offset;
+    // For exception message on failure
+    private int line;
+    private int lineStart;
+    private StringBuilder builder;
+
+    public JsonParser(char[] doc) {
+        this.doc = doc;
+    }
+
+    // Parses the lone JsonValue root
+    public JsonValue parseRoot() {
+        JsonValue root = parseValue();
+        if (hasInput()) {
+            throw failure("Unexpected character(s)");
+        }
+        return root;
+    }
+
+    /*
+     * Parse any one of the JSON value types: object, array, number, string,
+     * true, false, or null.
+     *      JSON-text = ws value ws
+     * See https://datatracker.ietf.org/doc/html/rfc8259#section-3
+     */
+    private JsonValue parseValue() {
+        skipWhitespaces();
+        if (!hasInput()) {
+            throw failure("Missing JSON value");
+        }
+        var val = switch (doc[offset]) {
+            case '{' -> parseObject();
+            case '[' -> parseArray();
+            case '"' -> parseString();
+            case 't' -> parseTrue();
+            case 'f' -> parseFalse();
+            case 'n' -> parseNull();
+            // While JSON Number does not support leading '+', '.', or 'e'
+            // we still accept, so that we can provide a better error message
+            case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '+', 'e', '.'
+                    -> parseNumber();
+            default -> throw failure("Unexpected character(s)");
+        };
+        skipWhitespaces();
+        return val;
+    }
+
+    /*
+     * The parsed JsonObject contains a map which holds all lazy member mappings.
+     * No offsets are required as member values hold their own offsets.
+     * See https://datatracker.ietf.org/doc/html/rfc8259#section-4
+     */
+    private JsonObject parseObject() {
+        // @@@ Do not preserve encounter order, requires adjustment to the API
+//        var members = new LinkedHashMap<String, JsonValue>();
+        var members = new HashMap<String, JsonValue>();
+        offset++; // Walk past the '{'
+        skipWhitespaces();
+        // Check for empty case
+        if (currCharEquals('}')) {
+            offset++;
+            return new JsonObjectImpl(members);
+        }
+        while (hasInput()) {
+            // Get the member name, which should be unescaped
+            // Why not parse the name as a JsonString and then return its value()?
+            // Would requires 2 passes; we should build the String as we parse.
+            var name = parseName();
+
+            if (members.containsKey(name)) {
+                throw failure("The duplicate member name: '%s' was already parsed".formatted(name));
+            }
+
+            // Move from name to ':'
+            skipWhitespaces();
+            if (!currCharEquals(':')) {
+                throw failure(
+                        "Expected ':' after the member name");
+            }
+
+            // Move from ':' to JsonValue
+            offset++;
+            members.put(name, parseValue());
+            // Ensure current char is either ',' or '}'
+            if (currCharEquals('}')) {
+                offset++;
+                return new JsonObjectImpl(members);
+            } else if (currCharEquals(',')) {
+                // Add the comma, and move to the next key
+                offset++;
+                skipWhitespaces();
+            } else {
+                // Neither ',' nor '}' so fail
+                break;
+            }
+        }
+        throw failure("Object was not closed with '}'");
+    }
+
+    /*
+     * Member name equality and storage in the map should be done with the
+     * unescaped String value.
+     * See https://datatracker.ietf.org/doc/html/rfc8259#section-8.3
+     */
+    private String parseName() {
+        if (!currCharEquals('"')) {
+            throw failure("Invalid member name");
+        }
+        offset++; // Move past the starting quote
+        var escape = false;
+        boolean useBldr = false;
+        var start = offset;
+        for (; hasInput(); offset++) {
+            var c = doc[offset];
+            if (escape) {
+                var escapeLength = 0;
+                switch (c) {
+                    // Allowed JSON escapes
+                    case '"', '\\', '/' -> {}
+                    case 'b' -> c = '\b';
+                    case 'f' -> c = '\f';
+                    case 'n' -> c = '\n';
+                    case 'r' -> c = '\r';
+                    case 't' -> c = '\t';
+                    case 'u' -> {
+                        if (offset + 4 < doc.length) {
+                            escapeLength = 4;
+                            offset++; // Move to first char in sequence
+                            c = codeUnit();
+                            // Move to the last hex digit, since outer loop will increment offset
+                            offset += 3;
+                        } else {
+                            throw failure("Invalid Unicode escape sequence");
+                        }
+                    }
+                    default -> throw failure("Illegal escape");
+                }
+                if (!useBldr) {
+                    initBuilder();
+                    // Append everything up to the first escape sequence
+                    builder.append(doc, start, offset - escapeLength - 1 - start);
+                    useBldr = true;
+                }
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+                continue;
+            } else if (c == '\"') {
+                offset++;
+                if (useBldr) {
+                    var name = builder.toString();
+                    builder.setLength(0);
+                    return name;
+                } else {
+                    return new String(doc, start, offset - start - 1);
+                }
+            } else if (c < ' ') {
+                throw failure("Unescaped control code");
+            }
+            if (useBldr) {
+                builder.append(c);
+            }
+        }
+        throw failure("Closing quote missing");
+    }
+
+    /*
+     * The parsed JsonArray contains a List which holds all lazy children
+     * elements. No offsets are required as children values hold their own offsets.
+     * See https://datatracker.ietf.org/doc/html/rfc8259#section-5
+     */
+    private JsonArray parseArray() {
+        var list = new ArrayList<JsonValue>();
+        offset++; // Walk past the '['
+        skipWhitespaces();
+        // Check for empty case
+        if (currCharEquals(']')) {
+            offset++;
+            return new JsonArrayImpl(list);
+        }
+        for (; hasInput(); offset++) {
+            // Get the JsonValue
+            list.add(parseValue());
+            // Ensure current char is either ']' or ','
+            if (currCharEquals(']')) {
+                offset++;
+                return new JsonArrayImpl(list);
+            } else if (!currCharEquals(',')) {
+                break;
+            }
+        }
+        throw failure("Array was not closed with ']'");
+    }
+
+    /*
+     * The parsed JsonString will contain offsets correlating to the beginning
+     * and ending quotation marks. All Unicode characters are allowed except the
+     * following that require escaping: quotation mark, reverse solidus, and the
+     * control characters (U+0000 through U+001F). Any character may be escaped
+     * either through a Unicode escape sequence or two-char sequence.
+     * See https://datatracker.ietf.org/doc/html/rfc8259#section-7
+     */
+    private JsonString parseString() {
+        int start = offset;
+        offset++; // Move past the starting quote
+        var escape = false;
+        for (; hasInput(); offset++) {
+            var c = doc[offset];
+            if (escape) {
+                switch (c) {
+                    // Allowed JSON escapes
+                    case '"', '\\', '/', 'b', 'f', 'n', 'r', 't' -> {}
+                    case 'u' -> {
+                        if (offset + 4 < doc.length) {
+                            offset++; // Move to first char in sequence
+                            checkEscapeSequence();
+                            offset += 3; // Move to the last hex digit, outer loop increments
+                        } else {
+                            throw failure("Invalid Unicode escape sequence");
+                        }
+                    }
+                    default -> throw failure("Illegal escape");
+                }
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+            } else if (c == '\"') {
+                return new JsonStringImpl(doc, start, offset += 1);
+            } else if (c < ' ') {
+                throw failure("Unescaped control code");
+            }
+        }
+        throw failure("Closing quote missing");
+    }
+
+    /*
+     * Parsing true, false, and null return singletons. These JsonValues
+     * do not require offsets to lazily compute their values.
+     */
+    private JsonBooleanImpl parseTrue() {
+        if (charsEqual("rue", offset + 1)) {
+            offset += 4;
+            return JsonBooleanImpl.TRUE;
+        }
+        throw failure("Expected true");
+    }
+
+    private JsonBooleanImpl parseFalse() {
+        if (charsEqual( "alse", offset + 1)) {
+            offset += 5;
+            return JsonBooleanImpl.FALSE;
+        }
+        throw failure("Expected false");
+    }
+
+    private JsonNullImpl parseNull() {
+        if (charsEqual("ull", offset + 1)) {
+            offset += 4;
+            return JsonNullImpl.NULL;
+        }
+        throw failure("Expected null");
+    }
+
+    /*
+     * The parsed JsonNumber contains offsets correlating to the first and last
+     * allowed chars permitted in the JSON numeric grammar:
+     *      number = [ minus ] int [ frac ] [ exp ]
+     * See https://datatracker.ietf.org/doc/html/rfc8259#section-6
+     */
+    private JsonNumberImpl parseNumber() {
+        boolean sawDecimal = false;
+        boolean sawExponent = false;
+        boolean sawZero = false;
+        boolean sawWhitespace = false;
+        boolean havePart = false;
+        boolean sawInvalid = false;
+        boolean sawSign = false;
+        var start = offset;
+        for (; hasInput() && !sawWhitespace && !sawInvalid; offset++) {
+            switch (doc[offset]) {
+                case '-' -> {
+                    if (offset != start && !sawExponent || sawSign) {
+                        throw failure("Invalid '-' position");
+                    }
+                    sawSign = true;
+                }
+                case '+' -> {
+                    if (!sawExponent || havePart || sawSign) {
+                        throw failure("Invalid '+' position");
+                    }
+                    sawSign = true;
+                }
+                case '0' -> {
+                    if (!havePart) {
+                        sawZero = true;
+                    }
+                    havePart = true;
+                }
+                case '1', '2', '3', '4', '5', '6', '7', '8', '9' -> {
+                    if (!sawDecimal && !sawExponent && sawZero) {
+                        throw failure("Invalid '0' position");
+                    }
+                    havePart = true;
+                }
+                case '.' -> {
+                    if (sawDecimal) {
+                        throw failure("Invalid '.' position");
+                    } else {
+                        if (!havePart) {
+                            throw failure("Invalid '.' position");
+                        }
+                        sawDecimal = true;
+                        havePart = false;
+                    }
+                }
+                case 'e', 'E' -> {
+                    if (sawExponent) {
+                        throw failure("Invalid '[e|E]' position");
+                    } else {
+                        if (!havePart) {
+                            throw failure("Invalid '[e|E]' position");
+                        }
+                        sawExponent = true;
+                        havePart = false;
+                        sawSign = false;
+                    }
+                }
+                case ' ', '\t', '\r', '\n' -> {
+                    sawWhitespace = true;
+                    offset --;
+                }
+                default -> {
+                    offset--;
+                    sawInvalid = true;
+                }
+            }
+        }
+        if (!havePart) {
+            throw failure("Input expected after '[.|e|E]'");
+        }
+        return new JsonNumberImpl(doc, start, offset);
+    }
+
+    // Utility functions
+
+    // Called when a SB is required to un-escape a member name
+    private void initBuilder() {
+        if (builder == null) {
+            builder = new StringBuilder();
+        }
+    }
+
+    // Validate unicode escape sequence
+    // This method does not increment offset
+    private void checkEscapeSequence() {
+        for (int index = 0; index < 4; index++) {
+            char c = doc[offset + index];
+            if ((c < 'a' || c > 'f') && (c < 'A' || c > 'F') && (c < '0' || c > '9')) {
+                throw failure("Invalid Unicode escape sequence");
+            }
+        }
+    }
+
+    // Unescapes the Unicode escape sequence and produces a char
+    private char codeUnit() {
+        try {
+            return Utils.codeUnit(doc, offset);
+        } catch (IllegalArgumentException _) {
+            // Catch and re-throw as JPE with correct row/col
+            throw failure("Invalid Unicode escape sequence");
+        }
+    }
+
+    // Returns true if the parser has not yet reached the end of the Document
+    private boolean hasInput() {
+        return offset < doc.length;
+    }
+
+    // Walk to the next non-white space char from the current offset
+    private void skipWhitespaces() {
+        while (hasInput()) {
+            if (notWhitespace()) {
+                break;
+            }
+            offset++;
+        }
+    }
+
+    // see https://datatracker.ietf.org/doc/html/rfc8259#section-2
+    private boolean notWhitespace() {
+        return switch (doc[offset]) {
+            case ' ', '\t','\r' -> false;
+            case '\n' -> {
+                // Increments the row and col
+                line += 1;
+                lineStart = offset + 1;
+                yield false;
+            }
+            default -> true;
+        };
+    }
+
+    private JsonParseException failure(String message) {
+        var errMsg = composeParseExceptionMessage(
+                message, line, lineStart, offset);
+        return new JsonParseException(errMsg, line, offset - lineStart);
+    }
+
+    // returns true if the char at the specified offset equals the input char
+    // and is within bounds of the char[]
+    private boolean currCharEquals(char c) {
+        return hasInput() && c == doc[offset];
+    }
+
+    // Returns true if the substring starting at the given offset equals the
+    // input String and is within bounds of the JSON document
+    private boolean charsEqual(String str, int o) {
+        if (o + str.length() - 1 < doc.length) {
+            for (int index = 0; index < str.length(); index++) {
+                if (doc[o] != str.charAt(index)) {
+                    return false; // char does not match
+                }
+                o++;
+            }
+            return true; // all chars match
+        }
+        return false; // not within bounds
+    }
+
+    // Utility method to compose parse exception message
+    private String composeParseExceptionMessage(String message, int line, int lineStart, int offset) {
+        return "%s: (%s) at Row %d, Col %d."
+            .formatted(message, new String(doc, offset, Math.min(offset + 8, doc.length) - offset),
+                line, offset - lineStart);
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/JsonStringImpl.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/JsonStringImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonString;
+
+import java.util.Objects;
+
+/**
+ * JsonString implementation class
+ */
+public final class JsonStringImpl implements JsonString {
+
+    private final char[] doc;
+    private final int startOffset;
+    private final int endOffset;
+    private final String str;// = StableSupplier.of(this::unescape);
+
+    public JsonStringImpl(String str) {
+        doc = ("\"" + str + "\"").toCharArray();
+        startOffset = 0;
+        endOffset = doc.length;
+        this.str = unescape();
+    }
+
+    public JsonStringImpl(char[] doc, int start, int end) {
+        this.doc = doc;
+        startOffset = start;
+        endOffset = end;
+        str = unescape();
+    }
+
+    @Override
+    public String value() {
+        var ret = str;
+        return str.substring(1, ret.length() - 1);
+    }
+
+    @Override
+    public String toString() {
+        return str;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof JsonString ojs &&
+                Objects.equals(value(), ojs.value());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value());
+    }
+
+    private String unescape() {
+        return Utils.unescape(doc, startOffset, endOffset);
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/json/impl/Utils.java
+++ b/hat/tools/src/main/java/hat/tools/json/impl/Utils.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package hat.tools.json.impl;
+
+
+import hat.tools.json.JsonArray;
+import hat.tools.json.JsonObject;
+import hat.tools.json.JsonValue;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared utilities for Json classes.
+ */
+public class Utils {
+
+    // Non instantiable
+    private Utils() {}
+
+    // Equivalent to JsonObject/Array.of() factories without the need for defensive copy
+    // and other input validation
+    public static JsonArray arrayOf(List<JsonValue> list) {
+        return new JsonArrayImpl(list);
+    }
+
+    public static JsonObject objectOf(Map<String, JsonValue> map) {
+        return new JsonObjectImpl(map);
+    }
+
+    // Used for escaping String values, applicable to JSON Strings and member names
+    public static String unescape(char[] doc, int startOffset, int endOffset) {
+        StringBuilder sb = null; // Only use if required
+        var escape = false;
+        int offset = startOffset;
+        boolean useBldr = false;
+        for (; offset < endOffset; offset++) {
+            var c = doc[offset];
+            if (escape) {
+                var length = 0;
+                switch (c) {
+                    case '"', '\\', '/' -> {}
+                    case 'b' -> c = '\b';
+                    case 'f' -> c = '\f';
+                    case 'n' -> c = '\n';
+                    case 'r' -> c = '\r';
+                    case 't' -> c = '\t';
+                    case 'u' -> {
+                        if (offset + 4 < endOffset) {
+                            c = codeUnit(doc, offset + 1);
+                            length = 4;
+                        } else {
+                            throw new IllegalArgumentException("Illegal Unicode escape sequence");
+                        }
+                    }
+                    default -> throw new IllegalArgumentException("Illegal escape sequence");
+                }
+                if (!useBldr) {
+                    useBldr = true;
+                    // At best, we know the size of the first escaped value
+                    sb = new StringBuilder(endOffset - startOffset - length - 1)
+                            .append(doc, startOffset, offset - 1 - startOffset);
+                }
+                offset+=length;
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+                continue;
+            }
+            if (useBldr) {
+                sb.append(c);
+            }
+        }
+        if (useBldr) {
+            return sb.toString();
+        } else {
+            return new String(doc, startOffset, endOffset - startOffset);
+        }
+    }
+
+    // Validate and construct corresponding value of Unicode escape sequence
+    // This method does not increment offset
+    static char codeUnit(char[] doc, int o) {
+        char val = 0;
+        for (int index = 0; index < 4; index ++) {
+            char c = doc[o + index];
+            val <<= 4;
+            val += (char) (
+                    switch (c) {
+                        case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> c - '0';
+                        case 'a', 'b', 'c', 'd', 'e', 'f' -> c - 'a' + 10;
+                        case 'A', 'B', 'C', 'D', 'E', 'F' -> c - 'A' + 10;
+                        default -> throw new IllegalArgumentException("Illegal Unicode escape sequence");
+                    });
+        }
+        return val;
+    }
+}

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/AbstractTextModelViewer.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/AbstractTextModelViewer.java
@@ -42,10 +42,13 @@ import hat.tools.textmodel.tokens.Ws;
 
 import javax.swing.JTextPane;
 import javax.swing.text.DefaultHighlighter;
+import javax.swing.text.Element;
 import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.geom.Rectangle2D;
+import java.util.List;
 
 public class AbstractTextModelViewer extends TextViewer {
     static Style style(JTextPane jTextPane, String name, Color color, boolean bold, boolean italic, boolean underline) {

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/FuncOpTextModelViewer.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/FuncOpTextModelViewer.java
@@ -28,7 +28,6 @@ import hat.tools.textmodel.BabylonTextModel;
 import hat.tools.textmodel.TextModel;
 
 import javax.swing.JTextPane;
-import javax.swing.text.BadLocationException;
 import javax.swing.text.Element;
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -36,22 +35,22 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.Stroke;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class FuncOpTextModelViewer extends AbstractTextModelViewer {
 
     JavaTextModelViewer javaTextModelViewer;
     Map<ElementSpan, List<ElementSpan>> opToJava = new HashMap<>();
-    int lineNumber =0;
+    int lineNumber = 0;
+
     static class FuncOpTextPane extends JTextPane {
         private FuncOpTextModelViewer viewer;
 
@@ -64,28 +63,25 @@ public class FuncOpTextModelViewer extends AbstractTextModelViewer {
         }
 
         void arrow(Graphics2D g2d, Element from, Element to) {
-            try {
-                var fromPoint1 = viewer.jtextPane.modelToView2D(from.getStartOffset());
-                var fromPoint2 = viewer.jtextPane.modelToView2D(from.getEndOffset());
-                var fromRect = new Rectangle2D.Double(fromPoint1.getBounds().getMinX(), fromPoint1.getMinY()
-                        , fromPoint2.getBounds().getWidth(), fromPoint2.getBounds().getHeight());
-                var toPoint1 = viewer.jtextPane.modelToView2D(to.getStartOffset() + 3);
-                var toPoint2 = viewer.jtextPane.modelToView2D(to.getEndOffset());
-                var toRect = new Rectangle2D.Double(toPoint1.getBounds().getMinX(), toPoint1.getMinY()
-                        , toPoint2.getBounds().getWidth(), toPoint2.getBounds().getHeight());
-                g2d.setColor(Color.GRAY);
-                var x0 = fromRect.getBounds().getMinX();
-                var y0 = fromRect.getBounds().getCenterY();
-                var x1 = toRect.getBounds().getMinX();
-                var y1 = toRect.getBounds().getCenterY();
-                final AffineTransform tx = AffineTransform.getTranslateInstance(x1, y1);
-                tx.rotate(Math.atan2(y1 - y0, x1 - x0));
+            if (viewer.getRect(from) instanceof Rectangle2D.Double frect
+                    && viewer.getRect(to) instanceof Rectangle2D.Double trect) {
+                g2d.setColor(Color.BLACK);
+                Line2D.Double arrow = new Line2D.Double(
+                        frect.getBounds().getMinX(), frect.getBounds().getCenterY(),
+                        trect.getBounds().getMinX(), trect.getBounds().getCenterY());
+                final AffineTransform tx = AffineTransform.getTranslateInstance(arrow.x2, arrow.y2);
+                tx.rotate(Math.atan2(arrow.y2 - arrow.y1, arrow.x2 - arrow.x1));// point the arrow to the target
                 g2d.fill(tx.createTransformedShape(arrowHead));
-                var line = new Line2D.Double(x0, y0, x1, y1);
-                g2d.setStroke(new BasicStroke(2));
-                g2d.draw(line);
-            } catch (BadLocationException e) {
-                throw new RuntimeException(e);
+                // Create a copy of the Graphics instance
+                Graphics2D g2d2 = (Graphics2D) g2d.create();
+                // Set the stroke of the copy, not the original
+                Stroke dashed = new BasicStroke(2, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL,
+                        0, new float[]{4f, 2f, 5f, 1f}, 0);
+                g2d2.setStroke(dashed);
+
+                //    g2d2.setStroke(new BasicStroke(1));
+                g2d2.draw(arrow);
+
             }
         }
 
@@ -116,39 +112,28 @@ public class FuncOpTextModelViewer extends AbstractTextModelViewer {
 
     FuncOpTextModelViewer(TextModel textModel, Font font, boolean dark) {
         super(textModel, new FuncOpTextPane(font), font, dark);
+        final var thisTextViewer = this;
         ((FuncOpTextPane) this.jtextPane).setViewer(this);
 
         jtextPane.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                var clicked = getElementFromMouseEvent(e);
+                var clickedElement = getElementFromMouseEvent(e);
                 removeHighlights();
-                javaTextModelViewer.removeHighlights();
-                if (clicked != null) {
-                    var optionalElementSpan = opToJava.keySet().stream()
-                            .filter(fromElementSpan -> fromElementSpan.includes(clicked.getStartOffset())).findFirst();
-                    if (optionalElementSpan.isPresent()) {
-                        ElementSpan elementSpan = optionalElementSpan.get();
-                        lineNumber = getLine(elementSpan.element().getStartOffset())+1;
+                if (javaTextModelViewer != null) {
+                    javaTextModelViewer.removeHighlights();
+                    if (clickedElement != null) {
+                        var elementsReferencedByClickedElement = opToJava.keySet().stream()
+                                .filter(fromElementSpan ->
+                                        fromElementSpan.includes(clickedElement.getStartOffset())
+                                ).toList();
+                        if (!elementsReferencedByClickedElement.isEmpty()) {
+                            lineNumber = getLine(elementsReferencedByClickedElement.getFirst().element()) + 1;
+                            elementsReferencedByClickedElement.forEach(fromElementSpan -> {
+                                thisTextViewer.highlight(fromElementSpan, opToJava.get(fromElementSpan));
+                            });
+                        }
                     }
-                    if (opToJava.keySet().stream()
-                            .anyMatch(fromElementSpan -> fromElementSpan.includes(clicked.getStartOffset()))) {
-                        opToJava.keySet().stream().
-                                filter(fromElementSpan -> fromElementSpan.includes(clicked.getStartOffset()))
-                                .forEach(fromElementSpan -> {
-                                    fromElementSpan.textViewer().highLight(fromElementSpan.element());
-                                    opToJava.get(fromElementSpan).forEach(targetElementSpan -> {
-                                        Element targetElement = targetElementSpan.element();
-
-                                        targetElementSpan.textViewer().highLight(targetElement);
-                                        targetElementSpan.textViewer().scrollTo(targetElement);
-                                    });
-                                });
-                    } else {
-                        System.out.println("not a locationmapping  from op");
-                    }
-                } else {
-                    System.out.println("nothing from op");
                 }
             }
         });

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/SSAIDViewer.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/SSAIDViewer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.tools.textmodel.ui;
+
+import hat.tools.jdot.DotBuilder;
+import hat.tools.jdot.ui.JDot;
+import hat.tools.textmodel.BabylonTextModel;
+import jdk.incubator.code.dialect.core.CoreOp;
+
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JSplitPane;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Font;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SSAIDViewer extends JPanel {
+
+    public SSAIDViewer(BabylonTextModel cr) {
+        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        var font = new Font("Monospaced", Font.PLAIN, 14);
+
+        var funcOpTextModelViewer = new FuncOpTextModelViewer(cr, font, false);
+
+        var dotViewer = new JDot(DotBuilder.dotDigraph("name", g -> {
+            g.nodeShape("record");
+            cr.ssaEdgeList.forEach(edge -> {
+                var ssaDef = edge.ssaDef();
+                String def = "%" + ssaDef.id;
+                g.record(def, def);
+            });
+            cr.ssaEdgeList.forEach(edge -> {
+                var ssaDef = edge.ssaDef();
+                String def = "%" + ssaDef.id;
+                int line = ssaDef.pos().line();
+                cr.ssaEdgeList.forEach(e -> {
+                    var ssaRef = e.ssaRef();
+                    if (ssaRef.pos().line() == line) {
+                        String ref = "%" + ssaRef.id;
+                        g.edge(def, ref);
+                    }
+                });
+            });
+        }));
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+        splitPane.setLeftComponent(funcOpTextModelViewer.scrollPane);
+        splitPane.setRightComponent(dotViewer.pane);
+        add(splitPane);
+    }
+
+    public static void launch(BabylonTextModel crDoc) {
+        SwingUtilities.invokeLater(() -> {
+            var viewer = new SSAIDViewer(crDoc);
+            var frame = new JFrame();
+            frame.setLayout(new BorderLayout());
+            frame.getContentPane().add(viewer);
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.pack();
+            frame.setVisible(true);
+        });
+
+    }
+
+    public static void launch(CoreOp.FuncOp javaFunc) {
+        BabylonTextModel crDoc = BabylonTextModel.of(javaFunc);
+        launch(crDoc);
+    }
+
+    public static void launch(Path path) throws IOException {
+        BabylonTextModel crDoc = BabylonTextModel.of(Files.readString(path));
+        launch(crDoc);
+    }
+
+    public static void main(String[] args) throws IOException {
+        SSAIDViewer.launch(Path.of(args[0]));
+    }
+}
+

--- a/hat/tools/src/main/java/hat/tools/textmodel/ui/TextGutter.java
+++ b/hat/tools/src/main/java/hat/tools/textmodel/ui/TextGutter.java
@@ -70,7 +70,6 @@ public class TextGutter extends JComponent {
         size = new Dimension(insets.left + insets.right + colWidth * 2, 1000 * fontMetrics.getHeight());
         this.currentLineForeground = Color.RED;
         this.lhs.jtextPane.addCaretListener(_ -> repaint());
-      //  this.rhs.jtextPane.addCaretListener(_ -> repaint());
         this.lhs.scrollPane.getViewport().addChangeListener(_->repaint());
         this.rhs.scrollPane.getViewport().addChangeListener(_->repaint());
 


### PR DESCRIPTION
Another HAT tool that I needed to find a home for. 

This one shows a dependency graph between the SSA id (refs to defs) for a given Babylon funcOp graph.

This is essentially a DOT graph view of the dependencies shown in the existing line based FuncOpViewer tool

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/511/head:pull/511` \
`$ git checkout pull/511`

Update a local copy of the PR: \
`$ git checkout pull/511` \
`$ git pull https://git.openjdk.org/babylon.git pull/511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 511`

View PR using the GUI difftool: \
`$ git pr show -t 511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/511.diff">https://git.openjdk.org/babylon/pull/511.diff</a>

</details>
