### PR TITLE
[hat][proposal] ComputeRange and ThreadMesh API for defining 1D, 2D and 3D Ranges

### DIFF
--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
@@ -136,31 +136,34 @@ void CudaBackend::CudaQueue::dispatch(KernelContext *kernelContext, CompilationU
     int threadsPerBlockX;
     int threadsPerBlockY = 1;
     int threadsPerBlockZ = 1;
-    if (kernelContext -> lsx > 0) {
-        threadsPerBlockX = kernelContext -> lsx;
+
+    // The local and global mesh dimensions match by design from the Java APIs
+    const int dimensions = kernelContext->globalMesh.dimensions;
+    if (kernelContext -> localMesh.maxX > 0) {
+        threadsPerBlockX = kernelContext -> localMesh.maxX;
     } else {
-        threadsPerBlockX = estimateThreadsPerBlock(kernelContext->dimensions);
+        threadsPerBlockX = estimateThreadsPerBlock(dimensions);
     }
-    if (kernelContext-> lsy > 0) {
-        threadsPerBlockY = kernelContext-> lsy;
-    } else if (kernelContext->dimensions > 1) {
-        threadsPerBlockY = estimateThreadsPerBlock(kernelContext->dimensions);
+    if (kernelContext-> localMesh.maxY > 0) {
+        threadsPerBlockY = kernelContext-> localMesh.maxY;
+    } else if (dimensions > 1) {
+        threadsPerBlockY = estimateThreadsPerBlock(dimensions);
     }
-    if (kernelContext-> lsz > 0) {
-        threadsPerBlockZ = kernelContext-> lsz;
-    } else if (kernelContext->dimensions > 2) {
-        threadsPerBlockZ = estimateThreadsPerBlock(kernelContext->dimensions);
+    if (kernelContext-> localMesh.maxZ > 0) {
+        threadsPerBlockZ = kernelContext-> localMesh.maxZ;
+    } else if (dimensions > 2) {
+        threadsPerBlockZ = estimateThreadsPerBlock(dimensions);
     }
 
-    int blocksPerGridX = (kernelContext->maxX + threadsPerBlockX - 1) / threadsPerBlockX;
+    int blocksPerGridX = (kernelContext->globalMesh.maxX + threadsPerBlockX - 1) / threadsPerBlockX;
     int blocksPerGridY = 1;
     int blocksPerGridZ = 1;
 
-    if (kernelContext->dimensions > 1) {
-        blocksPerGridY = (kernelContext->maxY + threadsPerBlockY - 1) / threadsPerBlockY;
+    if (dimensions > 1) {
+        blocksPerGridY = (kernelContext->globalMesh.maxY + threadsPerBlockY - 1) / threadsPerBlockY;
     }
-    if (kernelContext->dimensions > 2) {
-        blocksPerGridZ = (kernelContext->maxZ + threadsPerBlockZ - 1) / threadsPerBlockZ;
+    if (dimensions > 2) {
+        blocksPerGridZ = (kernelContext->globalMesh.maxZ + threadsPerBlockZ - 1) / threadsPerBlockZ;
     }
 
     // Enable debug information with trace. Use HAT=INFO

--- a/hat/backends/ffi/mock/src/main/native/cpp/mock_backend.cpp
+++ b/hat/backends/ffi/mock/src/main/native/cpp/mock_backend.cpp
@@ -64,7 +64,7 @@ public:
             std::cout << "mock dispatch() " << std::endl;
             size_t dims = 1;
             if (backend->config->trace | backend->config->traceEnqueues){
-                std::cout << "enqueued kernel dispatch \""<< kernel->name <<"\" globalSize=" << kernelContext->maxX << std::endl;
+                std::cout << "enqueued kernel dispatch \""<< kernel->name <<"\" globalSize=" << kernelContext->globalMesh.maxX << std::endl;
             }
 
         }

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
@@ -65,7 +65,6 @@ public class OpenCLBackend extends C99FFIBackend {
             }
         });
         compiledKernel.dispatch(ndRange, args);
-
     }
 
     String createC99(KernelCallGraph kernelCallGraph,  NDRange ndRange, Object[] args){

--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
@@ -258,7 +258,11 @@ void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend:
         std::cout << "[INFO] OpenCLBackend::OpenCLQueue::dispatch" << std::endl;
         std::cout << "[INFO] numDimensions: " << numDimensions << std::endl;
         std::cout << "[INFO] GLOBAL [" << global_work_size[0] << "," << global_work_size[1] << "," << global_work_size[2] << "]" << std::endl;
-        std::cout << "[INFO] LOCAL  [" << local_work_size[0] << "," << local_work_size[1] << "," << local_work_size[2] << "]" << std::endl;
+        if (kernelContext->localMesh.maxX > 0) {
+            std::cout << "[INFO] LOCAL  [" << local_work_size[0] << "," << local_work_size[1] << "," << local_work_size[2] << "]" << std::endl;
+        } else {
+            std::cout << "[INFO] LOCAL  [ nullptr ] // The driver will setup a default value" << std::endl;
+        }
     }
 
     cl_int status = clEnqueueNDRangeKernel(
@@ -267,7 +271,7 @@ void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend:
         numDimensions,
         nullptr,
         global_work_size,
-        kernelContext->localMesh.maxX> 0 ? local_work_size : nullptr,
+        kernelContext->localMesh.maxX > 0 ? local_work_size : nullptr,
         eventc,
         eventListPtr(),
         nextEventPtr());

--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
@@ -240,18 +240,18 @@ OpenCLBackend::OpenCLQueue::~OpenCLQueue() {
 }
 
 void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend::CompilationUnit::Kernel *kernel) {
-    size_t numDimensions = kernelContext->dimensions;
+    size_t numDimensions = kernelContext->globalMesh.dimensions;
 
     size_t global_work_size[] {
-        static_cast<size_t>(kernelContext->maxX),
-        static_cast<size_t>(kernelContext->maxY),
-        static_cast<size_t>(kernelContext->maxZ)
+        static_cast<size_t>(kernelContext->globalMesh.maxX),
+        static_cast<size_t>(kernelContext->globalMesh.maxY),
+        static_cast<size_t>(kernelContext->globalMesh.maxZ)
     };
 
     size_t local_work_size[] = {
-        static_cast<size_t>(kernelContext->lsx),
-        static_cast<size_t>(kernelContext->lsy),
-        static_cast<size_t>(kernelContext->lsz),
+        static_cast<size_t>(kernelContext->localMesh.maxX),
+        static_cast<size_t>(kernelContext->localMesh.maxY),
+        static_cast<size_t>(kernelContext->localMesh.maxZ),
     };
 
     if (backend->config->info) {
@@ -267,7 +267,7 @@ void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend:
         numDimensions,
         nullptr,
         global_work_size,
-        kernelContext->lsx > 0 ? local_work_size : nullptr,
+        kernelContext->localMesh.maxX> 0 ? local_work_size : nullptr,
         eventc,
         eventListPtr(),
         nextEventPtr());
@@ -277,7 +277,7 @@ void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend:
 
     OPENCL_CHECK(status, "clEnqueueNDRangeKernel");
     if (backend->config->trace | backend->config->traceEnqueues) {
-        std::cout << "enqueued kernel dispatch \"" << kernel->name << "\" globalSize=" << kernelContext->maxX <<
+        std::cout << "enqueued kernel dispatch \"" << kernel->name << "\" globalSize=" << kernelContext->globalMesh.maxX <<
                 std::endl;
     }
 }

--- a/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
+++ b/hat/backends/ffi/opencl/src/main/native/cpp/opencl_backend_queue.cpp
@@ -181,7 +181,6 @@ void OpenCLBackend::OpenCLQueue::marker(int bits, const char *arg) {
     inc(bits, arg);
 }
 
-
 void OpenCLBackend::OpenCLQueue::computeStart() {
     wait(); // should be no-op
     release(); // also ;
@@ -243,11 +242,24 @@ OpenCLBackend::OpenCLQueue::~OpenCLQueue() {
 void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend::CompilationUnit::Kernel *kernel) {
     size_t numDimensions = kernelContext->dimensions;
 
-    size_t global_work_size[]{
+    size_t global_work_size[] {
         static_cast<size_t>(kernelContext->maxX),
         static_cast<size_t>(kernelContext->maxY),
         static_cast<size_t>(kernelContext->maxZ)
     };
+
+    size_t local_work_size[] = {
+        static_cast<size_t>(kernelContext->lsx),
+        static_cast<size_t>(kernelContext->lsy),
+        static_cast<size_t>(kernelContext->lsz),
+    };
+
+    if (backend->config->info) {
+        std::cout << "[INFO] OpenCLBackend::OpenCLQueue::dispatch" << std::endl;
+        std::cout << "[INFO] numDimensions: " << numDimensions << std::endl;
+        std::cout << "[INFO] GLOBAL [" << global_work_size[0] << "," << global_work_size[1] << "," << global_work_size[2] << "]" << std::endl;
+        std::cout << "[INFO] LOCAL  [" << local_work_size[0] << "," << local_work_size[1] << "," << local_work_size[2] << "]" << std::endl;
+    }
 
     cl_int status = clEnqueueNDRangeKernel(
         command_queue,
@@ -255,7 +267,7 @@ void OpenCLBackend::OpenCLQueue::dispatch(KernelContext *kernelContext, Backend:
         numDimensions,
         nullptr,
         global_work_size,
-        nullptr, // TODO: Select a local work group instead of the default one
+        kernelContext->lsx > 0 ? local_work_size : nullptr,
         eventc,
         eventListPtr(),
         nextEventPtr());

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -92,14 +92,14 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
                 kernelContext.maxZ(globalMesh.getZ());
                 kernelContext.dimensions(globalMesh.getDims());
             }
-            if (!isComputeRangeDefined && !isLocalMeshDefined) {
-                kernelContext.lsx(0);
-                kernelContext.lsy(0);
-                kernelContext.lsz(0);
-            } else {
+            if (isComputeRangeDefined && isLocalMeshDefined) {
                 kernelContext.lsx(localMesh.getX());
                 kernelContext.lsy(localMesh.getY());
                 kernelContext.lsz(localMesh.getZ());
+            } else {
+                kernelContext.lsx(0);
+                kernelContext.lsy(0);
+                kernelContext.lsz(0);
             }
 
             args[0] = this.kernelContext;

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -26,8 +26,8 @@
 package hat.backend.ffi;
 
 import hat.ComputeRange;
-import hat.NDRange;
 import hat.ThreadMesh;
+import hat.NDRange;
 import hat.codebuilders.C99HATKernelBuilder;
 import hat.buffer.ArgArray;
 import hat.buffer.Buffer;

--- a/hat/backends/ffi/shared/src/main/native/cpp/shared.cpp
+++ b/hat/backends/ffi/shared/src/main/native/cpp/shared.cpp
@@ -375,7 +375,7 @@ long Backend::CompilationUnit::Kernel::ndrange(void *argArray) {
     }
 
     if (compilationUnit->backend->config->trace) {
-        std::cout << "kernelContext = " << kernelContext->maxX << std::endl;
+        std::cout << "kernelContext = " << kernelContext->globalMesh.maxX << std::endl;
     }
 
     // We 'double dispatch' back to the kernel to actually do the dispatch

--- a/hat/backends/ffi/shared/src/main/native/include/shared.h
+++ b/hat/backends/ffi/shared/src/main/native/include/shared.h
@@ -359,8 +359,7 @@ public:
     static void show(std::ostream &out, void *argArray);
 };
 
-
-class KernelContext {
+class ThreadMesh {
 public:
     int x;
     int maxX;
@@ -369,14 +368,13 @@ public:
     int z;
     int maxZ;
     int dimensions;
-    int lx;
-    int ly;
-    int lz;
-    int lsx;
-    int lsy;
-    int lsz;
 };
 
+class KernelContext {
+public:
+    ThreadMesh globalMesh;
+    ThreadMesh localMesh;
+};
 
 class Backend {
 public:

--- a/hat/backends/ffi/shared/src/main/native/include/shared.h
+++ b/hat/backends/ffi/shared/src/main/native/include/shared.h
@@ -369,6 +369,12 @@ public:
     int z;
     int maxZ;
     int dimensions;
+    int lx;
+    int ly;
+    int lz;
+    int lsx;
+    int lsy;
+    int lsz;
 };
 
 

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -29,7 +29,7 @@ import hat.NDRange;
 import hat.codebuilders.C99HATKernelBuilder;
 import hat.buffer.ArgArray;
 import hat.buffer.Buffer;
-import hat.buffer.KernelContext;
+import hat.buffer.KernelBufferContext;
 import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.BoundSchema;
 import hat.ifacemapper.Schema;
@@ -51,14 +51,16 @@ public abstract class C99JExtractedBackend extends JExtractedBackend {
         public final String text;
         public final long kernelHandle;
         public final ArgArray argArray;
-        public final KernelContext kernelContext;
+        public final KernelBufferContext kernelContext;
 
         public CompiledKernel(C99JExtractedBackend c99NativeBackend, KernelCallGraph kernelCallGraph, String text, long kernelHandle, Object[] ndRangeAndArgs) {
             this.c99NativeBackend = c99NativeBackend;
             this.kernelCallGraph = kernelCallGraph;
             this.text = text;
             this.kernelHandle = kernelHandle;
-            this.kernelContext = KernelContext.create(kernelCallGraph.computeContext.accelerator, 0, 0);
+            int[] empty = new int[] { 0, 0, 0 };
+            this.kernelContext = KernelBufferContext.create(kernelCallGraph.computeContext.accelerator, 0, 0, 0, 0, 0, 0, empty, empty);
+            //this.kernelContext = KernelBufferContext.create(kernelCallGraph.computeContext.accelerator, 0, 0);
             ndRangeAndArgs[0] = this.kernelContext;
             this.argArray = ArgArray.create(kernelCallGraph.computeContext.accelerator, kernelCallGraph,  ndRangeAndArgs);
         }

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -58,15 +58,13 @@ public abstract class C99JExtractedBackend extends JExtractedBackend {
             this.kernelCallGraph = kernelCallGraph;
             this.text = text;
             this.kernelHandle = kernelHandle;
-            int[] empty = new int[] { 0, 0, 0 };
-            this.kernelContext = KernelBufferContext.create(kernelCallGraph.computeContext.accelerator, 0, 0, 0, 0, 0, 0, empty, empty);
-            //this.kernelContext = KernelBufferContext.create(kernelCallGraph.computeContext.accelerator, 0, 0);
+            this.kernelContext = KernelBufferContext.createDefault(kernelCallGraph.computeContext.accelerator);
             ndRangeAndArgs[0] = this.kernelContext;
             this.argArray = ArgArray.create(kernelCallGraph.computeContext.accelerator, kernelCallGraph,  ndRangeAndArgs);
         }
 
         public void dispatch(NDRange ndRange, Object[] args) {
-            kernelContext.maxX(ndRange.kid.maxX);
+            kernelContext.globalMesh().maxX(ndRange.kid.maxX);
             args[0] = this.kernelContext;
             ArgArray.update(argArray,kernelCallGraph,  args);
          //   c99NativeBackend.ndRange(kernelHandle, this.argArray);

--- a/hat/core/src/main/java/hat/Accelerator.java
+++ b/hat/core/src/main/java/hat/Accelerator.java
@@ -213,7 +213,6 @@ public class Accelerator implements BufferAllocator, BufferTracker {
      * )
      * </pre>
      */
-
     public void compute(QuotableComputeContextConsumer quotableComputeContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableComputeContextConsumer).orElseThrow();
         LambdaOpWrapper lambda = OpWrapper.wrap(lookup,(JavaOp.LambdaOp) quoted.op());

--- a/hat/core/src/main/java/hat/Accelerator.java
+++ b/hat/core/src/main/java/hat/Accelerator.java
@@ -99,6 +99,12 @@ public class Accelerator implements BufferAllocator, BufferTracker {
         return ndRange;
     }
 
+    public NDRange range(ComputeRange computeRange) {
+        NDRange ndRange = new NDRange(this);
+        ndRange.kid = new KernelContext(ndRange, computeRange);
+        return ndRange;
+    }
+
     protected Accelerator(MethodHandles.Lookup lookup, ServiceLoader.Provider<Backend> provider) {
         this(lookup, provider.get());
     }

--- a/hat/core/src/main/java/hat/ComputeContext.java
+++ b/hat/core/src/main/java/hat/ComputeContext.java
@@ -140,13 +140,20 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
         dispatchKernelWithComputeRange(computeRange, quotableKernelContextConsumer);
     }
 
-    private void dispatchKernel(int rangeX, int rangeY, int rangeZ, int dimNumber, QuotableKernelContextConsumer quotableKernelContextConsumer) {
+    record CallGraph(Quoted quoted, LambdaOpWrapper lambdaOpWrapper, MethodRef methodRef, KernelCallGraph kernelCallGraph) {}
+
+    private CallGraph buildKernelCallGraph(QuotableKernelContextConsumer quotableKernelContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableKernelContextConsumer).orElseThrow();
         LambdaOpWrapper lambdaOpWrapper = OpWrapper.wrap(computeCallGraph.computeContext.accelerator.lookup,(JavaOp.LambdaOp) quoted.op());
         MethodRef methodRef = lambdaOpWrapper.getQuotableTargetMethodRef();
         KernelCallGraph kernelCallGraph = computeCallGraph.kernelCallGraphMap.get(methodRef);
+        return new CallGraph(quoted, lambdaOpWrapper, methodRef, kernelCallGraph);
+    }
+
+    private void dispatchKernel(int rangeX, int rangeY, int rangeZ, int dimNumber, QuotableKernelContextConsumer quotableKernelContextConsumer) {
+        CallGraph cg = buildKernelCallGraph(quotableKernelContextConsumer);
         try {
-            Object[] args = lambdaOpWrapper.getQuotableCapturedValues(quoted, kernelCallGraph.entrypoint.method);
+            Object[] args = cg.lambdaOpWrapper.getQuotableCapturedValues(cg.quoted, cg.kernelCallGraph.entrypoint.method);
             NDRange ndRange;
             switch (dimNumber) {
                 case 1 -> ndRange = accelerator.range(rangeX);
@@ -155,29 +162,27 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
                 default -> throw new RuntimeException("[Error] Unexpected dimension value: " + dimNumber + ". Allowed dimensions <1, 2, 3>");
             }
             args[0] = ndRange;
-            accelerator.backend.dispatchKernel(kernelCallGraph, ndRange, args);
+            accelerator.backend.dispatchKernel(cg.kernelCallGraph, ndRange, args);
         } catch (Throwable t) {
-            System.out.print("what?" + methodRef + " " + t);
+            System.out.print("what?" + cg.methodRef + " " + t);
             throw t;
         }
     }
 
     private void dispatchKernelWithComputeRange(ComputeRange computeRange, QuotableKernelContextConsumer quotableKernelContextConsumer) {
-        Quoted quoted = Op.ofQuotable(quotableKernelContextConsumer).orElseThrow();
-        LambdaOpWrapper lambdaOpWrapper = OpWrapper.wrap(computeCallGraph.computeContext.accelerator.lookup,(JavaOp.LambdaOp) quoted.op());
-        MethodRef methodRef = lambdaOpWrapper.getQuotableTargetMethodRef();
-        KernelCallGraph kernelCallGraph = computeCallGraph.kernelCallGraphMap.get(methodRef);
+        CallGraph cg = buildKernelCallGraph(quotableKernelContextConsumer);
         try {
-            Object[] args = lambdaOpWrapper.getQuotableCapturedValues(quoted, kernelCallGraph.entrypoint.method);
+            Object[] args = cg.lambdaOpWrapper.getQuotableCapturedValues(cg.quoted, cg.kernelCallGraph.entrypoint.method);
             NDRange ndRange = accelerator.range(computeRange);
             args[0] = ndRange;
-            accelerator.backend.dispatchKernel(kernelCallGraph, ndRange, args);
+            accelerator.backend.dispatchKernel(cg.kernelCallGraph, ndRange, args);
         } catch (Throwable t) {
-            System.out.print("what?" + methodRef + " " + t);
+            System.out.print("what?" + cg.methodRef + " " + t);
             throw t;
         }
     }
 
+    @Override
     public void preMutate(Buffer b) {
         if (accelerator.backend instanceof BufferTracker bufferTracker) {
             bufferTracker.preMutate(b);

--- a/hat/core/src/main/java/hat/ComputeRange.java
+++ b/hat/core/src/main/java/hat/ComputeRange.java
@@ -42,7 +42,7 @@ public class ComputeRange {
      * Total number of threads to run in 1D.
      * @param globalMesh {@link ThreadMesh1D}
      */
-    public ComputeRange(ThreadMesh1D globalMesh) {
+    public ComputeRange(GlobalMesh1D globalMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = null;
     }
@@ -52,7 +52,7 @@ public class ComputeRange {
      * @param globalMesh {@link ThreadMesh1D}
      * @param localMesh {@link ThreadMesh1D}
      */
-    public ComputeRange(ThreadMesh1D globalMesh, ThreadMesh1D localMesh) {
+    public ComputeRange(GlobalMesh1D globalMesh, LocalMesh1D localMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = localMesh;
     }
@@ -63,7 +63,7 @@ public class ComputeRange {
      * global mesh (total number of threads to run).
      * @param globalMesh {@link ThreadMesh2D}
      */
-    public ComputeRange(ThreadMesh2D globalMesh) {
+    public ComputeRange(GlobalMesh2D globalMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = null;
     }
@@ -74,7 +74,7 @@ public class ComputeRange {
      * @param globalMesh {@link ThreadMesh2D}
      * @param localMesh {@link ThreadMesh2D}
      */
-    public ComputeRange(ThreadMesh2D globalMesh, ThreadMesh2D localMesh) {
+    public ComputeRange(GlobalMesh2D globalMesh, LocalMesh2D localMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = localMesh;
     }
@@ -84,7 +84,7 @@ public class ComputeRange {
      * global mesh (total number of threads to run).
      * @param globalMesh {@link ThreadMesh3D}
      */
-    public ComputeRange(ThreadMesh3D globalMesh) {
+    public ComputeRange(GlobalMesh3D globalMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = null;
     }
@@ -95,7 +95,7 @@ public class ComputeRange {
      * @param globalMesh {@link ThreadMesh3D}
      * @param localMesh {@link ThreadMesh3D}
      */
-    public ComputeRange(ThreadMesh3D globalMesh, ThreadMesh3D localMesh) {
+    public ComputeRange(GlobalMesh3D globalMesh, LocalMesh3D localMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = localMesh;
     }
@@ -104,7 +104,7 @@ public class ComputeRange {
      * Factory method to run a single thread on a target accelerator. Although for some accelerators this could be
      * beneficial (e.g., FPGAs), in general, use only for debugging purposes.
      */
-    public static final ComputeRange SINGLE_THREADED = new ComputeRange(new ThreadMesh1D(1));
+    public static final ComputeRange SINGLE_THREADED = new ComputeRange(new GlobalMesh1D(1));
 
     /**
      * Obtain the total number of threads per dimension. The number of threads

--- a/hat/core/src/main/java/hat/ComputeRange.java
+++ b/hat/core/src/main/java/hat/ComputeRange.java
@@ -42,17 +42,37 @@ public class ComputeRange {
      * Total number of threads to run per dimension.
      * @param globalMesh {@link ThreadMesh}
      */
-    public ComputeRange(ThreadMesh globalMesh) {
+    public ComputeRange(ThreadMesh1D globalMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = null;
     }
 
+    public ComputeRange(ThreadMesh1D globalMesh, ThreadMesh1D localMesh) {
+        this.globalMesh = globalMesh;
+        this.localMesh = localMesh;
+    }
+
+
+    public ComputeRange(ThreadMesh2D globalMesh) {
+        this.globalMesh = globalMesh;
+        this.localMesh = null;
+    }
     /**
      * Total and local number of threads to run per dimension.
      * @param globalMesh {@link ThreadMesh}
      * @param localMesh {@link ThreadMesh}
      */
-    public ComputeRange(ThreadMesh globalMesh, ThreadMesh localMesh) {
+    public ComputeRange(ThreadMesh2D globalMesh, ThreadMesh2D localMesh) {
+        this.globalMesh = globalMesh;
+        this.localMesh = localMesh;
+    }
+
+    public ComputeRange(ThreadMesh3D globalMesh) {
+        this.globalMesh = globalMesh;
+        this.localMesh = null;
+    }
+
+    public ComputeRange(ThreadMesh3D globalMesh, ThreadMesh3D localMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = localMesh;
     }
@@ -61,7 +81,7 @@ public class ComputeRange {
      * Factory method to run a single thread on a target accelerator. Although for some accelerators this could be
      * beneficial (e.g., FPGAs), in general, use only for debugging purposes.
      */
-    public static final ComputeRange SINGLE_THREADED = new ComputeRange(new ThreadMesh(1));
+    public static final ComputeRange SINGLE_THREADED = new ComputeRange(new ThreadMesh1D(1));
 
     /**
      * Obtain the total number of threads per dimension. The number of threads

--- a/hat/core/src/main/java/hat/ComputeRange.java
+++ b/hat/core/src/main/java/hat/ComputeRange.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat;
+
+/**
+ * A compute range holds the number of threads to run on an accelerator.
+ * A compute range has two main properties:
+ * - The global number of threads: this means the total number of threads to run per dimension.
+ * This is specified by instancing a new object of type {@link ThreadMesh}.
+ * - A local group size: this is specified by instancing an object of type {@link ThreadMesh}.
+ * A local group size is optional. If it is not specified, the HAT runtime may device a default
+ * value.
+ */
+public class ComputeRange {
+
+    final private ThreadMesh globalMesh;
+    final private ThreadMesh localMesh;
+
+    /**
+     * Total number of threads to run per dimension.
+     * @param globalMesh {@link ThreadMesh}
+     */
+    public ComputeRange(ThreadMesh globalMesh) {
+        this.globalMesh = globalMesh;
+        this.localMesh = null;
+    }
+
+    /**
+     * Total and local number of threads to run per dimension.
+     * @param globalMesh {@link ThreadMesh}
+     * @param localMesh {@link ThreadMesh}
+     */
+    public ComputeRange(ThreadMesh globalMesh, ThreadMesh localMesh) {
+        this.globalMesh = globalMesh;
+        this.localMesh = localMesh;
+    }
+
+    /**
+     * Factory method to run a single thread on a target accelerator. Although for some accelerators this could be
+     * beneficial (e.g., FPGAs), in general, use only for debugging purposes.
+     */
+    public static final ComputeRange SINGLE_THREADED = new ComputeRange(new ThreadMesh(1));
+
+    /**
+     * Obtain the total number of threads per dimension. The number of threads
+     * per dimension is stored in a {@link ThreadMesh}
+     * @return {@link ThreadMesh}
+     */
+    public ThreadMesh getGlobalMesh() {
+        return globalMesh;
+    }
+
+    /**
+     * Obtain the local group size per dimension. The group size per dimension is stored
+     * in a {@link ThreadMesh}.
+     * @return {@link ThreadMesh}
+     */
+    public ThreadMesh getLocalMesh() {
+        return localMesh;
+    }
+}

--- a/hat/core/src/main/java/hat/ComputeRange.java
+++ b/hat/core/src/main/java/hat/ComputeRange.java
@@ -40,7 +40,7 @@ public class ComputeRange {
 
     /**
      * Total number of threads to run in 1D.
-     * @param globalMesh {@link ThreadMesh1D}
+     * @param globalMesh {@link GlobalMesh1D}
      */
     public ComputeRange(GlobalMesh1D globalMesh) {
         this.globalMesh = globalMesh;
@@ -49,8 +49,8 @@ public class ComputeRange {
 
     /**
      * Total number of threads to run in 1D for global and local mesh.
-     * @param globalMesh {@link ThreadMesh1D}
-     * @param localMesh {@link ThreadMesh1D}
+     * @param globalMesh {@link GlobalMesh1D}
+     * @param localMesh {@link LocalMesh1D}
      */
     public ComputeRange(GlobalMesh1D globalMesh, LocalMesh1D localMesh) {
         this.globalMesh = globalMesh;
@@ -61,7 +61,7 @@ public class ComputeRange {
     /**
      * Defines a compute range for a 2D mesh. The parameter specifies the
      * global mesh (total number of threads to run).
-     * @param globalMesh {@link ThreadMesh2D}
+     * @param globalMesh {@link GlobalMesh2D}
      */
     public ComputeRange(GlobalMesh2D globalMesh) {
         this.globalMesh = globalMesh;
@@ -71,8 +71,8 @@ public class ComputeRange {
     /**
      * Defines a compute range for a 2D mesh. The parameters specify the
      * global mesh (total number of threads to run) and the local mesh.
-     * @param globalMesh {@link ThreadMesh2D}
-     * @param localMesh {@link ThreadMesh2D}
+     * @param globalMesh {@link GlobalMesh2D}
+     * @param localMesh {@link LocalMesh2D}
      */
     public ComputeRange(GlobalMesh2D globalMesh, LocalMesh2D localMesh) {
         this.globalMesh = globalMesh;
@@ -82,7 +82,7 @@ public class ComputeRange {
     /**
      * Defines a compute range for a 3D mesh. The parameter specifies the
      * global mesh (total number of threads to run).
-     * @param globalMesh {@link ThreadMesh3D}
+     * @param globalMesh {@link GlobalMesh3D}
      */
     public ComputeRange(GlobalMesh3D globalMesh) {
         this.globalMesh = globalMesh;
@@ -92,8 +92,8 @@ public class ComputeRange {
     /**
      * Defines a compute range for a 3D mesh. The parameters specify the
      * global mesh (total number of threads to run) and the local mesh.
-     * @param globalMesh {@link ThreadMesh3D}
-     * @param localMesh {@link ThreadMesh3D}
+     * @param globalMesh {@link GlobalMesh3D}
+     * @param localMesh {@link LocalMesh3D}
      */
     public ComputeRange(GlobalMesh3D globalMesh, LocalMesh3D localMesh) {
         this.globalMesh = globalMesh;

--- a/hat/core/src/main/java/hat/ComputeRange.java
+++ b/hat/core/src/main/java/hat/ComputeRange.java
@@ -39,39 +39,62 @@ public class ComputeRange {
     final private ThreadMesh localMesh;
 
     /**
-     * Total number of threads to run per dimension.
-     * @param globalMesh {@link ThreadMesh}
+     * Total number of threads to run in 1D.
+     * @param globalMesh {@link ThreadMesh1D}
      */
     public ComputeRange(ThreadMesh1D globalMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = null;
     }
 
+    /**
+     * Total number of threads to run in 1D for global and local mesh.
+     * @param globalMesh {@link ThreadMesh1D}
+     * @param localMesh {@link ThreadMesh1D}
+     */
     public ComputeRange(ThreadMesh1D globalMesh, ThreadMesh1D localMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = localMesh;
     }
 
 
+    /**
+     * Defines a compute range for a 2D mesh. The parameter specifies the
+     * global mesh (total number of threads to run).
+     * @param globalMesh {@link ThreadMesh2D}
+     */
     public ComputeRange(ThreadMesh2D globalMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = null;
     }
+
     /**
-     * Total and local number of threads to run per dimension.
-     * @param globalMesh {@link ThreadMesh}
-     * @param localMesh {@link ThreadMesh}
+     * Defines a compute range for a 2D mesh. The parameters specify the
+     * global mesh (total number of threads to run) and the local mesh.
+     * @param globalMesh {@link ThreadMesh2D}
+     * @param localMesh {@link ThreadMesh2D}
      */
     public ComputeRange(ThreadMesh2D globalMesh, ThreadMesh2D localMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = localMesh;
     }
 
+    /**
+     * Defines a compute range for a 3D mesh. The parameter specifies the
+     * global mesh (total number of threads to run).
+     * @param globalMesh {@link ThreadMesh3D}
+     */
     public ComputeRange(ThreadMesh3D globalMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = null;
     }
 
+    /**
+     * Defines a compute range for a 3D mesh. The parameters specify the
+     * global mesh (total number of threads to run) and the local mesh.
+     * @param globalMesh {@link ThreadMesh3D}
+     * @param localMesh {@link ThreadMesh3D}
+     */
     public ComputeRange(ThreadMesh3D globalMesh, ThreadMesh3D localMesh) {
         this.globalMesh = globalMesh;
         this.localMesh = localMesh;

--- a/hat/core/src/main/java/hat/GlobalMesh1D.java
+++ b/hat/core/src/main/java/hat/GlobalMesh1D.java
@@ -24,35 +24,25 @@
  */
 package hat;
 
-/**
- * Interface that specifies the number of threads per dimension.
- * The Thread Mesh can be used to store the global number of threads,
- * local group sizes and offsets.
- */
-public interface ThreadMesh {
+public record GlobalMesh1D(int x) implements ThreadMesh {
 
-    /**
-     * Obtain the number of threads in the first dimension of the thread-mesh.
-     * @return
-     */
-    int getX();
+    @Override
+    public int getX() {
+        return x;
+    }
 
-    /**
-     * Obtain the number of threads in the second dimension of the thread-mesh.
-     * @return
-     */
-    int getY();
+    @Override
+    public int getY() {
+        return 1;
+    }
 
-    /**
-     * Obtain the number of threads in the third dimension of the thread-mesh.
-     * @return
-     */
-    int getZ();
+    @Override
+    public int getZ() {
+        return 1;
+    }
 
-    /**
-     * Return the mesh dimension. It could be 1, 2 or 3.
-     * @return int value
-     */
-    int getDims();
-
+    @Override
+    public int getDims() {
+        return 1;
+    }
 }

--- a/hat/core/src/main/java/hat/GlobalMesh2D.java
+++ b/hat/core/src/main/java/hat/GlobalMesh2D.java
@@ -24,9 +24,25 @@
  */
 package hat;
 
-public class ThreadMesh2D extends ThreadMesh{
+public record GlobalMesh2D(int x, int y) implements ThreadMesh {
 
-    public ThreadMesh2D(int x, int y) {
-        super(x, y);
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getZ() {
+        return 1;
+    }
+
+    @Override
+    public int getDims() {
+        return 2;
     }
 }

--- a/hat/core/src/main/java/hat/GlobalMesh3D.java
+++ b/hat/core/src/main/java/hat/GlobalMesh3D.java
@@ -24,35 +24,24 @@
  */
 package hat;
 
-/**
- * Interface that specifies the number of threads per dimension.
- * The Thread Mesh can be used to store the global number of threads,
- * local group sizes and offsets.
- */
-public interface ThreadMesh {
+public record GlobalMesh3D(int x, int y, int z) implements ThreadMesh {
+    @Override
+    public int getX() {
+        return x;
+    }
 
-    /**
-     * Obtain the number of threads in the first dimension of the thread-mesh.
-     * @return
-     */
-    int getX();
+    @Override
+    public int getY() {
+        return y;
+    }
 
-    /**
-     * Obtain the number of threads in the second dimension of the thread-mesh.
-     * @return
-     */
-    int getY();
+    @Override
+    public int getZ() {
+        return z;
+    }
 
-    /**
-     * Obtain the number of threads in the third dimension of the thread-mesh.
-     * @return
-     */
-    int getZ();
-
-    /**
-     * Return the mesh dimension. It could be 1, 2 or 3.
-     * @return int value
-     */
-    int getDims();
-
+    @Override
+    public int getDims() {
+        return 3;
+    }
 }

--- a/hat/core/src/main/java/hat/KernelContext.java
+++ b/hat/core/src/main/java/hat/KernelContext.java
@@ -52,6 +52,17 @@ public class KernelContext {
 
     final int dimensions;
 
+    private ComputeRange computeRange;
+
+    public KernelContext(NDRange ndRange, ComputeRange computeRange) {
+        this.ndRange = ndRange;
+        this.computeRange = computeRange;
+        this.maxX = computeRange.getGlobalMesh().getX();
+        this.maxY = computeRange.getGlobalMesh().getY();
+        this.maxZ = computeRange.getGlobalMesh().getZ();
+        this.dimensions = computeRange.getGlobalMesh().getDims();
+    }
+
     /**
      * 1D Kernel
      * @param ndRange {@link NDRange}
@@ -96,6 +107,21 @@ public class KernelContext {
 
     public int getDimensions() {
         return this.dimensions;
+    }
+
+    public ComputeRange getComputeRange() {
+        return this.computeRange;
+    }
+
+    public boolean hasComputeRange() {
+        return this.computeRange != null;
+    }
+
+    public boolean hasLocalMesh() {
+        if (hasComputeRange()) {
+            return this.computeRange.getLocalMesh() != null;
+        }
+        return false;
     }
 
 }

--- a/hat/core/src/main/java/hat/LocalMesh1D.java
+++ b/hat/core/src/main/java/hat/LocalMesh1D.java
@@ -24,9 +24,25 @@
  */
 package hat;
 
-public class ThreadMesh1D extends ThreadMesh {
+public record LocalMesh1D(int x) implements ThreadMesh {
 
-    public ThreadMesh1D(int x) {
-        super(x);
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return 1;
+    }
+
+    @Override
+    public int getZ() {
+        return 1;
+    }
+
+    @Override
+    public int getDims() {
+        return 1;
     }
 }

--- a/hat/core/src/main/java/hat/LocalMesh2D.java
+++ b/hat/core/src/main/java/hat/LocalMesh2D.java
@@ -24,9 +24,25 @@
  */
 package hat;
 
-public class ThreadMesh3D extends ThreadMesh {
+public record LocalMesh2D(int x, int y) implements ThreadMesh {
 
-    public ThreadMesh3D(int x, int y, int z) {
-        super(x, y, z);
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getZ() {
+        return 1;
+    }
+
+    @Override
+    public int getDims() {
+        return 2;
     }
 }

--- a/hat/core/src/main/java/hat/LocalMesh3D.java
+++ b/hat/core/src/main/java/hat/LocalMesh3D.java
@@ -24,35 +24,24 @@
  */
 package hat;
 
-/**
- * Interface that specifies the number of threads per dimension.
- * The Thread Mesh can be used to store the global number of threads,
- * local group sizes and offsets.
- */
-public interface ThreadMesh {
+public record LocalMesh3D(int x, int y, int z) implements ThreadMesh {
+    @Override
+    public int getX() {
+        return x;
+    }
 
-    /**
-     * Obtain the number of threads in the first dimension of the thread-mesh.
-     * @return
-     */
-    int getX();
+    @Override
+    public int getY() {
+        return y;
+    }
 
-    /**
-     * Obtain the number of threads in the second dimension of the thread-mesh.
-     * @return
-     */
-    int getY();
+    @Override
+    public int getZ() {
+        return z;
+    }
 
-    /**
-     * Obtain the number of threads in the third dimension of the thread-mesh.
-     * @return
-     */
-    int getZ();
-
-    /**
-     * Return the mesh dimension. It could be 1, 2 or 3.
-     * @return int value
-     */
-    int getDims();
-
+    @Override
+    public int getDims() {
+        return 3;
+    }
 }

--- a/hat/core/src/main/java/hat/ThreadMesh.java
+++ b/hat/core/src/main/java/hat/ThreadMesh.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat;
+
+/**
+ * Specifies the number of threads per dimension. The Thread Mesh can be used to
+ * store the global number of threads, local group sizes and offsets.
+ */
+public class ThreadMesh {
+
+    final private int x;
+    final private int y;
+    final private int z;
+    final private int dims;
+
+    /**
+     * 1D Mesh
+     * @param x
+     */
+    public ThreadMesh(int x) {
+        this.x = x;
+        this.y = 0;
+        this.z = 0;
+        this.dims = 1;
+    }
+
+    /**
+     * 2D Mesh
+     * @param x
+     * @param y
+     */
+    public ThreadMesh(int x, int y) {
+        this.x = x;
+        this.y = y;
+        this.z = 0;
+        this.dims = 2;
+    }
+
+    /**
+     * 3D Mesh of threads
+     * @param x
+     * @param y
+     * @param z
+     */
+    public ThreadMesh(int x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.dims = 3;
+    }
+
+    /**
+     * Obtain the number of threads in the first dimension of the thread-mesh.
+     * @return
+     */
+    public int getX() {
+        return x;
+    }
+
+    /**
+     * Obtain the number of threads in the second dimension of the thread-mesh.
+     * @return
+     */
+    public int getY() {
+        return y;
+    }
+
+    /**
+     * Obtain the number of threads in the third dimension of the thread-mesh.
+     * @return
+     */
+    public int getZ() {
+        return z;
+    }
+
+    /**
+     * Return the mesh dimension. It could be 1, 2 or 3.
+     * @return int value
+     */
+    public int getDims() {
+        return dims;
+    }
+}

--- a/hat/core/src/main/java/hat/ThreadMesh.java
+++ b/hat/core/src/main/java/hat/ThreadMesh.java
@@ -30,16 +30,16 @@ package hat;
  */
 public class ThreadMesh {
 
-    final private int x;
-    final private int y;
-    final private int z;
-    final private int dims;
+    final protected int x;
+    final protected int y;
+    final protected int z;
+    final protected int dims;
 
     /**
      * 1D Mesh
      * @param x
      */
-    public ThreadMesh(int x) {
+    protected ThreadMesh(int x) {
         this.x = x;
         this.y = 0;
         this.z = 0;
@@ -51,7 +51,7 @@ public class ThreadMesh {
      * @param x
      * @param y
      */
-    public ThreadMesh(int x, int y) {
+    protected ThreadMesh(int x, int y) {
         this.x = x;
         this.y = y;
         this.z = 0;
@@ -64,7 +64,7 @@ public class ThreadMesh {
      * @param y
      * @param z
      */
-    public ThreadMesh(int x, int y, int z) {
+    protected ThreadMesh(int x, int y, int z) {
         this.x = x;
         this.y = y;
         this.z = z;

--- a/hat/core/src/main/java/hat/ThreadMesh1D.java
+++ b/hat/core/src/main/java/hat/ThreadMesh1D.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat;
+
+public class ThreadMesh1D extends ThreadMesh {
+
+    public ThreadMesh1D(int x) {
+        super(x);
+    }
+}

--- a/hat/core/src/main/java/hat/ThreadMesh2D.java
+++ b/hat/core/src/main/java/hat/ThreadMesh2D.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat;
+
+public class ThreadMesh2D extends ThreadMesh{
+
+    public ThreadMesh2D(int x, int y) {
+        super(x, y);
+    }
+}

--- a/hat/core/src/main/java/hat/ThreadMesh3D.java
+++ b/hat/core/src/main/java/hat/ThreadMesh3D.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat;
+
+public class ThreadMesh3D extends ThreadMesh {
+
+    public ThreadMesh3D(int x, int y, int z) {
+        super(x, y, z);
+    }
+}

--- a/hat/core/src/main/java/hat/buffer/KernelBufferContext.java
+++ b/hat/core/src/main/java/hat/buffer/KernelBufferContext.java
@@ -28,80 +28,54 @@ import hat.Accelerator;
 import hat.ifacemapper.Schema;
 
 public interface KernelBufferContext extends Buffer {
-    int x();
-    void x(int x);
 
-    int y();
-    void y(int y);
+    interface MeshBuffer extends Struct {
+        int x();
+        void x(int x);
 
-    int z();
-    void z(int z);
+        int y();
+        void y(int y);
 
-    int maxX();
-    void maxX(int maxX);
+        int z();
+        void z(int z);
 
-    int maxY();
-    void maxY(int maxY);
+        int maxX();
+        void maxX(int maxX);
 
-    int maxZ();
-    void maxZ(int maxZ);
+        int maxY();
+        void maxY(int maxY);
 
-    int dimensions();
-    void dimensions(int numDimensions);
+        int maxZ();
+        void maxZ(int maxZ);
 
-    int lx();
-    void lx(int lx);
-    int ly();
-    void ly(int ly);
-    int lz();
-    void lz(int lz);
-
-    int lsx();
-    void lsx(int lsx);
-    int lsy();
-    void lsy(int lsy);
-    int lsz();
-    void lsz(int lsz);
-
-    // Important part here! do not forget the new fields.
-
-    Schema<KernelBufferContext> schema = Schema.of(KernelBufferContext.class,
-            s -> s.fields(
-                    "x","maxX", "y", "maxY", "z", "maxZ",
-                    "dimensions",
-                    "lx", "ly", "lz", "lsx",  "lsy", "lsz"));
-
-    static KernelBufferContext create(Accelerator accelerator, int x, int maxX) {
-        KernelBufferContext kernelContext =  schema.allocate(accelerator);
-        kernelContext.x(x);
-        kernelContext.maxX(maxX);
-        kernelContext.dimensions(1);
-        return kernelContext;
+        int dimensions();
+        void dimensions(int numDimensions);
     }
 
-    static KernelBufferContext create(Accelerator accelerator, int x, int y, int z, int maxX, int maxY, int maxZ, int[] locals, int[] sizeLocals) {
-        KernelBufferContext kernelBufferContext =  schema.allocate(accelerator);
+    MeshBuffer globalMesh();
 
-        kernelBufferContext.x(x);
-        kernelBufferContext.y(y);
-        kernelBufferContext.z(z);
-        kernelBufferContext.maxX(maxX);
-        kernelBufferContext.maxY(maxY);
-        kernelBufferContext.maxZ(maxZ);
-        kernelBufferContext.dimensions(3);
+    MeshBuffer localMesh();
 
-        if (locals != null) {
-            kernelBufferContext.lsx(locals[0]);
-            kernelBufferContext.lsy(locals[1]);
-            kernelBufferContext.lsz(locals[2]);
-        }
+    Schema<KernelBufferContext> schemaKernelBufferContext = Schema.of(KernelBufferContext.class,
+            kernelBufferContext -> kernelBufferContext
+                    .field("globalMesh", f -> f.fields("x","maxX", "y", "maxY", "z", "maxZ", "dimensions"))
+                    .field("localMesh", f -> f.fields("x","maxX", "y", "maxY", "z", "maxZ", "dimensions"))
+            );
 
-        if (sizeLocals != null) {
-            kernelBufferContext.lsx(sizeLocals[0]);
-            kernelBufferContext.lsy(sizeLocals[1]);
-            kernelBufferContext.lsz(sizeLocals[2]);
-        }
+    private static void setDefaultMesh(MeshBuffer meshBuffer) {
+        meshBuffer.x(0);
+        meshBuffer.maxX(0);
+        meshBuffer.y(0);
+        meshBuffer.maxY(0);
+        meshBuffer.z(0);
+        meshBuffer.maxZ(0);
+        meshBuffer.dimensions(3);
+    }
+
+    static KernelBufferContext createDefault(Accelerator accelerator) {
+        KernelBufferContext kernelBufferContext =  schemaKernelBufferContext.allocate(accelerator);
+        setDefaultMesh(kernelBufferContext.globalMesh());
+        setDefaultMesh(kernelBufferContext.localMesh());
         return kernelBufferContext;
     }
-
 }

--- a/hat/core/src/main/java/hat/buffer/KernelBufferContext.java
+++ b/hat/core/src/main/java/hat/buffer/KernelBufferContext.java
@@ -27,7 +27,7 @@ package hat.buffer;
 import hat.Accelerator;
 import hat.ifacemapper.Schema;
 
-public interface KernelContext extends Buffer {
+public interface KernelBufferContext extends Buffer {
     int x();
     void x(int x);
 
@@ -49,27 +49,59 @@ public interface KernelContext extends Buffer {
     int dimensions();
     void dimensions(int numDimensions);
 
-    // Important part here! do not forget the new fields.
-    Schema<KernelContext> schema = Schema.of(KernelContext.class, s->s.fields("x","maxX", "y", "maxY", "z", "maxZ", "dimensions"));
+    int lx();
+    void lx(int lx);
+    int ly();
+    void ly(int ly);
+    int lz();
+    void lz(int lz);
 
-    static KernelContext create(Accelerator accelerator, int x, int maxX) {
-        KernelContext kernelContext =  schema.allocate(accelerator);
+    int lsx();
+    void lsx(int lsx);
+    int lsy();
+    void lsy(int lsy);
+    int lsz();
+    void lsz(int lsz);
+
+    // Important part here! do not forget the new fields.
+
+    Schema<KernelBufferContext> schema = Schema.of(KernelBufferContext.class,
+            s -> s.fields(
+                    "x","maxX", "y", "maxY", "z", "maxZ",
+                    "dimensions",
+                    "lx", "ly", "lz", "lsx",  "lsy", "lsz"));
+
+    static KernelBufferContext create(Accelerator accelerator, int x, int maxX) {
+        KernelBufferContext kernelContext =  schema.allocate(accelerator);
         kernelContext.x(x);
         kernelContext.maxX(maxX);
         kernelContext.dimensions(1);
         return kernelContext;
     }
 
-    static KernelContext create(Accelerator accelerator, int x, int y, int z, int maxX, int maxY, int maxZ) {
-        KernelContext kernelContext =  schema.allocate(accelerator);
-        kernelContext.x(x);
-        kernelContext.y(y);
-        kernelContext.z(z);
-        kernelContext.maxX(maxX);
-        kernelContext.maxY(maxY);
-        kernelContext.maxZ(maxZ);
-        kernelContext.dimensions(3);
-        return kernelContext;
+    static KernelBufferContext create(Accelerator accelerator, int x, int y, int z, int maxX, int maxY, int maxZ, int[] locals, int[] sizeLocals) {
+        KernelBufferContext kernelBufferContext =  schema.allocate(accelerator);
+
+        kernelBufferContext.x(x);
+        kernelBufferContext.y(y);
+        kernelBufferContext.z(z);
+        kernelBufferContext.maxX(maxX);
+        kernelBufferContext.maxY(maxY);
+        kernelBufferContext.maxZ(maxZ);
+        kernelBufferContext.dimensions(3);
+
+        if (locals != null) {
+            kernelBufferContext.lsx(locals[0]);
+            kernelBufferContext.lsy(locals[1]);
+            kernelBufferContext.lsz(locals[2]);
+        }
+
+        if (sizeLocals != null) {
+            kernelBufferContext.lsx(sizeLocals[0]);
+            kernelBufferContext.lsy(sizeLocals[1]);
+            kernelBufferContext.lsz(sizeLocals[2]);
+        }
+        return kernelBufferContext;
     }
 
 }

--- a/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -26,7 +26,7 @@ package hat.optools;
 
 import hat.ComputeContext;
 import hat.buffer.Buffer;
-import hat.buffer.KernelContext;
+import hat.buffer.KernelBufferContext;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -60,12 +60,12 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     public boolean isRawKernelCall() {
         return (operandCount() > 1 && operandNAsValue(0) instanceof Value value
                 && value.type() instanceof JavaType javaType
-                && (isAssignable(javaType, hat.KernelContext.class) || isAssignable(javaType, KernelContext.class))
+                && (isAssignable(javaType, hat.KernelContext.class) || isAssignable(javaType, KernelBufferContext.class))
         );
     }
 
     public boolean isKernelContextMethod() {
-        return isAssignable(javaRefType(), KernelContext.class);
+        return isAssignable(javaRefType(), KernelBufferContext.class);
 
     }
 

--- a/hat/examples/matmul/src/main/java/matmul/Main.java
+++ b/hat/examples/matmul/src/main/java/matmul/Main.java
@@ -29,6 +29,9 @@ import hat.ComputeContext;
 import hat.ComputeRange;
 import hat.KernelContext;
 import hat.ThreadMesh;
+import hat.ThreadMesh1D;
+import hat.ThreadMesh2D;
+import hat.ThreadMesh3D;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 
@@ -130,7 +133,7 @@ public class Main {
 
     @CodeReflection
     public static void matrixMultiply1D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new ThreadMesh(globalSize));
+        ComputeRange computeRange = new ComputeRange(new ThreadMesh1D(globalSize));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel1D(kc, matrixA, matrixB, matrixC, globalSize)
         );
@@ -138,7 +141,7 @@ public class Main {
 
     @CodeReflection
     public static void matrixMultiply2D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new ThreadMesh(globalSize, globalSize), new ThreadMesh(16, 16));
+        ComputeRange computeRange = new ComputeRange(new ThreadMesh2D(globalSize, globalSize), new ThreadMesh2D(16, 16));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel2D(kc, matrixA, matrixB, matrixC, globalSize)
         );
@@ -146,7 +149,7 @@ public class Main {
 
     @CodeReflection
     public static void matrixMultiply2DLI(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new ThreadMesh(globalSize, globalSize), new ThreadMesh(16, 16));
+        ComputeRange computeRange = new ComputeRange(new ThreadMesh2D(globalSize, globalSize), new ThreadMesh2D(16, 16));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel2DLI(kc, matrixA, matrixB, matrixC, globalSize)
         );

--- a/hat/examples/matmul/src/main/java/matmul/Main.java
+++ b/hat/examples/matmul/src/main/java/matmul/Main.java
@@ -27,11 +27,10 @@ package matmul;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.ComputeRange;
+import hat.GlobalMesh1D;
+import hat.GlobalMesh2D;
 import hat.KernelContext;
-import hat.ThreadMesh;
-import hat.ThreadMesh1D;
-import hat.ThreadMesh2D;
-import hat.ThreadMesh3D;
+import hat.LocalMesh2D;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 
@@ -133,7 +132,7 @@ public class Main {
 
     @CodeReflection
     public static void matrixMultiply1D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new ThreadMesh1D(globalSize));
+        ComputeRange computeRange = new ComputeRange(new GlobalMesh1D(globalSize));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel1D(kc, matrixA, matrixB, matrixC, globalSize)
         );
@@ -141,7 +140,7 @@ public class Main {
 
     @CodeReflection
     public static void matrixMultiply2D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new ThreadMesh2D(globalSize, globalSize), new ThreadMesh2D(16, 16));
+        ComputeRange computeRange = new ComputeRange(new GlobalMesh2D(globalSize, globalSize), new LocalMesh2D(16, 16));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel2D(kc, matrixA, matrixB, matrixC, globalSize)
         );
@@ -149,7 +148,7 @@ public class Main {
 
     @CodeReflection
     public static void matrixMultiply2DLI(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new ThreadMesh2D(globalSize, globalSize), new ThreadMesh2D(16, 16));
+        ComputeRange computeRange = new ComputeRange(new GlobalMesh2D(globalSize, globalSize), new LocalMesh2D(16, 16));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel2DLI(kc, matrixA, matrixB, matrixC, globalSize)
         );

--- a/hat/examples/matmul/src/main/java/matmul/Main.java
+++ b/hat/examples/matmul/src/main/java/matmul/Main.java
@@ -26,7 +26,9 @@ package matmul;
 
 import hat.Accelerator;
 import hat.ComputeContext;
+import hat.ComputeRange;
 import hat.KernelContext;
+import hat.ThreadMesh;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 
@@ -127,23 +129,26 @@ public class Main {
     }
 
     @CodeReflection
-    public static void matrixMultiply1D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int size) {
-        cc.dispatchKernel(size,
-                kc -> matrixMultiplyKernel1D(kc, matrixA, matrixB, matrixC, size)
+    public static void matrixMultiply1D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
+        ComputeRange computeRange = new ComputeRange(new ThreadMesh(globalSize));
+        cc.dispatchKernel(computeRange,
+                kc -> matrixMultiplyKernel1D(kc, matrixA, matrixB, matrixC, globalSize)
         );
     }
 
     @CodeReflection
-    public static void matrixMultiply2D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int size) {
-        cc.dispatchKernel(size, size,
-                kc -> matrixMultiplyKernel2D(kc, matrixA, matrixB, matrixC, size)
+    public static void matrixMultiply2D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
+        ComputeRange computeRange = new ComputeRange(new ThreadMesh(globalSize, globalSize), new ThreadMesh(16, 16));
+        cc.dispatchKernel(computeRange,
+                kc -> matrixMultiplyKernel2D(kc, matrixA, matrixB, matrixC, globalSize)
         );
     }
 
     @CodeReflection
-    public static void matrixMultiply2DLI(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int size) {
-        cc.dispatchKernel(size, size,
-                kc -> matrixMultiplyKernel2DLI(kc, matrixA, matrixB, matrixC, size)
+    public static void matrixMultiply2DLI(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
+        ComputeRange computeRange = new ComputeRange(new ThreadMesh(globalSize, globalSize), new ThreadMesh(16, 16));
+        cc.dispatchKernel(computeRange,
+                kc -> matrixMultiplyKernel2DLI(kc, matrixA, matrixB, matrixC, globalSize)
         );
     }
 

--- a/hat/examples/matmul/src/main/java/matmul/Main.java
+++ b/hat/examples/matmul/src/main/java/matmul/Main.java
@@ -138,9 +138,11 @@ public class Main {
         );
     }
 
+    final static int BLOCK_SIZE = 16;
+
     @CodeReflection
     public static void matrixMultiply2D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new GlobalMesh2D(globalSize, globalSize), new LocalMesh2D(16, 16));
+        ComputeRange computeRange = new ComputeRange(new GlobalMesh2D(globalSize, globalSize), new LocalMesh2D(BLOCK_SIZE, BLOCK_SIZE));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel2D(kc, matrixA, matrixB, matrixC, globalSize)
         );
@@ -148,7 +150,7 @@ public class Main {
 
     @CodeReflection
     public static void matrixMultiply2DLI(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int globalSize) {
-        ComputeRange computeRange = new ComputeRange(new GlobalMesh2D(globalSize, globalSize), new LocalMesh2D(16, 16));
+        ComputeRange computeRange = new ComputeRange(new GlobalMesh2D(globalSize, globalSize), new LocalMesh2D(BLOCK_SIZE, BLOCK_SIZE));
         cc.dispatchKernel(computeRange,
                 kc -> matrixMultiplyKernel2DLI(kc, matrixA, matrixB, matrixC, globalSize)
         );


### PR DESCRIPTION
This PR proposes an extension of the HAT API to leverage 1D, 2D and 3D ranges for the compute context dispatch. 
A `ComputeRange` is an entity that holds global and local thread mesh. In the future, we can add offsets to it. 

Each `ThreadMesh` is a triplet representing the number of threads for x,y, and z dimensions. 

How to dispatch 1D kernels?

```java
ComputeRange range1D = new ComputeRange(new GlobalMesh1D(size));
cc.dispatchKernel(range1D,
                kc -> myKernel(...));
```

How to dispatch 2D kernels?

```java
ComputeRange range2D = new ComputeRange(new GlobalMesh2D(size, size));
cc.dispatchKernel(range2D,
                kc -> my2DKernel(...));
```

How to enable local mesh? 

We pass a second parameter to the ComputeRange constructor to define local mesh. If it is not passed, then it is `null` and the HAT runtime can select a default set of values. 

```java
ComputeRange computeRange = new ComputeRange(
        new GlobalMesh2D(globalSize, globalSize), 
        new LocalMesh2D(16, 16));
cc.dispatchKernel(computeRange,
                kc -> matrixMultiplyKernel2D(kc, matrixA, matrixB, matrixC, globalSize)
        );
```

In addition, this PR renames the `KernelContext` internal API to map the context ndrange object to native memory to `KernelBufferContext`.


#### How to check? 

```java
java @hat/run ffi-opencl matmul 1D
java @hat/run ffi-opencl matmul 2D

java @hat/run ffi-cuda matmul 1D
java @hat/run ffi-cuda matmul 2D
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/516/head:pull/516` \
`$ git checkout pull/516`

Update a local copy of the PR: \
`$ git checkout pull/516` \
`$ git pull https://git.openjdk.org/babylon.git pull/516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 516`

View PR using the GUI difftool: \
`$ git pr show -t 516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/516.diff">https://git.openjdk.org/babylon/pull/516.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/516#issuecomment-3174019498)
</details>
