### PR TITLE
Removing OpWrappers 1 of many

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
@@ -26,6 +26,7 @@ package hat.backend.ffi;
 
 import hat.NDRange;
 import hat.codebuilders.C99HATKernelBuilder;
+import hat.codebuilders.HATCodeBuilderContext;
 import hat.optools.OpWrapper;
 
 import jdk.incubator.code.Op;
@@ -105,7 +106,7 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
     }
 
     @Override
-    public CudaHATKernelBuilder functionDeclaration(CodeBuilderContext codeBuilderContext, JavaType javaType, String name) {
+    public CudaHATKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType javaType, String name) {
         return externC().space().keyword("__device__").space().keyword("inline").space().type(codeBuilderContext,javaType).space().identifier(name);
     }
 
@@ -116,9 +117,9 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
 
 
     @Override
-    public CudaHATKernelBuilder atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name){
+    public CudaHATKernelBuilder atomicInc(HATCodeBuilderContext buildContext, Op.Result instanceResult, String name){
         return identifier("atomicAdd").paren(_ -> {
-             ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
+             ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup,instanceResult.op()));
              rarrow().identifier(name).comma().literal(1);
         });
     }

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
@@ -210,7 +210,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
             case ReturnOpWrapper op -> ret(op);
             case JavaBreakOpWrapper op -> javaBreak(op);
             default -> {
-                switch (wrappedOp.op()){
+                switch (wrappedOp.op){
                     case CoreOp.BranchOp op -> branch(op);
                     case CoreOp.ConditionalBranchOp op -> condBranch(op);
                     case JavaOp.NegOp op -> neg(op);
@@ -240,21 +240,21 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
         }
     }
 
-    public void fieldLoad(FieldLoadOpWrapper op) {
-        if (op.fieldName().equals(Field.KC_X.toString())) {
+    public void fieldLoad(FieldLoadOpWrapper wop) {
+        if (wop.fieldName().equals(Field.KC_X.toString())) {
             if (!fieldToRegMap.containsKey(Field.KC_X)) {
-                loadKcX(op.result());
+                loadKcX(wop.op.result());
             } else {
-                mov().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().fieldReg(Field.KC_X);
+                mov().u32().space().resultReg(wop, PTXRegister.Type.U32).commaSpace().fieldReg(Field.KC_X);
             }
-        } else if (op.fieldName().equals(Field.KC_MAXX.toString())) {
+        } else if (wop.fieldName().equals(Field.KC_MAXX.toString())) {
             if (!fieldToRegMap.containsKey(Field.KC_X)) {
-                loadKcX(op.operandNAsValue(0));
+                loadKcX(wop.op.operands().getFirst());
             }
-            ld().global().u32().space().fieldReg(Field.KC_MAXX, op.result()).commaSpace()
+            ld().global().u32().space().fieldReg(Field.KC_MAXX, wop.op.result()).commaSpace()
                     .address(fieldToRegMap.get(Field.KC_ADDR).name(), 4);
         } else {
-            ld().global().u32().space().resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.operandNAsValue(0));
+            ld().global().u32().space().resultReg(wop, PTXRegister.Type.U64).commaSpace().reg(wop.op.operands().getFirst());
         }
     }
 
@@ -271,7 +271,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
 
     public void fieldStore(FieldStoreOpWrapper op) {
         // TODO: fix
-        st().global().u64().space().resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.operandNAsValue(0));
+        st().global().u64().space().resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.op.operands().getFirst());
     }
 
     PTXHATKernelBuilder symbol(Op op) {
@@ -297,63 +297,63 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     }
 
     public void binaryOperation(BinaryArithmeticOrLogicOperation op) {
-        symbol(op.op());
-        if (getResultType(op.resultType()).getBasicType().equals(PTXRegister.Type.BasicType.FLOATING)
-                && (op.op() instanceof JavaOp.DivOp || op.op() instanceof JavaOp.MulOp)) {
+        symbol(op.op);
+        if (getResultType(op.op.resultType()).getBasicType().equals(PTXRegister.Type.BasicType.FLOATING)
+                && (op.op instanceof JavaOp.DivOp || op.op instanceof JavaOp.MulOp)) {
             rn();
-        } else if (!getResultType(op.resultType()).getBasicType().equals(PTXRegister.Type.BasicType.FLOATING)
-                && op.op() instanceof JavaOp.MulOp) {
+        } else if (!getResultType(op.op.resultType()).getBasicType().equals(PTXRegister.Type.BasicType.FLOATING)
+                && op.op instanceof JavaOp.MulOp) {
             lo();
         }
-        resultType(op.resultType(), true).space();
-        resultReg(op, getResultType(op.resultType()));
+        resultType(op.op.resultType(), true).space();
+        resultReg(op, getResultType(op.op.resultType()));
         commaSpace();
-        reg(op.operandNAsValue(0));
+        reg(op.op.operands().getFirst());
         commaSpace();
-        reg(op.operandNAsValue(1));
+        reg(op.op.operands().get(1));
     }
 
     public void binaryTest(BinaryTestOpWrapper op) {
         setp().dot();
-        symbol(op.op()).resultType(op.operandNAsValue(0).type(), true).space();
+        symbol(op.op).resultType(op.op.operands().getFirst().type(), true).space();
         resultReg(op, PTXRegister.Type.PREDICATE);
         commaSpace();
-        reg(op.operandNAsValue(0));
+        reg(op.op.operands().getFirst());
         commaSpace();
-        reg(op.operandNAsValue(1));
+        reg(op.op.operands().get(1));
     }
 
     public void conv(ConvOpWrapper op) {
         if (op.resultJavaType().equals(JavaType.LONG)) {
             if (isIndex(op)) {
                 mul().wide().s32().space().resultReg(op, PTXRegister.Type.U64).commaSpace()
-                        .reg(op.operandNAsValue(0)).commaSpace().intVal(4);
+                        .reg(op.op.operands().getFirst()).commaSpace().intVal(4);
             } else {
-                cvt().u64().dot().regType(op.operandNAsValue(0)).space()
-                        .resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.operandNAsValue(0)).ptxNl();
+                cvt().u64().dot().regType(op.op.operands().getFirst()).space()
+                        .resultReg(op, PTXRegister.Type.U64).commaSpace().reg(op.op.operands().getFirst()).ptxNl();
             }
         } else if (op.resultJavaType().equals(JavaType.FLOAT)) {
-            cvt().rn().f32().dot().regType(op.operandNAsValue(0)).space()
-                    .resultReg(op, PTXRegister.Type.F32).commaSpace().reg(op.operandNAsValue(0));
+            cvt().rn().f32().dot().regType(op.op.operands().getFirst()).space()
+                    .resultReg(op, PTXRegister.Type.F32).commaSpace().reg(op.op.operands().getFirst());
         } else if (op.resultJavaType().equals(JavaType.DOUBLE)) {
             cvt();
-            if (op.operandNAsValue(0).type().equals(JavaType.INT)) {
+            if (op.op.operands().getFirst().type().equals(JavaType.INT)) {
                 rn();
             }
-            f64().dot().regType(op.operandNAsValue(0)).space()
-                    .resultReg(op, PTXRegister.Type.F64).commaSpace().reg(op.operandNAsValue(0));
+            f64().dot().regType(op.op.operands().getFirst()).space()
+                    .resultReg(op, PTXRegister.Type.F64).commaSpace().reg(op.op.operands().getFirst());
         } else if (op.resultJavaType().equals(JavaType.INT)) {
             cvt();
-            if (op.operandNAsValue(0).type().equals(JavaType.DOUBLE) || op.operandNAsValue(0).type().equals(JavaType.FLOAT)) {
+            if (op.op.operands().getFirst().type().equals(JavaType.DOUBLE) || op.op.operands().getFirst().type().equals(JavaType.FLOAT)) {
                 rzi();
             } else {
                 rn();
             }
-            s32().dot().regType(op.operandNAsValue(0)).space()
-                    .resultReg(op, PTXRegister.Type.S32).commaSpace().reg(op.operandNAsValue(0));
+            s32().dot().regType(op.op.operands().getFirst()).space()
+                    .resultReg(op, PTXRegister.Type.S32).commaSpace().reg(op.op.operands().getFirst());
         } else {
-            cvt().rn().s32().dot().regType(op.operandNAsValue(0)).space()
-                    .resultReg(op, PTXRegister.Type.S32).commaSpace().reg(op.operandNAsValue(0));
+            cvt().rn().s32().dot().regType(op.op.operands().getFirst()).space()
+                    .resultReg(op, PTXRegister.Type.S32).commaSpace().reg(op.op.operands().getFirst());
         }
     }
 
@@ -442,22 +442,22 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
 
 
     private boolean isIndex(ConvOpWrapper op) {
-        for (Op.Result r : op.result().uses()) {
+        for (Op.Result r : op.op.result().uses()) {
             if (r.op() instanceof PTXPtrOp) return true;
         }
         return false;
     }
 
     public void constant(ConstantOpWrapper op) {
-        mov().resultType(op.resultType(), false).space().resultReg(op, getResultType(op.resultType())).commaSpace();
-        if (op.resultType().toString().equals("float")) {
-            if (op.op().value().toString().equals("0.0")) {
+        mov().resultType(op.op.resultType(), false).space().resultReg(op, getResultType(op.op.resultType())).commaSpace();
+        if (op.op.resultType().toString().equals("float")) {
+            if (op.op.value().toString().equals("0.0")) {
                 floatVal("00000000");
             } else {
-                floatVal(Integer.toHexString(Float.floatToIntBits(Float.parseFloat(op.op().value().toString()))).toUpperCase());
+                floatVal(Integer.toHexString(Float.floatToIntBits(Float.parseFloat(op.op.value().toString()))).toUpperCase());
             }
         } else {
-            append(op.op().value().toString());
+            append(op.op.value().toString());
         }
     }
 
@@ -471,59 +471,59 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
             // S32Array functions
             case "hat.buffer.S32Array::array(long)int" -> {
                 PTXRegister temp = new PTXRegister(incrOrdinal(addressType()), addressType());
-                add().s64().space().regName(temp).commaSpace().reg(op.operandNAsValue(0)).commaSpace().reg(op.operandNAsValue(1)).ptxNl();
+                add().s64().space().regName(temp).commaSpace().reg(op.op.operands().getFirst()).commaSpace().reg(op.op.operands().get(1)).ptxNl();
                 ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(temp.name(), 4);
             }
             case "hat.buffer.S32Array::array(long, int)void" -> {
                 PTXRegister temp = new PTXRegister(incrOrdinal(addressType()), addressType());
-                add().s64().space().regName(temp).commaSpace().reg(op.operandNAsValue(0)).commaSpace().reg(op.operandNAsValue(1)).ptxNl();
-                st().global().u32().space().address(temp.name(), 4).commaSpace().reg(op.operandNAsValue(2));
+                add().s64().space().regName(temp).commaSpace().reg(op.op.operands().getFirst()).commaSpace().reg(op.op.operands().get(1)).ptxNl();
+                st().global().u32().space().address(temp.name(), 4).commaSpace().reg(op.op.operands().get(2));
             }
             case "hat.buffer.S32Array::length()int" -> {
-                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.operandNAsValue(0)).name());
+                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.op.operands().getFirst()).name());
             }
             // S32Array2D functions
             case "hat.buffer.S32Array2D::array(long, int)void" -> {
                 PTXRegister temp = new PTXRegister(incrOrdinal(addressType()), addressType());
-                add().s64().space().regName(temp).commaSpace().reg(op.operandNAsValue(0)).commaSpace().reg(op.operandNAsValue(1)).ptxNl();
-                st().global().u32().space().address(temp.name(), 8).commaSpace().reg(op.operandNAsValue(2));
+                add().s64().space().regName(temp).commaSpace().reg(op.op.operands().getFirst()).commaSpace().reg(op.op.operands().get(1)).ptxNl();
+                st().global().u32().space().address(temp.name(), 8).commaSpace().reg(op.op.operands().get(2));
             }
             case "hat.buffer.S32Array2D::width()int" -> {
-                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.operandNAsValue(0)).name());
+                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.op.operands().getFirst()).name());
             }
             case "hat.buffer.S32Array2D::height()int" -> {
-                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.operandNAsValue(0)).name(), 4);
+                ld().global().u32().space().resultReg(op, PTXRegister.Type.U32).commaSpace().address(getReg(op.op.operands().getFirst()).name(), 4);
             }
             // Java Math function
             case "java.lang.Math::sqrt(double)double" -> {
-                sqrt().rn().f64().space().resultReg(op, PTXRegister.Type.F64).commaSpace().reg(op.operandNAsValue(0)).semicolon();
+                sqrt().rn().f64().space().resultReg(op, PTXRegister.Type.F64).commaSpace().reg(op.op.operands().getFirst()).semicolon();
             }
             default -> {
                 obrace().nl().ptxIndent();
-                for (int i = 0; i < op.operands().size(); i++) {
-                    dot().param().space().paramType(op.operandNAsValue(i).type()).space().param().intVal(i).ptxNl();
-                    st().dot().param().paramType(op.operandNAsValue(i).type()).space().osbrace().param().intVal(i).csbrace().commaSpace().reg(op.operandNAsValue(i)).ptxNl();
+                for (int i = 0; i < op.op.operands().size(); i++) {
+                    dot().param().space().paramType(op.op.operands().get(i).type()).space().param().intVal(i).ptxNl();
+                    st().dot().param().paramType(op.op.operands().get(i).type()).space().osbrace().param().intVal(i).csbrace().commaSpace().reg(op.op.operands().get(i)).ptxNl();
                 }
-                dot().param().space().paramType(op.resultType()).space().retVal().ptxNl();
+                dot().param().space().paramType(op.op.resultType()).space().retVal().ptxNl();
                 call().uni().space().oparen().retVal().cparen().commaSpace().append(op.method().getName()).commaSpace();
                 final int[] counter = {0};
-                paren(_ -> commaSeparated(op.operands(), _ -> param().intVal(counter[0]++))).ptxNl();
-                ld().dot().param().paramType(op.resultType()).space().resultReg(op, getResultType(op.resultType())).commaSpace().osbrace().retVal().csbrace();
+                paren(_ -> commaSeparated(op.op.operands(), _ -> param().intVal(counter[0]++))).ptxNl();
+                ld().dot().param().paramType(op.op.resultType()).space().resultReg(op, getResultType(op.op.resultType())).commaSpace().osbrace().retVal().csbrace();
                 ptxNl().cbrace();
             }
         }
     }
 
     public void varDeclaration(VarDeclarationOpWrapper op) {
-        ld().dot().param().resultType(op.resultType(), false).space().resultReg(op, addressType()).commaSpace().reg(op.operandNAsValue(0));
+        ld().dot().param().resultType(op.op.resultType(), false).space().resultReg(op, addressType()).commaSpace().reg(op.op.operands().getFirst());
     }
 
     public void varFuncDeclaration(VarFuncDeclarationOpWrapper op) {
-        ld().dot().param().resultType(op.resultType(), false).space().resultReg(op, addressType()).commaSpace().reg(op.operandNAsValue(0));
+        ld().dot().param().resultType(op.op.resultType(), false).space().resultReg(op, addressType()).commaSpace().reg(op.op.operands().getFirst());
     }
 
     public void ret(ReturnOpWrapper op) {
-        if (op.hasOperands()) {
+        if (!op.op.operands().isEmpty()) {
             st().dot().param();
             if (returnReg.type().equals(PTXRegister.Type.U32)) {
                 b32();
@@ -532,7 +532,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
             } else {
                 dot().regType(returnReg.type());
             }
-            space().osbrace().regName(returnReg).csbrace().commaSpace().reg(op.operandNAsValue(0)).ptxNl();
+            space().osbrace().regName(returnReg).csbrace().commaSpace().reg(op.op.operands().getFirst()).ptxNl();
         }
         ret();
     }
@@ -607,7 +607,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     }
 
     public PTXHATKernelBuilder resultReg(OpWrapper<?> opWrapper, PTXRegister.Type type) {
-        return append(addReg(opWrapper.result(), type));
+        return append(addReg(opWrapper.op.result(), type));
     }
 
     public PTXHATKernelBuilder reg(Value val, PTXRegister.Type type) {

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
@@ -26,6 +26,7 @@ package hat.backend.ffi;
 
 import hat.NDRange;
 import hat.codebuilders.C99HATKernelBuilder;
+import hat.codebuilders.HATCodeBuilderContext;
 import hat.optools.OpWrapper;
 
 import jdk.incubator.code.Op;
@@ -85,7 +86,7 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
     }
 
     @Override
-    public OpenCLHATKernelBuilder functionDeclaration(CodeBuilderContext codeBuilderContext, JavaType type, String name) {
+    public OpenCLHATKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType type, String name) {
         return keyword("inline").space().type(codeBuilderContext,type).space().identifier(name);
     }
 
@@ -95,9 +96,9 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
     }
 
     @Override
-    public OpenCLHATKernelBuilder atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name){
+    public OpenCLHATKernelBuilder atomicInc(HATCodeBuilderContext buildContext, Op.Result instanceResult, String name){
           return identifier("atomic_inc").paren(_ -> {
-              ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
+              ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup,instanceResult.op()));
               rarrow().identifier(name);
           });
     }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -161,9 +161,9 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
 
         if (config.isSHOW_KERNEL_MODEL()) {
             System.out.println("Original");
-            System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op().toText());
+            System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op.toText());
             System.out.println("Lowered");
-            System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().lower().op().toText());
+            System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().lower().op.toText());
         }
         return builder.toString();
     }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackend.java
@@ -75,15 +75,15 @@ public abstract class FFIBackend extends FFIBackendDriver {
      //   long ns = System.nanoTime();
         backendBridge.computeStart();
         if (config.isINTERPRET()) {
-            Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op(), args);
+            Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op, args);
         } else {
             try {
                 if (computeContext.computeCallGraph.entrypoint.mh == null) {
-                    computeContext.computeCallGraph.entrypoint.mh = BytecodeGenerator.generate(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op());
+                    computeContext.computeCallGraph.entrypoint.mh = BytecodeGenerator.generate(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op);
                 }
                 computeContext.computeCallGraph.entrypoint.mh.invokeWithArguments(args);
             } catch (Throwable e) {
-                System.out.println(computeContext.computeCallGraph.entrypoint.lowered.op().toText());
+                System.out.println(computeContext.computeCallGraph.entrypoint.lowered.op.toText());
                 throw new RuntimeException(e);
             }
         }
@@ -93,7 +93,7 @@ public abstract class FFIBackend extends FFIBackendDriver {
 
     static void wrapInvoke(InvokeOpWrapper iow, Block.Builder bldr, ComputeContext.WRAPPER wrapper, Value cc, Value iface) {
         bldr.op(JavaOp.invoke(wrapper.pre, cc, iface));
-        bldr.op(iow.op());
+        bldr.op(iow.op);
         bldr.op(JavaOp.invoke(wrapper.post, cc, iface));
     }
 
@@ -145,9 +145,9 @@ public abstract class FFIBackend extends FFIBackendDriver {
 
             void apply(Block.Builder bldr, CopyContext bldrCntxt, Value computeContext, InvokeOpWrapper invokeOW) {
                 if (invokeOW.isIfaceMutator()) {                    // iface.v(newV)
-                    Value iface = bldrCntxt.getValue(invokeOW.operandNAsValue(0));
+                    Value iface = bldrCntxt.getValue(invokeOW.op.operands().getFirst());
                     bldr.op(JavaOp.invoke(MUTATE.pre, computeContext, iface));  // cc->preMutate(iface);
-                    bldr.op(invokeOW.op());                         // iface.v(newV);
+                    bldr.op(invokeOW.op);                         // iface.v(newV);
                     bldr.op(JavaOp.invoke(MUTATE.post, computeContext, iface));
                 }
             }
@@ -159,26 +159,26 @@ public abstract class FFIBackend extends FFIBackendDriver {
         if (config.isSHOW_COMPUTE_MODEL()) {
             if (config.isSHOW_COMPUTE_MODEL()) {
                 System.out.println("COMPUTE entrypoint before injecting buffer tracking...");
-                System.out.println(returnFOW.op().toText());
+                System.out.println(returnFOW.op.toText());
             }
             returnFOW = prevFOW.transformInvokes((bldr, invokeOW) -> {
                 CopyContext bldrCntxt = bldr.context();
                 //Map compute method's first param (computeContext) value to transformed model
                 Value cc = bldrCntxt.getValue(prevFOW.parameter(0));
                 if (invokeOW.isIfaceMutator()) {                    // iface.v(newV)
-                    Value iface = bldrCntxt.getValue(invokeOW.operandNAsValue(0));
+                    Value iface = bldrCntxt.getValue(invokeOW.op.operands().getFirst());
                     bldr.op(JavaOp.invoke(MUTATE.pre, cc, iface));  // cc->preMutate(iface);
-                    bldr.op(invokeOW.op());                         // iface.v(newV);
+                    bldr.op(invokeOW.op);                         // iface.v(newV);
                     bldr.op(JavaOp.invoke(MUTATE.post, cc, iface)); // cc->postMutate(iface)
                 } else if (invokeOW.isIfaceAccessor()) {            // iface.v()
-                    Value iface = bldrCntxt.getValue(invokeOW.operandNAsValue(0));
+                    Value iface = bldrCntxt.getValue(invokeOW.op.operands().getFirst());
                     bldr.op(JavaOp.invoke(ACCESS.pre, cc, iface));  // cc->preAccess(iface);
-                    bldr.op(invokeOW.op());                         // iface.v();
+                    bldr.op(invokeOW.op);                         // iface.v();
                     bldr.op(JavaOp.invoke(ACCESS.post, cc, iface)); // cc->postAccess(iface) } else {
                 } else if (invokeOW.isComputeContextMethod() || invokeOW.isRawKernelCall()) { //dispatchKernel
-                    bldr.op(invokeOW.op());
+                    bldr.op(invokeOW.op);
                 } else {
-                    List<Value> list = invokeOW.op().operands();
+                    List<Value> list = invokeOW.op.operands();
                  //   System.out.println("args "+list.size());
                     if (!list.isEmpty()) {
                        // System.out.println("method "+invokeOW.method());
@@ -209,7 +209,7 @@ public abstract class FFIBackend extends FFIBackendDriver {
                         //  .forEach(value ->
                         //          bldr.op(CoreOp.invoke(ESCAPE.pre, cc, bldrCntxt.getValue(value)))
                         //  );
-                        bldr.op(invokeOW.op());
+                        bldr.op(invokeOW.op);
                         typeAndAccesses.stream()
                                 .filter(typeAndAccess -> InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup, typeAndAccess.javaType))
                                 .forEach(typeAndAccess -> {
@@ -222,19 +222,19 @@ public abstract class FFIBackend extends FFIBackendDriver {
                                     }
                                 });
                     }else{
-                        bldr.op(invokeOW.op());
+                        bldr.op(invokeOW.op);
                     }
                 }
                 return bldr;
             });
             if (config.isSHOW_COMPUTE_MODEL()) {
                 System.out.println("COMPUTE entrypoint after injecting buffer tracking...");
-                System.out.println(returnFOW.op().toText());
+                System.out.println(returnFOW.op.toText());
             }
         }else{
             if (config.isSHOW_COMPUTE_MODEL()) {
                 System.out.println("COMPUTE entrypoint (we will not be injecting buffer tracking...)...");
-                System.out.println(returnFOW.op().toText());
+                System.out.println(returnFOW.op.toText());
             }
         }
         computeMethod.funcOpWrapper(returnFOW);

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
@@ -26,6 +26,7 @@ package hat.backend.jextracted;
 
 import hat.NDRange;
 import hat.codebuilders.C99HATKernelBuilder;
+import hat.codebuilders.HATCodeBuilderContext;
 import hat.optools.OpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.java.JavaType;
@@ -83,7 +84,7 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder functionDeclaration(CodeBuilderContext codeBuilderContext,JavaType type, String name) {
+    public OpenCLHatKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType type, String name) {
         return keyword("inline").space().type(codeBuilderContext,type).space().identifier(name);
     }
 
@@ -93,9 +94,9 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder atomicInc(CodeBuilderContext buildContext,  Op.Result instanceResult, String name){
+    public OpenCLHatKernelBuilder atomicInc(HATCodeBuilderContext buildContext, Op.Result instanceResult, String name){
           return identifier("atomic_inc").paren(_ -> {
-              ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
+              ampersand().recurse(buildContext, OpWrapper.wrap(buildContext.lookup,instanceResult.op()));
               rarrow().identifier(name);
           });
     }

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -96,9 +96,9 @@ public abstract class C99JExtractedBackend extends JExtractedBackend {
         builder.nl().kernelEntrypoint(kernelCallGraph.entrypoint, args).nl();
 
         System.out.println("Original");
-        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op().toText());
+        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op.toText());
         System.out.println("Lowered");
-        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().lower().op().toText());
+        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().lower().op.toText());
 
         return builder.toString();
     }

--- a/hat/core/src/main/java/hat/OpsAndTypes.java
+++ b/hat/core/src/main/java/hat/OpsAndTypes.java
@@ -124,7 +124,7 @@ public class OpsAndTypes {
 
                 if (op instanceof JavaOp.InvokeOp invokeOp
                         && OpWrapper.wrap(lookup, invokeOp) instanceof InvokeOpWrapper invokeOpWrapper
-                        && invokeOpWrapper.hasOperands()
+                        && !invokeOpWrapper.op.operands().isEmpty()
                         && invokeOpWrapper.isIfaceBufferMethod()
                         && invokeOpWrapper.getReceiver() instanceof Value iface // Is there a containing iface type Iface
                         && getMappableClassOrNull(lookup, iface.type()) != null
@@ -136,7 +136,7 @@ public class OpsAndTypes {
                     //    BoundSchema.FieldLayout layout= boundSchemaNode.getChild(fieldName);
                     OpsAndTypes.HatPtrOp<T> hatPtrOp = new OpsAndTypes.HatPtrOp<>(hatPtrTypeValue, fieldName);         // Create ptrOp to replace invokeOp
                     Op.Result ptrResult = builder.op(hatPtrOp);// replace and capture the result of the invoke
-                    if (invokeOpWrapper.operandCount() == 1) {                  // No args (operand(0)==containing iface))
+                    if (invokeOpWrapper.op.operands().size() == 1) {                  // No args (operand(0)==containing iface))
                         /*
                           this turns into a load
                           interface Iface extends Buffer // or Buffer.StructChild
@@ -150,7 +150,7 @@ public class OpsAndTypes {
                         } else {                                                 // pointing to another iface mappable
                             builder.context().mapValue(invokeOp.result(), ptrResult);
                         }
-                    } else if (invokeOpWrapper.operandCount() == 2) {
+                    } else if (invokeOpWrapper.op.operands().size() == 2) {
                          /*
                           This turns into a store
                           interface Iface extends Buffer // or Buffer.StructChild
@@ -158,7 +158,7 @@ public class OpsAndTypes {
                           }
                          */
                         if (hatPtrOp.hatPtrType == null) { // are we pointing to a primitive
-                            Value valueToStore = builder.context().getValue(invokeOpWrapper.operandNAsValue(1));
+                            Value valueToStore = builder.context().getValue(invokeOpWrapper.op.operands().get(1));
                             OpsAndTypes.HatPtrStoreValue primitiveStore = new OpsAndTypes.HatPtrStoreValue(iface.type(), ptrResult, valueToStore);
                             Op.Result replacedReturnValue = builder.op(primitiveStore);
                             builder.context().mapValue(invokeOp.result(), replacedReturnValue);

--- a/hat/core/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/core/src/main/java/hat/backend/DebugBackend.java
@@ -69,7 +69,7 @@ public class DebugBackend extends BackendAdaptor {
                 if (computeContext.computeCallGraph.entrypoint.lowered == null) {
                     computeContext.computeCallGraph.entrypoint.lowered = computeContext.computeCallGraph.entrypoint.funcOpWrapper().lower();
                 }
-                Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op(), args);
+                Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op, args);
                 break;
             }
             case BABYLON_CLASSFILE:{
@@ -78,11 +78,11 @@ public class DebugBackend extends BackendAdaptor {
                 }
                 try {
                     if (computeContext.computeCallGraph.entrypoint.mh == null) {
-                        computeContext.computeCallGraph.entrypoint.mh = BytecodeGenerator.generate(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op());
+                        computeContext.computeCallGraph.entrypoint.mh = BytecodeGenerator.generate(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op);
                     }
                     computeContext.computeCallGraph.entrypoint.mh.invokeWithArguments(args);
                 } catch (Throwable e) {
-                    System.out.println(computeContext.computeCallGraph.entrypoint.lowered.op().toText());
+                    System.out.println(computeContext.computeCallGraph.entrypoint.lowered.op.toText());
                     throw new RuntimeException(e);
                 }
                 break;
@@ -110,12 +110,12 @@ public class DebugBackend extends BackendAdaptor {
             }
             case BABYLON_INTERPRETER:{
                 var lowered = kernelCallGraph.entrypoint.funcOpWrapper().lower();
-                Interpreter.invoke(kernelCallGraph.computeContext.accelerator.lookup, lowered.op(), args);
+                Interpreter.invoke(kernelCallGraph.computeContext.accelerator.lookup, lowered.op, args);
                 break;
             }
             case BABYLON_CLASSFILE:{
                 var lowered = kernelCallGraph.entrypoint.funcOpWrapper().lower();
-                var mh = BytecodeGenerator.generate(kernelCallGraph.computeContext.accelerator.lookup, lowered.op());
+                var mh = BytecodeGenerator.generate(kernelCallGraph.computeContext.accelerator.lookup, lowered.op);
                 try {
                     mh.invokeWithArguments(args);
                 } catch (Throwable e) {

--- a/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
@@ -39,14 +39,14 @@ public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HA
     }
 
     public T compute(FuncOpWrapper funcOpWrapper) {
-        CodeBuilderContext buildContext = new CodeBuilderContext(funcOpWrapper);
+        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(funcOpWrapper.lookup,funcOpWrapper);
         computeDeclaration(funcOpWrapper.functionReturnTypeDesc(), funcOpWrapper.functionName());
         parenNlIndented(_ ->
                 commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );
 
         braceNlIndented(_ ->
-                funcOpWrapper.wrappedRootOpStream(funcOpWrapper.firstBlockOfFirstBody()).forEach(root ->
+                funcOpWrapper.wrappedRootOpStream(funcOpWrapper.op.bodies().getFirst().entryBlock()).forEach(root ->
                         recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>)).nl()
                 ));
 

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -153,8 +153,8 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     public abstract T globalPtrPrefix();
 
     @Override
-    public T type(CodeBuilderContext buildContext, JavaType javaType) {
-        if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup(),javaType) && javaType instanceof ClassType classType) {
+    public T type(HATCodeBuilderContext buildContext, JavaType javaType) {
+        if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup,javaType) && javaType instanceof ClassType classType) {
             globalPtrPrefix().space();
             String name = classType.toClassName();
             int dotIdx = name.lastIndexOf('.');
@@ -181,7 +181,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     }
 
     public T kernelMethod(KernelCallGraph.KernelReachableResolvedMethodCall kernelReachableResolvedMethodCall) {
-        CodeBuilderContext buildContext = new CodeBuilderContext(kernelReachableResolvedMethodCall.funcOpWrapper());
+        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(kernelReachableResolvedMethodCall.funcOpWrapper().lookup,kernelReachableResolvedMethodCall.funcOpWrapper());
         buildContext.scope(buildContext.funcOpWrapper, () -> {
             nl();
             functionDeclaration(buildContext,buildContext.funcOpWrapper.getReturnType(), buildContext.funcOpWrapper.functionName());
@@ -202,7 +202,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
     public T kernelMethod(FuncOpWrapper funcOpWrapper) {
 
-        CodeBuilderContext buildContext = new CodeBuilderContext(funcOpWrapper);
+        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(funcOpWrapper.lookup,funcOpWrapper);
         buildContext.scope(buildContext.funcOpWrapper, () -> {
             nl();
             functionDeclaration(buildContext,buildContext.funcOpWrapper.getReturnType(), buildContext.funcOpWrapper.functionName());
@@ -224,7 +224,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     public T kernelEntrypoint(KernelEntrypoint kernelEntrypoint,Object... args) {
 
         nl();
-        CodeBuilderContext buildContext = new CodeBuilderContext(kernelEntrypoint.funcOpWrapper());
+        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(kernelEntrypoint.funcOpWrapper().lookup,kernelEntrypoint.funcOpWrapper());
         //  System.out.print(kernelReachableResolvedMethodCall.funcOpWrapper().toText());
         buildContext.scope(buildContext.funcOpWrapper, () -> {
 
@@ -263,7 +263,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
     public abstract T kernelDeclaration(String name);
 
-    public abstract T functionDeclaration(CodeBuilderContext codeBuilderContext,JavaType javaType, String name);
+    public abstract T functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType javaType, String name);
 
     public abstract T globalId(int id);
 

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
@@ -33,7 +33,6 @@ import hat.optools.FieldLoadOpWrapper;
 import hat.optools.FieldStoreOpWrapper;
 import hat.optools.ForOpWrapper;
 import hat.optools.FuncCallOpWrapper;
-import hat.optools.FuncOpWrapper;
 import hat.optools.IfOpWrapper;
 import hat.optools.InvokeOpWrapper;
 import hat.optools.JavaBreakOpWrapper;
@@ -52,15 +51,10 @@ import hat.optools.VarLoadOpWrapper;
 import hat.optools.VarStoreOpWrapper;
 import hat.optools.WhileOpWrapper;
 import hat.optools.YieldOpWrapper;
-import jdk.incubator.code.Block;
 import jdk.incubator.code.Op;
-import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.core.CoreOp;
 
-import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Consumer;
 
 public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBuilder<T> {
@@ -281,73 +275,73 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
 
 
     /* this should not be too C99 specific */
-    public static interface CodeBuilderInterface<T extends HATCodeBuilderWithContext<?>> {
+    public  interface CodeBuilderInterface<T extends HATCodeBuilderWithContext<?>> {
 
 
-         T varLoad(CodeBuilderContext buildContext, VarLoadOpWrapper varAccessOpWrapper);
+         T varLoad(HATCodeBuilderContext buildContext, VarLoadOpWrapper varAccessOpWrapper);
 
-         T varStore(CodeBuilderContext buildContext, VarStoreOpWrapper varAccessOpWrapper);
+         T varStore(HATCodeBuilderContext buildContext, VarStoreOpWrapper varAccessOpWrapper);
 
         // public T var(BuildContext buildContext, VarDeclarationOpWrapper varDeclarationOpWrapper) ;
 
-         T varDeclaration(CodeBuilderContext buildContext, VarDeclarationOpWrapper varDeclarationOpWrapper);
+         T varDeclaration(HATCodeBuilderContext buildContext, VarDeclarationOpWrapper varDeclarationOpWrapper);
 
-         T varFuncDeclaration(CodeBuilderContext buildContext, VarFuncDeclarationOpWrapper varFuncDeclarationOpWrapper);
+         T varFuncDeclaration(HATCodeBuilderContext buildContext, VarFuncDeclarationOpWrapper varFuncDeclarationOpWrapper);
 
-         T fieldLoad(CodeBuilderContext buildContext, FieldLoadOpWrapper fieldLoadOpWrapper);
+         T fieldLoad(HATCodeBuilderContext buildContext, FieldLoadOpWrapper fieldLoadOpWrapper);
 
-         T fieldStore(CodeBuilderContext buildContext, FieldStoreOpWrapper fieldStoreOpWrapper);
+         T fieldStore(HATCodeBuilderContext buildContext, FieldStoreOpWrapper fieldStoreOpWrapper);
 
-        T unaryOperation(CodeBuilderContext buildContext, UnaryArithmeticOrLogicOpWrapper unaryOperatorOpWrapper);
-
-
-        T binaryOperation(CodeBuilderContext buildContext, BinaryArithmeticOrLogicOperation binaryOperatorOpWrapper);
-
-        T logical(CodeBuilderContext buildContext, LogicalOpWrapper logicalOpWrapper);
-
-        T binaryTest(CodeBuilderContext buildContext, BinaryTestOpWrapper binaryTestOpWrapper);
-
-        T conv(CodeBuilderContext buildContext, ConvOpWrapper convOpWrapper);
+        T unaryOperation(HATCodeBuilderContext buildContext, UnaryArithmeticOrLogicOpWrapper unaryOperatorOpWrapper);
 
 
-        T constant(CodeBuilderContext buildContext, ConstantOpWrapper constantOpWrapper);
+        T binaryOperation(HATCodeBuilderContext buildContext, BinaryArithmeticOrLogicOperation binaryOperatorOpWrapper);
 
-        T javaYield(CodeBuilderContext buildContext, YieldOpWrapper yieldOpWrapper);
+        T logical(HATCodeBuilderContext buildContext, LogicalOpWrapper logicalOpWrapper);
 
-        T lambda(CodeBuilderContext buildContext, LambdaOpWrapper lambdaOpWrapper);
+        T binaryTest(HATCodeBuilderContext buildContext, BinaryTestOpWrapper binaryTestOpWrapper);
 
-        T tuple(CodeBuilderContext buildContext, TupleOpWrapper lambdaOpWrapper);
-
-        T funcCall(CodeBuilderContext buildContext, FuncCallOpWrapper funcCallOpWrapper);
-
-        T javaIf(CodeBuilderContext buildContext, IfOpWrapper ifOpWrapper);
-
-        T javaWhile(CodeBuilderContext buildContext, WhileOpWrapper whileOpWrapper);
-
-        T javaLabeled(CodeBuilderContext buildContext, JavaLabeledOpWrapper javaLabeledOpWrapperOp);
-
-        T javaContinue(CodeBuilderContext buildContext, JavaContinueOpWrapper javaContinueOpWrapper);
-
-        T javaBreak(CodeBuilderContext buildContext, JavaBreakOpWrapper javaBreakOpWrapper);
-
-        T javaFor(CodeBuilderContext buildContext, ForOpWrapper forOpWrapper);
+        T conv(HATCodeBuilderContext buildContext, ConvOpWrapper convOpWrapper);
 
 
-         T methodCall(CodeBuilderContext buildContext, InvokeOpWrapper invokeOpWrapper);
+        T constant(HATCodeBuilderContext buildContext, ConstantOpWrapper constantOpWrapper);
 
-         T ternary(CodeBuilderContext buildContext, TernaryOpWrapper ternaryOpWrapper);
+        T javaYield(HATCodeBuilderContext buildContext, YieldOpWrapper yieldOpWrapper);
 
-         T parencedence(CodeBuilderContext buildContext, Op parent, OpWrapper<?> child);
+        T lambda(HATCodeBuilderContext buildContext, LambdaOpWrapper lambdaOpWrapper);
 
-         T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child);
+        T tuple(HATCodeBuilderContext buildContext, TupleOpWrapper lambdaOpWrapper);
 
-         T parencedence(CodeBuilderContext buildContext,  Op parent, Op child);
+        T funcCall(HATCodeBuilderContext buildContext, FuncCallOpWrapper funcCallOpWrapper);
 
-         T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, Op child);
+        T javaIf(HATCodeBuilderContext buildContext, IfOpWrapper ifOpWrapper);
 
-         T ret(CodeBuilderContext buildContext, ReturnOpWrapper returnOpWrapper);
+        T javaWhile(HATCodeBuilderContext buildContext, WhileOpWrapper whileOpWrapper);
 
-        default T recurse(CodeBuilderContext buildContext, OpWrapper<?> wrappedOp) {
+        T javaLabeled(HATCodeBuilderContext buildContext, JavaLabeledOpWrapper javaLabeledOpWrapperOp);
+
+        T javaContinue(HATCodeBuilderContext buildContext, JavaContinueOpWrapper javaContinueOpWrapper);
+
+        T javaBreak(HATCodeBuilderContext buildContext, JavaBreakOpWrapper javaBreakOpWrapper);
+
+        T javaFor(HATCodeBuilderContext buildContext, ForOpWrapper forOpWrapper);
+
+
+         T methodCall(HATCodeBuilderContext buildContext, InvokeOpWrapper invokeOpWrapper);
+
+         T ternary(HATCodeBuilderContext buildContext, TernaryOpWrapper ternaryOpWrapper);
+
+         T parencedence(HATCodeBuilderContext buildContext, Op parent, OpWrapper<?> child);
+
+         T parencedence(HATCodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child);
+
+         T parencedence(HATCodeBuilderContext buildContext, Op parent, Op child);
+
+         T parencedence(HATCodeBuilderContext buildContext, OpWrapper<?> parent, Op child);
+
+         T ret(HATCodeBuilderContext buildContext, ReturnOpWrapper returnOpWrapper);
+
+        default T recurse(HATCodeBuilderContext buildContext, OpWrapper<?> wrappedOp) {
             switch (wrappedOp) {
                 case VarLoadOpWrapper $ -> varLoad(buildContext, $);
                 case VarStoreOpWrapper $ -> varStore(buildContext, $);
@@ -370,229 +364,15 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
                 case WhileOpWrapper $ -> javaWhile(buildContext, $);
                 case IfOpWrapper $ -> javaIf(buildContext, $);
                 case ForOpWrapper $ -> javaFor(buildContext, $);
-
                 case ReturnOpWrapper $ -> ret(buildContext, $);
                 case JavaLabeledOpWrapper $ -> javaLabeled(buildContext, $);
                 case JavaBreakOpWrapper $ -> javaBreak(buildContext, $);
                 case JavaContinueOpWrapper $ -> javaContinue(buildContext, $);
-                default -> throw new IllegalStateException("handle nesting of op " + wrappedOp.op());
+                default -> throw new IllegalStateException("handle nesting of op " + wrappedOp.op);
             }
             return (T) this;
         }
 
-
-    }
-
-    public static class CodeBuilderContext {
-        public MethodHandles.Lookup lookup(){
-            return funcOpWrapper.lookup;
-        }
-        public static class Scope<OW extends OpWrapper<?>> {
-            final Scope<?> parent;
-            final OW opWrapper;
-
-            public Scope(Scope<?> parent, OW opWrapper) {
-                this.parent = parent;
-                this.opWrapper = opWrapper;
-            }
-
-            public CoreOp.VarOp resolve(Value value) {
-                if (value instanceof Op.Result result && result.op() instanceof CoreOp.VarOp varOp) {
-                    return varOp;
-                }
-                if (parent != null) {
-                    return parent.resolve(value);
-                }
-                throw new IllegalStateException("failed to resolve VarOp for value " + value);
-            }
-        }
-
-        public static class FuncScope extends Scope<FuncOpWrapper> {
-            FuncScope(Scope<?> parent, FuncOpWrapper funcOpWrapper) {
-                super(parent, funcOpWrapper);
-            }
-
-            @Override
-            public CoreOp.VarOp resolve(Value value) {
-                if (value instanceof Block.Parameter blockParameter) {
-                    if (opWrapper.parameterVarOpMap.containsKey(blockParameter)) {
-                        return opWrapper.parameterVarOpMap.get(blockParameter);
-                    } else {
-                        throw new IllegalStateException("what ?");
-                    }
-                } else {
-                    return super.resolve(value);
-                }
-            }
-        }
-
-        public static abstract class LoopScope<T extends OpWrapper<?>> extends Scope<T> {
-
-            public LoopScope(Scope<?> parent, T opWrapper) {
-                super(parent, opWrapper);
-            }
-        }
-
-
-        public  static class ForScope extends LoopScope<ForOpWrapper> {
-            Map<Block.Parameter, CoreOp.VarOp> blockParamToVarOpMap = new HashMap<>();
-
-            ForOpWrapper forOpWrapper() {
-                return opWrapper;
-            }
-
-            ForScope(Scope<?> parent, ForOpWrapper forOpWrapper) {
-                super(parent, forOpWrapper);
-                var loopParams = forOpWrapper().op().loopBody().entryBlock().parameters().toArray(new Block.Parameter[0]);
-                var updateParams = forOpWrapper().op().update().entryBlock().parameters().toArray(new Block.Parameter[0]);
-                var condParams = forOpWrapper().op().cond().entryBlock().parameters().toArray(new Block.Parameter[0]);
-                var lastInitOp = forOpWrapper().op().init().entryBlock().ops().getLast();
-                var lastInitOpOperand0Result = (Op.Result) lastInitOp.operands().getFirst();
-                var lastInitOpOperand0ResultOp = lastInitOpOperand0Result.op();
-                CoreOp.VarOp varOps[];
-                if (lastInitOpOperand0ResultOp instanceof CoreOp.TupleOp tupleOp) {
-                     /*
-                     for (int j = 1, i=2, k=3; j < size; k+=1,i+=2,j+=3) {
-                        float sum = k+i+j;
-                     }
-                     java.for
-                     ()Tuple<Var<int>, Var<int>, Var<int>> -> {
-                         %0 : int = constant @"1";
-                         %1 : Var<int> = var %0 @"j";
-                         %2 : int = constant @"2";
-                         %3 : Var<int> = var %2 @"i";
-                         %4 : int = constant @"3";
-                         %5 : Var<int> = var %4 @"k";
-                         %6 : Tuple<Var<int>, Var<int>, Var<int>> = tuple %1 %3 %5;
-                         yield %6;
-                     }
-                     (%7 : Var<int>, %8 : Var<int>, %9 : Var<int>)boolean -> {
-                         %10 : int = var.load %7;
-                         %11 : int = var.load %12;
-                         %13 : boolean = lt %10 %11;
-                         yield %13;
-                     }
-                     (%14 : Var<int>, %15 : Var<int>, %16 : Var<int>)void -> {
-                         %17 : int = var.load %16;
-                         %18 : int = constant @"1";
-                         %19 : int = add %17 %18;
-                         var.store %16 %19;
-                         %20 : int = var.load %15;
-                         %21 : int = constant @"2";
-                         %22 : int = add %20 %21;
-                         var.store %15 %22;
-                         %23 : int = var.load %14;
-                         %24 : int = constant @"3";
-                         %25 : int = add %23 %24;
-                         var.store %14 %25;
-                         yield;
-                     }
-                     (%26 : Var<int>, %27 : Var<int>, %28 : Var<int>)void -> {
-                         %29 : int = var.load %28;
-                         %30 : int = var.load %27;
-                         %31 : int = add %29 %30;
-                         %32 : int = var.load %26;
-                         %33 : int = add %31 %32;
-                         %34 : float = conv %33;
-                         %35 : Var<float> = var %34 @"sum";
-                         java.continue;
-                     };
-                     */
-                    varOps = tupleOp.operands().stream().map(operand -> (CoreOp.VarOp) (((Op.Result) operand).op())).toList().toArray(new CoreOp.VarOp[0]);
-                } else {
-                     /*
-                     for (int j = 0; j < size; j+=1) {
-                        float sum = j;
-                     }
-                     java.for
-                        ()Var<int> -> {
-                            %0 : int = constant @"0";
-                            %1 : Var<int> = var %0 @"j";
-                            yield %1;
-                        }
-                        (%2 : Var<int>)boolean -> {
-                            %3 : int = var.load %2;
-                            %4 : int = var.load %5;
-                            %6 : boolean = lt %3 %4;
-                            yield %6;
-                        }
-                        (%7 : Var<int>)void -> {
-                            %8 : int = var.load %7;
-                            %9 : int = constant @"1";
-                            %10 : int = add %8 %9;
-                            var.store %7 %10;
-                            yield;
-                        }
-                        (%11 : Var<int>)void -> {
-                            %12 : int = var.load %11;
-                            %13 : float = conv %12;
-                            %14 : Var<float> = var %13 @"sum";
-                            java.continue;
-                        };
-
-                     */
-                    varOps = new CoreOp.VarOp[]{(CoreOp.VarOp) lastInitOpOperand0ResultOp};
-                }
-                for (int i = 0; i < varOps.length; i++) {
-                    blockParamToVarOpMap.put(condParams[i], varOps[i]);
-                    blockParamToVarOpMap.put(updateParams[i], varOps[i]);
-                    blockParamToVarOpMap.put(loopParams[i], varOps[i]);
-                }
-            }
-
-
-            @Override
-            public CoreOp.VarOp resolve(Value value) {
-                if (value instanceof Block.Parameter blockParameter) {
-                    CoreOp.VarOp varOp = this.blockParamToVarOpMap.get(blockParameter);
-                    if (varOp != null) {
-                        return varOp;
-                    }
-                }
-                return super.resolve(value);
-            }
-        }
-
-        public static class IfScope extends Scope<IfOpWrapper> {
-            IfScope(Scope<?> parent, IfOpWrapper opWrapper) {
-                super(parent, opWrapper);
-            }
-        }
-
-        public static class WhileScope extends LoopScope<WhileOpWrapper> {
-            WhileScope(Scope<?> parent, WhileOpWrapper opWrapper) {
-                super(parent, opWrapper);
-            }
-
-        }
-
-        public Scope<?> scope = null;
-
-        private void popScope() {
-            scope = scope.parent;
-        }
-
-        private void pushScope(OpWrapper<?> opWrapper) {
-            scope = switch (opWrapper) {
-                case FuncOpWrapper $ -> new FuncScope(scope, $);
-                case ForOpWrapper $ -> new ForScope(scope, $);
-                case IfOpWrapper $ -> new IfScope(scope, $);
-                case WhileOpWrapper $ -> new WhileScope(scope, $);
-                default -> new Scope<>(scope, opWrapper);
-            };
-        }
-
-        public void scope(OpWrapper<?> opWrapper, Runnable r) {
-            pushScope(opWrapper);
-            r.run();
-            popScope();
-        }
-
-        public  FuncOpWrapper funcOpWrapper;
-
-        public CodeBuilderContext(FuncOpWrapper funcOpWrapper) {
-            this.funcOpWrapper = funcOpWrapper;
-        }
 
     }
 

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderContext.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.codebuilders;
+
+import hat.optools.ForOpWrapper;
+import hat.optools.FuncOpWrapper;
+import hat.optools.IfOpWrapper;
+import hat.optools.OpWrapper;
+import hat.optools.WhileOpWrapper;
+import jdk.incubator.code.Block;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Value;
+import jdk.incubator.code.dialect.core.CoreOp;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HATCodeBuilderContext {
+  //  public MethodHandles.Lookup lookup() {
+    //    return funcOpWrapper.lookup;
+    //}
+
+    public static class Scope<OW extends OpWrapper<?>> {
+        final Scope<?> parent;
+        final OW opWrapper;
+
+        public Scope(Scope<?> parent, OW opWrapper) {
+            this.parent = parent;
+            this.opWrapper = opWrapper;
+        }
+
+        public CoreOp.VarOp resolve(Value value) {
+            if (value instanceof Op.Result result && result.op() instanceof CoreOp.VarOp varOp) {
+                return varOp;
+            }
+            if (parent != null) {
+                return parent.resolve(value);
+            }
+            throw new IllegalStateException("failed to resolve VarOp for value " + value);
+        }
+    }
+
+    public static class FuncScope extends Scope<FuncOpWrapper> {
+        FuncScope(Scope<?> parent, FuncOpWrapper funcOpWrapper) {
+            super(parent, funcOpWrapper);
+        }
+
+        @Override
+        public CoreOp.VarOp resolve(Value value) {
+            if (value instanceof Block.Parameter blockParameter) {
+                if (opWrapper.parameterVarOpMap.containsKey(blockParameter)) {
+                    return opWrapper.parameterVarOpMap.get(blockParameter);
+                } else {
+                    throw new IllegalStateException("what ?");
+                }
+            } else {
+                return super.resolve(value);
+            }
+        }
+    }
+
+    public static abstract class LoopScope<T extends OpWrapper<?>> extends Scope<T> {
+
+        public LoopScope(Scope<?> parent, T opWrapper) {
+            super(parent, opWrapper);
+        }
+    }
+
+
+    public static class ForScope extends LoopScope<ForOpWrapper> {
+        Map<Block.Parameter, CoreOp.VarOp> blockParamToVarOpMap = new HashMap<>();
+
+        ForOpWrapper forOpWrapper() {
+            return opWrapper;
+        }
+
+        ForScope(Scope<?> parent, ForOpWrapper forOpWrapper) {
+            super(parent, forOpWrapper);
+            var loopParams = forOpWrapper.op.loopBody().entryBlock().parameters().toArray(new Block.Parameter[0]);
+            var updateParams = forOpWrapper.op.update().entryBlock().parameters().toArray(new Block.Parameter[0]);
+            var condParams = forOpWrapper.op.cond().entryBlock().parameters().toArray(new Block.Parameter[0]);
+            var lastInitOp = forOpWrapper.op.init().entryBlock().ops().getLast();
+            var lastInitOpOperand0Result = (Op.Result) lastInitOp.operands().getFirst();
+            var lastInitOpOperand0ResultOp = lastInitOpOperand0Result.op();
+            CoreOp.VarOp varOps[];
+            if (lastInitOpOperand0ResultOp instanceof CoreOp.TupleOp tupleOp) {
+                 /*
+                 for (int j = 1, i=2, k=3; j < size; k+=1,i+=2,j+=3) {
+                    float sum = k+i+j;
+                 }
+                 java.for
+                 ()Tuple<Var<int>, Var<int>, Var<int>> -> {
+                     %0 : int = constant @"1";
+                     %1 : Var<int> = var %0 @"j";
+                     %2 : int = constant @"2";
+                     %3 : Var<int> = var %2 @"i";
+                     %4 : int = constant @"3";
+                     %5 : Var<int> = var %4 @"k";
+                     %6 : Tuple<Var<int>, Var<int>, Var<int>> = tuple %1 %3 %5;
+                     yield %6;
+                 }
+                 (%7 : Var<int>, %8 : Var<int>, %9 : Var<int>)boolean -> {
+                     %10 : int = var.load %7;
+                     %11 : int = var.load %12;
+                     %13 : boolean = lt %10 %11;
+                     yield %13;
+                 }
+                 (%14 : Var<int>, %15 : Var<int>, %16 : Var<int>)void -> {
+                     %17 : int = var.load %16;
+                     %18 : int = constant @"1";
+                     %19 : int = add %17 %18;
+                     var.store %16 %19;
+                     %20 : int = var.load %15;
+                     %21 : int = constant @"2";
+                     %22 : int = add %20 %21;
+                     var.store %15 %22;
+                     %23 : int = var.load %14;
+                     %24 : int = constant @"3";
+                     %25 : int = add %23 %24;
+                     var.store %14 %25;
+                     yield;
+                 }
+                 (%26 : Var<int>, %27 : Var<int>, %28 : Var<int>)void -> {
+                     %29 : int = var.load %28;
+                     %30 : int = var.load %27;
+                     %31 : int = add %29 %30;
+                     %32 : int = var.load %26;
+                     %33 : int = add %31 %32;
+                     %34 : float = conv %33;
+                     %35 : Var<float> = var %34 @"sum";
+                     java.continue;
+                 };
+                 */
+                varOps = tupleOp.operands().stream().map(operand -> (CoreOp.VarOp) (((Op.Result) operand).op())).toList().toArray(new CoreOp.VarOp[0]);
+            } else {
+                 /*
+                 for (int j = 0; j < size; j+=1) {
+                    float sum = j;
+                 }
+                 java.for
+                    ()Var<int> -> {
+                        %0 : int = constant @"0";
+                        %1 : Var<int> = var %0 @"j";
+                        yield %1;
+                    }
+                    (%2 : Var<int>)boolean -> {
+                        %3 : int = var.load %2;
+                        %4 : int = var.load %5;
+                        %6 : boolean = lt %3 %4;
+                        yield %6;
+                    }
+                    (%7 : Var<int>)void -> {
+                        %8 : int = var.load %7;
+                        %9 : int = constant @"1";
+                        %10 : int = add %8 %9;
+                        var.store %7 %10;
+                        yield;
+                    }
+                    (%11 : Var<int>)void -> {
+                        %12 : int = var.load %11;
+                        %13 : float = conv %12;
+                        %14 : Var<float> = var %13 @"sum";
+                        java.continue;
+                    };
+
+                 */
+                varOps = new CoreOp.VarOp[]{(CoreOp.VarOp) lastInitOpOperand0ResultOp};
+            }
+            for (int i = 0; i < varOps.length; i++) {
+                blockParamToVarOpMap.put(condParams[i], varOps[i]);
+                blockParamToVarOpMap.put(updateParams[i], varOps[i]);
+                blockParamToVarOpMap.put(loopParams[i], varOps[i]);
+            }
+        }
+
+
+        @Override
+        public CoreOp.VarOp resolve(Value value) {
+            if (value instanceof Block.Parameter blockParameter) {
+                CoreOp.VarOp varOp = this.blockParamToVarOpMap.get(blockParameter);
+                if (varOp != null) {
+                    return varOp;
+                }
+            }
+            return super.resolve(value);
+        }
+    }
+
+    public static class IfScope extends Scope<IfOpWrapper> {
+        IfScope(Scope<?> parent, IfOpWrapper opWrapper) {
+            super(parent, opWrapper);
+        }
+    }
+
+    public static class WhileScope extends LoopScope<WhileOpWrapper> {
+        WhileScope(Scope<?> parent, WhileOpWrapper opWrapper) {
+            super(parent, opWrapper);
+        }
+
+    }
+
+    public Scope<?> scope = null;
+
+    private void popScope() {
+        scope = scope.parent;
+    }
+
+    private void pushScope(OpWrapper<?> opWrapper) {
+        scope = switch (opWrapper) {
+            case FuncOpWrapper $ -> new FuncScope(scope, $);
+            case ForOpWrapper $ -> new ForScope(scope, $);
+            case IfOpWrapper $ -> new IfScope(scope, $);
+            case WhileOpWrapper $ -> new WhileScope(scope, $);
+            default -> new Scope<>(scope, opWrapper);
+        };
+    }
+
+    public void scope(OpWrapper<?> opWrapper, Runnable r) {
+        pushScope(opWrapper);
+        r.run();
+        popScope();
+    }
+    public MethodHandles.Lookup lookup;
+    public FuncOpWrapper funcOpWrapper;
+
+    public HATCodeBuilderContext(MethodHandles.Lookup lookup,FuncOpWrapper funcOpWrapper) {
+        this.lookup = lookup;
+        this.funcOpWrapper = funcOpWrapper;
+    }
+
+}

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -136,8 +136,8 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
 
-    public T type(CodeBuilderContext buildContext,JavaType javaType) {
-        if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup(),javaType) && javaType instanceof ClassType classType) {
+    public T type(HATCodeBuilderContext buildContext, JavaType javaType) {
+        if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup,javaType) && javaType instanceof ClassType classType) {
             String name = classType.toClassName();
             int dotIdx = name.lastIndexOf('.');
             int dollarIdx = name.lastIndexOf('$');
@@ -155,40 +155,40 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
 
     @Override
-    public T varLoad(CodeBuilderContext buildContext, VarLoadOpWrapper varAccessOpWrapper) {
-        CoreOp.VarOp varOp = buildContext.scope.resolve(varAccessOpWrapper.operandNAsValue(0));
+    public T varLoad(HATCodeBuilderContext buildContext, VarLoadOpWrapper varAccessOpWrapper) {
+        CoreOp.VarOp varOp = buildContext.scope.resolve(varAccessOpWrapper.op.operands().getFirst());
         varName(varOp);
         return self();
     }
 
     @Override
-    public T varStore(CodeBuilderContext buildContext, VarStoreOpWrapper varAccessOpWrapper) {
-        CoreOp.VarOp varOp = buildContext.scope.resolve(varAccessOpWrapper.operandNAsValue(0));
+    public T varStore(HATCodeBuilderContext buildContext, VarStoreOpWrapper varAccessOpWrapper) {
+        CoreOp.VarOp varOp = buildContext.scope.resolve(varAccessOpWrapper.op.operands().getFirst());
         varName(varOp).equals();
-        parencedence(buildContext, varAccessOpWrapper, varAccessOpWrapper.operandNAsResult(1).op());
+        parencedence(buildContext, varAccessOpWrapper, ((Op.Result)varAccessOpWrapper.op.operands().get(1)).op());
         return self();
     }
 
     @Override
-    public T varDeclaration(CodeBuilderContext buildContext, VarDeclarationOpWrapper varDeclarationOpWrapper) {
-        if (varDeclarationOpWrapper.op().isUninitialized()) {
+    public T varDeclaration(HATCodeBuilderContext buildContext, VarDeclarationOpWrapper varDeclarationOpWrapper) {
+        if (varDeclarationOpWrapper.op.isUninitialized()) {
             // Variable is uninitialized
             type(buildContext,varDeclarationOpWrapper.javaType()).space().identifier(varDeclarationOpWrapper.varName());
         } else {
             type(buildContext,varDeclarationOpWrapper.javaType()).space().identifier(varDeclarationOpWrapper.varName()).space().equals().space();
-            parencedence(buildContext, varDeclarationOpWrapper, varDeclarationOpWrapper.operandNAsResult(0).op());
+            parencedence(buildContext, varDeclarationOpWrapper, ((Op.Result)varDeclarationOpWrapper.op.operands().getFirst()).op());
         }
         return self();
     }
 
     @Override
-    public T varFuncDeclaration(CodeBuilderContext buildContext, VarFuncDeclarationOpWrapper varFuncDeclarationOpWrapper) {
+    public T varFuncDeclaration(HATCodeBuilderContext buildContext, VarFuncDeclarationOpWrapper varFuncDeclarationOpWrapper) {
         // append("/* skipping ").type(varFuncDeclarationOpWrapper.javaType()).append(" param declaration  */");
         return self();
     }
 
     @Override
-    public T fieldLoad(CodeBuilderContext buildContext, FieldLoadOpWrapper fieldLoadOpWrapper) {
+    public T fieldLoad(HATCodeBuilderContext buildContext, FieldLoadOpWrapper fieldLoadOpWrapper) {
         if (fieldLoadOpWrapper.isKernelContextAccess()) {
             identifier("kc").rarrow().identifier(fieldLoadOpWrapper.fieldName());
         } else if (fieldLoadOpWrapper.isStaticFinalPrimitive()) {    Object value = fieldLoadOpWrapper.getStaticFinalPrimitiveValue();
@@ -201,7 +201,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T fieldStore(CodeBuilderContext buildContext, FieldStoreOpWrapper fieldStoreOpWrapper) {
+    public T fieldStore(HATCodeBuilderContext buildContext, FieldStoreOpWrapper fieldStoreOpWrapper) {
         //throw new IllegalStateException("What is this field store ?" + fieldStoreOpWrapper.fieldRef());
         return self();
     }
@@ -235,27 +235,27 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T unaryOperation(CodeBuilderContext buildContext, UnaryArithmeticOrLogicOpWrapper unaryOperatorOpWrapper) {
+    public T unaryOperation(HATCodeBuilderContext buildContext, UnaryArithmeticOrLogicOpWrapper unaryOperatorOpWrapper) {
       //  parencedence(buildContext, binaryOperatorOpWrapper.op(), binaryOperatorOpWrapper.lhsAsOp());
-        symbol(unaryOperatorOpWrapper.op());
-        parencedence(buildContext, unaryOperatorOpWrapper.op(), unaryOperatorOpWrapper.operandNAsResult(0).op());
+        symbol(unaryOperatorOpWrapper.op);
+        parencedence(buildContext, unaryOperatorOpWrapper.op, ((Op.Result)unaryOperatorOpWrapper.op.operands().getFirst()).op());
         return self();
     }
 
     @Override
-    public T binaryOperation(CodeBuilderContext buildContext, BinaryArithmeticOrLogicOperation binaryOperatorOpWrapper) {
-        parencedence(buildContext, binaryOperatorOpWrapper.op(), binaryOperatorOpWrapper.lhsAsOp());
-        symbol(binaryOperatorOpWrapper.op());
-        parencedence(buildContext, binaryOperatorOpWrapper.op(), binaryOperatorOpWrapper.rhsAsOp());
+    public T binaryOperation(HATCodeBuilderContext buildContext, BinaryArithmeticOrLogicOperation binaryOperatorOpWrapper) {
+        parencedence(buildContext, binaryOperatorOpWrapper.op, binaryOperatorOpWrapper.lhsAsOp());
+        symbol(binaryOperatorOpWrapper.op);
+        parencedence(buildContext, binaryOperatorOpWrapper.op, binaryOperatorOpWrapper.rhsAsOp());
         return self();
     }
 
     @Override
-    public T logical(CodeBuilderContext buildContext, LogicalOpWrapper logicalOpWrapper) {
+    public T logical(HATCodeBuilderContext buildContext, LogicalOpWrapper logicalOpWrapper) {
         logicalOpWrapper.lhsWrappedYieldOpStream().forEach((wrapped) -> {
             recurse(buildContext, wrapped);
         });
-        space().symbol(logicalOpWrapper.op()).space();
+        space().symbol(logicalOpWrapper.op).space();
         logicalOpWrapper.rhsWrappedYieldOpStream().forEach((wrapped) -> {
             recurse(buildContext, wrapped);
         });
@@ -263,61 +263,57 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T binaryTest(CodeBuilderContext buildContext, BinaryTestOpWrapper binaryTestOpWrapper) {
-        parencedence(buildContext, binaryTestOpWrapper.op(), binaryTestOpWrapper.lhsAsOp());
-        symbol(binaryTestOpWrapper.op());
-        parencedence(buildContext, binaryTestOpWrapper.op(), binaryTestOpWrapper.rhsAsOp());
+    public T binaryTest(HATCodeBuilderContext buildContext, BinaryTestOpWrapper binaryTestOpWrapper) {
+        parencedence(buildContext, binaryTestOpWrapper.op, binaryTestOpWrapper.lhsAsOp());
+        symbol(binaryTestOpWrapper.op);
+        parencedence(buildContext, binaryTestOpWrapper.op, binaryTestOpWrapper.rhsAsOp());
         return self();
     }
 
     @Override
 
-    public T conv(CodeBuilderContext buildContext, ConvOpWrapper convOpWrapper) {
+    public T conv(HATCodeBuilderContext buildContext, ConvOpWrapper convOpWrapper) {
         if (convOpWrapper.resultJavaType() == JavaType.DOUBLE) {
             paren(_ -> type(buildContext,JavaType.FLOAT));
         } else {
             paren(_ -> type(buildContext,convOpWrapper.resultJavaType()));
         }
-        //paren(() -> type(convOpWrapper.resultJavaType()));
-        parencedence(buildContext, convOpWrapper, convOpWrapper.operandNAsResult(0).op());
+        parencedence(buildContext, convOpWrapper, ((Op.Result)convOpWrapper.op.operands().getFirst()).op());
         return self();
     }
 
     @Override
-    public T constant(CodeBuilderContext buildContext, ConstantOpWrapper constantOpWrapper) {
-        Object object = constantOpWrapper.op().value();
+    public T constant(HATCodeBuilderContext buildContext, ConstantOpWrapper constantOpWrapper) {
+        Object object = constantOpWrapper.op.value();
         if (object == null) {
             nullKeyword();
         } else {
-            literal(constantOpWrapper.op().value().toString());
+            literal(constantOpWrapper.op.value().toString());
         }
         return self();
     }
 
     @Override
-    public T javaYield(CodeBuilderContext buildContext, YieldOpWrapper yieldOpWrapper) {
-        var operand0 = yieldOpWrapper.operandNAsValue(0);
-        if (operand0 instanceof Op.Result result) {
-            recurse(buildContext, OpWrapper.wrap(buildContext.lookup(), result.op()));
-        } else {
-            // append("/*nothing to yield*/");
+    public T javaYield(HATCodeBuilderContext buildContext, YieldOpWrapper yieldOpWrapper) {
+        if (yieldOpWrapper.op.operands().getFirst() instanceof Op.Result result) {
+            recurse(buildContext, OpWrapper.wrap(buildContext.lookup, result.op()));
         }
         return self();
     }
 
     @Override
-    public T lambda(CodeBuilderContext buildContext, LambdaOpWrapper lambdaOpWrapper) {
+    public T lambda(HATCodeBuilderContext buildContext, LambdaOpWrapper lambdaOpWrapper) {
         return commented("/*LAMBDA*/");
     }
 
     @Override
-    public T tuple(CodeBuilderContext buildContext, TupleOpWrapper tupleOpWrapper) {
-        StreamCounter.of(tupleOpWrapper.operands(), (c, operand) -> {
+    public T tuple(HATCodeBuilderContext buildContext, TupleOpWrapper tupleOpWrapper) {
+        StreamCounter.of(tupleOpWrapper.op.operands(), (c, operand) -> {
             if (c.isNotFirst()) {
                 comma().space();
             }
             if (operand instanceof Op.Result result) {
-                recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),result.op()));
+                recurse(buildContext, OpWrapper.wrap(buildContext.lookup,result.op()));
             } else {
                 commented("/*nothing to tuple*/");
             }
@@ -326,12 +322,12 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T funcCall(CodeBuilderContext buildContext, FuncCallOpWrapper funcCallOpWrapper) {
+    public T funcCall(HATCodeBuilderContext buildContext, FuncCallOpWrapper funcCallOpWrapper) {
           identifier(funcCallOpWrapper.funcName());
         paren(_ -> {
-            commaSeparated(funcCallOpWrapper.operands(), (e) -> {
-                if (e instanceof Op.Result r) {
-                    parencedence(buildContext, funcCallOpWrapper, r.op());
+            commaSeparated(funcCallOpWrapper.op.operands(), (e) -> {
+                if (e instanceof Op.Result result) {
+                    parencedence(buildContext, funcCallOpWrapper, result.op());
                 } else {
                     throw new IllegalStateException("Value?");
                 }
@@ -341,19 +337,19 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T javaLabeled(CodeBuilderContext buildContext, JavaLabeledOpWrapper javaLabeledOpWrapper) {
-        var labelNameOp = OpWrapper.wrap(buildContext.lookup(),javaLabeledOpWrapper.firstBlockOfFirstBody().ops().get(0));
-        CoreOp.ConstantOp constantOp = (CoreOp.ConstantOp) labelNameOp.op();
+    public T javaLabeled(HATCodeBuilderContext buildContext, JavaLabeledOpWrapper javaLabeledOpWrapper) {
+        var labelNameOp = OpWrapper.wrap(buildContext.lookup,javaLabeledOpWrapper.op.bodies().getFirst().entryBlock().ops().getFirst());
+        CoreOp.ConstantOp constantOp = (CoreOp.ConstantOp) labelNameOp.op;
         literal(constantOp.value().toString()).colon().nl();
-        var forLoopOp = javaLabeledOpWrapper.firstBlockOfFirstBody().ops().get(1);
-        recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),forLoopOp));
+        var forLoopOp = javaLabeledOpWrapper.op.bodies().getFirst().entryBlock().ops().get(1);
+        recurse(buildContext, OpWrapper.wrap(buildContext.lookup,forLoopOp));
         // var yieldOp = javaLabeledOpWrapper.firstBlockOfFirstBody().ops().get(2);
         return self();
     }
 
-    public T javaBreak(CodeBuilderContext buildContext, JavaBreakOpWrapper javaBreakOpWrapper) {
+    public T javaBreak(HATCodeBuilderContext buildContext, JavaBreakOpWrapper javaBreakOpWrapper) {
         breakKeyword();
-        if (javaBreakOpWrapper.hasOperands() && javaBreakOpWrapper.operandNAsResult(0) instanceof Op.Result result) {
+        if (!javaBreakOpWrapper.op.operands().isEmpty() && javaBreakOpWrapper.op.operands().getFirst() instanceof Op.Result result) {
             space();
             if (result.op() instanceof CoreOp.ConstantOp c) {
                 literal(c.value().toString());
@@ -362,13 +358,13 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
         return self();
     }
 
-    public T javaContinue(CodeBuilderContext buildContext, JavaContinueOpWrapper javaContinueOpWrapper) {
-        if (javaContinueOpWrapper.hasOperands()
-                && javaContinueOpWrapper.operandNAsResult(0) instanceof Op.Result result
+    public T javaContinue(HATCodeBuilderContext buildContext, JavaContinueOpWrapper javaContinueOpWrapper) {
+        if (!javaContinueOpWrapper.op.operands().isEmpty()
+                && javaContinueOpWrapper.op.operands().getFirst() instanceof Op.Result result
                 && result.op() instanceof CoreOp.ConstantOp c
         ) {
             continueKeyword().space().literal(c.value().toString());
-        } else if (buildContext.scope.parent instanceof CodeBuilderContext.LoopScope<?>) {
+        } else if (buildContext.scope.parent instanceof HATCodeBuilderContext.LoopScope<?>) {
             // nope
         } else {
             continueKeyword();
@@ -378,17 +374,20 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T javaIf(CodeBuilderContext buildContext, IfOpWrapper ifOpWrapper) {
+    public T javaIf(HATCodeBuilderContext buildContext, IfOpWrapper ifOpWrapper) {
         buildContext.scope(ifOpWrapper, () -> {
             boolean[] lastWasBody = new boolean[]{false};
-            StreamCounter.of(ifOpWrapper.bodies(), (c, b) -> {
+            StreamCounter.of(ifOpWrapper.op.bodies(), (c, b) -> {
                 if (b.yieldType() instanceof JavaType javaType && javaType == JavaType.VOID) {
                     if (ifOpWrapper.hasElseN(c.value())) {
                         if (lastWasBody[0]) {
                             elseKeyword();
                         }
                         braceNlIndented(_ ->
-                                StreamCounter.of(ifOpWrapper.wrappedRootOpStream(ifOpWrapper.firstBlockOfBodyN(c.value())), (innerc, root) ->
+                                StreamCounter.of(ifOpWrapper.wrappedRootOpStream(
+                                        ifOpWrapper.op.bodies().get(c.value()).entryBlock())
+                                        //ifOpWrapper.firstBlockOfBodyN(c.value()))
+                                        , (innerc, root) ->
                                         nlIf(innerc.isNotFirst())
                                                 .recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>))
                                 )
@@ -400,7 +399,10 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                         elseKeyword().space();
                     }
                     ifKeyword().paren(_ ->
-                            ifOpWrapper.wrappedYieldOpStream(ifOpWrapper.firstBlockOfBodyN(c.value())).forEach((wrapped) ->
+                            ifOpWrapper.wrappedYieldOpStream(
+                                    ifOpWrapper.op.bodies().get(c.value()).entryBlock())
+                            //        ifOpWrapper.firstBlockOfBodyN(c.value()))
+                            .forEach((wrapped) ->
                                     recurse(buildContext, wrapped))
                     );
                     lastWasBody[0] = false;
@@ -412,7 +414,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T javaWhile(CodeBuilderContext buildContext, WhileOpWrapper whileOpWrapper) {
+    public T javaWhile(HATCodeBuilderContext buildContext, WhileOpWrapper whileOpWrapper) {
         whileKeyword().paren(_ ->
                 whileOpWrapper.conditionWrappedYieldOpStream().forEach((wrapped) -> recurse(buildContext, wrapped))
         ).braceNlIndented(_ ->
@@ -424,7 +426,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T javaFor(CodeBuilderContext buildContext, ForOpWrapper forOpWrapper) {
+    public T javaFor(HATCodeBuilderContext buildContext, ForOpWrapper forOpWrapper) {
         buildContext.scope(forOpWrapper, () ->
                 forKeyword().paren(_ -> {
                     forOpWrapper.initWrappedYieldOpStream().forEach((wrapped) -> recurse(buildContext, wrapped));
@@ -523,22 +525,22 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
         return self();
     }
 
-    public T atomicInc(CodeBuilderContext buildContext, Op.Result instanceResult, String name) {
+    public T atomicInc(HATCodeBuilderContext buildContext, Op.Result instanceResult, String name) {
         throw new IllegalStateException("atomicInc not implemented");
     }
 
     @Override
-    public T methodCall(CodeBuilderContext buildContext, InvokeOpWrapper invokeOpWrapper) {
+    public T methodCall(HATCodeBuilderContext buildContext, InvokeOpWrapper invokeOpWrapper) {
         var name = invokeOpWrapper.name();
 
         if (invokeOpWrapper.isIfaceBufferMethod()) {
-            var operandCount = invokeOpWrapper.operandCount();
+            var operandCount = invokeOpWrapper.op.operands().size();
             var returnType = invokeOpWrapper.javaReturnType();
 
             if (operandCount == 1 && name.startsWith("atomic") && name.endsWith("Inc")
                     && returnType instanceof PrimitiveType primitiveType && primitiveType.equals(JavaType.INT)) {
                 // this is a bit of a hack for atomics.
-                if (invokeOpWrapper.operandNAsResult(0) instanceof Op.Result instanceResult) {
+                if (invokeOpWrapper.op.operands().getFirst() instanceof Op.Result instanceResult) {
                     atomicInc(buildContext, instanceResult, name.substring(0, name.length() - 3));
                     //identifier("atomic_inc").paren(_ -> {
                     //    ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
@@ -548,7 +550,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                     throw new IllegalStateException("bad atomic");
                 }
             } else {
-                if (invokeOpWrapper.operandNAsResult(0) instanceof Op.Result instanceResult) {
+                if (invokeOpWrapper.op.operands().getFirst() instanceof Op.Result instanceResult) {
                 /*
                 We have three types of returned values from an ifaceBuffer
                 A primitive
@@ -595,7 +597,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
                      */
                     }
-                    recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),instanceResult.op()));
+                    recurse(buildContext, OpWrapper.wrap(buildContext.lookup,instanceResult.op()));
                     rarrow().identifier(name);
                     //if (invokeOpWrapper.name().equals("value") || invokeOpWrapper.name().equals("anon")){
                     //System.out.println("value|anon");
@@ -604,18 +606,18 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                         //   setter
                         switch (operandCount) {
                             case 2: {
-                                if (invokeOpWrapper.operandNAsResult(1) instanceof Op.Result result1) {
-                                    equals().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),result1.op()));
+                                if (invokeOpWrapper.op.operands().get(1) instanceof Op.Result result1) {
+                                    equals().recurse(buildContext, OpWrapper.wrap(buildContext.lookup,result1.op()));
                                 } else {
                                     throw new IllegalStateException("How ");
                                 }
                                 break;
                             }
                             case 3: {
-                                if (invokeOpWrapper.operandNAsResult(1) instanceof Op.Result result1
-                                        && invokeOpWrapper.operandNAsResult(2) instanceof Op.Result result2) {
-                                    sbrace(_ -> recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),result1.op())));
-                                    equals().recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),result2.op()));
+                                if (invokeOpWrapper.op.operands().get(1) instanceof Op.Result result1
+                                        && invokeOpWrapper.op.operands().get(2) instanceof Op.Result result2) {
+                                    sbrace(_ -> recurse(buildContext, OpWrapper.wrap(buildContext.lookup,result1.op())));
+                                    equals().recurse(buildContext, OpWrapper.wrap(buildContext.lookup,result2.op()));
                                 } else {
                                     throw new IllegalStateException("How ");
                                 }
@@ -626,8 +628,8 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                             }
                         }
                     } else {
-                        if (invokeOpWrapper.operandNAsResult(1) instanceof Op.Result result1) {
-                            var rhs = OpWrapper.wrap(buildContext.lookup(),result1.op());
+                        if (invokeOpWrapper.op.operands().size()>1 && invokeOpWrapper.op.operands().get(1) instanceof Op.Result result1) {
+                            var rhs = OpWrapper.wrap(buildContext.lookup,result1.op());
                             sbrace(_ -> recurse(buildContext, rhs));
                         } else {
                             // This is a simple usage.   So scaleTable->multiScaleAccumRange
@@ -640,9 +642,9 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
             }
         } else {
             identifier(name).paren(_ ->
-                    commaSeparated(invokeOpWrapper.operands(), (op) -> {
+                    commaSeparated(invokeOpWrapper.op.operands(), (op) -> {
                         if (op instanceof Op.Result result) {
-                            recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),result.op()));
+                            recurse(buildContext, OpWrapper.wrap(buildContext.lookup,result.op()));
                         } else {
                             throw new IllegalStateException("wtf?");
                         }
@@ -653,7 +655,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T ternary(CodeBuilderContext buildContext, TernaryOpWrapper ternaryOpWrapper) {
+    public T ternary(HATCodeBuilderContext buildContext, TernaryOpWrapper ternaryOpWrapper) {
         ternaryOpWrapper.conditionWrappedYieldOpStream().forEach((wrapped) -> recurse(buildContext, wrapped));
         questionMark();
         ternaryOpWrapper.thenWrappedYieldOpStream().forEach((wrapped) -> recurse(buildContext, wrapped));
@@ -671,28 +673,31 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
      * @param child
      */
     @Override
-    public T parencedence(CodeBuilderContext buildContext, Op parent, OpWrapper<?> child) {
-        return parenWhen(precedenceOf(parent) < precedenceOf(child.op()), _ -> recurse(buildContext, child));
+    public T parencedence(HATCodeBuilderContext buildContext, Op parent, OpWrapper<?> child) {
+        return parenWhen(precedenceOf(parent) < precedenceOf(child.op), _ -> recurse(buildContext, child));
     }
 
-    public T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child) {
-        return parenWhen(precedenceOf(parent.op()) < precedenceOf(child.op()), _ -> recurse(buildContext, child));
-    }
-@Override
-    public T parencedence(CodeBuilderContext buildContext,  Op parent, Op child) {
-        return parenWhen(precedenceOf(parent) < precedenceOf(child), _ -> recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),child)));
+    @Override
+    public T parencedence(HATCodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child) {
+        return parenWhen(precedenceOf(parent.op) < precedenceOf(child.op), _ -> recurse(buildContext, child));
     }
 
-    public T parencedence(CodeBuilderContext buildContext, OpWrapper<?> parent, Op child) {
-        return parenWhen(precedenceOf(parent.op()) < precedenceOf(child), _ -> recurse(buildContext, OpWrapper.wrap(buildContext.lookup(),child)));
+    @Override
+    public T parencedence(HATCodeBuilderContext buildContext, Op parent, Op child) {
+        return parenWhen(precedenceOf(parent) < precedenceOf(child), _ -> recurse(buildContext, OpWrapper.wrap(buildContext.lookup,child)));
+    }
+
+    @Override
+    public T parencedence(HATCodeBuilderContext buildContext, OpWrapper<?> parent, Op child) {
+        return parenWhen(precedenceOf(parent.op) < precedenceOf(child), _ -> recurse(buildContext, OpWrapper.wrap(buildContext.lookup,child)));
     }
 
 
     @Override
-    public T ret(CodeBuilderContext buildContext, ReturnOpWrapper returnOpWrapper) {
+    public T ret(HATCodeBuilderContext buildContext, ReturnOpWrapper returnOpWrapper) {
         returnKeyword();
-        if (returnOpWrapper.hasOperands()) {
-            space().parencedence(buildContext, returnOpWrapper, returnOpWrapper.operandNAsResult(0).op());
+        if (!returnOpWrapper.op.operands().isEmpty()) {
+            space().parencedence(buildContext, returnOpWrapper, ((Op.Result)returnOpWrapper.op.operands().getFirst()).op());
         }
         return self();
     }

--- a/hat/core/src/main/java/hat/optools/BinaryOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/BinaryOpWrapper.java
@@ -34,11 +34,11 @@ public abstract class BinaryOpWrapper<T extends Op> extends OpWrapper<T> {
     }
 
     public Op lhsAsOp() {
-        return operandNAsResult(0).op();
+        return ((Op.Result)op.operands().getFirst()).op();
     }
 
     public Op rhsAsOp() {
-        return operandNAsResult(1).op();
+        return  ((Op.Result)op.operands().get(1)).op();
     }
 
 

--- a/hat/core/src/main/java/hat/optools/BodyWrapper.java
+++ b/hat/core/src/main/java/hat/optools/BodyWrapper.java
@@ -40,13 +40,4 @@ public class BodyWrapper extends CodeElementWrapper<Body> {
         return new BodyWrapper(body);
     }
 
-    public static void onlyBlock(Body body, Consumer<BlockWrapper> blockWrapperConsumer) {
-        blockWrapperConsumer.accept(new BlockWrapper(body.entryBlock()));
-    }
-
-    public void onlyBlock(Consumer<BlockWrapper> blockWrapperConsumer) {
-        onlyBlock(body(), blockWrapperConsumer);
-    }
-
-
 }

--- a/hat/core/src/main/java/hat/optools/ConvOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/ConvOpWrapper.java
@@ -35,6 +35,6 @@ public class ConvOpWrapper extends UnaryOpWrapper<JavaOp.ConvOp> {
     }
 
     public JavaType resultJavaType() {
-        return (JavaType) op().resultType();
+        return (JavaType) op.resultType();
     }
 }

--- a/hat/core/src/main/java/hat/optools/FieldAccessOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/FieldAccessOpWrapper.java
@@ -45,12 +45,12 @@ public abstract class FieldAccessOpWrapper<T extends JavaOp.FieldAccessOp> exten
     }
 
     public boolean isStaticFinalPrimitive() {
-      return hasNoOperands() && resultType() instanceof PrimitiveType;
+      return op.operands().isEmpty() && op.result().type() instanceof PrimitiveType;
       // Can we check for final?
     }
 
     public FieldRef fieldRef() {
-        return op().fieldDescriptor();
+        return op.fieldDescriptor();
     }
 
     public String fieldName() {

--- a/hat/core/src/main/java/hat/optools/ForOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/ForOpWrapper.java
@@ -35,20 +35,20 @@ public class ForOpWrapper extends LoopOpWrapper<JavaOp.ForOp> {
     }
 
     public Stream<OpWrapper<?>> initWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(0));
+        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*firstBlockOfBodyN(0)*/);
     }
 
     @Override
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(1));
+        return wrappedYieldOpStream(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
     }
 
     public Stream<OpWrapper<?>> mutateRootWrappedOpStream() {
-        return wrappedRootOpStream(firstBlockOfBodyN(2));
+        return wrappedRootOpStream(op.bodies().get(2).entryBlock()/*firstBlockOfBodyN(2)*/);
     }
 
     @Override
     public Stream<OpWrapper<?>> loopWrappedRootOpStream() {
-        return wrappedRootOpStreamSansFinalContinue(firstBlockOfBodyN(3));
+        return wrappedRootOpStreamSansFinalContinue(op.bodies().get(3).entryBlock()/*firstBlockOfBodyN(3)*/);
     }
 }

--- a/hat/core/src/main/java/hat/optools/FuncCallOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/FuncCallOpWrapper.java
@@ -35,6 +35,6 @@ public class FuncCallOpWrapper extends OpWrapper<CoreOp.FuncCallOp> {
 
 
     public String funcName() {
-        return op().funcName();
+        return op.funcName();
     }
 }

--- a/hat/core/src/main/java/hat/optools/IfOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/IfOpWrapper.java
@@ -27,7 +27,6 @@ package hat.optools;
 import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.lang.invoke.MethodHandles;
-import java.util.stream.Stream;
 
 public class IfOpWrapper extends StructuralOpWrapper<JavaOp.IfOp> {
     public IfOpWrapper(MethodHandles.Lookup lookup,JavaOp.IfOp op) {
@@ -35,18 +34,6 @@ public class IfOpWrapper extends StructuralOpWrapper<JavaOp.IfOp> {
     }
 
     public boolean hasElseN(int idx) {
-        return hasBodyN(idx) && firstBlockOfBodyN(idx).ops().size() > 1;
-    }
-
-    public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {
-        return wrappedYieldOpStream(bodyN(0).entryBlock());
-    }
-
-    public Stream<OpWrapper<?>> thenWrappedRootOpStream() {
-        return wrappedRootOpStream(bodyN(1).entryBlock());
-    }
-
-    public Stream<OpWrapper<?>> elseWrappedRootOpStream() {
-        return wrappedRootOpStream(bodyN(2).entryBlock());
+        return op.bodies().size()>idx && op.bodies().get(idx).entryBlock().ops().size() > 1;
     }
 }

--- a/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -47,7 +47,7 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     }
 
     public MethodRef methodRef() {
-        return op().invokeDescriptor();
+        return op.invokeDescriptor();
     }
 
     public JavaType javaRefType() {
@@ -59,7 +59,7 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     }
 
     public boolean isRawKernelCall() {
-        return (operandCount() > 1 && operandNAsValue(0) instanceof Value value
+        return (op.operands().size() > 1 && op.operands().getFirst() instanceof Value value
                 && value.type() instanceof JavaType javaType
                 && (isAssignable(javaType, hat.KernelContext.class) || isAssignable(javaType, KernelContext.class))
         );
@@ -87,42 +87,21 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     public boolean returnsVoid() {
         return javaReturnType().equals(JavaType.VOID);
     }
-/*
-    public Method methodNoLookup() {
-        Class<?> declaringClass = javaRefClass().orElseThrow();
-        // TODO this is just matching the name....
-        Optional<Method> declaredMethod = Stream.of(declaringClass.getDeclaredMethods())
-                .filter(method -> method.getName().equals(methodRef().name()))
-                .findFirst();
-        if (declaredMethod.isPresent()) {
-            return declaredMethod.get();
-        }
-        Optional<Method> nonDeclaredMethod = Stream.of(declaringClass.getMethods())
-                .filter(method -> method.getName().equals(methodRef().name()))
-                .findFirst();
-        if (nonDeclaredMethod.isPresent()) {
-            return nonDeclaredMethod.get();
-        } else {
-            throw new IllegalStateException("what were we looking for ?"); // getClass causes this
-        }
-    } */
+
     public Method method() {
-        Method invokedMethod = null;
         try {
-            return methodRef().resolveToMethod(lookup, op().invokeKind());
-          //  MethodRef methodRef = methodRef();
-         //   return invokedMethod;
+            return methodRef().resolveToMethod(lookup, op.invokeKind());
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }
 
     public Value getReceiver() {
-        return hasReceiver() ? operandNAsValue(0) : null;
+        return hasReceiver() ? op.operands().getFirst() : null;
     }
 
     public boolean hasReceiver() {
-        return op().hasReceiver();
+        return op.hasReceiver();
     }
 
     public enum IfaceBufferAccess {None, Access, Mutate}
@@ -145,7 +124,7 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     }
 
     public String name() {
-        return op().invokeDescriptor().name();
+        return op.invokeDescriptor().name();
     }
 
     public Optional<Class<?>> javaRefClass() {

--- a/hat/core/src/main/java/hat/optools/LambdaOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/LambdaOpWrapper.java
@@ -44,16 +44,8 @@ public class LambdaOpWrapper extends OpWrapper<JavaOp.LambdaOp> {
         super(lookup,op);
     }
 
-    public InvokeOpWrapper getInvoke(int index) {
-        var result = new Result<JavaOp.InvokeOp>();
-        selectOnlyBlockOfOnlyBody(blockWrapper ->
-                result.of(blockWrapper.op(index))
-        );
-        return OpWrapper.wrap(lookup, result.get());
-    }
-
     public List<Value> operands() {
-        return op().operands();
+        return op.operands();
     }
 
     public Method getQuotableTargetMethod() {
@@ -61,7 +53,7 @@ public class LambdaOpWrapper extends OpWrapper<JavaOp.LambdaOp> {
     }
 
     public InvokeOpWrapper getQuotableTargetInvokeOpWrapper() {
-        return OpWrapper.wrap(lookup, op().body().entryBlock().ops().stream()
+        return OpWrapper.wrap(lookup, op.body().entryBlock().ops().stream()
                 .filter(op -> op instanceof JavaOp.InvokeOp)
                 .map(op -> (JavaOp.InvokeOp) op)
                 .findFirst().get());
@@ -72,7 +64,7 @@ public class LambdaOpWrapper extends OpWrapper<JavaOp.LambdaOp> {
     }
 
     public Object[] getQuotableCapturedValues(Quoted quoted, Method method) {
-        var block = op().body().entryBlock();
+        var block = op.body().entryBlock();
         var ops = block.ops();
         Object[] varLoadNames = ops.stream()
                 .filter(op -> op instanceof CoreOp.VarAccessOp.VarLoadOp)

--- a/hat/core/src/main/java/hat/optools/LogicalOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/LogicalOpWrapper.java
@@ -35,10 +35,10 @@ public class LogicalOpWrapper extends BinaryOpWrapper<JavaOp.JavaConditionalOp> 
     }
 
     public Stream<OpWrapper<?>> lhsWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(0));
+        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*firstBlockOfBodyN(0)*/);
     }
 
     public Stream<OpWrapper<?>> rhsWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(1));
+        return wrappedYieldOpStream(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
     }
 }

--- a/hat/core/src/main/java/hat/optools/OpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/OpWrapper.java
@@ -93,125 +93,13 @@ public class OpWrapper<T extends Op> {
         };
     }
 
-    private final T op;
-public MethodHandles.Lookup lookup;
+    public final T op;
+    public final MethodHandles.Lookup lookup;
     OpWrapper( MethodHandles.Lookup lookup,T op) {
         this.lookup= lookup;
         this.op = op;
 
     }
-
-    public T op() {
-        return (T) op;
-    }
-
-    public Body firstBody() {
-        if (op.bodies().isEmpty()) {
-            throw new IllegalStateException("no body!");
-        }
-        return op.bodies().getFirst();
-    }
-
-    public Body onlyBody() {
-        if (op.bodies().size() != 1) {
-            throw new IllegalStateException("not the only body!");
-        }
-        return firstBody();
-    }
-
-    public void onlyBody(Consumer<BodyWrapper> bodyWrapperConsumer) {
-        bodyWrapperConsumer.accept(new BodyWrapper(onlyBody()));
-    }
-
-    public final Stream<Body> bodies() {
-        return op.bodies().stream();
-    }
-
-    public void selectOnlyBlockOfOnlyBody(Consumer<BlockWrapper> blockWrapperConsumer) {
-        onlyBody(w -> {
-            w.onlyBlock(blockWrapperConsumer);
-        });
-    }
-
-    public void selectCalls(Consumer<InvokeOpWrapper> consumer) {
-        this.op.traverse(null, (map, op) -> {
-            if (op instanceof JavaOp.InvokeOp invokeOp) {
-                consumer.accept(wrap(lookup,invokeOp));
-            }
-            return map;
-        });
-    }
-    public void selectAssignments(Consumer<VarOpWrapper> consumer) {
-        this.op.traverse(null, (map, op) -> {
-            if (op instanceof CoreOp.VarOp varOp) {
-                consumer.accept(wrap(lookup,varOp));
-            }
-            return map;
-        });
-    }
-
-    public BlockWrapper parentBlock() {
-        return new BlockWrapper(op.ancestorBlock());
-    }
-
-    public BodyWrapper parentBodyOfParentBlock() {
-//        return new BodyWrapper(op.ancestorBody());
-        return parentBlock().parentBody();
-    }
-
-
-    public Op.Result operandNAsResult(int i) {
-        if (operandNAsValue(i) instanceof Op.Result result) {
-            return result;
-        } else {
-            return null;
-        }
-    }
-
-    public Value operandNAsValue(int i) {
-        return hasOperandN(i) ? op().operands().get(i) : null;
-    }
-
-    public boolean hasOperandN(int i) {
-        return operandCount() > i;
-    }
-
-    public int operandCount() {
-        return op().operands().size();
-    }
-
-    public boolean hasOperands() {
-        return !hasNoOperands();
-    }
-
-    public boolean hasNoOperands() {
-        return operands().isEmpty();
-    }
-
-    public List<Value> operands() {
-        return op.operands();
-    }
-
-    public Body bodyN(int i) {
-        return op().bodies().get(i);
-    }
-
-    public boolean hasBodyN(int i) {
-        return op().bodies().size() > i;
-    }
-
-    public Block firstBlockOfBodyN(int i) {
-        return bodyN(i).entryBlock();
-    }
-
-    public Block firstBlockOfFirstBody() {
-        return op().bodies().getFirst().entryBlock();
-    }
-
-    public String toText() {
-        return op().toText();
-    }
-
     public Stream<OpWrapper<?>> wrappedOpStream(Block block) {
         return block.ops().stream().map(o->wrap(lookup,o));
     }
@@ -245,18 +133,11 @@ public MethodHandles.Lookup lookup;
         return list.stream();
     }
 
-    public Op.Result result() {
-        return op.result();
-    }
-
-    public TypeElement resultType() {
-        return op.resultType();
-    }
     public  static boolean isIfaceUsingLookup(MethodHandles.Lookup lookup,JavaType javaType) {
-        return  (isAssignableUsingLookup(lookup,javaType, MappableIface.class));
+        return  isAssignableUsingLookup(lookup,javaType, MappableIface.class);
     }
     public  boolean isIface(JavaType javaType) {
-        return  (isAssignable(javaType, MappableIface.class));
+        return  isAssignable(javaType, MappableIface.class);
     }
 
     public  static Type classTypeToTypeUsingLookup(MethodHandles.Lookup lookup,ClassType classType) {
@@ -286,6 +167,5 @@ public MethodHandles.Lookup lookup;
     }
     public  boolean isAssignable(JavaType javaType, Class<?> ... classes) {
        return isAssignableUsingLookup(lookup,javaType,classes);
-
     }
 }

--- a/hat/core/src/main/java/hat/optools/RootSet.java
+++ b/hat/core/src/main/java/hat/optools/RootSet.java
@@ -36,24 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-//Recursive
-/*
-static Node<Value> dependencyTree(Value value) {
-    // @@@ There should exactly one Node in the tree for a given Value
-    List<Node<Value>> children = new ArrayList<>();
-    for (Value dependencyOnValue : value.dependsOn()) {
-        Node<Value> child;
-        if (dependencyOnValue instanceof Op.Result or && or.op() instanceof JavaOps.VarAccessOp.VarLoadOp) {
-            // Break the tree at a var load
-            child = new Node<>(dependencyOnValue, List.of());
-        } else {
-            // Traverse backwards
-            child = dependencyTree(dependencyOnValue); // recurses
-        }
-        children.add(child);
-    }
-    return new Node<>(value, children);
-} */
 public class RootSet {
     record Node<T extends Value>(T node, List<Node<T>> children) {
     }
@@ -75,7 +57,7 @@ public class RootSet {
             trees.put(op, new Node<>(op.result(), children));
         });
 
-        trees.forEach((op, valueNode) -> {
+        trees.forEach((op, _) -> {
             if (op instanceof CoreOp.VarAccessOp.VarStoreOp) {
                 Value value = op.operands().get(1);
                 if (value.uses().size() < 2) {

--- a/hat/core/src/main/java/hat/optools/TernaryOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/TernaryOpWrapper.java
@@ -36,14 +36,14 @@ public class TernaryOpWrapper extends OpWrapper<JavaOp.ConditionalExpressionOp> 
     }
 
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(0));
+        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*,firstBlockOfBodyN(0)*/);
     }
 
     public Stream<OpWrapper<?>> thenWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(1));
+        return wrappedYieldOpStream(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
     }
 
     public Stream<OpWrapper<?>> elseWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(2));
+        return wrappedYieldOpStream(op.bodies().get(2).entryBlock()/*firstBlockOfBodyN(2)*/);
     }
 }

--- a/hat/core/src/main/java/hat/optools/VarAccessOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/VarAccessOpWrapper.java
@@ -40,7 +40,7 @@ public abstract class VarAccessOpWrapper<T extends CoreOp.VarAccessOp> extends O
         // @@@ At a high-level a Var value occur as a BlockArgument.
         // Lowering should remove such cases and the var definition should emerge
         // @@@ This method is used when transforming to pure SSA
-        Value value = operands().getFirst();
+        Value value = op.operands().getFirst();
         Op.Result variable = (Op.Result) value;
         return (CoreOp.VarOp) variable.op();
     }

--- a/hat/core/src/main/java/hat/optools/VarOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/VarOpWrapper.java
@@ -35,14 +35,11 @@ public abstract class VarOpWrapper extends OpWrapper<CoreOp.VarOp> {
     }
 
     public JavaType javaType() {
-        return (JavaType) op().varValueType();
+        return (JavaType) op.varValueType();
     }
 
     public String varName() {
-        return op().varName();
+        return op.varName();
     }
 
-    public boolean isIfaceAssignment() {
-        return isIface(javaType());
-    }
 }

--- a/hat/core/src/main/java/hat/optools/WhileOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/WhileOpWrapper.java
@@ -37,11 +37,11 @@ public class WhileOpWrapper extends LoopOpWrapper<JavaOp.WhileOp> {
 
     @Override
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {
-        return wrappedYieldOpStream(firstBlockOfBodyN(0));
+        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*firstBlockOfBodyN(0)*/);
     }
 
     @Override
     public Stream<OpWrapper<?>> loopWrappedRootOpStream() {
-        return wrappedRootOpStreamSansFinalContinue(firstBlockOfBodyN(1));
+        return wrappedRootOpStreamSansFinalContinue(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
     }
 }

--- a/hat/intellij/wrap_opengl.iml
+++ b/hat/intellij/wrap_opengl.iml
@@ -12,7 +12,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/../build/hat-extraction-opengl-1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../build/hat-extracted-opengl-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/hat/tools/src/main/java/hat/tools/jdot/ui/JDot.java
+++ b/hat/tools/src/main/java/hat/tools/jdot/ui/JDot.java
@@ -685,21 +685,22 @@ public class JDot {
         this(dotToJson(dotText));
     }
 
+
     public static void main(String[] args) throws IOException {
         SwingUtilities.invokeLater(() -> {
             JDot jDot = new JDot(DotBuilder.dotDigraph("cmake",db->db
-                            .assign("rankdir", "RL")
-                            .nodeShape("record")
-                            .record("backend-ffi-opencl", "backend|{ffi|extracted}|opencl")
-                            .record("backend-ffi-shared", "backend|ffi|<in>shared")
-                            .record("backend-ffi", "backend|ffi")
-                            .record("core",  "core")
-                            .record("cmake-info-opencl", "<in>cmake|info|opencl")
-                            .edge("backend-ffi-opencl","backend-ffi-shared:se")
-                            .edge("backend-ffi-shared","backend-ffi:n")
-                            .edge("backend-ffi","core:s")
-                            .edge("backend-ffi-opencl","cmake-info-opencl:ne")
-                    ));
+                    .assign("rankdir", "RL")
+                    .nodeShape("record")
+                    .record("backend-ffi-opencl", "backend|{ffi|extracted}|opencl")
+                    .record("backend-ffi-shared", "backend|ffi|<in>shared")
+                    .record("backend-ffi", "backend|ffi")
+                    .record("core",  "core")
+                    .record("cmake-info-opencl", "<in>cmake|info|opencl")
+                    .edge("backend-ffi-opencl","backend-ffi-shared:se")
+                    .edge("backend-ffi-shared","backend-ffi:n")
+                    .edge("backend-ffi","core:s")
+                    .edge("backend-ffi-opencl","cmake-info-opencl:ne")
+            ));
             var frame = new JFrame();
             frame.setLayout(new BorderLayout());
             frame.getContentPane().add(jDot.pane);

--- a/hat/tools/src/main/java/hat/tools/text/TestJavaHATCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/text/TestJavaHATCodeBuilder.java
@@ -78,7 +78,7 @@ public class TestJavaHATCodeBuilder {
         Method method = Compute.class.getDeclaredMethod(methodName,
                 KernelContext.class, S32Array2D.class, S32Array.class, float.class, float.class,float.class);
         CoreOp.FuncOp javaFunc = Op.ofMethod(method).get();
-        builder.compute(OpWrapper.wrap(lookup,javaFunc));
+        builder.compute(lookup,OpWrapper.wrap(lookup,javaFunc));
         System.out.println(builder.toString());
     }
 }


### PR DESCRIPTION
In HAT we wrap babylon ops to minimize churn as the core API's change.  As the code model API has stabalized, we should dismantal these. 

This is the first step.  Refactoring some low OpWrapper calls with raw CodeModel calls. 