### PR TITLE
HAT remove OpWrapper round 3

### DIFF
--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackend.java
@@ -102,7 +102,7 @@ public abstract class FFIBackend extends FFIBackendDriver {
             return new TypeAndAccess(annotations, value, (JavaType) value.type());
         }
         boolean isIface(MethodHandles.Lookup lookup) {
-            return InvokeOpWrapper.isIfaceUsingLookup(lookup, javaType);
+            return InvokeOpWrapper.isAssignable(lookup, javaType,MappableIface.class);
         }
         boolean ro(){
             for (Annotation annotation : annotations) {
@@ -211,7 +211,7 @@ public abstract class FFIBackend extends FFIBackendDriver {
                         //  );
                         bldr.op(invokeOW.op);
                         typeAndAccesses.stream()
-                                .filter(typeAndAccess -> InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup, typeAndAccess.javaType))
+                                .filter(typeAndAccess -> InvokeOpWrapper.isAssignable(prevFOW.lookup, typeAndAccess.javaType,MappableIface.class))
                                 .forEach(typeAndAccess -> {
                                     if (typeAndAccess.ro()) {
                                         bldr.op(JavaOp.invoke(ACCESS.post, cc,  bldrCntxt.getValue(typeAndAccess.value)));

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.buffer.Buffer;
 import hat.callgraph.CallGraph;
 import hat.ifacemapper.BoundSchema;
+import hat.ifacemapper.MappableIface;
 import hat.ifacemapper.SegmentMapper;
 import hat.optools.FuncOpWrapper;
 import hat.optools.InvokeOpWrapper;
@@ -113,14 +114,18 @@ public abstract class JExtractedBackend extends JExtractedBackendDriver {
                     bldr.op(invokeOW.op);
                 } else {
                     invokeOW.op.operands().stream()
-                            .filter(val -> val.type() instanceof JavaType javaType && InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
+                            .filter(val -> val.type() instanceof JavaType javaType &&
+                                    InvokeOpWrapper.isAssignable(prevFOW.lookup,javaType, MappableIface.class))
+                                           // isIfaceUsingLookup(prevFOW.lookup,javaType))
                             .forEach(val ->
                                     bldr.op(JavaOp.invoke(MUTATE.pre, cc, bldrCntxt.getValue(val)))
                             );
                     bldr.op(invokeOW.op);
                     invokeOW.op.operands().stream()
                             .filter(val -> val.type() instanceof JavaType javaType &&
-                                    InvokeOpWrapper.isIfaceUsingLookup(prevFOW.lookup,javaType))
+                                    InvokeOpWrapper.isAssignable(prevFOW.lookup,javaType,MappableIface.class))
+                                           // isIfaceUsingLookup(prevFOW.lookup,javaType))
+
                             .forEach(val -> bldr.op(
                                     JavaOp.invoke(MUTATE.post, cc, bldrCntxt.getValue(val)))
                             );

--- a/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
 import hat.buffer.Buffer;
+import hat.ifacemapper.MappableIface;
 import hat.optools.FuncOpWrapper;
 import hat.optools.InvokeOpWrapper;
 import hat.optools.ModuleOpWrapper;
@@ -103,7 +104,8 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
                     } else {
                         if (paramInfo.isPrimitive()) {
                             // OK
-                        } else if (InvokeOpWrapper.isIfaceUsingLookup(fow.lookup, paramInfo.javaType)) {
+                        } else if (InvokeOpWrapper.isAssignable(fow.lookup,paramInfo.javaType, MappableIface.class)){
+                             //   .isIfaceUsingLookup(fow.lookup, paramInfo.javaType)) {
                             atLeastOneIfaceBufferParam.of(true);
                         } else {
                             hasOnlyPrimitiveAndIfaceBufferParams.of(false);

--- a/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
@@ -46,7 +46,9 @@ public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HA
         );
 
         braceNlIndented(_ ->
-                funcOpWrapper.wrappedRootOpStream(funcOpWrapper.op.bodies().getFirst().entryBlock()).forEach(root ->
+                funcOpWrapper.wrappedRootOpStream()
+                      //  .rootsWithoutVarFuncDeclarationsOrYields(funcOpWrapper.op.bodies().getFirst().entryBlock())
+                        .forEach(root ->
                         recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>)).nl()
                 ));
 

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -30,6 +30,7 @@ import hat.NDRange;
 import hat.buffer.Buffer;
 import hat.callgraph.KernelCallGraph;
 import hat.callgraph.KernelEntrypoint;
+import hat.ifacemapper.MappableIface;
 import hat.optools.FuncOpWrapper;
 import hat.optools.InvokeOpWrapper;
 import hat.optools.StructuralOpWrapper;
@@ -154,7 +155,8 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
     @Override
     public T type(HATCodeBuilderContext buildContext, JavaType javaType) {
-        if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup,javaType) && javaType instanceof ClassType classType) {
+        if (InvokeOpWrapper.isAssignable(buildContext.lookup,javaType, MappableIface.class) && javaType instanceof ClassType classType){
+              //  .isIfaceUsingLookup(buildContext.lookup,javaType) && javaType instanceof ClassType classType) {
             globalPtrPrefix().space();
             String name = classType.toClassName();
             int dotIdx = name.lastIndexOf('.');

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -26,6 +26,7 @@ package hat.codebuilders;
 
 
 import hat.ifacemapper.BoundSchema;
+import hat.ifacemapper.MappableIface;
 import hat.ifacemapper.Schema;
 import hat.optools.BinaryArithmeticOrLogicOperation;
 import hat.optools.BinaryTestOpWrapper;
@@ -44,6 +45,7 @@ import hat.optools.LambdaOpWrapper;
 import hat.optools.LogicalOpWrapper;
 import hat.optools.OpWrapper;
 import hat.optools.ReturnOpWrapper;
+import hat.optools.RootSet;
 import hat.optools.StructuralOpWrapper;
 import hat.optools.TernaryOpWrapper;
 import hat.optools.TupleOpWrapper;
@@ -137,7 +139,9 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
 
     public T type(HATCodeBuilderContext buildContext, JavaType javaType) {
-        if (InvokeOpWrapper.isIfaceUsingLookup(buildContext.lookup,javaType) && javaType instanceof ClassType classType) {
+        if (InvokeOpWrapper.isAssignable(buildContext.lookup,javaType, MappableIface.class)
+                //isIfaceUsingLookup(buildContext.lookup,javaType)
+                        && javaType instanceof ClassType classType) {
             String name = classType.toClassName();
             int dotIdx = name.lastIndexOf('.');
             int dollarIdx = name.lastIndexOf('$');
@@ -384,9 +388,8 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                             elseKeyword();
                         }
                         braceNlIndented(_ ->
-                                StreamCounter.of(ifOpWrapper.wrappedRootOpStream(
+                                StreamCounter.of(RootSet.rootsWithoutVarFuncDeclarationsOrYields(ifOpWrapper.lookup,
                                         ifOpWrapper.op.bodies().get(c.value()).entryBlock())
-                                        //ifOpWrapper.firstBlockOfBodyN(c.value()))
                                         , (innerc, root) ->
                                         nlIf(innerc.isNotFirst())
                                                 .recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>))

--- a/hat/core/src/main/java/hat/optools/FieldLoadOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/FieldLoadOpWrapper.java
@@ -37,7 +37,7 @@ public class FieldLoadOpWrapper extends FieldAccessOpWrapper<JavaOp.FieldAccessO
 
     public Object getStaticFinalPrimitiveValue() {
         if (fieldType() instanceof ClassType classType) {
-            Class<?> clazz = (Class<?>) classTypeToType(classType);
+            Class<?> clazz = (Class<?>) classTypeToType(lookup,classType);
             try {
                 Field field = clazz.getField(fieldName());
                 field.setAccessible(true);

--- a/hat/core/src/main/java/hat/optools/ForOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/ForOpWrapper.java
@@ -28,6 +28,7 @@ import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.stream.Stream;
 
 public class ForOpWrapper extends LoopOpWrapper<JavaOp.ForOp> {
@@ -45,11 +46,15 @@ public class ForOpWrapper extends LoopOpWrapper<JavaOp.ForOp> {
     }
 
     public Stream<OpWrapper<?>> mutateRootWrappedOpStream() {
-          return wrappedRootOpStream(op.bodies().get(2).entryBlock()/*firstBlockOfBodyN(2)*/);
+          return RootSet.rootsWithoutVarFuncDeclarationsOrYields(lookup,op.bodies().get(2).entryBlock());
     }
 
     @Override
     public Stream<OpWrapper<?>> loopWrappedRootOpStream() {
-          return wrappedRootOpStreamSansFinalContinue(op.bodies().get(3).entryBlock()/*firstBlockOfBodyN(3)*/);
+        var list = new ArrayList<>(RootSet.rootsWithoutVarFuncDeclarationsOrYields(lookup,op.bodies().get(3).entryBlock()).toList());
+        if (list.getLast() instanceof JavaContinueOpWrapper) {
+            list.removeLast();
+        }
+        return list.stream();
     }
 }

--- a/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -31,6 +31,7 @@ import hat.buffer.KernelContext;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 
+import hat.ifacemapper.MappableIface;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.java.ClassType;
 import jdk.incubator.code.dialect.java.JavaOp;
@@ -55,18 +56,18 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     }
 
     public boolean isIfaceBufferMethod() {
-        return isIface(javaRefType());
+        return  isAssignable(lookup,javaRefType(), MappableIface.class) ;
     }
 
     public boolean isRawKernelCall() {
         return (op.operands().size() > 1 && op.operands().getFirst() instanceof Value value
                 && value.type() instanceof JavaType javaType
-                && (isAssignable(javaType, hat.KernelContext.class) || isAssignable(javaType, KernelContext.class))
+                && (isAssignable(lookup,javaType, hat.KernelContext.class) || isAssignable(lookup,javaType, KernelContext.class))
         );
     }
 
     public boolean isComputeContextMethod() {
-        return isAssignable(javaRefType(), ComputeContext.class);
+        return isAssignable(lookup,javaRefType(), ComputeContext.class);
     }
     public JavaType javaReturnType() {
         return (JavaType) methodRef().type().returnType();
@@ -110,7 +111,7 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
 
     public Optional<Class<?>> javaRefClass() {
         if (javaRefType() instanceof ClassType classType) {
-            return Optional.of((Class<?>)classTypeToType(classType));
+            return Optional.of((Class<?>) classTypeToType(lookup,classType));
         }else{
             return Optional.empty();
         }
@@ -118,7 +119,7 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
 
     public Optional<Class<?>> javaReturnClass() {
         if (javaReturnType() instanceof ClassType classType) {
-            return Optional.of((Class<?>)classTypeToType(classType));
+            return Optional.of((Class<?>) classTypeToType(lookup,classType));
         }else{
             return Optional.empty();
         }

--- a/hat/core/src/main/java/hat/optools/ModuleOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/ModuleOpWrapper.java
@@ -97,7 +97,7 @@ public class ModuleOpWrapper extends OpWrapper<CoreOp.ModuleOp> {
                 continue;
             }
 
-            CoreOp.FuncOp tf = rf.f.transform(rf.r.name(), (blockBuilder, op) -> {
+            CoreOp.FuncOp tf = rf.f.op.transform(rf.r.name(), (blockBuilder, op) -> {
                 if (op instanceof JavaOp.InvokeOp iop) {
                     InvokeOpWrapper iopWrapper = OpWrapper.wrap(entry.lookup, iop);
                     MethodRef methodRef = iopWrapper.methodRef();

--- a/hat/core/src/main/java/hat/optools/WhileOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/WhileOpWrapper.java
@@ -28,6 +28,7 @@ import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.stream.Stream;
 
 public class WhileOpWrapper extends LoopOpWrapper<JavaOp.WhileOp> {
@@ -43,6 +44,10 @@ public class WhileOpWrapper extends LoopOpWrapper<JavaOp.WhileOp> {
 
     @Override
     public Stream<OpWrapper<?>> loopWrappedRootOpStream() {
-        return wrappedRootOpStreamSansFinalContinue(op.bodies().get(1).entryBlock()/*firstBlockOfBodyN(1)*/);
+        var list = new ArrayList<>(RootSet.rootsWithoutVarFuncDeclarationsOrYields(lookup,op.bodies().get(1).entryBlock()).toList());
+        if (list.getLast() instanceof JavaContinueOpWrapper) {
+            list.removeLast();
+        }
+        return list.stream();
     }
 }

--- a/hat/examples/experiments/src/main/java/experiments/DependencyTree.java
+++ b/hat/examples/experiments/src/main/java/experiments/DependencyTree.java
@@ -162,10 +162,11 @@ public class DependencyTree {
     public static void main(String[] args) {
         CoreOp.FuncOp f = getFuncOp("f");
         System.out.println(f.toText());
+        RootSet rootSet = new RootSet(f.body().entryBlock().ops().stream());
 
-        Set<Op> roots = RootSet.getRootSet(f.body().entryBlock().ops().stream());
-        f.body().entryBlock().ops().stream().filter(roots::contains).forEach(op -> {
-            System.out.print(op.toText());
+       // Set<Op> roots = RootSet.getRootSet(f.body().entryBlock().ops().stream());
+        f.body().entryBlock().ops().stream().filter(rootSet.set::contains).forEach(op -> {
+            System.out.println(op.toText());
         });
 
 

--- a/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
@@ -81,22 +81,11 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
                 commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );
         braceNlIndented(_ ->
-                funcOpWrapper.wrappedRootOpStream(funcOpWrapper.op.bodies().getFirst().entryBlock()).forEach(root ->
+                funcOpWrapper.wrappedRootOpStream()
+                        .forEach(root ->
                         recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>)).nl()
                 ));
         return self();
     }
 
-   /* public T compute(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp) {
-        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(funcOpWrapper);
-        typeName(funcOpWrapper.functionReturnTypeDesc().toString()).space().identifier(funcOpWrapper.functionName());
-        parenNlIndented(_ ->
-                commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
-        );
-        braceNlIndented(_ ->
-                funcOpWrapper.wrappedRootOpStream(funcOpWrapper.firstBlockOfFirstBody()).forEach(root ->
-                        recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>)).nl()
-                ));
-        return self();
-    }*/
 }


### PR DESCRIPTION
Round 3 removing OpWrapper. 

Moved common code into RootSet.  

Attempting to make all the OpWrapper method static so we can build a static class toolkit instead of wrapping each op. 