### PR TITLE
Hat remove opwrapper 5

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -27,10 +27,10 @@ package hat.backend.ffi;
 
 import hat.ComputeContext;
 import hat.NDRange;
+import hat.callgraph.CallGraph;
 import hat.callgraph.KernelCallGraph;
 import hat.buffer.Buffer;
 import hat.ifacemapper.BoundSchema;
-import hat.optools.FuncOpWrapper;
 import hat.optools.InvokeOpWrapper;
 import hat.optools.OpTk;
 import hat.optools.OpWrapper;
@@ -413,9 +413,9 @@ public class CudaBackend extends C99FFIBackend {
         builder.ptxHeader(major, minor, target, addressSize);
         out.append(builder.getTextAndReset());
 
-        if (Boolean.getBoolean("moduleOp")) {
+        if (CallGraph.usingModuleOp) {
             System.out.println("Using ModuleOp for CudaBackend");
-            kernelCallGraph.moduleOpWrapper.op.functionTable().forEach((_, funcOp) -> {
+            kernelCallGraph.moduleOp.functionTable().forEach((_, funcOp) -> {
               //  FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,funcOp);
                 CoreOp.FuncOp loweredFunc = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,funcOp);
                 loweredFunc = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,loweredFunc, argsMap, usedMathFns);

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -41,6 +41,7 @@ import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -402,11 +403,12 @@ public class CudaBackend extends C99FFIBackend {
         var builder = new PTXHATKernelBuilder();
         StringBuilder out = new StringBuilder();
         StringBuilder invokedMethods = new StringBuilder();
-        FuncOpWrapper f = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOpWrapper().op);
-        FuncOpWrapper lowered = OpTk.lower(f.lookup,f.op);
+       // FuncOpWrapper f = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp());
+        CoreOp.FuncOp lowered = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp());
+        var paramTable = new OpTk.ParamTable(kernelCallGraph.entrypoint.funcOp());
         HashMap<String, Object> argsMap = new HashMap<>();
         for (int i = 0; i < args.length; i++) {
-            argsMap.put(f.paramTable().list().get(i).varOp.varName(), args[i]);
+            argsMap.put(paramTable.list().get(i).varOp.varName(), args[i]);
         }
         builder.ptxHeader(major, minor, target, addressSize);
         out.append(builder.getTextAndReset());
@@ -414,29 +416,29 @@ public class CudaBackend extends C99FFIBackend {
         if (Boolean.getBoolean("moduleOp")) {
             System.out.println("Using ModuleOp for CudaBackend");
             kernelCallGraph.moduleOpWrapper.op.functionTable().forEach((_, funcOp) -> {
-                FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,funcOp);
-                FuncOpWrapper loweredFunc = OpTk.lower(calledFunc.lookup,calledFunc.op);
-                loweredFunc = transformPTXPtrs(loweredFunc, argsMap, usedMathFns);
-                invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
+              //  FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,funcOp);
+                CoreOp.FuncOp loweredFunc = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,funcOp);
+                loweredFunc = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,loweredFunc, argsMap, usedMathFns);
+                invokedMethods.append(createFunction(kernelCallGraph.computeContext.accelerator.lookup,new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
             });
         } else {
             System.out.println("NOT using ModuleOp for CudaBackend");
             for (KernelCallGraph.KernelReachableResolvedMethodCall k : kernelCallGraph.kernelReachableResolvedStream().toList()) {
-                FuncOpWrapper calledFunc = new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup,k.funcOpWrapper().op);
-                FuncOpWrapper loweredFunc = OpTk.lower(calledFunc.lookup,calledFunc.op);
-                loweredFunc = transformPTXPtrs(loweredFunc, argsMap, usedMathFns);
-                invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
+                CoreOp.FuncOp calledFunc = k.funcOp();
+                CoreOp.FuncOp loweredFunc = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,calledFunc);
+                loweredFunc = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,loweredFunc, argsMap, usedMathFns);
+                invokedMethods.append(createFunction(kernelCallGraph.computeContext.accelerator.lookup,new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
             }
         }
 
-        lowered = transformPTXPtrs(lowered, argsMap, usedMathFns);
+        lowered = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,lowered, argsMap, usedMathFns);
         for (String s : usedMathFns) {
             out.append("\n").append(mathFns.get(s)).append("\n");
         }
 
         out.append(invokedMethods);
 
-        out.append(createFunction(builder.nl().nl(), lowered, true));
+        out.append(createFunction(kernelCallGraph.computeContext.accelerator.lookup,builder.nl().nl(), lowered, true));
         if (config.isSHOW_KERNEL_MODEL()){
             System.out.println("ptx follows\n"+out);
         }
@@ -444,13 +446,13 @@ public class CudaBackend extends C99FFIBackend {
         return out.toString();
     }
 
-      static  public FuncOpWrapper transformPTXPtrs(FuncOpWrapper func, HashMap<String, Object> argsMap, Set<String> usedMathFns) {
-        return FuncOpWrapper.wrap(func.lookup,func.op.transform((block, op) -> {
+      static  public CoreOp.FuncOp transformPTXPtrs(MethodHandles.Lookup lookup,CoreOp.FuncOp func, HashMap<String, Object> argsMap, Set<String> usedMathFns) {
+        return func.transform((block, op) -> {
             CopyContext cc = block.context();
             // use first operand of invoke to figure out schema
-            if (op instanceof JavaOp.InvokeOp invokeOp
-                    && OpWrapper.wrap(func.lookup,invokeOp) instanceof InvokeOpWrapper invokeOpWrapper) {
-                if (invokeOpWrapper.isIfaceBufferMethod()
+            if (op instanceof JavaOp.InvokeOp invokeOp){
+                   // && OpWrapper.wrap(func.lookup,invokeOp) instanceof InvokeOpWrapper invokeOpWrapper) {
+                if (InvokeOpWrapper.isIfaceBufferMethod(lookup,invokeOp)
                         && invokeOp.operands().getFirst() instanceof Op.Result invokeResult
                         && invokeResult.op().operands().getFirst() instanceof Op.Result varLoadResult
                         && varLoadResult.op() instanceof CoreOp.VarOp varOp
@@ -462,9 +464,9 @@ public class CudaBackend extends C99FFIBackend {
                     PTXHATKernelBuilder.PTXPtrOp ptxOp = new PTXHATKernelBuilder.PTXPtrOp(inputResult.type(), invokeOp.invokeDescriptor().name(), outputOperands, boundSchema);
                     Op.Result outputResult = block.op(ptxOp);
                     cc.mapValue(inputResult, outputResult);
-                } else if (invokeOpWrapper.op.invokeDescriptor().refType().toString().equals("java.lang.Math")
-                        && mathFns.containsKey(invokeOpWrapper.op.invokeDescriptor().name() + "_" + invokeOpWrapper.op.resultType().toString())){
-                    usedMathFns.add(invokeOpWrapper.op.invokeDescriptor().name() + "_" + invokeOpWrapper.op.resultType().toString());
+                } else if (invokeOp.invokeDescriptor().refType().toString().equals("java.lang.Math")
+                        && mathFns.containsKey(invokeOp.invokeDescriptor().name() + "_" + invokeOp.resultType().toString())){
+                    usedMathFns.add(invokeOp.invokeDescriptor().name() + "_" + invokeOp.resultType().toString());
                     block.op(op);
                 } else {
                     block.op(op);
@@ -473,24 +475,24 @@ public class CudaBackend extends C99FFIBackend {
                 block.op(op);
             }
             return block;
-        }));
+        });
     }
 
-    static public String createFunction(PTXHATKernelBuilder builder, FuncOpWrapper lowered, boolean entry) {
-        FuncOpWrapper ssa = OpTk.ssa(lowered.lookup,lowered.op);
+    static public String createFunction(MethodHandles.Lookup lookup,PTXHATKernelBuilder builder, CoreOp.FuncOp lowered, boolean entry) {
+        CoreOp.FuncOp ssa = OpTk.ssa(lookup,lowered);
         String out, body;
 
         // building fn info (name, params)
-        builder.functionHeader(lowered.op.funcName(), entry, lowered.op.body().yieldType());
-
+        builder.functionHeader(lowered.funcName(), entry, lowered.body().yieldType());
+var paramTable = new OpTk.ParamTable(lowered);
         // printing out params
-        builder.parameters(lowered.paramTable().list());
+        builder.parameters(paramTable.list());
 
         // building body of fn
         builder.functionPrologue();
 
         out = builder.getTextAndReset();
-        ssa.op.bodies().getFirst().blocks().forEach(block -> builder.blockBody(block, block.ops().stream().map(o->OpWrapper.wrap(lowered.lookup,o))));
+        ssa.bodies().getFirst().blocks().forEach(block -> builder.blockBody(block, block.ops().stream().map(o->OpWrapper.wrap(lookup,o))));
 
         builder.functionEpilogue();
         body = builder.getTextAndReset();

--- a/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
+++ b/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
@@ -27,11 +27,8 @@ package hat.backend.ffi;
 
 import hat.ComputeContext;
 import hat.NDRange;
+import hat.callgraph.CallGraph;
 import hat.callgraph.KernelCallGraph;
-
-import java.lang.invoke.MethodHandle;
-
-import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public class MockBackend extends FFIBackend {
     //final FFILib.LongIntMethodPtr getBackend_MPtr;
@@ -59,10 +56,9 @@ public class MockBackend extends FFIBackend {
         // Here we receive a callgraph from the kernel entrypoint
         // The first time we see this we need to convert the kernel entrypoint
         // and rechable methods to a form that our mock backend can execute.
-        if (Boolean.getBoolean("moduleOp")) {
+        if (CallGraph.usingModuleOp) {
             System.out.println("Using ModuleOp for MockBackend");
-            kernelCallGraph.moduleOpWrapper.op.functionTable().forEach((_, funcOp) -> {
-
+            kernelCallGraph.moduleOp.functionTable().forEach((_, funcOp) -> {
             });
         } else {
             System.out.println("NOT using ModuleOp for MockBackend");

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -151,7 +151,7 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
         if (Boolean.getBoolean("moduleOp")) {
             System.out.println("Using ModuleOp for C99FFIBackend");
             kernelCallGraph.moduleOpWrapper.op.functionTable()
-                    .forEach((_, funcOp) -> builder.nl().kernelMethod(new FuncOpWrapper(kernelCallGraph.computeContext.accelerator.lookup, funcOp)).nl());
+                    .forEach((_, funcOp) -> builder.nl().kernelMethod(kernelCallGraph.computeContext.accelerator.lookup, funcOp).nl());
         } else {
             System.out.println("NOT using ModuleOp for C99FFIBackend");
             kernelCallGraph.kernelReachableResolvedStream().sorted((lhs, rhs) -> rhs.rank - lhs.rank)
@@ -162,9 +162,9 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
 
         if (config.isSHOW_KERNEL_MODEL()) {
             System.out.println("Original");
-            System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op.toText());
+            System.out.println(kernelCallGraph.entrypoint.funcOp().toText());
             System.out.println("Lowered");
-            System.out.println(OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOpWrapper().op).op.toText());
+            System.out.println(OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp()).toText());
         }
         return builder.toString();
     }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -28,6 +28,7 @@ package hat.backend.ffi;
 import hat.ComputeRange;
 import hat.ThreadMesh;
 import hat.NDRange;
+import hat.callgraph.CallGraph;
 import hat.codebuilders.C99HATKernelBuilder;
 import hat.buffer.ArgArray;
 import hat.buffer.Buffer;
@@ -37,7 +38,6 @@ import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.BoundSchema;
 import hat.ifacemapper.BufferState;
 import hat.ifacemapper.Schema;
-import hat.optools.FuncOpWrapper;
 import hat.optools.OpTk;
 
 import java.util.Arrays;
@@ -148,9 +148,9 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
                 });
 
         // Sorting by rank ensures we don't need forward declarations
-        if (Boolean.getBoolean("moduleOp")) {
+        if (CallGraph.usingModuleOp) {
             System.out.println("Using ModuleOp for C99FFIBackend");
-            kernelCallGraph.moduleOpWrapper.op.functionTable()
+            kernelCallGraph.moduleOp.functionTable()
                     .forEach((_, funcOp) -> builder.nl().kernelMethod(kernelCallGraph.computeContext.accelerator.lookup, funcOp).nl());
         } else {
             System.out.println("NOT using ModuleOp for C99FFIBackend");

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -97,9 +97,9 @@ public abstract class C99JExtractedBackend extends JExtractedBackend {
         builder.nl().kernelEntrypoint(kernelCallGraph.entrypoint, args).nl();
 
         System.out.println("Original");
-        System.out.println(kernelCallGraph.entrypoint.funcOpWrapper().op.toText());
+        System.out.println(kernelCallGraph.entrypoint.funcOp().toText());
         System.out.println("Lowered");
-        System.out.println(OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOpWrapper().op).op.toText());
+        System.out.println(OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp()).toText());
 
         return builder.toString();
     }

--- a/hat/core/src/main/java/hat/Accelerator.java
+++ b/hat/core/src/main/java/hat/Accelerator.java
@@ -215,8 +215,8 @@ public class Accelerator implements BufferAllocator, BufferTracker {
      */
     public void compute(QuotableComputeContextConsumer quotableComputeContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableComputeContextConsumer).orElseThrow();
-        LambdaOpWrapper lambda = OpWrapper.wrap(lookup,(JavaOp.LambdaOp) quoted.op());
-        Method method = OpTk.getQuotableTargetInvokeOpWrapper(lookup,lambda.op).method();
+        JavaOp.LambdaOp lambda = (JavaOp.LambdaOp) quoted.op();
+        Method method = OpTk.getQuotableTargetInvokeOpWrapper(lookup,lambda).method();
 
         // Create (or get cached) a compute context which closes over compute entryppint and reachable kernels.
         // The models of all compute and kernel methods are passed to the backend during creation
@@ -226,7 +226,7 @@ public class Accelerator implements BufferAllocator, BufferTracker {
                 new ComputeContext(this, method)
         );
         // Here we get the captured values  from the Quotable
-        Object[] args = OpTk.getQuotableCapturedValues(lambda.op,quoted, method);
+        Object[] args = OpTk.getQuotableCapturedValues(lambda,quoted, method);
         args[0] = computeContext;
 
         // now ask the backend to execute

--- a/hat/core/src/main/java/hat/ComputeContext.java
+++ b/hat/core/src/main/java/hat/ComputeContext.java
@@ -38,6 +38,7 @@ import hat.optools.OpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.Quotable;
 import jdk.incubator.code.Quoted;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 
@@ -106,15 +107,8 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
 
     protected ComputeContext(Accelerator accelerator, Method computeMethod) {
         this.accelerator = accelerator;
-
-        //   ModuleOpWrapper module = ModuleOpWrapper.createTransitiveInvokeModule(accelerator.lookup, computeMethod);
-
-        // System.out.println(module.op().toText());
-
-        FuncOpWrapper funcOpWrapper = OpWrapper.wrap(accelerator.lookup,Op.ofMethod(computeMethod).orElseThrow());
-
-        this.computeCallGraph = new ComputeCallGraph(this, computeMethod, funcOpWrapper);
-
+        CoreOp.FuncOp funcOp = Op.ofMethod(computeMethod).orElseThrow();
+        this.computeCallGraph = new ComputeCallGraph(this, computeMethod, funcOp);
         this.computeCallGraph.close();
         this.accelerator.backend.computeContextHandoff(this);
     }

--- a/hat/core/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/core/src/main/java/hat/backend/DebugBackend.java
@@ -67,22 +67,22 @@ public class DebugBackend extends BackendAdaptor {
             }
             case BABYLON_INTERPRETER:{
                 if (computeContext.computeCallGraph.entrypoint.lowered == null) {
-                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.accelerator.lookup,computeContext.computeCallGraph.entrypoint.funcOpWrapper().op);
+                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.accelerator.lookup,computeContext.computeCallGraph.entrypoint.funcOp());
                 }
-                Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op, args);
+                Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered, args);
                 break;
             }
             case BABYLON_CLASSFILE:{
                 if (computeContext.computeCallGraph.entrypoint.lowered == null) {
-                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.accelerator.lookup,computeContext.computeCallGraph.entrypoint.funcOpWrapper().op);
+                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.accelerator.lookup,computeContext.computeCallGraph.entrypoint.funcOp());
                 }
                 try {
                     if (computeContext.computeCallGraph.entrypoint.mh == null) {
-                        computeContext.computeCallGraph.entrypoint.mh = BytecodeGenerator.generate(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered.op);
+                        computeContext.computeCallGraph.entrypoint.mh = BytecodeGenerator.generate(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered);
                     }
                     computeContext.computeCallGraph.entrypoint.mh.invokeWithArguments(args);
                 } catch (Throwable e) {
-                    System.out.println(computeContext.computeCallGraph.entrypoint.lowered.op.toText());
+                    System.out.println(computeContext.computeCallGraph.entrypoint.lowered.toText());
                     throw new RuntimeException(e);
                 }
                 break;
@@ -109,13 +109,13 @@ public class DebugBackend extends BackendAdaptor {
                 break;
             }
             case BABYLON_INTERPRETER:{
-                var lowered = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOpWrapper().op);
-                Interpreter.invoke(kernelCallGraph.computeContext.accelerator.lookup, lowered.op, args);
+                var lowered = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp());
+                Interpreter.invoke(kernelCallGraph.computeContext.accelerator.lookup, lowered, args);
                 break;
             }
             case BABYLON_CLASSFILE:{
-                var lowered = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOpWrapper().op);
-                var mh = BytecodeGenerator.generate(kernelCallGraph.computeContext.accelerator.lookup, lowered.op);
+                var lowered = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp());
+                var mh = BytecodeGenerator.generate(kernelCallGraph.computeContext.accelerator.lookup, lowered);
                 try {
                     mh.invokeWithArguments(args);
                 } catch (Throwable e) {

--- a/hat/core/src/main/java/hat/callgraph/CallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/CallGraph.java
@@ -25,14 +25,10 @@
 package hat.callgraph;
 
 import hat.ComputeContext;
-import hat.optools.FuncOpWrapper;
-import hat.optools.InvokeOpWrapper;
-import hat.optools.ModuleOpWrapper;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -45,8 +41,8 @@ public abstract class CallGraph<E extends Entrypoint> {
     public final E entrypoint;
     public final Set<MethodCall> calls = new HashSet<>();
     public final Map<MethodRef, MethodCall> methodRefToMethodCallMap = new LinkedHashMap<>();
-    public ModuleOpWrapper moduleOpWrapper;
-
+    public CoreOp.ModuleOp moduleOp;
+    public static boolean usingModuleOp = Boolean.getBoolean("moduleOp");
     public Stream<MethodCall> callStream() {
         return methodRefToMethodCallMap.values().stream();
     }
@@ -65,7 +61,6 @@ public abstract class CallGraph<E extends Entrypoint> {
         public CallGraph<?> callGraph;
         public final Method method;
         public final Class<?> declaringClass;
-       // private final Annotation[][] annotatedParameters;
         public final Set<MethodCall> calls = new HashSet<>();
         public final Set<MethodCall> callers = new HashSet<>();
         public final MethodRef targetMethodRef;
@@ -77,16 +72,6 @@ public abstract class CallGraph<E extends Entrypoint> {
             this.targetMethodRef = targetMethodRef;
             this.method = method;
             this.declaringClass = method.getDeclaringClass();
-         /*   this.annotatedParameters= method.getParameterAnnotations();
-            for (int i = 0; i < annotatedParameters.length; i++) {
-                Annotation[] annotations = annotatedParameters[i];
-                if (annotations.length != 0) {
-                    for (int a = 0; a < annotations.length; a++) {
-                        Annotation annotation = annotations[a];
-                        //System.out.println("annotation: " + annotation);
-                    }
-                }
-            } */
         }
 
 

--- a/hat/core/src/main/java/hat/callgraph/CallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/CallGraph.java
@@ -29,6 +29,7 @@ import hat.optools.FuncOpWrapper;
 import hat.optools.InvokeOpWrapper;
 import hat.optools.ModuleOpWrapper;
 import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 
 import java.lang.annotation.Annotation;
@@ -50,12 +51,11 @@ public abstract class CallGraph<E extends Entrypoint> {
         return methodRefToMethodCallMap.values().stream();
     }
 
-    public abstract boolean filterCalls(CoreOp.FuncOp f, InvokeOpWrapper invokeOpWrapper, Method method, MethodRef methodRef, Class<?> javaRefTypeClass);
+    public abstract boolean filterCalls(CoreOp.FuncOp f, JavaOp.InvokeOp invokeOp, Method method, MethodRef methodRef, Class<?> javaRefTypeClass);
 
     public interface Resolved {
-        FuncOpWrapper funcOpWrapper();
-
-        void funcOpWrapper(FuncOpWrapper funcOpWrapper);
+        CoreOp.FuncOp funcOp();
+        void funcOp(CoreOp.FuncOp funcOp);
     }
 
     public interface Unresolved {
@@ -65,7 +65,7 @@ public abstract class CallGraph<E extends Entrypoint> {
         public CallGraph<?> callGraph;
         public final Method method;
         public final Class<?> declaringClass;
-        private final Annotation[][] annotatedParameters;
+       // private final Annotation[][] annotatedParameters;
         public final Set<MethodCall> calls = new HashSet<>();
         public final Set<MethodCall> callers = new HashSet<>();
         public final MethodRef targetMethodRef;
@@ -77,7 +77,7 @@ public abstract class CallGraph<E extends Entrypoint> {
             this.targetMethodRef = targetMethodRef;
             this.method = method;
             this.declaringClass = method.getDeclaringClass();
-            this.annotatedParameters= method.getParameterAnnotations();
+         /*   this.annotatedParameters= method.getParameterAnnotations();
             for (int i = 0; i < annotatedParameters.length; i++) {
                 Annotation[] annotations = annotatedParameters[i];
                 if (annotations.length != 0) {
@@ -86,7 +86,7 @@ public abstract class CallGraph<E extends Entrypoint> {
                         //System.out.println("annotation: " + annotation);
                     }
                 }
-            }
+            } */
         }
 
 
@@ -115,21 +115,21 @@ public abstract class CallGraph<E extends Entrypoint> {
     }
 
     public abstract static class ResolvedMethodCall extends MethodCall implements Resolved {
-        private FuncOpWrapper funcOpWrapper;
+        private CoreOp.FuncOp funcOp;
 
-        ResolvedMethodCall(CallGraph<?> callGraph, MethodRef targetMethodRef, Method method, FuncOpWrapper funcOpWrapper) {
+        ResolvedMethodCall(CallGraph<?> callGraph, MethodRef targetMethodRef, Method method,  CoreOp.FuncOp funcOp) {
             super(callGraph, targetMethodRef, method);
-            this.funcOpWrapper = funcOpWrapper;
+            this.funcOp = funcOp;
         }
 
         @Override
-        public FuncOpWrapper funcOpWrapper() {
-            return funcOpWrapper;
+        public CoreOp.FuncOp funcOp() {
+            return funcOp;
         }
 
         @Override
-        public void funcOpWrapper(FuncOpWrapper funcOpWrapper) {
-            this.funcOpWrapper = funcOpWrapper;
+        public void funcOp(CoreOp.FuncOp funcOp) {
+            this.funcOp = funcOp;
         }
     }
 

--- a/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
@@ -29,11 +29,8 @@ import hat.ComputeContext;
 import hat.KernelContext;
 import hat.buffer.Buffer;
 import hat.ifacemapper.MappableIface;
-import hat.optools.FuncOpWrapper;
 import hat.optools.InvokeOpWrapper;
-import hat.optools.ModuleOpWrapper;
 import hat.optools.OpTk;
-import hat.optools.OpWrapper;
 import hat.util.StreamMutable;
 
 import java.lang.invoke.MethodHandles;
@@ -45,12 +42,11 @@ import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.dialect.java.MethodRef;
 
 import java.util.*;
-import java.util.stream.Stream;
 
 public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
 
     public final Map<MethodRef, MethodCall> bufferAccessToMethodCallMap = new LinkedHashMap<>();
-    boolean moduleOp = Boolean.getBoolean("moduleOp");
+
     ComputeContextMethodCall computeContextMethodCall;
 
     public interface ComputeReachable {
@@ -225,7 +221,7 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
     }
 
     public void close() {
-        if (moduleOp) {
+        if (CallGraph.usingModuleOp) {
             closeWithModuleOp(entrypoint);
         } else {
             updateDag(entrypoint);
@@ -233,8 +229,8 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
     }
 
     public void closeWithModuleOp(ComputeReachableResolvedMethodCall computeReachableResolvedMethodCall) {
-        CoreOp.ModuleOp moduleOp = OpTk.createTransitiveInvokeModule(computeContext.accelerator.lookup, computeReachableResolvedMethodCall.funcOp(), this);
-        moduleOpWrapper = OpWrapper.wrap(computeContext.accelerator.lookup, moduleOp);
+        moduleOp = OpTk.createTransitiveInvokeModule(computeContext.accelerator.lookup, computeReachableResolvedMethodCall.funcOp(), this);
+       // moduleOpWrapper = moduleOp;// OpWrapper.wrap(computeContext.accelerator.lookup, moduleOp);
     }
 
     @Override

--- a/hat/core/src/main/java/hat/callgraph/ComputeEntrypoint.java
+++ b/hat/core/src/main/java/hat/callgraph/ComputeEntrypoint.java
@@ -25,16 +25,17 @@
 package hat.callgraph;
 
 import hat.optools.FuncOpWrapper;
+import jdk.incubator.code.dialect.core.CoreOp;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 
 public class ComputeEntrypoint extends ComputeCallGraph.ComputeReachableResolvedMethodCall implements Entrypoint {
-    public FuncOpWrapper lowered;
+    public CoreOp.FuncOp lowered;
     public MethodHandle mh;
 
-    public ComputeEntrypoint(CallGraph<ComputeEntrypoint> callGraph, Method method, FuncOpWrapper funcOpWrapper) {
-        super(callGraph, null, method, funcOpWrapper);
+    public ComputeEntrypoint(CallGraph<ComputeEntrypoint> callGraph, Method method, CoreOp.FuncOp funcOp) {
+        super(callGraph, null, method, funcOp);
     }
     @Override
     public Method getMethod() {

--- a/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -25,11 +25,8 @@
 package hat.callgraph;
 
 import hat.buffer.Buffer;
-import hat.optools.FuncOpWrapper;
 import hat.optools.InvokeOpWrapper;
-import hat.optools.ModuleOpWrapper;
 import hat.optools.OpTk;
-import hat.optools.OpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
@@ -97,10 +94,10 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
 
         kernelReachableResolvedMethodCall.funcOp().traverse(null, (map, op) -> {
             if (op instanceof JavaOp.InvokeOp invokeOp) {
-                var invokeOpWrapper = (InvokeOpWrapper)OpWrapper.wrap(  kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp);
-                MethodRef methodRef = invokeOpWrapper.methodRef();
-                Class<?> javaRefTypeClass = invokeOpWrapper.javaRefClass().orElseThrow();
-                Method invokeOpCalledMethod = invokeOpWrapper.method();
+              //  var invokeOpWrapper = (InvokeOpWrapper)OpWrapper.wrap(  kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp);
+                MethodRef methodRef = InvokeOpWrapper.methodRef(invokeOp);
+                Class<?> javaRefTypeClass = InvokeOpWrapper.javaRefClass(kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp).orElseThrow();
+                Method invokeOpCalledMethod = InvokeOpWrapper.method(kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp);
                 if (Buffer.class.isAssignableFrom(javaRefTypeClass)) {
                     //System.out.println("kernel reachable iface mapped buffer call  -> " + methodRef);
                     kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
@@ -155,8 +152,8 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
     }
 
     KernelCallGraph closeWithModuleOp() {
-        CoreOp.ModuleOp moduleOp = OpTk.createTransitiveInvokeModule(computeContext.accelerator.lookup, entrypoint.funcOp(), this);
-        moduleOpWrapper = OpWrapper.wrap(computeContext.accelerator.lookup, moduleOp);
+        moduleOp = OpTk.createTransitiveInvokeModule(computeContext.accelerator.lookup, entrypoint.funcOp(), this);
+       // moduleOpWrapper = OpWrapper.wrap(computeContext.accelerator.lookup, moduleOp);
         return this;
     }
 

--- a/hat/core/src/main/java/hat/callgraph/KernelEntrypoint.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelEntrypoint.java
@@ -25,13 +25,14 @@
 package hat.callgraph;
 
 import hat.optools.FuncOpWrapper;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 
 import java.lang.reflect.Method;
 
 public class KernelEntrypoint extends KernelCallGraph.KernelReachableResolvedMethodCall implements Entrypoint {
-    public KernelEntrypoint(CallGraph<KernelEntrypoint> callGraph, MethodRef targetMethodRef, Method method, FuncOpWrapper funcOpWrapper) {
-        super(callGraph, targetMethodRef, method, funcOpWrapper);
+    public KernelEntrypoint(CallGraph<KernelEntrypoint> callGraph, MethodRef targetMethodRef, Method method, CoreOp.FuncOp funcOp) {
+        super(callGraph, targetMethodRef, method, funcOp);
     }
     @Override
     public Method getMethod() {

--- a/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
@@ -30,7 +30,10 @@ import hat.optools.OpTk;
 import hat.optools.StructuralOpWrapper;
 
 import jdk.incubator.code.TypeElement;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaType;
+
+import java.lang.invoke.MethodHandles;
 
 
 public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HATCodeBuilderWithContext<T> {
@@ -39,15 +42,15 @@ public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HA
         return typeName(typeElement.toString()).space().identifier(name);
     }
 
-    public T compute(FuncOpWrapper funcOpWrapper) {
-        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(funcOpWrapper.lookup,funcOpWrapper);
-        computeDeclaration(funcOpWrapper.op.resultType(), funcOpWrapper.op.funcName());
+    public T compute(MethodHandles.Lookup lookup,CoreOp.FuncOp funcOp) {
+        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(lookup,funcOp);
+        computeDeclaration(funcOp.resultType(), funcOp.funcName());
         parenNlIndented(_ ->
-                commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
+                commaSeparated(buildContext.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );
 
         braceNlIndented(_ ->
-                OpTk.wrappedRootOpStream(buildContext.lookup,funcOpWrapper.op)
+                OpTk.wrappedRootOpStream(buildContext.lookup,funcOp)
                         .forEach(root ->
                                 recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>)).nl()
                         )

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
@@ -53,6 +53,7 @@ import hat.optools.WhileOpWrapper;
 import hat.optools.YieldOpWrapper;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
@@ -314,7 +315,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
 
         T funcCall(HATCodeBuilderContext buildContext, FuncCallOpWrapper funcCallOpWrapper);
 
-        T javaIf(HATCodeBuilderContext buildContext, IfOpWrapper ifOpWrapper);
+        T javaIf(HATCodeBuilderContext buildContext, JavaOp.IfOp ifOp);
 
         T javaWhile(HATCodeBuilderContext buildContext, WhileOpWrapper whileOpWrapper);
 
@@ -324,7 +325,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
 
         T javaBreak(HATCodeBuilderContext buildContext, JavaBreakOpWrapper javaBreakOpWrapper);
 
-        T javaFor(HATCodeBuilderContext buildContext, ForOpWrapper forOpWrapper);
+        T javaFor(HATCodeBuilderContext buildContext, JavaOp.ForOp forOp);
 
 
          T methodCall(HATCodeBuilderContext buildContext, InvokeOpWrapper invokeOpWrapper);
@@ -362,8 +363,8 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
                 case LambdaOpWrapper $ -> lambda(buildContext, $);
                 case TupleOpWrapper $ -> tuple(buildContext, $);
                 case WhileOpWrapper $ -> javaWhile(buildContext, $);
-                case IfOpWrapper $ -> javaIf(buildContext, $);
-                case ForOpWrapper $ -> javaFor(buildContext, $);
+                case IfOpWrapper $ -> javaIf(buildContext, $.op);
+                case ForOpWrapper $ -> javaFor(buildContext, $.op);
                 case ReturnOpWrapper $ -> ret(buildContext, $);
                 case JavaLabeledOpWrapper $ -> javaLabeled(buildContext, $);
                 case JavaBreakOpWrapper $ -> javaBreak(buildContext, $);

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -381,18 +381,18 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T javaIf(HATCodeBuilderContext buildContext, IfOpWrapper ifOpWrapper) {
-        buildContext.scope(ifOpWrapper, () -> {
+    public T javaIf(HATCodeBuilderContext buildContext, JavaOp.IfOp ifOp) {
+        buildContext.scope(ifOp, () -> {
             var lastWasBody = StreamMutable.of(false);
-            StreamCounter.of(ifOpWrapper.op.bodies(), (c, b) -> {
+            StreamCounter.of(ifOp.bodies(), (c, b) -> {
                 if (b.yieldType() instanceof JavaType javaType && javaType == JavaType.VOID) {
-                    if (OpTk.hasElse(ifOpWrapper.op,c.value())) { // we might have more than one else
+                    if (OpTk.hasElse(ifOp,c.value())) { // we might have more than one else
                         if (lastWasBody.get()) {
                             elseKeyword();
                         }
                         braceNlIndented(_ ->
                                 StreamCounter.of(RootSet.rootsWithoutVarFuncDeclarationsOrYields(buildContext.lookup,
-                                        ifOpWrapper.op.bodies().get(c.value()).entryBlock())
+                                        ifOp.bodies().get(c.value()).entryBlock())
                                         , (innerc, root) ->
                                         nlIf(innerc.isNotFirst())
                                                 .recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>))
@@ -406,7 +406,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                     }
 
                     ifKeyword().paren(_ ->
-                            ifOpWrapper.op.bodies().get(c.value()).entryBlock()            // get the entryblock if bodies[c.value]
+                            ifOp.bodies().get(c.value()).entryBlock()            // get the entryblock if bodies[c.value]
                                     .ops().stream().filter(o->o instanceof CoreOp.YieldOp) // we want all the yields
                                     .forEach((yield) ->
                                             recurse(buildContext, OpWrapper.wrap(buildContext.lookup,yield))
@@ -432,18 +432,18 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     }
 
     @Override
-    public T javaFor(HATCodeBuilderContext buildContext, ForOpWrapper forOpWrapper) {
-        buildContext.scope(forOpWrapper, () ->
+    public T javaFor(HATCodeBuilderContext buildContext, JavaOp.ForOp forOp) {
+        buildContext.scope(forOp, () ->
                 forKeyword().paren(_ -> {
-                    OpTk.initWrappedYieldOpStream(buildContext.lookup,forOpWrapper.op).forEach((wrapped) -> recurse(buildContext, wrapped));
+                    OpTk.initWrappedYieldOpStream(buildContext.lookup,forOp).forEach((wrapped) -> recurse(buildContext, wrapped));
                     semicolon().space();
-                    OpTk.conditionWrappedYieldOpStream(buildContext.lookup,forOpWrapper.op).forEach((wrapped) -> recurse(buildContext, wrapped));
+                    OpTk.conditionWrappedYieldOpStream(buildContext.lookup,forOp).forEach((wrapped) -> recurse(buildContext, wrapped));
                     semicolon().space();
-                    StreamCounter.of(OpTk.mutateRootWrappedOpStream(buildContext.lookup,forOpWrapper.op), (c, wrapped) ->
+                    StreamCounter.of(OpTk.mutateRootWrappedOpStream(buildContext.lookup,forOp), (c, wrapped) ->
                             commaSpaceIf(c.isNotFirst()).recurse(buildContext, wrapped)
                     );
                 }).braceNlIndented(_ ->
-                        StreamCounter.of(OpTk.loopWrappedRootOpStream(buildContext.lookup,forOpWrapper.op), (c, root) ->
+                        StreamCounter.of(OpTk.loopWrappedRootOpStream(buildContext.lookup,forOp), (c, root) ->
                                 nlIf(c.isNotFirst()).recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>))
                         )
                 )

--- a/hat/core/src/main/java/hat/optools/FuncOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/FuncOpWrapper.java
@@ -29,14 +29,8 @@ import jdk.incubator.code.dialect.core.CoreOp;
 import java.lang.invoke.MethodHandles;
 
 public class FuncOpWrapper extends OpWrapper<CoreOp.FuncOp> {
-
     public final OpTk.ParamTable paramTable;
-
-    public OpTk.ParamTable paramTable() {
-        return paramTable;
-    }
     public final MethodHandles.Lookup lookup;
-
     public FuncOpWrapper(MethodHandles.Lookup lookup,CoreOp.FuncOp op) {
         super(op);
         this.lookup=lookup;

--- a/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
+++ b/hat/core/src/main/java/hat/optools/InvokeOpWrapper.java
@@ -47,15 +47,25 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
         super(op);
         this.lookup=lookup;
     }
-
-    public MethodRef methodRef() {
+    public static  MethodRef methodRef(JavaOp.InvokeOp op) {
         return op.invokeDescriptor();
     }
 
-    public JavaType javaRefType() {
-        return (JavaType) methodRef().refType();
+    public static JavaType javaRefType(JavaOp.InvokeOp op) {
+        return (JavaType) methodRef(op).refType();
     }
 
+
+    public MethodRef methodRef() {
+        return methodRef(op);
+    }
+
+    public JavaType javaRefType() {
+        return javaRefType(op);
+    }
+    public static  boolean isIfaceBufferMethod(MethodHandles.Lookup lookup, JavaOp.InvokeOp invokeOp) {
+        return  OpTk.isAssignable(lookup,javaRefType(invokeOp), MappableIface.class) ;
+    }
     public boolean isIfaceBufferMethod() {
         return  OpTk.isAssignable(lookup,javaRefType(), MappableIface.class) ;
     }
@@ -70,21 +80,27 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
     public boolean isComputeContextMethod() {
         return OpTk.isAssignable(lookup,javaRefType(), ComputeContext.class);
     }
-    public JavaType javaReturnType() {
-        return (JavaType) methodRef().type().returnType();
+
+    public static JavaType javaReturnType(JavaOp.InvokeOp op) {
+        return (JavaType) methodRef(op).type().returnType();
     }
 
-    public Method method() {
+    public JavaType javaReturnType() {
+        return javaReturnType(op);
+    }
+
+    public static Method method(MethodHandles.Lookup lookup,JavaOp.InvokeOp op ) {
         try {
-            return methodRef().resolveToMethod(lookup, op.invokeKind());
+            return methodRef(op).resolveToMethod(lookup, op.invokeKind());
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }
 
-  //  public Value getReceiver() {
-    //    return op.hasReceiver() ? op.operands().getFirst() : null;
-   // }
+    public Method method() {
+        return method(lookup,op);
+    }
+
 
     public enum IfaceBufferAccess {None, Access, Mutate}
 
@@ -110,20 +126,24 @@ public class InvokeOpWrapper extends OpWrapper<JavaOp.InvokeOp> {
         return op.invokeDescriptor().name();
     }
 
+    public static Optional<Class<?>> javaRefClass(MethodHandles.Lookup lookup,JavaOp.InvokeOp op) {
+        if (javaRefType(op) instanceof ClassType classType) {
+            return Optional.of((Class<?>) OpTk.classTypeToType(lookup,classType));
+        }else{
+            return Optional.empty();
+        }
+    }
     public Optional<Class<?>> javaRefClass() {
-        if (javaRefType() instanceof ClassType classType) {
+       return javaRefClass(lookup,op);
+    }
+    public static Optional<Class<?>> javaReturnClass(MethodHandles.Lookup lookup,JavaOp.InvokeOp op) {
+        if (javaReturnType(op) instanceof ClassType classType) {
             return Optional.of((Class<?>) OpTk.classTypeToType(lookup,classType));
         }else{
             return Optional.empty();
         }
     }
-
     public Optional<Class<?>> javaReturnClass() {
-        if (javaReturnType() instanceof ClassType classType) {
-            return Optional.of((Class<?>) OpTk.classTypeToType(lookup,classType));
-        }else{
-            return Optional.empty();
-        }
+        return javaReturnClass(lookup,op);
     }
-
 }

--- a/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedTest.java
@@ -80,8 +80,8 @@ public class QuotedTest {
         System.out.println(f.toText());
         MethodHandles.Lookup lookup =  MethodHandles.lookup();
         C99HATComputeBuilder codeBuilder = new C99HATComputeBuilder();
-        FuncOpWrapper wf = OpWrapper.wrap(lookup,f);
-        codeBuilder.compute(wf);
+        //FuncOpWrapper wf = OpWrapper.wrap(lookup,f);
+        codeBuilder.compute(lookup,f);
         System.out.println(codeBuilder);
 
         // target type of a lambda must be an interface

--- a/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
@@ -33,6 +33,7 @@ import hat.optools.OpTk;
 import hat.optools.OpWrapper;
 import hat.optools.StructuralOpWrapper;
 import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.dialect.java.PrimitiveType;
 
@@ -75,14 +76,14 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
         return self();
     }
 
-    public T compute(MethodHandles.Lookup lookup,FuncOpWrapper funcOpWrapper) {
-        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(lookup,funcOpWrapper);
-        typeName(funcOpWrapper.op.resultType().toString()).space().identifier(funcOpWrapper.op.funcName());
+    public T compute(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp) {
+        HATCodeBuilderContext buildContext = new HATCodeBuilderContext(lookup,funcOp);
+        typeName(funcOp.resultType().toString()).space().identifier(funcOp.funcName());
         parenNlIndented(_ ->
-                commaSeparated(funcOpWrapper.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
+                commaSeparated(buildContext.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );
         braceNlIndented(_ ->
-                OpTk.wrappedRootOpStream(buildContext.lookup,funcOpWrapper.op)
+                OpTk.wrappedRootOpStream(buildContext.lookup,funcOp)
                         .forEach(root ->
                                 recurse(buildContext, root).semicolonIf(!(root instanceof StructuralOpWrapper<?>)).nl()
                         )

--- a/hat/tools/src/main/java/hat/tools/text/TestJavaHATCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/text/TestJavaHATCodeBuilder.java
@@ -78,7 +78,7 @@ public class TestJavaHATCodeBuilder {
         Method method = Compute.class.getDeclaredMethod(methodName,
                 KernelContext.class, S32Array2D.class, S32Array.class, float.class, float.class,float.class);
         CoreOp.FuncOp javaFunc = Op.ofMethod(method).get();
-        builder.compute(lookup,OpWrapper.wrap(lookup,javaFunc));
+        builder.compute(lookup,javaFunc);
         System.out.println(builder.toString());
     }
 }


### PR DESCRIPTION
Removed OpWrappers from callgraph creation.  

One more round of refactoring and OpWrappers should be gone.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/540/head:pull/540` \
`$ git checkout pull/540`

Update a local copy of the PR: \
`$ git checkout pull/540` \
`$ git pull https://git.openjdk.org/babylon.git pull/540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 540`

View PR using the GUI difftool: \
`$ git pr show -t 540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/540.diff">https://git.openjdk.org/babylon/pull/540.diff</a>

</details>
