### PR TITLE
Expand the example suite with Inlining and Bytecode generation

### DIFF
--- a/cr-examples/samples/README.md
+++ b/cr-examples/samples/README.md
@@ -2,9 +2,28 @@
 
 List of examples to learn and play with the Code Reflection API.
 
-https://github.com/openjdk/babylon
+- GitHub repo: [https://github.com/openjdk/babylon](https://github.com/openjdk/babylon)
 
-### How to build?
+### Learning Code Reflection?
+
+Here's an ordered list of code example to start learning code reflection and some of its features.
+Each example is self-contained, and it can be used within the IDE to explore and understand how code reflection
+transforms and executes code.
+
+1. [`HelloCodeReflection`](https://github.com/openjdk/babylon/blob/code-reflection/cr-examples/samples/src/main/java/oracle/code/samples/HelloCodeReflection.java): Just start using code reflection and lowering code models.
+2. [`MathOptimizer`](https://github.com/openjdk/babylon/blob/code-reflection/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java): First code transformations to optimize a math function.
+3. [`InlineExample`](https://github.com/openjdk/babylon/blob/code-reflection/cr-examples/samples/src/main/java/oracle/code/samples/InliningExample.java): Simple example to illustrate the inlining.
+4. [`MathOptimizerWithInlining`](https://github.com/openjdk/babylon/blob/code-reflection/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizerWithInlining.java): Follow up of the [`MathOptimizer`](https://github.com/openjdk/babylon/blob/code-reflection/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java) to inline optimize calls into the code model.
+
+### Resources
+
+1. [Article] [Code Models](https://openjdk.org/projects/babylon/articles/code-models)
+2. [Article] [Emulating C# LINQ in Java using Code Reflection
+   ](https://openjdk.org/projects/babylon/articles/linq)
+3. [Video] [Project Babylon - Code Reflection @JVMLS 2024](https://www.youtube.com/watch?v=6c0DB2kwF_Q)
+4. [Video] [Java and GPUs using Code Reflection @JVMLS 2023](https://www.youtube.com/watch?v=lbKBu3lTftc)
+
+### How to build with project?
 
 #### 1. Build Babylon JDK
 

--- a/cr-examples/samples/src/main/java/oracle/code/samples/HelloCodeReflection.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/HelloCodeReflection.java
@@ -29,9 +29,11 @@ import jdk.incubator.code.CodeElement;
 import jdk.incubator.code.CodeReflection;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.analysis.SSA;
+import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.interpreter.Interpreter;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.Optional;
@@ -109,7 +111,19 @@ public class HelloCodeReflection {
         Block.Parameter _second = ssaCodeModel.body().entryBlock().parameters().get(1);
         System.out.println("Second parameter: " + _second);
 
-        // Another way to print a code model, traversing each element until we reach the parent
+        // We can generate Java bytecode from a code model.
+        // The BytecodeGenerator.generate method receives a code model, and returns
+        // a method handle to be able to invoke the code.
+        MethodHandle methodHandle = BytecodeGenerator.generate(MethodHandles.lookup(), ssaCodeModel);
+        try {
+            var res = methodHandle.invoke(obj, 10);
+            System.out.println("Result from bytecode generation: " + res);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+
+        // Just for illustration purposes, this is another way to print a code model,
+        // traversing each element until we reach the parent
         codeModel.traverse(null, (acc, codeElement) -> {
             int depth = 0;
             CodeElement<?, ?> parent = codeElement;

--- a/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
@@ -61,6 +61,7 @@ public class InlineExample {
         return a * b + c;
     }
 
+    // Utility for building a code model from a given method from a class.
     private static CoreOp.FuncOp buildCodeModelForMethod(Class<?> klass, String methodName) {
         Optional<Method> function = Stream.of(klass.getDeclaredMethods())
                 .filter(m -> m.getName().equals(methodName))
@@ -72,15 +73,17 @@ public class InlineExample {
 
     public static void main(String[] args) {
 
-        // 1. Build a new function
+        // 1. Build the code model for the fma static method of this class.
         CoreOp.FuncOp fmaCodeModel = buildCodeModelForMethod(InlineExample.class, "fma");
 
+        // 2. Builds a new FuncOp with the copy of the fmaCodeModel and with the specialized values
+        // This example is useful, for example, to apply partial evaluation of expression at runtime,
         CoreOp.FuncOp f = CoreOp.func("myFunction", CoreType.functionType(JavaType.FLOAT, // return type
                                                                                     JavaType.FLOAT, // param 1
                                                                                     JavaType.FLOAT  // param 2 (the new function has 2 params
                                         ))
                 .body(blockBuilder -> {
-                    // Get parameters
+                    // Get parameters for the new function
                     Block.Parameter parameter1 = blockBuilder.parameters().get(0);
                     Block.Parameter parameter2 = blockBuilder.parameters().get(1);
 

--- a/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
@@ -43,6 +43,13 @@ import java.util.stream.Stream;
  * Example of inlining based on one of the example from the code-reflection unit-tests.
  * This example illustrates how to embed a value into a function and propagate that
  * change in the code model.
+ *
+ * <p>
+ *     How to run from the terminal?
+ *     <code>
+ *      java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.InlineExample
+ *     </code>
+ * </p>
  */
 public class InlineExample {
 

--- a/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package oracle.code.samples;
+
+import jdk.incubator.code.Block;
+import jdk.incubator.code.CodeReflection;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.analysis.Inliner;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.core.CoreType;
+import jdk.incubator.code.dialect.java.JavaType;
+import jdk.incubator.code.interpreter.Interpreter;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Example of inlining based on one of the example from the code-reflection unit-tests.
+ * This example illustrates how to embed a value into a function and propagate that
+ * change in the code model.
+ */
+public class InlineExample {
+
+    // We are going to inline this function and specialize one of the parameters
+    // (e.g., parameter b) to a constant value.
+    // The new function will contain two parameters to perform a * CONSTANT + c
+    @CodeReflection
+    private static float fma(float a, float b, float c) {
+        return a * b + c;
+    }
+
+    private static CoreOp.FuncOp buildCodeModelForMethod(Class<?> klass, String methodName) {
+        Optional<Method> function = Stream.of(klass.getDeclaredMethods())
+                .filter(m -> m.getName().equals(methodName))
+                .findFirst();
+        Method method = function.get();
+        CoreOp.FuncOp funcOp = Op.ofMethod(method).get();
+        return funcOp;
+    }
+
+    public static void main(String[] args) {
+
+        // 1. Build a new function
+        CoreOp.FuncOp fmaCodeModel = buildCodeModelForMethod(InlineExample.class, "fma");
+
+        CoreOp.FuncOp f = CoreOp.func("myFunction", CoreType.functionType(JavaType.FLOAT, // return type
+                                                                                    JavaType.FLOAT, // param 1
+                                                                                    JavaType.FLOAT  // param 2 (the new function has 2 params
+                                        ))
+                .body(blockBuilder -> {
+                    // Get parameters
+                    Block.Parameter parameter1 = blockBuilder.parameters().get(0);
+                    Block.Parameter parameter2 = blockBuilder.parameters().get(1);
+
+                    // Build a new op with a pre-defined constant. We will place this constant
+                    // as one of the parameters of the function and then inline with the new values.
+                    Op.Result myConstantValue = blockBuilder.op(CoreOp.ConstantOp.constant(JavaType.FLOAT, 50.f));
+
+                    // Inline the function with the new values
+                    Inliner.inline(blockBuilder,
+                            fmaCodeModel,      // inline the fmaCodeModel
+                            List.of(parameter1, myConstantValue, parameter2),  // apply the 3 parameters to the function to inline
+                            Inliner.INLINE_RETURN);
+                });
+
+        System.out.println(f.toText());
+
+        var result = Interpreter.invoke(MethodHandles.lookup(), f, 10.f, 20.f);
+        // 10 * 50 + 20 => 520.0f
+        System.out.println("Result: " + result);
+    }
+}

--- a/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
@@ -98,10 +98,12 @@ public class InlineExample {
                             Inliner.INLINE_RETURN);
                 });
 
+        // 3. Print the resulting code model
         System.out.println(f.toText());
 
+        // 4. Evaluate the code model using the Code Reflection Interpreter
         var result = Interpreter.invoke(MethodHandles.lookup(), f, 10.f, 20.f);
-        // 10 * 50 + 20 => 520.0f
+        // We expect: 10 * 50 + 20 => 520.0f
         System.out.println("Result: " + result);
     }
 }

--- a/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
@@ -235,13 +235,15 @@ public class MathOptimizer {
             return map;
         });
 
+
         // In addition, we can generate bytecodes from a new code model that
         // has been transformed.
-        MethodHandle mhNewTransform2 = BytecodeGenerator.generate(MethodHandles.lookup(), codeModel);
+        // TODO: As in Babylon version 2a03661669b, the following line throws
+        // an IllegalArgumentException, but it will be fixed.
+        MethodHandle methodHandle = BytecodeGenerator.generate(MethodHandles.lookup(), codeModel);
         // And invoke the method handle result
-        var resultBC2 = mhNewTransform.invoke( 10);
+        var resultBC2 = methodHandle.invoke( 10);
         System.out.println("Result after BC generation: " + resultBC2);
-
     }
 
     // Goal: obtain and check the value of the function parameters.

--- a/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
@@ -31,12 +31,15 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
+import jdk.incubator.code.analysis.SSA;
+import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.dialect.java.MethodRef;
 import jdk.incubator.code.interpreter.Interpreter;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -109,7 +112,7 @@ public class MathOptimizer {
         }
     }
 
-    static void main(String[] args) {
+    static void main(String[] args) throws Throwable {
 
         Optional<Method> myFunction = Stream.of(MathOptimizer.class.getDeclaredMethods())
                 .filter(m -> m.getName().equals("myFunction"))
@@ -120,6 +123,13 @@ public class MathOptimizer {
         // Obtain the code model for the annotated method
         CoreOp.FuncOp codeModel = Op.ofMethod(myMathMethod).get();
         System.out.println(codeModel.toText());
+
+        // In addition, we can generate bytecodes from a new code model that
+        // has been transformed.
+        MethodHandle mhNewTransform = BytecodeGenerator.generate(MethodHandles.lookup(), codeModel);
+        // And invoke the method handle result
+        var resultBC = mhNewTransform.invoke( 10);
+        System.out.println("Result after BC generation: " + resultBC);
 
         System.out.println("\nLet's transform the code");
         codeModel = codeModel.transform(CopyContext.create(), (blockBuilder, op) -> {
@@ -224,6 +234,14 @@ public class MathOptimizer {
             }
             return map;
         });
+
+        // In addition, we can generate bytecodes from a new code model that
+        // has been transformed.
+        MethodHandle mhNewTransform2 = BytecodeGenerator.generate(MethodHandles.lookup(), codeModel);
+        // And invoke the method handle result
+        var resultBC2 = mhNewTransform.invoke( 10);
+        System.out.println("Result after BC generation: " + resultBC2);
+
     }
 
     // Goal: obtain and check the value of the function parameters.

--- a/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizerWithInlining.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizerWithInlining.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package oracle.code.samples;
+
+import jdk.incubator.code.CodeReflection;
+import jdk.incubator.code.CopyContext;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.OpTransformer;
+import jdk.incubator.code.TypeElement;
+import jdk.incubator.code.Value;
+import jdk.incubator.code.analysis.Inliner;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
+import jdk.incubator.code.dialect.java.MethodRef;
+import jdk.incubator.code.extern.OpWriter;
+import jdk.incubator.code.interpreter.Interpreter;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+/**
+ * Simple example of how to use the code reflection API.
+ *
+ * <p>
+ * This example is based on the {@link MathOptimizer} example to add inlining for the new replaced
+ * methods. In this example, we focus on explaining in detail the inlining component.
+ * </p>
+ *
+ * <p>
+ * Optimizations:
+ *     <ol>Replace Pow(x, y) when x == 2 to (1 << y), if only if the parameter y is an integer.</ol>
+ *     <ol>Replace Pow(x, y) when y == 2 to (x * x).</ol>
+ *     <ol>After a replacement has been done, we inline the new invoke into the main code model.</ol>
+ * </p>
+ *
+ * <p>
+ *     In a nutshell, we apply a second transform to perform the inlining. Note that the inlining could be done
+ *     also in within the first transform.
+ *     To be able to inline, we need to also annotate the new invoke nodes that were replaced during the first
+ *     transform with the <code>@CodeReflection</code> annotation. In this way, we can build the code models for
+ *     each of the methods and apply the inlining directly using the <code>Inliner.inline</code> from the code
+ *     reflection API.
+ * </p>
+ *
+ * <p>
+ *     Babylon repository: {@see <a href="https://github.com/openjdk/babylon/tree/code-reflection">link</a>}
+ * </p>
+ *
+ * <p>
+ *     How to run?
+ *     <code>
+ *         java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.MathOptimizerWithInlining
+ *     </code>
+ * </p>:
+ */
+public class MathOptimizerWithInlining {
+
+    // New functions are also annotated with code reflection
+    @CodeReflection
+    private static double myFunction(int value) {
+        return Math.pow(2, value);
+    }
+
+    @CodeReflection
+    private static int functionShift(int val) {
+        return 1 << val;
+    }
+
+    @CodeReflection
+    private static double functionMult(double x) {
+        return x * x;
+    }
+
+    private static final MethodRef MY_SHIFT_FUNCTION = MethodRef.method(MathOptimizerWithInlining.class, "functionShift", int.class, int.class);
+
+    private static final MethodRef MY_MULT_FUNCTION = MethodRef.method(MathOptimizerWithInlining.class, "functionMult", double.class, double.class);
+
+    private static CoreOp.FuncOp buildCodeModelForMethod(Class<?> klass, String methodName) {
+        Optional<Method> function = Stream.of(klass.getDeclaredMethods())
+                .filter(m -> m.getName().equals(methodName))
+                .findFirst();
+        Method method = function.get();
+        CoreOp.FuncOp funcOp = Op.ofMethod(method).get();
+        return funcOp;
+    }
+
+    static void main(String[] args) {
+
+        // Obtain the code model for the annotated method
+        CoreOp.FuncOp codeModel = buildCodeModelForMethod(MathOptimizerWithInlining.class, "myFunction");
+        System.out.println(codeModel.toText());
+
+        enum FunctionToUse {
+            SHIFT,
+            MULT,
+            GENERIC;
+        }
+
+        AtomicReference<FunctionToUse> replace = new AtomicReference<>(FunctionToUse.GENERIC);
+
+        codeModel = codeModel.transform(CopyContext.create(), (blockBuilder, op) -> {
+            // The idea here is to create a new JavaOp.invoke with the optimization and replace it.
+            if (Objects.requireNonNull(op) instanceof JavaOp.InvokeOp invokeOp && whenIsMathPowFunction(invokeOp)) {
+                List<Value> operands = blockBuilder.context().getValues(op.operands());
+
+                // Analyse second operand of the Math.pow(x, y).
+                // if the x == 2, and both are integers, then we can optimize the function using bitwise operations
+                // pow(2, y) replace with (1 << y)
+                Value operand = operands.getFirst();  // obtain the first parameter
+                // inspect if the base (as in pow(base, exp) is value 2
+                boolean canApplyBitShift = inspectParameterRecursive(operand, 2);
+                if (canApplyBitShift) {
+                    // We also need to inspect types. We can apply this optimization
+                    // if the exp type is also an integer.
+                    boolean isIntType = analyseType(operands.get(1), JavaType.INT);
+                    if (!isIntType) {
+                        canApplyBitShift = false;
+                    }
+                }
+
+                // If the conditions to apply the first optimization failed, we try the second optimization
+                // if types are not int, and base is not 2.
+                // pow(x, 2) => replace with x * x
+                boolean canApplyMultiplication = false;
+                if (!canApplyBitShift) {
+                    // inspect if exp (as in pow(base, exp) is value 2
+                    canApplyMultiplication = inspectParameterRecursive(operands.get(1), 2);
+                }
+
+                if (canApplyBitShift) {
+                    // Narrow type from DOUBLE to INT for the input parameter of the new function.
+                    Op.Result op2 = blockBuilder.op(JavaOp.conv(JavaType.INT, operands.get(1)));
+                    List<Value> newOperandList = new ArrayList<>();
+                    newOperandList.add(op2);
+
+                    // Create a new invoke with the optimised method
+                    JavaOp.InvokeOp newInvoke = JavaOp.invoke(MY_SHIFT_FUNCTION, newOperandList);
+                    // Copy the original location info to the new invoke
+                    newInvoke.setLocation(invokeOp.location());
+
+                    // Replace the invoke node with the new optimized invoke
+                    Op.Result newResult = blockBuilder.op(newInvoke);
+                    blockBuilder.context().mapValue(invokeOp.result(), newResult);
+
+                    replace.set(FunctionToUse.SHIFT);
+
+                } else if (canApplyMultiplication) {
+                    // Adapt the parameters to the new function. We only need the first
+                    // parameter from the initial parameter list  - pow(x, 2) -
+                    // Create a new invoke function with the optimised method
+                    JavaOp.InvokeOp newInvoke = JavaOp.invoke(MY_MULT_FUNCTION, operands.get(0));
+                    // Copy the location info to the new invoke
+                    newInvoke.setLocation(invokeOp.location());
+
+                    // Replace the invoke node with the new optimized invoke
+                    Op.Result newResult = blockBuilder.op(newInvoke);
+                    blockBuilder.context().mapValue(invokeOp.result(), newResult);
+                    replace.set(FunctionToUse.MULT);
+
+                } else {
+                    // ignore the transformation
+                    blockBuilder.op(op);
+                }
+            } else {
+                blockBuilder.op(op);
+            }
+            return blockBuilder;
+        });
+
+        System.out.println("Code Model after the first transform (replace with a new method): ");
+        System.out.println(codeModel.toText());
+
+        // Let's now apply a second transformation
+        // We want to inline the functions. Note that we can apply this transformation if any of the new functions
+        // have been replaced.
+        System.out.println("Second transform: apply inlining for the new methods into the main code model");
+        if (replace.get() != FunctionToUse.GENERIC) {
+
+            // Build code model for the functions we want to inline.
+            // Since we apply two replacements (depending on the values of the input code), we can apply two different
+            // inline functions.
+            CoreOp.FuncOp shiftCodeModel = buildCodeModelForMethod(MathOptimizerWithInlining.class, "functionShift");
+            CoreOp.FuncOp multCodeModel = buildCodeModelForMethod(MathOptimizerWithInlining.class, "functionMult");
+
+            // Apply inlining
+            codeModel = codeModel.transform(codeModel.funcName(),
+                                            (blockBuilder, op) -> {
+
+                if (op instanceof JavaOp.InvokeOp invokeOp && isMethodWeWantToInline(invokeOp)) {
+                    // Let's inline the function
+
+                    // 1. Select the function we want to inline.
+                    // Since we have two possible replacements, depending on the input code, we need to
+                    // apply the corresponding replacement function
+                    CoreOp.FuncOp codeModelToInline = isShiftFunction(invokeOp) ? shiftCodeModel : multCodeModel;
+
+                    // 2. Apply the inlining
+                    Inliner.inline(
+                            blockBuilder,   // the current block builder
+                            codeModelToInline,  // the method to inline which we obtained using code reflection too
+                            blockBuilder.context().getValues(invokeOp.operands()),  // operands to this call. Since we already replace the function,
+                            // we can use the same operands as the invoke call
+                            (builder, val) -> blockBuilder.context().mapValue(invokeOp.result(), val)); // Propagate the new result
+                } else {
+                    // copy the op into the builder if it is not the invoke node we are looking for
+                    blockBuilder.op(op);
+                }
+
+                // return new transformed block builder
+                return blockBuilder;
+            });
+
+            System.out.println("After inlining: " + codeModel.toText());
+        }
+
+        codeModel = codeModel.transform(OpTransformer.LOWERING_TRANSFORMER);
+        System.out.println("After Lowering: ");
+        System.out.println(codeModel.toText());
+
+        System.out.println("\nEvaluate with Interpreter.invoke");
+        // The Interpreter Invoke should launch new exceptions
+        var result = Interpreter.invoke(MethodHandles.lookup(), codeModel, 10);
+        System.out.println(result);
+    }
+
+    // Utility methods
+
+    // Analyze type methods: taken from example of String Concat Transformer to traverse the tree.
+    static boolean analyseType(JavaOp.ConvOp convOp, JavaType typeToMatch) {
+        return analyseType(convOp.operands().get(0), typeToMatch);
+    }
+
+    static boolean analyseType(Value v, JavaType typeToMatch) {
+        // Maybe there is a utility already to do tree traversal
+        if (v instanceof Op.Result r && r.op() instanceof JavaOp.ConvOp convOp) {
+            // Node of tree, recursively traverse the operands
+            return analyseType(convOp, typeToMatch);
+        } else {
+            // Leaf of tree: analyze type
+            TypeElement type = v.type();
+            return type.equals(typeToMatch);
+        }
+    }
+
+    // Inspect a value for a parameter
+    static boolean inspectParameterRecursive(JavaOp.ConvOp convOp, int valToMatch) {
+        return inspectParameterRecursive(convOp.operands().get(0), valToMatch);
+    }
+
+    static boolean inspectParameterRecursive(Value v, int valToMatch) {
+        if (v instanceof Op.Result r && r.op() instanceof JavaOp.ConvOp convOp) {
+            return inspectParameterRecursive(convOp, valToMatch);
+        } else {
+            // Leaf of tree - we want to obtain the actual value of the parameter and check
+            if (v instanceof CoreOp.Result r && r.op() instanceof CoreOp.ConstantOp constant) {
+                return constant.value().equals(valToMatch);
+            }
+            return false;
+        }
+    }
+
+    static final MethodRef JAVA_LANG_MATH_POW = MethodRef.method(Math.class, "pow", double.class, double.class, double.class);
+
+    private static boolean whenIsMathPowFunction(JavaOp.InvokeOp invokeOp) {
+        return invokeOp.invokeDescriptor().equals(JAVA_LANG_MATH_POW);
+    }
+
+    private static boolean isMethodWeWantToInline(JavaOp.InvokeOp invokeOp) {
+        return (invokeOp.invokeDescriptor().toString().startsWith("oracle.code.samples.MathOptimizerWithInlining::functionShift")
+                || invokeOp.invokeDescriptor().toString().startsWith("oracle.code.samples.MathOptimizerWithInlining::functionMult"));
+    }
+
+    private static boolean isShiftFunction(JavaOp.InvokeOp invokeOp) {
+        return invokeOp.invokeDescriptor().toString().contains("functionShift");
+    }
+}


### PR DESCRIPTION
This PR extends the sample suite for learning code reflection.  It adds a couple of examples to learn how to apply inlining.
1. Inline values 
2. Inline new code-reflected methods after code transformations. 

In addition, it expands the examples to generate Java bytecode from code models. 

All examples have been documented. 

#### How to compile and run 

```java
export JAVA_HOME=<jdk-babylon-build>
mvn clean package

java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.InlineExample
java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.MathOptimizerWithInlining
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/525/head:pull/525` \
`$ git checkout pull/525`

Update a local copy of the PR: \
`$ git checkout pull/525` \
`$ git pull https://git.openjdk.org/babylon.git pull/525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 525`

View PR using the GUI difftool: \
`$ git pr show -t 525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/525.diff">https://git.openjdk.org/babylon/pull/525.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/525#issuecomment-3187242222)
</details>
