### PR TITLE
[fix][hat] Codegen fixed when passing the kernel context to multiple invoke functions

### DIFF
--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -25,6 +25,7 @@
 package hat.codebuilders;
 
 
+import hat.KernelContext;
 import hat.NDRange;
 import hat.buffer.Buffer;
 import hat.callgraph.KernelCallGraph;
@@ -36,6 +37,7 @@ import hat.util.StreamCounter;
 import jdk.incubator.code.dialect.java.ClassType;
 import jdk.incubator.code.dialect.java.JavaType;
 
+import javax.annotation.processing.SupportedSourceVersion;
 import java.lang.foreign.GroupLayout;
 
 import java.util.function.Consumer;
@@ -116,7 +118,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     public abstract T globalPtrPrefix();
 
     @Override
-    public T type(CodeBuilderContext buildContext,JavaType javaType) {
+    public T type(CodeBuilderContext buildContext, JavaType javaType) {
         if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup(),javaType) && javaType instanceof ClassType classType) {
             globalPtrPrefix().space();
             String name = classType.toClassName();
@@ -128,7 +130,14 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
             }
             suffix_t(name).asterisk();
         } else {
-            typeName(javaType.toString());
+            // In the case we call a new invoke method and pass the kernel context around, t
+            // then we need to do the mapping between the Java type and its low level interface
+            String kernelContextFullClassName = KernelContext.class.getCanonicalName();
+            if (javaType.toString().equals(kernelContextFullClassName)) {
+                typeName("KernelContext_t *");
+            } else {
+                typeName(javaType.toString());
+            }
         }
 
         return self();

--- a/hat/examples/matmul/src/main/java/matmul/Main.java
+++ b/hat/examples/matmul/src/main/java/matmul/Main.java
@@ -104,6 +104,15 @@ public class Main {
         }
     }
 
+    @CodeReflection
+    public static float compute(@RO KernelContext kc, @RO F32Array matrixA, @RO F32Array matrixB, int size, int j) {
+        float acc = 0;
+        for (int k = 0; k < size; k++) {
+            acc += (matrixA.array(kc.x * size + k) * matrixB.array(k * size + j));
+        }
+        return acc;
+    }
+
     /**
      * Naive Matrix Multiplication implemented in 1D.
      *
@@ -126,10 +135,30 @@ public class Main {
         }
     }
 
+    /**
+     * 1D Matrix Multiply with function calls passing the kernel context ID. This is just for testing purposes.
+     */
+    @CodeReflection
+    public static void matrixMultiplyKernel1DWithFunctionCalls(@RO KernelContext kc, @RO F32Array matrixA, @RO F32Array matrixB, @RW F32Array matrixC, int size) {
+        if (kc.x < kc.maxX) {
+            for (int j = 0; j < size; j++) {
+                float acc = compute(kc, matrixA, matrixB, size, j);
+                matrixC.array(kc.x * size + j, acc);
+            }
+        }
+    }
+
     @CodeReflection
     public static void matrixMultiply1D(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int size) {
         cc.dispatchKernel(size,
                 kc -> matrixMultiplyKernel1D(kc, matrixA, matrixB, matrixC, size)
+        );
+    }
+
+    @CodeReflection
+    public static void matrixMultiply1DWithFunctionCalls(@RO ComputeContext cc, @RO F32Array matrixA, @RO F32Array matrixB, @RW  F32Array matrixC, int size) {
+        cc.dispatchKernel(size,
+                kc -> matrixMultiplyKernel1DWithFunctionCalls(kc, matrixA, matrixB, matrixC, size)
         );
     }
 
@@ -166,8 +195,9 @@ public class Main {
      * 1D range or 2D range.
      */
     private enum Configuration {
-        _1D, //
-        _2D, //
+        _1D,   //
+        _1DFC, // 1D with multiple function calls: This is just for testing
+        _2D,   //
         _2DLI
     }
 
@@ -184,6 +214,9 @@ public class Main {
         if (args.length > 0) {
             if (args[0].equals("1D")) {
                 configuration = Configuration._1D;
+            }
+            if (args[0].equals("1DFC")) {
+                configuration = Configuration._1DFC;
             }
             if (args[0].equals("2DLI")) {
                 configuration = Configuration._2DLI;
@@ -221,6 +254,8 @@ public class Main {
             switch (configuration) {
                 case _1D -> accelerator.compute(cc ->
                         Main.matrixMultiply1D(cc, matrixA, matrixB, matrixC, size));
+                case _1DFC -> accelerator.compute(cc ->
+                        Main.matrixMultiply1DWithFunctionCalls(cc, matrixA, matrixB, matrixC, size));
                 case _2D -> accelerator.compute(cc ->
                         Main.matrixMultiply2D(cc, matrixA, matrixB, matrixC, size));
                 case _2DLI -> accelerator.compute(cc ->


### PR DESCRIPTION
This PR fixes the code generator when passing the `kernelContext` object to new invoke functions within the main compute kernel. 

Code like this:
```java 
@CodeReflection
public static float compute(@RO KernelContext kc, @RO F32Array matrixA, @RO F32Array matrixB, int size, int j) {
    float acc = 0;
    for (int k = 0; k < size; k++) {
        acc += (matrixA.array(kc.x * size + k) * matrixB.array(k * size + j));
    }
    return acc;
}

@CodeReflection
public static void matrixMultiplyKernel1D(@RO KernelContext kc, @RO F32Array matrixA, @RO F32Array matrixB, @RW F32Array matrixC, int size) {
    if (kc.x < kc.maxX) {
        for (int j = 0; j < size; j++) {
            float acc = compute(kc, matrixA, matrixB, size, j);
            matrixC.array(kc.x * size + j, acc);
        }
    }
}
```

Generated the following error when compiling the kernel:

```bash
UNSUPPORTED (log once): buildComputeProgram: cl2Metal failed
buildStatus =failed
logLen = 1993 log  = program_source:33:5: error: unknown type name 'hat'
    hat.KernelContext kc, __global F32Array_t* matrixA, __global F32Array_t* matrixB, int size, int j
    ^
```

This is due to the wrong naming from the `kernelContext` when it gets compiled to OpenCL or CUDA.
This PR patches this by checking the argument type and replacing with the appropriate CUDA/OpenCL struct. 

### How to check?

```bash
HAT=INFO,SHOW_CODE java @hat/run ffi-opencl matmul 1DFC
```

This patch has been tested for both the OpenCL and the CUDA HAT Backends.