### PR TITLE
Use existing code for creating KernelContext_s from its iface buffer schema

### DIFF
--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -62,31 +62,12 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
                 .floatTypeDefs("f32_t")
                 .longTypeDefs("s64_t")
                 .unsignedLongTypeDefs("u64_t")
-                .typedefStructOrUnion(true, "KernelContext", _ -> {
-
-                    // The context is customized depending on the NDRange of the application:
-                    // 1D, 2D or 3D.
-                    // An alternative is to always generate the 3D range for OpenCL.
-
-                    // Kernels are, at least, 1D
-                    intDeclaration("x").semicolonNl();
-                    intDeclaration("maxX").semicolonNl();
-
-                    if (ndRange.kid.getDimensions() > 1) {
-                        // The code builder needs the NDRange
-                        intDeclaration("y").semicolonNl();
-                        intDeclaration("maxY").semicolon().nl();
-                    }
-
-                    if (ndRange.kid.getDimensions() > 2) {
-                        // The code builder needs the NDRange
-                        intDeclaration("z").semicolonNl();
-                        intDeclaration("maxZ").semicolon().nl();
-                    }
-
-                    // It could be an alternative solution for doing this:
-                    // NDRAnge is an iFACE with some restrictions
-                });
+                .lineComment("KernelContext_s created from iface buffer")
+                // Previously we created KernelContext explicitly here.  That was required before KernelContext was an iface buffer
+                // It is reasonable to use hat.codebuilders.HATCodeBuilderWithContext.typedef()
+                // But note that we pass null as first arg which is normally expected to be a bound schema
+                // Clearly this will fail if we ever make KernelContext a variant array.  But that seems unlikely.
+                .typedef(null,hat.buffer.KernelContext.schema.rootIfaceType);
     }
 
     T typedefStructOrUnion(boolean isStruct, String name, Consumer<T> consumer) {

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -461,14 +461,18 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                                         sbrace(_ -> literal(1));
                                     } else {
                                         boolean[] done = new boolean[]{false};
-                                        boundSchema.boundArrayFields().forEach(a -> {
-                                            if (a.field.equals(array)) {
-                                                sbrace(_ -> literal(a.len));
-                                                done[0] = true;
+                                        if (boundSchema != null) {
+                                            boundSchema.boundArrayFields().forEach(a -> {
+                                                if (a.field.equals(array)) {
+                                                    sbrace(_ -> literal(a.len));
+                                                    done[0] = true;
+                                                }
+                                            });
+                                            if (!done[0]) {
+                                                throw new IllegalStateException("we need to extract the array size hat kind of array ");
                                             }
-                                        });
-                                        if (!done[0]) {
-                                            throw new IllegalStateException("we need to extract the array size hat kind of array ");
+                                        }else {
+                                            throw new IllegalStateException("bound schema is null  !");
                                         }
                                     }
                                 } else if (array instanceof Schema.FieldNode.PrimitiveFixedArray fixed) {
@@ -485,15 +489,19 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                                     if (isLast && ifaceType.parent == null) {
                                         sbrace(_ -> literal(1));
                                     } else {
-                                        boolean[] done = new boolean[]{false};
-                                        boundSchema.boundArrayFields().forEach(a -> {
-                                            if (a.field.equals(ifaceField)) {
-                                                sbrace(_ -> literal(a.len));
-                                                done[0] = true;
+                                        if (boundSchema != null) {
+                                            boolean[] done = new boolean[]{false};
+                                            boundSchema.boundArrayFields().forEach(a -> {
+                                                if (a.field.equals(ifaceField)) {
+                                                    sbrace(_ -> literal(a.len));
+                                                    done[0] = true;
+                                                }
+                                            });
+                                            if (!done[0]) {
+                                                throw new IllegalStateException("we need to extract the array size hat kind of array ");
                                             }
-                                        });
-                                        if (!done[0]) {
-                                            throw new IllegalStateException("we need to extract the array size hat kind of array ");
+                                        }else {
+                                        throw new IllegalStateException("bound schema is null  !");
                                         }
                                     }
                                 } else if (array instanceof Schema.FieldNode.IfaceFixedArray fixed) {


### PR DESCRIPTION
Previously we had custom code for creating KernelContext_s C99 code.  

We already had code which could create typedefed structs from iface schemas.

Now KernelContext is an iface mapped buffer we can use this same code.  This stops us from having tto manually ensure that the class and generated C99 code were in sync.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/526/head:pull/526` \
`$ git checkout pull/526`

Update a local copy of the PR: \
`$ git checkout pull/526` \
`$ git pull https://git.openjdk.org/babylon.git pull/526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 526`

View PR using the GUI difftool: \
`$ git pr show -t 526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/526.diff">https://git.openjdk.org/babylon/pull/526.diff</a>

</details>
