### PR TITLE
ModuleOp support for HAT CallGraph

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -410,11 +410,20 @@ public class CudaBackend extends C99FFIBackend {
         builder.ptxHeader(major, minor, target, addressSize);
         out.append(builder.getTextAndReset());
 
-        for (KernelCallGraph.KernelReachableResolvedMethodCall k : kernelCallGraph.kernelReachableResolvedStream().toList()) {
-            FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,k.funcOpWrapper().op());
-            FuncOpWrapper loweredFunc = calledFunc.lower();
-            loweredFunc = transformPTXPtrs(loweredFunc, argsMap, usedMathFns);
-            invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
+        if (Boolean.getBoolean("moduleOp")) {
+            kernelCallGraph.moduleOpWrapper.functionTable().forEach((_, funcOp) -> {
+                FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,funcOp);
+                FuncOpWrapper loweredFunc = calledFunc.lower();
+                loweredFunc = transformPTXPtrs(loweredFunc, argsMap, usedMathFns);
+                invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
+            });
+        } else {
+            for (KernelCallGraph.KernelReachableResolvedMethodCall k : kernelCallGraph.kernelReachableResolvedStream().toList()) {
+                FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,k.funcOpWrapper().op());
+                FuncOpWrapper loweredFunc = calledFunc.lower();
+                loweredFunc = transformPTXPtrs(loweredFunc, argsMap, usedMathFns);
+                invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
+            }
         }
 
         lowered = transformPTXPtrs(lowered, argsMap, usedMathFns);

--- a/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
+++ b/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
@@ -59,8 +59,14 @@ public class MockBackend extends FFIBackend {
         // Here we receive a callgraph from the kernel entrypoint
         // The first time we see this we need to convert the kernel entrypoint
         // and rechable methods to a form that our mock backend can execute.
-        kernelCallGraph.kernelReachableResolvedStream().forEach(kr -> {
+        if (Boolean.getBoolean("moduleOp")) {
+            kernelCallGraph.moduleOpWrapper.functionTable().forEach((_, funcOp) -> {
 
-        });
+            });
+        } else {
+            kernelCallGraph.kernelReachableResolvedStream().forEach(kr -> {
+
+            });
+        }
     }
 }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -35,6 +35,7 @@ import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.BoundSchema;
 import hat.ifacemapper.BufferState;
 import hat.ifacemapper.Schema;
+import hat.optools.FuncOpWrapper;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -99,8 +100,13 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
                 });
 
         // Sorting by rank ensures we don't need forward declarations
-        kernelCallGraph.kernelReachableResolvedStream().sorted((lhs, rhs) -> rhs.rank - lhs.rank)
-                .forEach(kernelReachableResolvedMethod -> builder.nl().kernelMethod(kernelReachableResolvedMethod).nl());
+        if (Boolean.getBoolean("moduleOp")) {
+            kernelCallGraph.moduleOpWrapper.functionTable()
+                    .forEach((_, funcOp) -> builder.nl().kernelMethod(new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup, funcOp)).nl());
+        } else {
+            kernelCallGraph.kernelReachableResolvedStream().sorted((lhs, rhs) -> rhs.rank - lhs.rank)
+                    .forEach(kernelReachableResolvedMethod -> builder.nl().kernelMethod(kernelReachableResolvedMethod).nl());
+        }
 
         builder.nl().kernelEntrypoint(kernelCallGraph.entrypoint, args).nl();
 

--- a/hat/core/src/main/java/hat/callgraph/CallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/CallGraph.java
@@ -26,6 +26,9 @@ package hat.callgraph;
 
 import hat.ComputeContext;
 import hat.optools.FuncOpWrapper;
+import hat.optools.InvokeOpWrapper;
+import hat.optools.ModuleOpWrapper;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 
 import java.lang.annotation.Annotation;
@@ -41,10 +44,13 @@ public abstract class CallGraph<E extends Entrypoint> {
     public final E entrypoint;
     public final Set<MethodCall> calls = new HashSet<>();
     public final Map<MethodRef, MethodCall> methodRefToMethodCallMap = new LinkedHashMap<>();
+    public ModuleOpWrapper moduleOpWrapper;
 
     public Stream<MethodCall> callStream() {
         return methodRefToMethodCallMap.values().stream();
     }
+
+    public abstract boolean filterCalls(CoreOp.FuncOp f, InvokeOpWrapper invokeOpWrapper, Method method, MethodRef methodRef, Class<?> javaRefTypeClass);
 
     public interface Resolved {
         FuncOpWrapper funcOpWrapper();

--- a/hat/core/src/main/java/hat/optools/ModuleOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/ModuleOpWrapper.java
@@ -26,40 +26,34 @@ package hat.optools;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
-import jdk.incubator.code.CopyContext;
+
+import hat.callgraph.CallGraph;
 import jdk.incubator.code.Op;
-import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.MethodRef;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Optional;
+
+import java.util.*;
 
 public class ModuleOpWrapper extends OpWrapper<CoreOp.ModuleOp> {
-    ModuleOpWrapper(MethodHandles.Lookup lookup, CoreOp.ModuleOp op) {
+    public ModuleOpWrapper(MethodHandles.Lookup lookup, CoreOp.ModuleOp op) {
         super(lookup,op);
     }
 
-    record MethodRefToEntryFuncOpCall(MethodRef methodRef, CoreOp.FuncOp funcOp) {
+    public SequencedMap<String, CoreOp.FuncOp> functionTable() {
+        return op().functionTable();
     }
 
-    record Closure(Deque<MethodRefToEntryFuncOpCall> work, LinkedHashSet<MethodRef> funcsVisited,
-                   List<CoreOp.FuncOp> moduleFuncOps) {
-    }
+//    public static ModuleOpWrapper createTransitiveInvokeModule(MethodHandles.Lookup lookup,
+//                                                               CallGraph.ResolvedMethodCall resolvedMethodCall) {
+//        Optional<CoreOp.FuncOp> codeModel = Op.ofMethod(entryPoint);
+//        if (codeModel.isPresent()) {
+//            return OpWrapper.wrap(lookup, createTransitiveInvokeModule(lookup, resolvedMethodCall.targetMethodRef, resolvedMethodCall.funcOpWrapper()));
+//        } else {
+//            return OpWrapper.wrap(lookup, CoreOp.module(List.of()));
+//        }
+//    }
 
-    public  ModuleOpWrapper createTransitiveInvokeModule(
-                                                               Method entryPoint) {
-        Optional<CoreOp.FuncOp> codeModel = Op.ofMethod(entryPoint);
-        if (codeModel.isPresent()) {
-            return OpWrapper.wrap(lookup, createTransitiveInvokeModule( MethodRef.method(entryPoint), codeModel.get()));
-        } else {
-            return OpWrapper.wrap(lookup, CoreOp.module(List.of()));
-        }
-    }
    /*  Method resolveToMethod(MethodHandles.Lookup lookup, MethodRef invokedMethodRef){
         Method invokedMethod = null;
         try {
@@ -70,44 +64,62 @@ public class ModuleOpWrapper extends OpWrapper<CoreOp.ModuleOp> {
         return invokedMethod;
     } */
 
-    CoreOp.ModuleOp createTransitiveInvokeModule(
-                                                        MethodRef methodRef, CoreOp.FuncOp entryFuncOp) {
-        Closure closure = new Closure(new ArrayDeque<>(), new LinkedHashSet<>(), new ArrayList<>());
-        closure.work.push(new MethodRefToEntryFuncOpCall(methodRef, entryFuncOp));
-        while (!closure.work.isEmpty()) {
-            MethodRefToEntryFuncOpCall methodRefToEntryFuncOpCall = closure.work.pop();
-            if (closure.funcsVisited.add(methodRefToEntryFuncOpCall.methodRef)) {
-                CoreOp.FuncOp tf = methodRefToEntryFuncOpCall.funcOp.transform(
-                        methodRefToEntryFuncOpCall.methodRef.toString(), (blockBuilder, op) -> {
-                            if (op instanceof JavaOp.InvokeOp invokeOp && OpWrapper.wrap(lookup, invokeOp) instanceof InvokeOpWrapper invokeOpWrapper) {
-                                Method invokedMethod = invokeOpWrapper.method();
-                                Optional<CoreOp.FuncOp> optionalInvokedFuncOp = Op.ofMethod(invokedMethod);
-                                if (optionalInvokedFuncOp.isPresent() && OpWrapper.wrap(lookup, optionalInvokedFuncOp.get()) instanceof FuncOpWrapper funcOpWrapper) {
-                                    MethodRefToEntryFuncOpCall call =
-                                            new MethodRefToEntryFuncOpCall(invokeOpWrapper.methodRef(), funcOpWrapper.op());
-                                    closure.work.push(call);
-                                    CopyContext copyContext = blockBuilder.context();
-                                    List<Value> operands = copyContext.getValues(invokeOp.operands());
-                                    CoreOp.FuncCallOp replacementCall = CoreOp.funcCall(
-                                            call.methodRef.toString(),
-                                            call.funcOp.invokableType(),
-                                            operands);
-                                    Op.Result replacementResult = blockBuilder.op(replacementCall);
-                                    copyContext.mapValue(invokeOp.result(), replacementResult);
-                                    // System.out.println("replaced " + call);
-                                } else {
-                                    // System.out.println("We have no code model for " + invokeOpWrapper.methodRef());
-                                    blockBuilder.op(invokeOp);
-                                }
-                            } else {
-                                blockBuilder.op(op);
-                            }
-                            return blockBuilder;
-                        });
-                closure.moduleFuncOps.add(tf);
+    public static CoreOp.ModuleOp createTransitiveInvokeModule(MethodHandles.Lookup l,
+                                                        FuncOpWrapper entry, CallGraph<?> callGraph) {
+        LinkedHashSet<MethodRef> funcsVisited = new LinkedHashSet<>();
+        List<CoreOp.FuncOp> funcs = new ArrayList<>();
+        record RefAndFunc(MethodRef r, FuncOpWrapper f) {}
+
+        Deque<RefAndFunc> work = new ArrayDeque<>();
+
+        entry.selectCalls((invokeOpWrapper) -> {
+            MethodRef methodRef = invokeOpWrapper.methodRef();
+            Method method = null;
+            Class<?> javaRefTypeClass = invokeOpWrapper.javaRefClass().orElseThrow();
+            try {
+                method = methodRef.resolveToMethod(l, invokeOpWrapper.op().invokeKind());
+            } catch (ReflectiveOperationException _) {}
+            Optional<CoreOp.FuncOp> f = Op.ofMethod(method);
+            if (f.isPresent() && !callGraph.filterCalls(f.get(), invokeOpWrapper, method, methodRef, javaRefTypeClass)) {
+                work.push(new RefAndFunc(methodRef, new FuncOpWrapper(l, f.get())));
             }
+        });
+
+        while (!work.isEmpty()) {
+            RefAndFunc rf = work.pop();
+            if (!funcsVisited.add(rf.r)) {
+                continue;
+            }
+
+            CoreOp.FuncOp tf = rf.f.transform(rf.r.name(), (blockBuilder, op) -> {
+                if (op instanceof JavaOp.InvokeOp iop) {
+                    InvokeOpWrapper iopWrapper = OpWrapper.wrap(entry.lookup, iop);
+                    MethodRef methodRef = iopWrapper.methodRef();
+                    Method invokeOpCalledMethod = null;
+                    try {
+                        invokeOpCalledMethod = methodRef.resolveToMethod(l, iop.invokeKind());
+                    } catch (ReflectiveOperationException _) {}
+                    if (invokeOpCalledMethod instanceof Method m) {
+                        Optional<CoreOp.FuncOp> f = Op.ofMethod(m);
+                        if (f.isPresent()) {
+                            RefAndFunc call = new RefAndFunc(methodRef, new FuncOpWrapper(l, f.get()));
+                            work.push(call);
+
+                            Op.Result result = blockBuilder.op(CoreOp.funcCall(
+                                    call.r.name(),
+                                    call.f.op().invokableType(),
+                                    blockBuilder.context().getValues(iop.operands())));
+                            blockBuilder.context().mapValue(op.result(), result);
+                            return blockBuilder;
+                        }
+                    }
+                }
+                blockBuilder.op(op);
+                return blockBuilder;
+            });
+            funcs.addFirst(tf);
         }
 
-        return CoreOp.module(closure.moduleFuncOps);
+        return CoreOp.module(funcs);
     }
 }

--- a/hat/hat/Script.java
+++ b/hat/hat/Script.java
@@ -1284,6 +1284,7 @@ public class Script {
         public StringList args = new StringList();
         public StringList nativeAccessModules = new StringList();
         private boolean headless;
+        public boolean moduleOp;
 
 
         public JavaBuilder enable_native_access(String module) {
@@ -1342,6 +1343,10 @@ public class Script {
         public void headless() {
             this.headless = true;
         }
+
+        public void moduleOp() {
+            this.moduleOp = true;
+        }
     }
 
     public static final class JavaResult extends Result<JavaBuilder> {
@@ -1372,6 +1377,9 @@ public class Script {
         }
         if (javaBuilder.headless) {
             result.opts.add("-Dheadless=true");
+        }
+        if (javaBuilder.moduleOp) {
+            result.opts.add("-DmoduleOp=true");
         }
         if (javaBuilder.startOnFirstThread) {
             result.opts.add("-XstartOnFirstThread");

--- a/hat/hat/run.java
+++ b/hat/hat/run.java
@@ -28,6 +28,7 @@ import static java.lang.IO.println;
 
 class Config{
      boolean headless=false;
+     boolean moduleOp = false;
      boolean verbose = false;
      boolean startOnFirstThread = false;
      boolean justShowCommandline = false;
@@ -71,6 +72,7 @@ class Config{
             }else{
                 switch (args[arg]) {
                    case "headless" -> headless = true;
+                   case "moduleOp" -> moduleOp = true;
                    case "verbose" -> verbose = true;
                    case "justShowCommandLine" -> justShowCommandline = true;
                    case "startOnFirstThread" -> startOnFirstThread = true;
@@ -170,6 +172,7 @@ void main(String[] argv) {
               }
               default -> {}
           }
+          if (config.moduleOp) System.out.println("Currently using ModuleOp config for CallGraphs");
       }
       Script.java(java -> java
               .enable_preview()
@@ -177,6 +180,7 @@ void main(String[] argv) {
               .enable_native_access("ALL-UNNAMED")
               .library_path(buildDir)
               .when(config.headless, Script.JavaBuilder::headless)
+              .when(config.moduleOp, Script.JavaBuilder::moduleOp)
               .when(config.startOnFirstThread, Script.JavaBuilder::start_on_first_thread)
               .class_path(config.classpath)
               .vmargs(config.vmargs)


### PR DESCRIPTION
Add an option to use `ModuleOp` when generating `KernelCallGraph` and `ComputeCallGraph` for HAT. 

To use, pass `moduleOp` as an arg to the `hat/run.java` script when running a HAT example. For example, running the `mandel` example with the `ffi-opencl` backend and `moduleOp` enabled can be done with 
```
java @hat/run moduleOp ffi-opencl squares
```
Adding `moduleOp` sets `-DmoduleOp=true` and passes it to the backend, which uses the flag to choose between the original `CallGraph` implementation and the new `moduleOp` implementation.

`ModuleOpWrapper` now contains `createTransitiveInvokeModule()`, which creates a `ModuleOp` representing a call graph when given an entrypoint. This method is called in `KernelCallGraph` and `ComputeCallGraph` to generate their respective call graphs. The kernel and compute call graph classes also maintain a map of buffer accesses, along with structures storing other useful methods.

The `C99FFIBackend`, `CudaBackend`, `MockBackend`, and `C99HATKernelBuilder` access call graphs structures differently depending on the `moduleOp` flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/517/head:pull/517` \
`$ git checkout pull/517`

Update a local copy of the PR: \
`$ git checkout pull/517` \
`$ git pull https://git.openjdk.org/babylon.git pull/517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 517`

View PR using the GUI difftool: \
`$ git pr show -t 517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/517.diff">https://git.openjdk.org/babylon/pull/517.diff</a>

</details>
