### PR TITLE
Fix SSABraun bug and add SSA tests

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/SSABraun.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/analysis/SSABraun.java
@@ -190,13 +190,16 @@ final class SSABraun implements OpTransformer {
         }
         // we shouldn't have phis without operands (other than itself)
         assert same != null : "phi without different operands";
-        List<Phi> phiUsers = phi.replaceBy(same, this);
         List<Phi> phis = this.additionalParameters.get(phi.block());
         if (phis != null) {
             phis.remove(phi);
         }
-        for (Phi user : phiUsers) {
-            tryRemoveTrivialPhi(user);
+        phi.users.remove(phi);
+        phi.replaceBy(same, this);
+        for (Object o : phi.users()) {
+            if (o instanceof Phi user){
+                tryRemoveTrivialPhi(user);
+            }
         }
         return same;
     }

--- a/test/jdk/java/lang/reflect/code/TestSSA.java
+++ b/test/jdk/java/lang/reflect/code/TestSSA.java
@@ -153,6 +153,155 @@ public class TestSSA {
         Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 10), nestedLambdaCapture(10));
     }
 
+    @CodeReflection
+    static int deadCode(int n) {
+        int factorial = 1;
+        int unused = factorial;
+        int unusedLoop = 0;
+        for (int i = 0; i < 4; i++) {
+            unusedLoop++;
+        }
+        while (n > 0) {
+            factorial *= n;
+            n--;
+            if (factorial == 0) {
+                factorial = -1;
+                int unusedNested = factorial;
+            }
+        }
+        return factorial;
+    }
+
+    @Test
+    public void testDeadCode() {
+        CoreOp.FuncOp f = getFuncOp("deadCode");
+
+        CoreOp.FuncOp lf = generate(f);
+
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 10), deadCode(10));
+    }
+
+    @CodeReflection
+    static int ifelseLoopNested(int n) {
+        int counter = 10;
+        while (n > 0) {
+            if (n % 2 == 0) {
+                int sum = n;
+                for (int i = 0; i < 5; i++) {
+                    if (sum > n / 2) {
+                        sum -= i;
+                    } else {
+                        sum += i;
+                        break;
+                    }
+                }
+                n += sum;
+            } else {
+                int difference = (n % 3 == 0) ? n / 2 : n * 2;
+                n -= difference;
+            }
+            counter--;
+        }
+        return n;
+    }
+
+    @Test
+    public void testIfelseLoopNested() {
+        CoreOp.FuncOp f = getFuncOp("ifelseLoopNested");
+
+        CoreOp.FuncOp lf = generate(f);
+
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 10), ifelseLoopNested(10));
+    }
+
+    @CodeReflection
+    static int violaJones(int x, int maxX, int length, int integral) {
+        int scale = 0;
+        scale++;
+        while (x > scale && scale < length) {
+        }
+        for (int i = 0; i < integral; i++) {
+            scale--;
+        }
+        return scale;
+    }
+
+    @Test
+    public void testViolaJones() {
+        CoreOp.FuncOp f = getFuncOp("violaJones");
+
+        CoreOp.FuncOp lf = generate(f);
+
+        Assert.assertEquals((int) Interpreter.invoke(MethodHandles.lookup(), lf, 0, 1, 0, 0), violaJones(0, 1, 0, 0));
+    }
+
+    @CodeReflection
+    static boolean binarySearch(int[] arr, int target) {
+        int l = 0;
+        int r = arr.length - 1;
+        while (l < r) {
+            int m = (r - l) / 2;
+            m += l;
+            if (arr[m] < target) {
+                l = m + 1;
+            } else if (arr[m] > target) {
+                r = m - 1;
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void testBinarySearch() {
+        CoreOp.FuncOp f = getFuncOp("binarySearch");
+
+        CoreOp.FuncOp lf = generate(f);
+
+        int[] arr = new int[]{1, 2, 4, 7, 11, 19, 21, 29, 30, 36};
+
+        Assert.assertEquals((boolean) Interpreter.invoke(MethodHandles.lookup(), lf, arr, 4), binarySearch(arr, 4));
+    }
+
+    @CodeReflection
+    static void quicksort(int[] arr, int lo, int hi) {
+        if (lo >= hi || lo < 0) {
+            return;
+        }
+
+        int pivot = arr[hi];
+        int i = lo;
+        for (int j = lo; j < hi; j++) {
+            if (arr[j] <= pivot) {
+                int temp = arr[i];
+                arr[i] = arr[j];
+                arr[j] = temp;
+                i++;
+            }
+        }
+        int temp = arr[i];
+        arr[i] = arr[hi];
+        arr[hi] = temp;
+
+        quicksort(arr, lo, i - 1);
+        quicksort(arr, i + 1, hi);
+    }
+
+    @Test
+    public void testQuicksort() {
+        CoreOp.FuncOp f = getFuncOp("quicksort");
+
+        CoreOp.FuncOp lf = generate(f);
+
+        int[] arr1 = new int[]{5, 2, 7, 45, 34, 14, 0, 27, 43, 11, 38, 56, 81};
+        int[] arr2 = new int[]{2, 11, 45, 34, 0, 27, 38, 56, 7, 43, 14, 5, 81};
+
+        Interpreter.invoke(MethodHandles.lookup(), lf, arr1, 0, arr1.length - 1);
+        quicksort(arr2, 0, arr2.length - 1);
+        Assert.assertEquals(arr1, arr2);
+    }
+
     static CoreOp.FuncOp generate(CoreOp.FuncOp f) {
         System.out.println(f.toText());
 


### PR DESCRIPTION
Fix a bug in SSABraun where, in `tryRemoveTrivialPhi()`, a trivial phi is not removed from its own user list before `phi.replaceBy(same, this)` is called to replace all users of the trivial phi.  

Add five tests to TestSSA: `deadCode(), ifelseLoopNested(), violaJones(), binarySearch(),` and `quicksort()`. `violaJones()` is inspired by the method `findFeaturesKernel` in HAT kernel ViolaJones.