### PR TITLE
hat opwrapper removal round 2

### DIFF
--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -398,12 +398,13 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                     if (c.isNotFirst()) {
                         elseKeyword().space();
                     }
+
                     ifKeyword().paren(_ ->
-                            ifOpWrapper.wrappedYieldOpStream(
-                                    ifOpWrapper.op.bodies().get(c.value()).entryBlock())
-                            //        ifOpWrapper.firstBlockOfBodyN(c.value()))
-                            .forEach((wrapped) ->
-                                    recurse(buildContext, wrapped))
+                            ifOpWrapper.op.bodies().get(c.value()).entryBlock()            // get the entryblock if bodies[c.value]
+                                    .ops().stream().filter(o->o instanceof CoreOp.YieldOp) // we want all the yields
+                                    .forEach((yield) ->
+                                            recurse(buildContext, OpWrapper.wrap(ifOpWrapper.lookup,yield))
+                                    )
                     );
                     lastWasBody[0] = false;
                 }

--- a/hat/core/src/main/java/hat/optools/ForOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/ForOpWrapper.java
@@ -24,6 +24,7 @@
  */
 package hat.optools;
 
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.lang.invoke.MethodHandles;
@@ -35,20 +36,20 @@ public class ForOpWrapper extends LoopOpWrapper<JavaOp.ForOp> {
     }
 
     public Stream<OpWrapper<?>> initWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*firstBlockOfBodyN(0)*/);
+       return  op.init().entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->OpWrapper.wrap(lookup,o) );
     }
 
     @Override
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
+        return  op.cond().entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->OpWrapper.wrap(lookup,o) );
     }
 
     public Stream<OpWrapper<?>> mutateRootWrappedOpStream() {
-        return wrappedRootOpStream(op.bodies().get(2).entryBlock()/*firstBlockOfBodyN(2)*/);
+          return wrappedRootOpStream(op.bodies().get(2).entryBlock()/*firstBlockOfBodyN(2)*/);
     }
 
     @Override
     public Stream<OpWrapper<?>> loopWrappedRootOpStream() {
-        return wrappedRootOpStreamSansFinalContinue(op.bodies().get(3).entryBlock()/*firstBlockOfBodyN(3)*/);
+          return wrappedRootOpStreamSansFinalContinue(op.bodies().get(3).entryBlock()/*firstBlockOfBodyN(3)*/);
     }
 }

--- a/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -65,27 +65,11 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
         );
     }
 
-    public boolean isKernelContextMethod() {
-        return isAssignable(javaRefType(), KernelContext.class);
-
-    }
-
     public boolean isComputeContextMethod() {
         return isAssignable(javaRefType(), ComputeContext.class);
-
     }
-
-    private boolean isReturnTypeAssignableFrom(Class<?> clazz) {
-        Optional<Class<?>> optionalClazz = javaReturnClass();
-        return optionalClazz.isPresent() && clazz.isAssignableFrom(optionalClazz.get());
-    }
-
     public JavaType javaReturnType() {
         return (JavaType) methodRef().type().returnType();
-    }
-
-    public boolean returnsVoid() {
-        return javaReturnType().equals(JavaType.VOID);
     }
 
     public Method method() {
@@ -97,18 +81,15 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     }
 
     public Value getReceiver() {
-        return hasReceiver() ? op.operands().getFirst() : null;
-    }
-
-    public boolean hasReceiver() {
-        return op.hasReceiver();
+        return op.hasReceiver() ? op.operands().getFirst() : null;
     }
 
     public enum IfaceBufferAccess {None, Access, Mutate}
 
     public boolean isIfaceAccessor() {
-        if (isIfaceBufferMethod() && !returnsVoid()) {
-            return !isReturnTypeAssignableFrom(Buffer.class);
+        if (isIfaceBufferMethod() && !javaReturnType().equals(JavaType.VOID)) {
+            Optional<Class<?>> optionalClazz = javaReturnClass();
+            return optionalClazz.isPresent() && Buffer.class.isAssignableFrom(optionalClazz.get());
         } else {
             return false;
         }
@@ -116,7 +97,7 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
 
 
     public boolean isIfaceMutator() {
-        return isIfaceBufferMethod() && returnsVoid();
+        return isIfaceBufferMethod() && javaReturnType().equals(JavaType.VOID);
     }
 
     public IfaceBufferAccess getIfaceBufferAccess() {

--- a/hat/core/src/main/java/hat/optools/LambdaOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/LambdaOpWrapper.java
@@ -47,7 +47,6 @@ public class LambdaOpWrapper extends OpWrapper<JavaOp.LambdaOp> {
     public List<Value> operands() {
         return op.operands();
     }
-
     public Method getQuotableTargetMethod() {
         return getQuotableTargetInvokeOpWrapper().method();
     }
@@ -69,9 +68,9 @@ public class LambdaOpWrapper extends OpWrapper<JavaOp.LambdaOp> {
         Object[] varLoadNames = ops.stream()
                 .filter(op -> op instanceof CoreOp.VarAccessOp.VarLoadOp)
                 .map(op -> (CoreOp.VarAccessOp.VarLoadOp) op)
-                .map(varLoadOp -> (Op.Result) varLoadOp.operands().get(0))
+                .map(varLoadOp -> (Op.Result) varLoadOp.operands().getFirst())
                 .map(varLoadOp -> (CoreOp.VarOp) varLoadOp.op())
-                .map(varOp -> varOp.varName()).toArray();
+                .map(CoreOp.VarOp::varName).toArray();
 
 
         Map<String, Object> nameValueMap = new HashMap<>();

--- a/hat/core/src/main/java/hat/optools/LogicalOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/LogicalOpWrapper.java
@@ -24,6 +24,7 @@
  */
 package hat.optools;
 
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.lang.invoke.MethodHandles;
@@ -35,10 +36,10 @@ public class LogicalOpWrapper extends BinaryOpWrapper<JavaOp.JavaConditionalOp> 
     }
 
     public Stream<OpWrapper<?>> lhsWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*firstBlockOfBodyN(0)*/);
+        return op.bodies().get(0).entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->wrap(lookup,o));
     }
 
     public Stream<OpWrapper<?>> rhsWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
+        return op.bodies().get(1).entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->wrap(lookup,o));
     }
 }

--- a/hat/core/src/main/java/hat/optools/OpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/OpWrapper.java
@@ -100,14 +100,6 @@ public class OpWrapper<T extends Op> {
         this.op = op;
 
     }
-    public Stream<OpWrapper<?>> wrappedOpStream(Block block) {
-        return block.ops().stream().map(o->wrap(lookup,o));
-    }
-
-    public Stream<OpWrapper<?>> wrappedYieldOpStream(Block block) {
-        return wrappedOpStream(block).filter(wrapped -> wrapped instanceof YieldOpWrapper);
-    }
-
     private Stream<OpWrapper<?>> roots(Block block) {
         var rootSet = RootSet.getRootSet(block.ops().stream());
         return block.ops().stream().filter(rootSet::contains).map(o->wrap(lookup,o));

--- a/hat/core/src/main/java/hat/optools/TernaryOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/TernaryOpWrapper.java
@@ -25,6 +25,7 @@
 package hat.optools;
 
 
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.lang.invoke.MethodHandles;
@@ -36,14 +37,14 @@ public class TernaryOpWrapper extends OpWrapper<JavaOp.ConditionalExpressionOp> 
     }
 
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*,firstBlockOfBodyN(0)*/);
+        return op.bodies().get(0).entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->wrap(lookup,o));
     }
 
     public Stream<OpWrapper<?>> thenWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
+        return op.bodies().get(1).entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->wrap(lookup,o));
     }
 
     public Stream<OpWrapper<?>> elseWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().get(2).entryBlock()/*firstBlockOfBodyN(2)*/);
+        return op.bodies().get(2).entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->wrap(lookup,o));
     }
 }

--- a/hat/core/src/main/java/hat/optools/WhileOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/WhileOpWrapper.java
@@ -24,6 +24,7 @@
  */
 package hat.optools;
 
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.lang.invoke.MethodHandles;
@@ -37,7 +38,7 @@ public class WhileOpWrapper extends LoopOpWrapper<JavaOp.WhileOp> {
 
     @Override
     public Stream<OpWrapper<?>> conditionWrappedYieldOpStream() {
-        return wrappedYieldOpStream(op.bodies().getFirst().entryBlock()/*firstBlockOfBodyN(0)*/);
+        return op.bodies().getFirst().entryBlock().ops().stream().filter(o->o instanceof CoreOp.YieldOp).map(o->wrap(lookup,o));
     }
 
     @Override


### PR DESCRIPTION
Second round of hat OpWrapper removal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/537/head:pull/537` \
`$ git checkout pull/537`

Update a local copy of the PR: \
`$ git checkout pull/537` \
`$ git pull https://git.openjdk.org/babylon.git pull/537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 537`

View PR using the GUI difftool: \
`$ git pr show -t 537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/537.diff">https://git.openjdk.org/babylon/pull/537.diff</a>

</details>
