### PR TITLE
Fix lambda bugs

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -736,6 +736,9 @@ public class ReflectMethods extends TreeTranslator {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
+            if (targetType.hasTag(TypeTag.VOID)) {
+                return sourceValue;
+            }
             if (sourceType.isReference() && targetType.isReference() &&
                     !types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
                 return append(JavaOp.cast(typeToTypeElement(targetType), sourceValue));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1468,11 +1468,13 @@ public class ReflectMethods extends TreeTranslator {
             // Push quoted body
             // We can either be explicitly quoted or a structural quoted expression
             // within some larger reflected code
-            // a lambda targeted to Quoted is always going to be quoted regardless of whether
-            // we are visiting the method that contain it or we are visiting the lambda itself
-            // a lambda target it to subtype of Quotable is only going to be quoted when we are visiting the lambda
-            // also, we will not introduce nested quoting in case the top level lambda
-            // contain other lambdas targeted for quoting
+
+            // a lambda targeted to Quoted is always going to have its model wrapped in QuotedOp, regardless of whether
+            // we are producing the model of the method that contain it or we are producing the model of the lambda itself
+            // on the other hand, a lambda targeted to a subtype of Quotable is going to have its model wrapped in QuotedOp
+            // only when we are producing the model of the lambda, thus the condition (isQuoted ...)
+            // also, a lambda contained in a quotable lambda, will not have its model wrapped in QuotedOp,
+            // thus the condition (... body == tree)
             boolean toQuote = (isQuoted && body == tree) || kind == FunctionalExpressionKind.QUOTED_STRUCTURAL;
             if (toQuote) {
                 pushBody(tree.body, CoreType.FUNCTION_TYPE_VOID);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1030,6 +1030,10 @@ public class ReflectMethods extends TreeTranslator {
                 case FIELD, ENUM_CONSTANT -> {
                     if (sym.name.equals(names._this) || sym.name.equals(names._super)) {
                         result = thisValue();
+                    } else if (isQuoted && top.localToOp.containsKey(sym)) {
+                        // if we are scanning a quotable lambda
+                        // and the field being loaded is registered as constant capture, load the associated VarOp result
+                        result = loadVar(sym);
                     } else {
                         FieldRef fr = symbolToFieldRef(sym, symbolSiteType(sym));
                         TypeElement resultType = typeToTypeElement(sym.type);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1482,9 +1482,10 @@ public class ReflectMethods extends TreeTranslator {
             }
 
             // Scan the lambda body
+            Type lambdaReturnType = tree.getDescriptorType(types).getReturnType();
             if (tree.getBodyKind() == LambdaExpressionTree.BodyKind.EXPRESSION) {
-                Value exprVal = toValue(((JCExpression) tree.body), tree.getDescriptorType(types).getReturnType());
-                if (!tree.body.type.hasTag(TypeTag.VOID)) {
+                Value exprVal = toValue(((JCExpression) tree.body), lambdaReturnType);
+                if (!lambdaReturnType.hasTag(TypeTag.VOID)) {
                     append(CoreOp.return_(exprVal));
                 } else {
                     appendTerminating(CoreOp::return_);
@@ -1492,7 +1493,7 @@ public class ReflectMethods extends TreeTranslator {
             } else {
                 Type prevBodyTarget = bodyTarget;
                 try {
-                    bodyTarget = tree.getDescriptorType(types).getReturnType();
+                    bodyTarget = lambdaReturnType;
                     toValue(((JCTree.JCStatement) tree.body));
                     appendReturnOrUnreachable(tree.body);
                 } finally {

--- a/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
+++ b/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
@@ -266,4 +266,34 @@ public class QuotableSubtypeTest {
     static QuotableRunnable QUOTED_CAPTURE_FINAL_STATIC_FIELD = () -> {
         int x = Z;
     };
+
+    @IR("""
+            func @"f" ()java.type:"void" -> {
+                  %1 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                      %2 : java.type:"int" = constant @1;
+                      %3 : java.type:"int" = invoke %2 @java.ref:"QuotableSubtypeTest::n(int):int";
+                      return;
+                  };
+                  return;
+            };
+            """)
+    // the lambda model used to contain operation that perform unnecessary type conversion
+    static QuotableRunnable QUOTED_RETURN_VOID = () -> {
+        n(1);
+    };
+    static int n(int i) {
+        return i;
+    }
+
+    @IR("""
+            func @"f" ()java.type:"void" -> {
+                  %1 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                      %2 : java.type:"java.lang.Object" = new @java.ref:"java.lang.Object::()";
+                      return;
+                  };
+                  return;
+            };
+            """)
+    // the lambda model used to contain ReturnOp with a value, even though the lambda type is void
+    static QuotableRunnable QUOTED_EXPRESSION_RETURN_VOID = () -> new Object();
 }

--- a/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
+++ b/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
@@ -296,4 +296,37 @@ public class QuotableSubtypeTest {
             """)
     // the lambda model used to contain ReturnOp with a value, even though the lambda type is void
     static QuotableRunnable QUOTED_EXPRESSION_RETURN_VOID = () -> new Object();
+
+    @IR("""
+            func @"f" ()java.type:"void" -> {
+                  %1 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                      %2 : java.type:"java.lang.Runnable" = lambda ()java.type:"void" -> {
+                          return;
+                      };
+                      %3 : Var<java.type:"java.lang.Runnable"> = var %2 @"r";
+                      return;
+                  };
+                  return;
+            };
+            """)
+    static QuotableRunnable QUOTED_NESTED_LAMBDA = () -> {
+        Runnable r = () -> {};
+    };
+
+    @IR("""
+            func @"f" ()java.type:"void" -> {
+                  %1 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                      %2 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                          return;
+                      };
+                      %3 : Var<java.type:"QuotableSubtypeTest$QuotableRunnable"> = var %2 @"r";
+                      return;
+                  };
+                  return;
+            };
+            """)
+    // @@@ should this be the excepted behaviour in case we have a nested quotable lambda ?
+    static QuotableRunnable QUOTED_NESTED_QUOTABLE_LAMBDA = () -> {
+        QuotableRunnable r = () -> {};
+    };
 }

--- a/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
+++ b/test/langtools/tools/javac/reflect/QuotableSubtypeTest.java
@@ -251,4 +251,19 @@ public class QuotableSubtypeTest {
             };
             """)
     static final QuotableIntUnaryOperator QUOTED_CAPTURE_THIS_REF = new ContextRef().capture();
+
+    static final int Z = 42;
+    @IR("""
+            func @"f" (%0 : Var<java.type:"int">)java.type:"void" -> {
+                %1 : java.type:"QuotableSubtypeTest$QuotableRunnable" = lambda ()java.type:"void" -> {
+                    %2 : java.type:"int" = var.load %0;
+                    %3 : Var<java.type:"int"> = var %2 @"x";
+                    return;
+                };
+                return;
+            };
+            """)
+    static QuotableRunnable QUOTED_CAPTURE_FINAL_STATIC_FIELD = () -> {
+        int x = Z;
+    };
 }


### PR DESCRIPTION
Fix lambda bugs:
1. Unnecessary load of static fields accessed inside the lambda body (bug 1).
2. The model of a lambda expression that returns void, contains additional boxing whose result is not used (bug 2).
3. Inner lambda is incorrectly quoted (bug 3).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [815e5f9f](https://git.openjdk.org/babylon/pull/532/files/815e5f9fa2a4f5d77a66efa517789c950319d4ee)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/532/head:pull/532` \
`$ git checkout pull/532`

Update a local copy of the PR: \
`$ git checkout pull/532` \
`$ git pull https://git.openjdk.org/babylon.git pull/532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 532`

View PR using the GUI difftool: \
`$ git pr show -t 532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/532.diff">https://git.openjdk.org/babylon/pull/532.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/532#issuecomment-3219091160)
</details>
