### PR TITLE
Fix interpreter arg checking

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
@@ -108,12 +108,16 @@ public final class Interpreter {
             Object rv = args.get(i);
             try {
                 JavaType typeToResolve = switch (sv.type()) {
-                    case PrimitiveType pt -> pt.box().orElseThrow();
+                    // @@@ Deconstruct and test what the var holds
+                    case VarType _ -> JavaType.type(CoreOp.Var.class);
+                    // Allow reflection to convert between primitive values
+                    // @@@ Check conversion compatible
+                    case PrimitiveType _ -> JavaType.J_L_OBJECT;
                     case JavaType jt -> jt;
                     default -> throw new IllegalStateException("Unexpected type: " + sv.type());
                 };
                 Class<?> c = typeToResolve.toNominalDescriptor().resolveConstantDesc(l);
-                if (!c.isInstance(rv)) {
+                if (rv != null && !c.isInstance(rv)) {
                     throw interpreterException(new IllegalArgumentException(("Runtime argument at position %d has type %s " +
                             "but the corresponding symbolic value has type %s").formatted(i, rv.getClass(), sv.type())));
                 }

--- a/test/jdk/java/lang/reflect/code/interpreter/TestArgsTypesValidationWhenInterpreting.java
+++ b/test/jdk/java/lang/reflect/code/interpreter/TestArgsTypesValidationWhenInterpreting.java
@@ -58,9 +58,6 @@ public class TestArgsTypesValidationWhenInterpreting {
 
         Assert.assertThrows(() -> Interpreter.invoke(MethodHandles.lookup(), funcOp, new Object(), 2));
 
-        Assert.assertThrows(() -> Interpreter.invoke(MethodHandles.lookup(), funcOp, null, 2));
-
         Assert.assertThrows(() -> Interpreter.invoke(MethodHandles.lookup(), funcOp, this, 2d));
-
     }
 }


### PR DESCRIPTION
A prior update to the interpreter to check its arguments caused some test failures. This is a quick fix to ensure test pass while still ensuring most checks are still in place
1. ensure run time representation of variables (Var) are supported. 
2. allow for primitive conversions, which for now i punt on and just let them through, as the check needs more thought.
3. accept null for any argument, refine later for primitive values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/524/head:pull/524` \
`$ git checkout pull/524`

Update a local copy of the PR: \
`$ git checkout pull/524` \
`$ git pull https://git.openjdk.org/babylon.git pull/524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 524`

View PR using the GUI difftool: \
`$ git pr show -t 524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/524.diff">https://git.openjdk.org/babylon/pull/524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/524#issuecomment-3186044222)
</details>
