### PR TITLE
[samples] Apply type conversion for the int-shift function after the new result op has been built

### DIFF
--- a/cr-examples/samples/README.md
+++ b/cr-examples/samples/README.md
@@ -50,6 +50,7 @@ mvn clean package
 
 #### 3. Run the examples
 
+
 ##### Run HelloCodeReflection
 
 ```bash
@@ -60,4 +61,16 @@ java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.
 
 ```bash
 java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.MathOptimizer
+```
+
+##### Run InlineExample
+
+```bash
+java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.InlineExample
+```
+
+##### Run MathOptimizerWithInlining
+
+```bash
+java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.MathOptimizerWithInlining
 ```

--- a/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
@@ -175,6 +175,9 @@ public class MathOptimizer {
 
                         // Replace the invoke node with the new optimized invoke
                         Op.Result newResult = blockBuilder.op(newInvoke);
+                        // Apply type conversion to double
+                        newResult = blockBuilder.op(JavaOp.conv(JavaType.DOUBLE, newResult));
+                        // Propagate the new result
                         blockBuilder.context().mapValue(invokeOp.result(), newResult);
 
                     } else if (canApplyMultiplication) {
@@ -235,11 +238,8 @@ public class MathOptimizer {
             return map;
         });
 
-
         // In addition, we can generate bytecodes from a new code model that
         // has been transformed.
-        // TODO: As in Babylon version 2a03661669b, the following line throws
-        // an IllegalArgumentException, but it will be fixed.
         MethodHandle methodHandle = BytecodeGenerator.generate(MethodHandles.lookup(), codeModel);
         // And invoke the method handle result
         var resultBC2 = methodHandle.invoke( 10);

--- a/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizerWithInlining.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizerWithInlining.java
@@ -169,6 +169,8 @@ public class MathOptimizerWithInlining {
 
                     // Replace the invoke node with the new optimized invoke
                     Op.Result newResult = blockBuilder.op(newInvoke);
+                    // Type conversion to double
+                    newResult = blockBuilder.op(JavaOp.conv(JavaType.DOUBLE, newResult));
                     blockBuilder.context().mapValue(invokeOp.result(), newResult);
 
                     replace.set(FunctionToUse.SHIFT);


### PR DESCRIPTION
This patch fixes the example suite for the `MathOptimizer` example for the integer function transformation.

To me the transformation correct, we need to convert back from `int` to `double`:

```java
newResult = blockBuilder.op(JavaOp.conv(JavaType.DOUBLE, newResult));
```

How to test it?

```bash
java --enable-preview -cp target/crsamples-1.0-SNAPSHOT.jar oracle.code.samples.MathOptimizer
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/528/head:pull/528` \
`$ git checkout pull/528`

Update a local copy of the PR: \
`$ git checkout pull/528` \
`$ git pull https://git.openjdk.org/babylon.git pull/528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 528`

View PR using the GUI difftool: \
`$ git pr show -t 528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/528.diff">https://git.openjdk.org/babylon/pull/528.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/528#issuecomment-3204808017)
</details>
