### PR TITLE
[hat][fix] create context with v4 function

### DIFF
--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
@@ -82,7 +82,8 @@ CudaBackend::CudaBackend(int configBits)
         CUDA_CHECK(cuDeviceGetCount(&deviceCount), "cuDeviceGetCount");
         std::cout << "CudaBackend device count = " << deviceCount << std::endl;
         CUDA_CHECK(cuDeviceGet(&device, 0), "cuDeviceGet");
-        CUDA_CHECK(cuCtxCreate(&context, 0, device), "cuCtxCreate");
+        CUctxCreateParams ctxCreateParams = {};
+        CUDA_CHECK(cuCtxCreate_v4(&context, &ctxCreateParams, 0, device), "cuCtxCreate");
         std::cout << "CudaBackend context created ok (id=" << context << ")" << std::endl;
         dynamic_cast<CudaQueue *>(queue)->init();
     } else {


### PR DESCRIPTION
Invoke the `cuCtxCreate` with 4 parameters to match the CUDA 13.0 default API. 

This patch has been tested for CUDA 12.8 and CUDA 13.0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/543/head:pull/543` \
`$ git checkout pull/543`

Update a local copy of the PR: \
`$ git checkout pull/543` \
`$ git pull https://git.openjdk.org/babylon.git pull/543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 543`

View PR using the GUI difftool: \
`$ git pr show -t 543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/543.diff">https://git.openjdk.org/babylon/pull/543.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/543#issuecomment-3249322096)
</details>
