### PR TITLE
Stop intellij red-squiggling lambda parms called value

### DIFF
--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
@@ -87,7 +87,7 @@ public abstract class JExtractedBackend extends JExtractedBackendDriver {
         bldr.op(iow.op());
         bldr.op(JavaOp.invoke(wrapper.post, cc, iface));
     }
-
+ // This code should be common with ffi-shared probably should be pushed down into another lib?
     protected static FuncOpWrapper injectBufferTracking(CallGraph.ResolvedMethodCall computeMethod) {
         FuncOpWrapper prevFOW = computeMethod.funcOpWrapper();
         FuncOpWrapper returnFOW = prevFOW;
@@ -113,15 +113,16 @@ public abstract class JExtractedBackend extends JExtractedBackendDriver {
                     bldr.op(invokeOW.op());
                 } else {
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
-                            .forEach(value ->
-                                    bldr.op(JavaOp.invoke(MUTATE.pre, cc, bldrCntxt.getValue(value)))
+                            .filter(val -> val.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
+                            .forEach(val ->
+                                    bldr.op(JavaOp.invoke(MUTATE.pre, cc, bldrCntxt.getValue(val)))
                             );
                     bldr.op(invokeOW.op());
                     invokeOW.op().operands().stream()
-                            .filter(value -> value.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
-                            .forEach(value -> bldr.op(
-                                    JavaOp.invoke(MUTATE.post, cc, bldrCntxt.getValue(value)))
+                            .filter(val -> val.type() instanceof JavaType javaType &&
+                                    InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
+                            .forEach(val -> bldr.op(
+                                    JavaOp.invoke(MUTATE.post, cc, bldrCntxt.getValue(val)))
                             );
                 }
                 return bldr;

--- a/hat/intellij/example_nbody.iml
+++ b/hat/intellij/example_nbody.iml
@@ -16,7 +16,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opencl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extracted-opengl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
@@ -25,7 +25,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opengl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extracted-opencl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />


### PR DESCRIPTION
Intellij has started red-squiggling (reporting as errors) lambda params called value. 

Just renaming params here to get around this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/530/head:pull/530` \
`$ git checkout pull/530`

Update a local copy of the PR: \
`$ git checkout pull/530` \
`$ git pull https://git.openjdk.org/babylon.git pull/530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 530`

View PR using the GUI difftool: \
`$ git pr show -t 530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/530.diff">https://git.openjdk.org/babylon/pull/530.diff</a>

</details>
