### PR TITLE
Update ReflectMethods.BodyScanner.coerce to handle null targetType

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -736,8 +736,8 @@ public class ReflectMethods extends TreeTranslator {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
-            if (targetType == null || targetType.hasTag(TypeTag.VOID)) {
-                // if target type null or void, nothing to coerce
+            if (targetType.hasTag(TypeTag.VOID)) {
+                // if target type is void, nothing to coerce
                 return sourceValue;
             }
             if (sourceType.isReference() && targetType.isReference() &&
@@ -1777,7 +1777,7 @@ public class ReflectMethods extends TreeTranslator {
 
         private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, FunctionType caseBodyType) {
             Body.Builder body = null;
-            Type yieldType = tree.type != null ? adaptBottom(tree.type) : null;
+            Type yieldType = tree.type != null ? adaptBottom(tree.type) : syms.voidType;
 
             JCTree.JCCaseLabel headCl = c.labels.head;
             switch (c.caseKind) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -736,16 +736,15 @@ public class ReflectMethods extends TreeTranslator {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
-            if (targetType.hasTag(TypeTag.VOID)) {
-                // if target type is void, nothing to coerce
+            if (targetType == null || targetType.hasTag(TypeTag.VOID)) {
+                // if target type null or void, nothing to coerce
                 return sourceValue;
             }
             if (sourceType.isReference() && targetType.isReference() &&
                     !types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
                 return append(JavaOp.cast(typeToTypeElement(targetType), sourceValue));
-            } else {
-                return convert(sourceValue, targetType);
             }
+            return convert(sourceValue, targetType);
         }
 
         Value boxIfNeeded(Value exprVal) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -717,7 +717,8 @@ public class ReflectMethods extends TreeTranslator {
             try {
                 pt = targetType;
                 scan(expression);
-                return result == null || targetType.hasTag(TypeTag.VOID) ? result : coerce(result, expression.type, targetType);
+                return (result == null || targetType.hasTag(TypeTag.VOID) || targetType.hasTag(NONE)) ?
+                        result : coerce(result, expression.type, targetType);
             } finally {
                 pt = prevPt;
             }
@@ -1771,7 +1772,7 @@ public class ReflectMethods extends TreeTranslator {
 
         private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, FunctionType caseBodyType) {
             Body.Builder body = null;
-            Type yieldType = tree.type != null ? adaptBottom(tree.type) : syms.voidType;
+            Type yieldType = tree.type != null ? adaptBottom(tree.type) : Type.noType;
 
             JCTree.JCCaseLabel headCl = c.labels.head;
             switch (c.caseKind) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -717,9 +717,7 @@ public class ReflectMethods extends TreeTranslator {
             try {
                 pt = targetType;
                 scan(expression);
-                return result != null ?
-                        coerce(result, expression.type, targetType) :
-                        null;
+                return result == null || targetType.hasTag(TypeTag.VOID) ? result : coerce(result, expression.type, targetType);
             } finally {
                 pt = prevPt;
             }
@@ -736,10 +734,6 @@ public class ReflectMethods extends TreeTranslator {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
-            if (targetType.hasTag(TypeTag.VOID)) {
-                // if target type is void, nothing to coerce
-                return sourceValue;
-            }
             if (sourceType.isReference() && targetType.isReference() &&
                     !types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
                 return append(JavaOp.cast(typeToTypeElement(targetType), sourceValue));

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -2008,4 +2008,32 @@ public class SwitchStatementTest {
         }
         return r;
     }
+
+    @IR("""
+            func @"f" (%0 : java.type:"int")java.type:"int" -> {
+                  %1 : Var<java.type:"int"> = var %0 @"i";
+                  %2 : java.type:"int" = var.load %1;
+                  java.switch.statement %2
+                      (%3 : java.type:"int")java.type:"boolean" -> {
+                          %4 : java.type:"int" = constant @0;
+                          %5 : java.type:"boolean" = eq %3 %4;
+                          yield %5;
+                      }
+                      ()java.type:"void" -> {
+                          %6 : java.type:"int" = constant @0;
+                          return %6;
+                      };
+                  %7 : java.type:"int" = constant @0;
+                  return %7;
+              };
+            """)
+    @CodeReflection
+    static int f(int i) {
+        switch (i) {
+            case 0 -> {
+                return 0;
+            }
+        }
+        return 0;
+    }
 }


### PR DESCRIPTION
`ReflectMethods.BodyScanner.coerce` wasn't handling `null` targetType. For example, a `null` targetType may propagate to reach the method `coerce` when visiting case body of switch statement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/536/head:pull/536` \
`$ git checkout pull/536`

Update a local copy of the PR: \
`$ git checkout pull/536` \
`$ git pull https://git.openjdk.org/babylon.git pull/536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 536`

View PR using the GUI difftool: \
`$ git pr show -t 536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/536.diff">https://git.openjdk.org/babylon/pull/536.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/536#issuecomment-3238720967)
</details>
