### PR TITLE
hat cleanup after removing OpWrappers

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
@@ -29,6 +29,7 @@ import hat.codebuilders.C99HATKernelBuilder;
 import hat.codebuilders.HATCodeBuilderContext;
 
 import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaType;
 
 public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuilder> {
@@ -100,13 +101,13 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
     }
 
     @Override
-    public CudaHATKernelBuilder kernelDeclaration(String name) {
-        return externC().space().keyword("__global__").space().voidType().space().identifier(name);
+    public CudaHATKernelBuilder kernelDeclaration(CoreOp.FuncOp funcOp) {
+        return externC().space().keyword("__global__").space().voidType().space().identifier(funcOp.funcName());
     }
 
     @Override
-    public CudaHATKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType javaType, String name) {
-        return externC().space().keyword("__device__").space().keyword("inline").space().type(codeBuilderContext,javaType).space().identifier(name);
+    public CudaHATKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType javaType, CoreOp.FuncOp funcOp) {
+        return externC().space().keyword("__device__").space().keyword("inline").space().type(codeBuilderContext,javaType).space().identifier(funcOp.funcName());
     }
 
     @Override

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
@@ -109,7 +109,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
         funcName(funcName);
     }
 
-    public PTXHATKernelBuilder parameters(List<OpTk.ParamTable.Info> infoList) {
+    public PTXHATKernelBuilder parameters(List<FuncOpParams.Info> infoList) {
         paren(_ -> nl().commaNlSeparated(infoList, (info) -> {
             ptxIndent().dot().param().space().paramType(info.javaType);
             space().regName(info.varOp.varName());
@@ -466,7 +466,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
 
     // S32Array and S32Array2D functions can be deleted after schema is done
     public void methodCall(JavaOp.InvokeOp op) {
-        switch (OpTk.methodRef(op).toString()) {
+        switch (op.invokeDescriptor().toString()) {
             // S32Array functions
             case "hat.buffer.S32Array::array(long)int" -> {
                 PTXRegister temp = new PTXRegister(incrOrdinal(addressType()), addressType());
@@ -504,7 +504,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
                     st().dot().param().paramType(op.operands().get(i).type()).space().osbrace().param().intVal(i).csbrace().commaSpace().reg(op.operands().get(i)).ptxNl();
                 }
                 dot().param().space().paramType(op.resultType()).space().retVal().ptxNl();
-                call().uni().space().oparen().retVal().cparen().commaSpace().append(OpTk.method(MethodHandles.lookup(),op).getName()).commaSpace();
+                call().uni().space().oparen().retVal().cparen().commaSpace().append(OpTk.methodOrThrow(MethodHandles.lookup(),op).getName()).commaSpace();
                 final int[] counter = {0};
                 paren(_ -> commaSeparated(op.operands(), _ -> param().intVal(counter[0]++))).ptxNl();
                 ld().dot().param().paramType(op.resultType()).space().resultReg(op, getResultType(op.resultType())).commaSpace().osbrace().retVal().csbrace();

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
@@ -29,6 +29,7 @@ import hat.codebuilders.C99HATKernelBuilder;
 import hat.codebuilders.HATCodeBuilderContext;
 
 import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaType;
 
 public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelBuilder> {
@@ -80,13 +81,13 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
     }
 
     @Override
-    public OpenCLHATKernelBuilder kernelDeclaration(String name) {
-        return keyword("__kernel").space().voidType().space().identifier(name);
+    public OpenCLHATKernelBuilder kernelDeclaration(CoreOp.FuncOp funcOp) {
+        return keyword("__kernel").space().voidType().space().identifier(funcOp.funcName());
     }
 
     @Override
-    public OpenCLHATKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType type, String name) {
-        return keyword("inline").space().type(codeBuilderContext,type).space().identifier(name);
+    public OpenCLHATKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType type, CoreOp.FuncOp funcOp) {
+        return keyword("inline").space().type(codeBuilderContext,type).space().identifier(funcOp.funcName());
     }
 
     @Override
@@ -96,9 +97,8 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
 
     @Override
     public OpenCLHATKernelBuilder atomicInc(HATCodeBuilderContext buildContext, Op.Result instanceResult, String name){
-          return identifier("atomic_inc").paren(_ -> {
-              ampersand().recurse(buildContext, instanceResult.op());
-              rarrow().identifier(name);
-          });
+          return identifier("atomic_inc").paren(_ ->
+              ampersand().recurse(buildContext, instanceResult.op()).rarrow().identifier(name)
+          );
     }
 }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -164,7 +164,7 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
             System.out.println("Original");
             System.out.println(kernelCallGraph.entrypoint.funcOp().toText());
             System.out.println("Lowered");
-            System.out.println(OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp()).toText());
+            System.out.println(OpTk.lower(kernelCallGraph.entrypoint.funcOp()).toText());
         }
         return builder.toString();
     }

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
@@ -28,6 +28,7 @@ import hat.NDRange;
 import hat.codebuilders.C99HATKernelBuilder;
 import hat.codebuilders.HATCodeBuilderContext;
 import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaType;
 
 public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelBuilder> {
@@ -78,13 +79,13 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder kernelDeclaration(String name) {
-        return keyword("__kernel").space().voidType().space().identifier(name);
+    public OpenCLHatKernelBuilder kernelDeclaration(CoreOp.FuncOp funcOp) {
+        return keyword("__kernel").space().voidType().space().identifier(funcOp.funcName());
     }
 
     @Override
-    public OpenCLHatKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType type, String name) {
-        return keyword("inline").space().type(codeBuilderContext,type).space().identifier(name);
+    public OpenCLHatKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType type, CoreOp.FuncOp funcOp) {
+        return keyword("inline").space().type(codeBuilderContext,type).space().identifier(funcOp.funcName());
     }
 
     @Override

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -99,7 +99,7 @@ public abstract class C99JExtractedBackend extends JExtractedBackend {
         System.out.println("Original");
         System.out.println(kernelCallGraph.entrypoint.funcOp().toText());
         System.out.println("Lowered");
-        System.out.println(OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp()).toText());
+        System.out.println(OpTk.lower(kernelCallGraph.entrypoint.funcOp()).toText());
 
         return builder.toString();
     }

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
@@ -31,21 +31,20 @@ import hat.callgraph.CallGraph;
 import hat.ifacemapper.BoundSchema;
 import hat.ifacemapper.MappableIface;
 import hat.ifacemapper.SegmentMapper;
-//import hat.optools.InvokeOpWrapper;
+import hat.optools.FuncOpParams;
 import hat.optools.OpTk;
-import jdk.incubator.code.Block;
-import jdk.incubator.code.CopyContext;
+import jdk.incubator.code.Op;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.dialect.core.CoreOp;
-import jdk.incubator.code.interpreter.Interpreter;
+import jdk.incubator.code.dialect.java.ClassType;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
+import jdk.incubator.code.interpreter.Interpreter;
 
 import java.lang.foreign.Arena;
 
 import static hat.ComputeContext.WRAPPER.ACCESS;
-//import static hat.ComputeContext.WRAPPER.ESCAPE;
 import static hat.ComputeContext.WRAPPER.MUTATE;
 
 public abstract class JExtractedBackend extends JExtractedBackendDriver {
@@ -65,10 +64,8 @@ public abstract class JExtractedBackend extends JExtractedBackendDriver {
     public void dispatchCompute(ComputeContext computeContext, Object... args) {
         if (computeContext.computeCallGraph.entrypoint.lowered == null) {
             computeContext.computeCallGraph.entrypoint.lowered =
-                    OpTk.lower(computeContext.accelerator.lookup,computeContext.computeCallGraph.entrypoint.funcOp());
+                    OpTk.lower(computeContext.computeCallGraph.entrypoint.funcOp());
         }
-
-
         boolean interpret = false;
         if (interpret) {
             Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered, args);
@@ -85,62 +82,50 @@ public abstract class JExtractedBackend extends JExtractedBackendDriver {
         }
     }
 
- // This code should be common with ffi-shared probably should be pushed down into another lib?
+    // This code should be common with ffi-shared probably should be pushed down into another lib?
     protected static CoreOp.FuncOp injectBufferTracking(CallGraph.ResolvedMethodCall computeMethod) {
-        CoreOp.FuncOp prevFO = computeMethod.funcOp();
-        CoreOp.FuncOp returnFO = prevFO;
-        boolean transform = true;
-        if (transform) {
-            System.out.println("COMPUTE entrypoint before injecting buffer tracking...");
-            System.out.println(returnFO.toText());
-            var paramTable = new OpTk.ParamTable(prevFO);
-            var lookup = computeMethod.callGraph.computeContext.accelerator.lookup;
-            returnFO = prevFO.transform((bldr, op)->{
-
-                if (op instanceof JavaOp.InvokeOp invokeO) {
-                    CopyContext bldrCntxt = bldr.context();
-                    //Map compute method's first param (computeContext) value to transformed model
-                    Value cc = bldrCntxt.getValue(paramTable.list().getFirst().parameter);
-                    if (OpTk.isIfaceMutator(lookup,invokeO)) {                    // iface.v(newV)
-                        Value iface = bldrCntxt.getValue(invokeO.operands().getFirst());
-                        bldr.op(JavaOp.invoke(MUTATE.pre, cc, iface));  // cc->preMutate(iface);
-                        bldr.op(invokeO);                         // iface.v(newV);
-                        bldr.op(JavaOp.invoke(MUTATE.post, cc, iface)); // cc->postMutate(iface)
-                    } else if (OpTk.isIfaceAccessor(lookup,invokeO)) {            // iface.v()
-                        Value iface = bldrCntxt.getValue(invokeO.operands().getFirst());
-                        bldr.op(JavaOp.invoke(ACCESS.pre, cc, iface));  // cc->preAccess(iface);
-                        bldr.op(invokeO);                         // iface.v();
-                        bldr.op(JavaOp.invoke(ACCESS.post, cc, iface)); // cc->postAccess(iface) } else {
-                    } else if (OpTk.isComputeContextMethod(lookup,invokeO) || OpTk.isRawKernelCall(lookup,invokeO)) { //dispatchKernel
-                        bldr.op(invokeO);
-                    } else {
-                        invokeO.operands().stream()
-                                .filter(val -> val.type() instanceof JavaType javaType &&
-                                        OpTk.isAssignable(lookup, javaType, MappableIface.class))
-                                // isIfaceUsingLookup(prevFOW.lookup,javaType))
-                                .forEach(val ->
-                                        bldr.op(JavaOp.invoke(MUTATE.pre, cc, bldrCntxt.getValue(val)))
-                                );
-                        bldr.op(invokeO);
-                        invokeO.operands().stream()
-                                .filter(val -> val.type() instanceof JavaType javaType &&
-                                        OpTk.isAssignable(lookup, javaType, MappableIface.class))
-                                // isIfaceUsingLookup(prevFOW.lookup,javaType))
-
-                                .forEach(val -> bldr.op(
-                                        JavaOp.invoke(MUTATE.post, cc, bldrCntxt.getValue(val)))
-                                );
-                    }
-                    return bldr;
-                }else{
-                    bldr.op(op);
+        System.out.println("COMPUTE entrypoint before injecting buffer tracking...");
+        System.out.println(computeMethod.funcOp().toText());
+        var paramTable = new FuncOpParams(computeMethod.funcOp());
+        var lookup = computeMethod.callGraph.computeContext.accelerator.lookup;
+        var transformedFuncOp = computeMethod.funcOp().transform((bldr, op) -> {
+            if (op instanceof JavaOp.InvokeOp invokeOp) {
+                Value computeContext = bldr.context().getValue(paramTable.list().getFirst().parameter);
+                if (OpTk.isIfaceBufferMethod(lookup, invokeOp) && OpTk.javaReturnType(invokeOp).equals(JavaType.VOID)) {                    // iface.v(newV)
+                    Value iface = bldr.context().getValue(invokeOp.operands().getFirst());
+                    bldr.op(JavaOp.invoke(MUTATE.pre, computeContext, iface));  // cc->preMutate(iface);
+                    bldr.op(invokeOp);                                          // iface.v(newV);
+                    bldr.op(JavaOp.invoke(MUTATE.post, computeContext, iface)); // cc->postMutate(iface)
+                } else if (OpTk.isIfaceBufferMethod(lookup, invokeOp)
+                        //&& !OpTk.javaReturnType(invokeOp).equals(JavaType.VOID) not sure we need this
+                        && OpTk.javaReturnType(invokeOp) instanceof ClassType returnClassType
+                        && OpTk.classTypeToTypeOrThrow(lookup, returnClassType) instanceof Class<?> type
+                        && Buffer.class.isAssignableFrom(type)
+                ) {            // iface.v()
+                    Value iface = bldr.context().getValue(invokeOp.operands().getFirst());
+                    bldr.op(JavaOp.invoke(ACCESS.pre, computeContext, iface));  // cc->preAccess(iface);
+                    bldr.op(invokeOp);                                          // iface.v();
+                    bldr.op(JavaOp.invoke(ACCESS.post, computeContext, iface)); // cc->postAccess(iface) } else {
+                } else if (OpTk.isComputeContextMethod(lookup, invokeOp) || OpTk.isKernelContextMethod(lookup, invokeOp)) { //dispatchKernel
+                    bldr.op(invokeOp);
+                } else {
+                    invokeOp.operands().stream()
+                            .filter(val -> val.type() instanceof JavaType javaType && OpTk.isAssignable(lookup, javaType, MappableIface.class))
+                            .forEach(val -> bldr.op(JavaOp.invoke(MUTATE.pre, computeContext, bldr.context().getValue(val))));
+                    bldr.op(invokeOp);
+                    invokeOp.operands().stream()
+                            .filter(val -> val.type() instanceof JavaType javaType && OpTk.isAssignable(lookup, javaType, MappableIface.class))
+                            .forEach(val -> bldr.op(JavaOp.invoke(MUTATE.post, computeContext, bldr.context().getValue(val))));
                 }
                 return bldr;
-            });
-            System.out.println("COMPUTE entrypoint after injecting buffer tracking...");
-            System.out.println(returnFO.toText());
-        }
-        computeMethod.funcOp(returnFO);
-        return returnFO;
+            } else {
+                bldr.op(op);
+            }
+            return bldr;
+        });
+        System.out.println("COMPUTE entrypoint after injecting buffer tracking...");
+        System.out.println(transformedFuncOp.toText());
+        computeMethod.funcOp(transformedFuncOp);
+        return transformedFuncOp;
     }
 }

--- a/hat/core/src/main/java/hat/ComputeContext.java
+++ b/hat/core/src/main/java/hat/ComputeContext.java
@@ -137,7 +137,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
     private CallGraph buildKernelCallGraph(QuotableKernelContextConsumer quotableKernelContextConsumer) {
         Quoted quoted = Op.ofQuotable(quotableKernelContextConsumer).orElseThrow();
         JavaOp.LambdaOp lambdaOp = (JavaOp.LambdaOp) quoted.op();
-        MethodRef methodRef =OpTk.getQuotableTargetMethodRef(lambdaOp);
+        MethodRef methodRef =OpTk.getQuotableTargetInvokeOpWrapper( lambdaOp).invokeDescriptor();
         KernelCallGraph kernelCallGraph = computeCallGraph.kernelCallGraphMap.get(methodRef);
         return new CallGraph(quoted, lambdaOp, methodRef, kernelCallGraph);
     }

--- a/hat/core/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/core/src/main/java/hat/backend/DebugBackend.java
@@ -67,14 +67,14 @@ public class DebugBackend extends BackendAdaptor {
             }
             case BABYLON_INTERPRETER:{
                 if (computeContext.computeCallGraph.entrypoint.lowered == null) {
-                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.accelerator.lookup,computeContext.computeCallGraph.entrypoint.funcOp());
+                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.computeCallGraph.entrypoint.funcOp());
                 }
                 Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered, args);
                 break;
             }
             case BABYLON_CLASSFILE:{
                 if (computeContext.computeCallGraph.entrypoint.lowered == null) {
-                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.accelerator.lookup,computeContext.computeCallGraph.entrypoint.funcOp());
+                    computeContext.computeCallGraph.entrypoint.lowered = OpTk.lower(computeContext.computeCallGraph.entrypoint.funcOp());
                 }
                 try {
                     if (computeContext.computeCallGraph.entrypoint.mh == null) {
@@ -109,12 +109,12 @@ public class DebugBackend extends BackendAdaptor {
                 break;
             }
             case BABYLON_INTERPRETER:{
-                var lowered = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp());
+                var lowered = OpTk.lower(kernelCallGraph.entrypoint.funcOp());
                 Interpreter.invoke(kernelCallGraph.computeContext.accelerator.lookup, lowered, args);
                 break;
             }
             case BABYLON_CLASSFILE:{
-                var lowered = OpTk.lower(kernelCallGraph.computeContext.accelerator.lookup,kernelCallGraph.entrypoint.funcOp());
+                var lowered = OpTk.lower(kernelCallGraph.entrypoint.funcOp());
                 var mh = BytecodeGenerator.generate(kernelCallGraph.computeContext.accelerator.lookup, lowered);
                 try {
                     mh.invokeWithArguments(args);
@@ -153,20 +153,10 @@ public class DebugBackend extends BackendAdaptor {
                 System.out.println("Lowered form which maintains original invokes and args");
                 System.out.println(loweredForm.toText());
                 System.out.println("-------------- ----");
-                // highLevelForm.lower();
                 CoreOp.FuncOp ssaInvokeForm = SSA.transform(loweredForm);
                 System.out.println("SSA form which maintains original invokes and args");
                 System.out.println(ssaInvokeForm.toText());
                 System.out.println("------------------");
-/*
-                FunctionType functionType = OpsAndTypes.transformTypes(kernelCallGraph.computeContext.accelerator.lookup, ssaInvokeForm);
-                System.out.println("SSA form with types transformed args");
-                System.out.println(ssaInvokeForm.toText());
-                System.out.println("------------------");
-
-                CoreOp.FuncOp ssaPtrForm = OpsAndTypes.transformInvokesToPtrs(kernelCallGraph.computeContext.accelerator.lookup, ssaInvokeForm, functionType);
-                System.out.println("SSA form with invokes replaced by ptrs");
-                System.out.println(ssaPtrForm.toText()); */
             }
         }
     }

--- a/hat/core/src/main/java/hat/buffer/BufferTracker.java
+++ b/hat/core/src/main/java/hat/buffer/BufferTracker.java
@@ -34,8 +34,4 @@ public interface BufferTracker {
 
      void postAccess(Buffer b);
 
-   //  void preEscape(Buffer b);
-
-    // void postEscape(Buffer b) ;
-
 }

--- a/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -93,32 +93,27 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
 
         kernelReachableResolvedMethodCall.funcOp().traverse(null, (map, op) -> {
             if (op instanceof JavaOp.InvokeOp invokeOp) {
-              //  var invokeOpWrapper = (InvokeOpWrapper)OpWrapper.wrap(  kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp);
-                MethodRef methodRef = OpTk.methodRef(invokeOp);
-                Class<?> javaRefTypeClass = OpTk.javaRefClass(kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp).orElseThrow();
-                Method invokeOpCalledMethod = OpTk.method(kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp);
+              //  MethodRef methodRef = invokeOp.invokeDescriptor();
+                Class<?> javaRefTypeClass = OpTk.javaRefClassOrThrow(kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp);
+                Method invokeOpCalledMethod = OpTk.methodOrThrow(kernelReachableResolvedMethodCall.callGraph.computeContext.accelerator.lookup,invokeOp);
                 if (Buffer.class.isAssignableFrom(javaRefTypeClass)) {
-                    //System.out.println("kernel reachable iface mapped buffer call  -> " + methodRef);
-                    kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
-                            new KernelReachableUnresolvedIfaceMappedMethodCall(this, methodRef, invokeOpCalledMethod)
+                        kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(invokeOp.invokeDescriptor(), _ ->
+                            new KernelReachableUnresolvedIfaceMappedMethodCall(this, invokeOp.invokeDescriptor(), invokeOpCalledMethod)
                     ));
                 } else if (entrypoint.method.getDeclaringClass().equals(javaRefTypeClass)) {
                     Optional<CoreOp.FuncOp> optionalFuncOp = Op.ofMethod(invokeOpCalledMethod);
                     if (optionalFuncOp.isPresent()) {
-                        //System.out.println("A call to a method on the kernel class which we have code model for " + methodRef);
-                        kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
-                                new KernelReachableResolvedMethodCall(this, methodRef, invokeOpCalledMethod, optionalFuncOp.get()
+                             kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(invokeOp.invokeDescriptor(), _ ->
+                                new KernelReachableResolvedMethodCall(this, invokeOp.invokeDescriptor(), invokeOpCalledMethod, optionalFuncOp.get()
                                 )));
                     } else {
-                        // System.out.println("A call to a method on the compute class which we DO NOT have code model for " + methodRef);
-                        kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
-                                new KernelReachableUnresolvedMethodCall(this, methodRef, invokeOpCalledMethod)
+                           kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(invokeOp.invokeDescriptor(), _ ->
+                                new KernelReachableUnresolvedMethodCall(this, invokeOp.invokeDescriptor(), invokeOpCalledMethod)
                         ));
                     }
                 } else {
-                    //  System.out.println("A call to a method on the compute class which we DO NOT have code model for " + methodRef);
-                    kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(methodRef, _ ->
-                            new KernelReachableUnresolvedMethodCall(this, methodRef, invokeOpCalledMethod)
+                       kernelReachableResolvedMethodCall.addCall(methodRefToMethodCallMap.computeIfAbsent(invokeOp.invokeDescriptor(), _ ->
+                            new KernelReachableUnresolvedMethodCall(this, invokeOp.invokeDescriptor(), invokeOpCalledMethod)
                     ));
                     // System.out.println("Were we expecting " + methodRef + " here ");
                 }

--- a/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
@@ -47,7 +47,7 @@ public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HA
         );
 
         braceNlIndented(_ ->
-                OpTk.rootOpStream(buildContext.lookup,funcOp)
+                OpTk.rootOpStream(funcOp)
                         .forEach(root ->
                                 recurse(buildContext, root).semicolonIf(!OpTk.isStructural(root)).nl()
                         )

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -31,6 +31,7 @@ import hat.buffer.Buffer;
 import hat.callgraph.KernelCallGraph;
 import hat.callgraph.KernelEntrypoint;
 import hat.ifacemapper.MappableIface;
+import hat.optools.FuncOpParams;
 import hat.optools.OpTk;
 import hat.util.StreamCounter;
 import jdk.incubator.code.dialect.core.CoreOp;
@@ -187,8 +188,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
                 ,kernelReachableResolvedMethodCall.funcOp());
         buildContext.scope(buildContext.funcOp, () -> {
             nl();
-            functionDeclaration(buildContext,(JavaType) buildContext.funcOp.body().yieldType(),
-                    buildContext.funcOp.funcName());
+            functionDeclaration(buildContext,(JavaType) buildContext.funcOp.body().yieldType(), buildContext.funcOp);
 
             var list = buildContext.paramTable.list();
             parenNlIndented(_ ->
@@ -196,7 +196,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
             );
 
             braceNlIndented(_ -> {
-                StreamCounter.of(OpTk.rootOpStream(buildContext.lookup,buildContext.funcOp), (c, root) ->
+                StreamCounter.of(OpTk.rootOpStream(buildContext.funcOp), (c, root) ->
                         nlIf(c.isNotFirst()).recurse(buildContext, root).semicolonIf(!OpTk.isStructural(root))
                 );
             });
@@ -210,7 +210,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
         buildContext.scope(buildContext.funcOp, () -> {
             nl();
             functionDeclaration(buildContext,(JavaType) buildContext.funcOp.body().yieldType(),
-                    buildContext.funcOp.funcName());
+                    buildContext.funcOp);
 
             var list = buildContext.paramTable.list();
             parenNlIndented(_ ->
@@ -218,7 +218,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
             );
 
             braceNlIndented(_ -> {
-                StreamCounter.of(OpTk.rootOpStream(buildContext.lookup,buildContext.funcOp), (c, root) ->
+                StreamCounter.of(OpTk.rootOpStream(buildContext.funcOp), (c, root) ->
                         nlIf(c.isNotFirst()).recurse(buildContext, root).semicolonIf(!OpTk.isStructural(root))
                 );
             });
@@ -230,13 +230,12 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
         nl();
         HATCodeBuilderContext buildContext = new HATCodeBuilderContext(kernelEntrypoint.callGraph.computeContext.accelerator.lookup,kernelEntrypoint.funcOp());
         buildContext.scope(buildContext.funcOp, () -> {
-            kernelDeclaration(buildContext.funcOp.funcName());
+            kernelDeclaration(buildContext.funcOp);
             // We skip the first arg which was KernelContext.
             var list = buildContext.paramTable.list();
             for (int arg = 1; arg < args.length; arg++) {
-                if (args[arg] instanceof Buffer buffer) {
-                    OpTk.ParamTable.Info info = list.get(arg);
-                    info.setLayout((GroupLayout) Buffer.getLayout(buffer));
+                if (args[arg] instanceof Buffer) {
+                    FuncOpParams.Info info = list.get(arg);
                     info.setClass(args[arg].getClass());
                 }
             }
@@ -250,7 +249,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
             braceNlIndented(_ -> {
                 scope();
-                StreamCounter.of(OpTk.rootOpStream(buildContext.lookup,buildContext.funcOp), (c, root) ->
+                StreamCounter.of(OpTk.rootOpStream(buildContext.funcOp), (c, root) ->
                         nlIf(c.isNotFirst()).recurse(buildContext, root).semicolonIf(!OpTk.isStructural(root))
                 );
             });
@@ -263,9 +262,9 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
     public abstract T pragmas();
 
-    public abstract T kernelDeclaration(String name);
+    public abstract T kernelDeclaration(CoreOp.FuncOp funcOp);
 
-    public abstract T functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType javaType, String name);
+    public abstract T functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType javaType, CoreOp.FuncOp funcOp);
 
     public abstract T globalId(int id);
 

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderContext.java
@@ -24,7 +24,7 @@
  */
 package hat.codebuilders;
 
-import hat.optools.OpTk;
+import hat.optools.FuncOpParams;
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.Value;
@@ -57,10 +57,10 @@ public class HATCodeBuilderContext {
     }
 
     public static class FuncScope extends Scope<CoreOp.FuncOp> {
-        final OpTk.ParamTable paramTable;
+        final FuncOpParams paramTable;
         FuncScope(Scope<?> parent, CoreOp.FuncOp funcOp) {
             super(parent, funcOp);
-            paramTable = new OpTk.ParamTable(funcOp);
+            paramTable = new FuncOpParams(funcOp);
         }
 
         @Override
@@ -240,11 +240,11 @@ public class HATCodeBuilderContext {
     }
     final public MethodHandles.Lookup lookup;
     final public CoreOp.FuncOp funcOp;
-    final public OpTk.ParamTable paramTable;
+    final public FuncOpParams paramTable;
     public HATCodeBuilderContext(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp) {
         this.lookup = lookup;
         this.funcOp = funcOp;
-        this.paramTable = new OpTk.ParamTable(funcOp);
+        this.paramTable = new FuncOpParams(funcOp);
     }
 
 }

--- a/hat/core/src/main/java/hat/optools/FuncOpParams.java
+++ b/hat/core/src/main/java/hat/optools/FuncOpParams.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.optools;
+
+import hat.util.BiMap;
+import jdk.incubator.code.Block;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
+import jdk.incubator.code.dialect.java.PrimitiveType;
+
+import java.lang.foreign.GroupLayout;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class FuncOpParams {
+    public static class Info {
+        public final int idx;
+        public final Block.Parameter parameter;
+        public final JavaType javaType;
+        public final CoreOp.VarOp varOp;
+        public Class<?> clazz = null;
+
+        Info(int idx, Block.Parameter parameter, CoreOp.VarOp varOp) {
+            this.idx = idx;
+            this.parameter = parameter;
+            this.javaType = (JavaType) parameter.type();
+            this.varOp = varOp;
+        }
+
+        public boolean isPrimitive() {
+            return javaType instanceof PrimitiveType;
+        }
+
+        public void setClass(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+    }
+
+    final public BiMap<Block.Parameter, CoreOp.VarOp> parameterVarOpMap = new BiMap<>();
+    final public BiMap<Block.Parameter, JavaOp.InvokeOp> parameterInvokeOpMap = new BiMap<>();
+
+    final private Map<Block.Parameter, Info> parameterToInfo = new LinkedHashMap<>();
+    final private Map<CoreOp.VarOp, Info> varOpToInfo = new LinkedHashMap<>();
+
+    final private List<Info> list = new ArrayList<>();
+
+    public Info info(Block.Parameter parameter) {
+        return parameterToInfo.get(parameter);
+    }
+
+    void add(Map.Entry<Block.Parameter, CoreOp.VarOp> parameterToVarOp) {
+        //We add a new ParameterInfo to both maps using parameter and varOp as keys
+        varOpToInfo.put(parameterToVarOp.getValue(),
+                // always called but convenient because computeIfAbsent returns what we added :)
+                parameterToInfo.computeIfAbsent(parameterToVarOp.getKey(), (parameterKey) -> {
+                    var info = new Info(list.size(), parameterKey, parameterToVarOp.getValue());
+                    list.add(info);
+                    return info;
+                })
+        );
+    }
+
+    public List<Info> list() {
+        return list;
+    }
+
+    public Stream<Info> stream() {
+        return list.stream();
+    }
+
+    final public CoreOp funcOp;
+
+    public FuncOpParams(CoreOp.FuncOp funcOp) {
+        this.funcOp = funcOp;
+        funcOp.parameters().forEach(parameter -> {
+            Optional<Op.Result> optionalResult = parameter.uses().stream().findFirst();
+            optionalResult.ifPresentOrElse(result -> {
+                if (result.op() instanceof CoreOp.VarOp varOp) {
+                    parameterVarOpMap.add(parameter, varOp);
+                    add(Map.entry(parameter, varOp));
+                } else if (result.op() instanceof JavaOp.InvokeOp invokeOp) {
+                    parameterInvokeOpMap.add(parameter, invokeOp);
+                }
+            }, () -> {
+                throw new IllegalStateException("FuncOp has unused params ");
+            });
+        });
+    }
+}

--- a/hat/core/src/main/java/hat/optools/OpTk.java
+++ b/hat/core/src/main/java/hat/optools/OpTk.java
@@ -25,26 +25,20 @@
 package hat.optools;
 
 import hat.ComputeContext;
-import hat.buffer.Buffer;
 import hat.buffer.KernelContext;
 import hat.callgraph.CallGraph;
 import hat.ifacemapper.MappableIface;
-import hat.util.BiMap;
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.OpTransformer;
 import jdk.incubator.code.Quoted;
-import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.Value;
-import jdk.incubator.code.analysis.SSA;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.ClassType;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.dialect.java.MethodRef;
-import jdk.incubator.code.dialect.java.PrimitiveType;
 
-import java.lang.foreign.GroupLayout;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -57,59 +51,25 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class OpTk {
-
-
-    public static Op lhsAsOp(Op op) {
-        return ((Op.Result) op.operands().getFirst()).op();
-    }
-
-    public static Op rhsAsOp(Op op) {
-        return ((Op.Result) op.operands().get(1)).op();
-    }
-
-   // public static Stream<OpWrapper<?>> lhsWrappedYieldOpStream(MethodHandles.Lookup lookup, JavaOp.JavaConditionalOp op) {
-     //   return op.bodies().get(0).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp).map(o -> OpWrapper.wrap(lookup, o));
-   // }
-    public static Stream<Op> lhsYieldOpStream(JavaOp.JavaConditionalOp op) {
-        return op.bodies().get(0).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
-
-   // public static Stream<OpWrapper<?>> rhsWrappedYieldOpStream(MethodHandles.Lookup lookup, JavaOp.JavaConditionalOp op) {
-     //   return op.bodies().get(1).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp).map(o -> OpWrapper.wrap(lookup, o));
-   // }
-    public static Stream<Op> rhsYieldOpStream( JavaOp.JavaConditionalOp op) {
-        return op.bodies().get(1).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
 
     public static boolean isKernelContextAccess(JavaOp.FieldAccessOp fieldAccessOp) {
         return fieldAccessOp.fieldDescriptor().refType() instanceof ClassType classType && classType.toClassName().equals("hat.KernelContext");
     }
 
-    public static TypeElement fieldType(JavaOp.FieldAccessOp fieldAccessOp) {
-        return fieldAccessOp.fieldDescriptor().refType();
-    }
 
     public static String fieldName(JavaOp.FieldAccessOp fieldAccessOp) {
         return fieldAccessOp.fieldDescriptor().name();
     }
 
-    public static JavaType javaType(CoreOp.VarOp op) {
-        return (JavaType) op.varValueType();
-    }
-
-    public static String varName(CoreOp.VarOp op) {
-        return op.varName();
-    }
-
     public static Object getStaticFinalPrimitiveValue(MethodHandles.Lookup lookup, JavaOp.FieldAccessOp.FieldLoadOp fieldLoadOp) {
-        if (fieldType(fieldLoadOp) instanceof ClassType classType) {
-            Class<?> clazz = (Class<?>) classTypeToType(lookup, classType);
+        if (fieldLoadOp.fieldDescriptor().refType() instanceof ClassType classType) {
+            Class<?> clazz = (Class<?>) classTypeToTypeOrThrow(lookup, classType);
             try {
                 Field field = clazz.getField(fieldName(fieldLoadOp));
                 field.setAccessible(true);
@@ -121,55 +81,14 @@ public class OpTk {
         throw new RuntimeException("Could not find field value" + fieldLoadOp);
     }
 
-   // public static Stream<OpWrapper<?>> initWrappedYieldOpStream(MethodHandles.Lookup lookup, JavaOp.ForOp op) {
-     //   return op.init().entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp).map(o -> OpWrapper.wrap(lookup, o));
-   // }
 
-    public static Stream<Op> initYieldOpStream(JavaOp.ForOp op) {
-        return op.init().entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
-    // Maybe instead of three of these we can add cond() to Op.Loop?
-  //  public static Stream<OpWrapper<?>> conditionWrappedYieldOpStream(MethodHandles.Lookup lookup, JavaOp.ForOp op) {
-    //    return op.cond().entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp).map(o -> OpWrapper.wrap(lookup, o));
-   // }
-    public static Stream<Op> conditionYieldOpStream(JavaOp.ForOp op) {
-        return op.cond().entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
-    public static Stream<Op> conditionYieldOpStream( JavaOp.WhileOp op) {
-        // ADD op.cond() to JavaOp.WhileOp  match ForOp?
-        return op.bodies().getFirst().entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
-    public static Stream<Op> conditionYieldOpStream( JavaOp.ConditionalExpressionOp op) {
-        // ADD op.cond() to JavaOp.WhileOp  match ForOp?
-        return op.bodies().getFirst().entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
-    public static Stream<Op> loopRootOpStream(MethodHandles.Lookup lookup, Op.Loop op) {
+    public static Stream<Op> loopRootOpStream(Op.Loop op) {
         var list = new ArrayList<>(rootsExcludingVarFuncDeclarationsAndYields( op.loopBody().entryBlock()).toList());
         if (list.getLast() instanceof JavaOp.ContinueOp) {
             list.removeLast();
         }
         return list.stream();
     }
-
-
-    public static Stream<Op> mutateRootOpStream(MethodHandles.Lookup lookup, JavaOp.ForOp op) {
-        return rootsExcludingVarFuncDeclarationsAndYields( op.bodies().get(2).entryBlock());
-    }
-
-
-    public static Stream<Op> thenYieldOpStream( JavaOp.ConditionalExpressionOp op) {
-        return op.bodies().get(1).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
-
-    public static Stream<Op> elseYieldOpStream(JavaOp.ConditionalExpressionOp op) {
-        return op.bodies().get(2).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp);
-    }
-
-
-    public static boolean hasElse(JavaOp.IfOp op, int idx) {
-        return op.bodies().size() > idx && op.bodies().get(idx).entryBlock().ops().size() > 1;
-    }
-
 
     public static CoreOp.ModuleOp createTransitiveInvokeModule(MethodHandles.Lookup l,
                                                                CoreOp.FuncOp entry, CallGraph<?> callGraph) {
@@ -181,17 +100,15 @@ public class OpTk {
         Deque<RefAndFunc> work = new ArrayDeque<>();
         entry.traverse(null, (map, op) -> {
             if (op instanceof JavaOp.InvokeOp invokeOp) {
-                MethodRef methodRef = methodRef(invokeOp);
-                Method method = null;
-                Class<?> javaRefTypeClass = javaRefClass(callGraph.computeContext.accelerator.lookup, invokeOp).orElseThrow();
+                Class<?> javaRefTypeClass = javaRefClassOrThrow(callGraph.computeContext.accelerator.lookup, invokeOp);
                 try {
-                    method = methodRef.resolveToMethod(l, invokeOp.invokeKind());
+                    var method = invokeOp.invokeDescriptor().resolveToMethod(l, invokeOp.invokeKind());
+                    CoreOp.FuncOp f = Op.ofMethod(method).orElse(null);
+                    if (f != null && !callGraph.filterCalls(f, invokeOp, method, invokeOp.invokeDescriptor(), javaRefTypeClass)) {
+                        work.push(new RefAndFunc(invokeOp.invokeDescriptor(),  f));
+                    }
                 } catch (ReflectiveOperationException _) {
                     throw new IllegalStateException("Could not resolve invokeWrapper to method");
-                }
-                Optional<CoreOp.FuncOp> f = Op.ofMethod(method);
-                if (f.isPresent() && !callGraph.filterCalls(f.get(), invokeOp, method, methodRef, javaRefTypeClass)) {
-                    work.push(new RefAndFunc(methodRef,  f.get()));
                 }
             }
             return map;
@@ -205,27 +122,23 @@ public class OpTk {
 
             CoreOp.FuncOp tf = rf.f.transform(rf.r.name(), (blockBuilder, op) -> {
                 if (op instanceof JavaOp.InvokeOp iop) {
-                    //  InvokeOpWrapper iopWrapper = OpWrapper.wrap(entry.lookup, iop);
-                    MethodRef methodRef = methodRef(iop);
-                    Method invokeOpCalledMethod = null;
                     try {
-                        invokeOpCalledMethod = methodRef.resolveToMethod(l, iop.invokeKind());
+                        Method invokeOpCalledMethod = iop.invokeDescriptor().resolveToMethod(l, iop.invokeKind());
+                        if (invokeOpCalledMethod instanceof Method m) {
+                            CoreOp.FuncOp f = Op.ofMethod(m).orElse(null);
+                            if (f!=null) {
+                                RefAndFunc call = new RefAndFunc(iop.invokeDescriptor(), f);
+                                work.push(call);
+                                Op.Result result = blockBuilder.op(CoreOp.funcCall(
+                                        call.r.name(),
+                                        call.f.invokableType(),
+                                        blockBuilder.context().getValues(iop.operands())));
+                                blockBuilder.context().mapValue(op.result(), result);
+                                return blockBuilder;
+                            }
+                        }
                     } catch (ReflectiveOperationException _) {
                         throw new IllegalStateException("Could not resolve invokeWrapper to method");
-                    }
-                    if (invokeOpCalledMethod instanceof Method m) {
-                        Optional<CoreOp.FuncOp> f = Op.ofMethod(m);
-                        if (f.isPresent()) {
-                            RefAndFunc call = new RefAndFunc(methodRef, f.get());
-                            work.push(call);
-
-                            Op.Result result = blockBuilder.op(CoreOp.funcCall(
-                                    call.r.name(),
-                                    call.f.invokableType(),
-                                    blockBuilder.context().getValues(iop.operands())));
-                            blockBuilder.context().mapValue(op.result(), result);
-                            return blockBuilder;
-                        }
                     }
                 }
                 blockBuilder.op(op);
@@ -237,20 +150,17 @@ public class OpTk {
         return CoreOp.module(funcs);
     }
 
-    public static Type classTypeToType(MethodHandles.Lookup lookup, ClassType classType) {
-        Type javaTypeClass = null;
+    public static Type classTypeToTypeOrThrow(MethodHandles.Lookup lookup, ClassType classType) {
         try {
-            javaTypeClass = classType.resolve(lookup);
+            return classType.resolve(lookup);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
-        return javaTypeClass;
-
     }
 
     public static boolean isAssignable(MethodHandles.Lookup lookup, JavaType javaType, Class<?>... classes) {
         if (javaType instanceof ClassType classType) {
-            Type type = classTypeToType(lookup, classType);
+            Type type = classTypeToTypeOrThrow(lookup, classType);
             for (Class<?> clazz : classes) {
                 if (clazz.isAssignableFrom((Class<?>) type)) {
                     return true;
@@ -266,11 +176,7 @@ public class OpTk {
         return lambdaOp.body().entryBlock().ops().stream()
                 .filter(op -> op instanceof JavaOp.InvokeOp)
                 .map(op -> (JavaOp.InvokeOp) op)
-                .findFirst().get();
-    }
-
-    public static MethodRef getQuotableTargetMethodRef(JavaOp.LambdaOp lambdaOp) {
-        return methodRef(getQuotableTargetInvokeOpWrapper( lambdaOp));
+                .findFirst().orElseThrow();
     }
 
     public static Object[] getQuotableCapturedValues(JavaOp.LambdaOp lambdaOp, Quoted quoted, Method method) {
@@ -282,8 +188,6 @@ public class OpTk {
                 .map(varLoadOp -> (Op.Result) varLoadOp.operands().getFirst())
                 .map(varLoadOp -> (CoreOp.VarOp) varLoadOp.op())
                 .map(CoreOp.VarOp::varName).toArray();
-
-
         Map<String, Object> nameValueMap = new HashMap<>();
 
         quoted.capturedValues().forEach((k, v) -> {
@@ -306,72 +210,35 @@ public class OpTk {
         return args;
     }
 
-    public static CoreOp.FuncOp lower(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp) {
+    public static CoreOp.FuncOp lower( CoreOp.FuncOp funcOp) {
         return funcOp.transform(OpTransformer.LOWERING_TRANSFORMER);
     }
 
-    public static CoreOp.FuncOp ssa(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp) {
-        return SSA.transform(funcOp);
-    }
-/*
-    public static Stream<OpWrapper<?>> wrappedRootOpStream(MethodHandles.Lookup lookup, CoreOp.FuncOp op) {
-        return wrappedRootsExcludingVarFuncDeclarationsAndYields(lookup, op.bodies().getFirst().entryBlock());
-    } */
-    public static Stream<Op> rootOpStream(MethodHandles.Lookup lookup, CoreOp.FuncOp op) {
+    public static Stream<Op> rootOpStream( CoreOp.FuncOp op) {
         return rootsExcludingVarFuncDeclarationsAndYields(op.bodies().getFirst().entryBlock());
     }
 
 
-    static public Set<Op> roots(Block block) {
-        record Node<T extends Value>(T node, List<Node<T>> children) {
-        }
-        Set<Op> roots = new LinkedHashSet<>();
-        Map<Op, Node<Value>> trees = new LinkedHashMap<>();
-        Map<Value, Node<Value>> params = new HashMap<>();
-        block.ops().forEach(op -> {
-            List<Node<Value>> children = new ArrayList<>();
-
-            op.operands().forEach(operand -> {
-                if (operand instanceof Op.Result result) {
-                    children.add(trees.get(result.op()));
-                } else {
-                    children.add(params.computeIfAbsent(operand, _ -> new Node<>(operand, List.of())));
-                }
-            });
-            trees.put(op, new Node<>(op.result(), children));
-        });
-
-        trees.keySet().forEach(op -> {
-            if (op instanceof CoreOp.VarAccessOp.VarStoreOp && op.operands().get(1).uses().size() < 2) {
-                roots.add(op);
-            } else if (op instanceof CoreOp.VarOp || op.result().uses().isEmpty()) {
-                roots.add(op);
-            }
-        });
-        return roots;
-    }
+    static Predicate<Op> rootFilter = op->
+            (   (op instanceof CoreOp.VarAccessOp.VarStoreOp && op.operands().get(1).uses().size() < 2)
+              || (op instanceof CoreOp.VarOp || op.result().uses().isEmpty())
+            )
+            && !(op instanceof CoreOp.VarOp varOp && paramVar(varOp) != null)
+            && !(op instanceof CoreOp.YieldOp);
 
     static public Stream<Op> rootsExcludingVarFuncDeclarationsAndYields(Block block) {
-        var roots = roots(block);
-        return block.ops().stream()
-                .filter(roots::contains)
-                .filter(w -> !(w instanceof CoreOp.VarOp varOp && paramVar(varOp) != null))
-                .filter(w -> !(w instanceof CoreOp.YieldOp));
-    }
-
-    public static MethodRef methodRef(JavaOp.InvokeOp op) {
-        return op.invokeDescriptor();
+        return block.ops().stream().filter(rootFilter);
     }
 
     public static JavaType javaRefType(JavaOp.InvokeOp op) {
-        return (JavaType) methodRef(op).refType();
+        return (JavaType) op.invokeDescriptor().refType();
     }
 
     public static boolean isIfaceBufferMethod(MethodHandles.Lookup lookup, JavaOp.InvokeOp invokeOp) {
         return isAssignable(lookup, javaRefType(invokeOp), MappableIface.class);
     }
 
-    public static boolean isRawKernelCall(MethodHandles.Lookup lookup, JavaOp.InvokeOp op) {
+    public static boolean isKernelContextMethod(MethodHandles.Lookup lookup, JavaOp.InvokeOp op) {
         return (op.operands().size() > 1 && op.operands().getFirst() instanceof Value value
                 && value.type() instanceof JavaType javaType
                 && (isAssignable(lookup, javaType, hat.KernelContext.class) || isAssignable(lookup, javaType, KernelContext.class))
@@ -383,130 +250,24 @@ public class OpTk {
     }
 
     public static JavaType javaReturnType(JavaOp.InvokeOp op) {
-        return (JavaType) methodRef(op).type().returnType();
+        return (JavaType) op.invokeDescriptor().type().returnType();
     }
 
-    public static Method method(MethodHandles.Lookup lookup, JavaOp.InvokeOp op) {
+    public static Method methodOrThrow(MethodHandles.Lookup lookup, JavaOp.InvokeOp op) {
         try {
-            return methodRef(op).resolveToMethod(lookup, op.invokeKind());
+            return op.invokeDescriptor().resolveToMethod(lookup, op.invokeKind());
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }
-
-    public static boolean isIfaceAccessor(MethodHandles.Lookup lookup, JavaOp.InvokeOp invokeOp) {
-        if (isIfaceBufferMethod(lookup, invokeOp) && !javaReturnType(invokeOp).equals(JavaType.VOID)) {
-            Optional<Class<?>> optionalClazz = javaReturnClass(lookup, invokeOp);
-            return optionalClazz.isPresent() && Buffer.class.isAssignableFrom(optionalClazz.get());
-        } else {
-            return false;
-        }
-    }
-
-    public static boolean isIfaceMutator(MethodHandles.Lookup lookup, JavaOp.InvokeOp invokeOp) {
-        return isIfaceBufferMethod(lookup, invokeOp) && javaReturnType(invokeOp).equals(JavaType.VOID);
-    }
-
-    public static Optional<Class<?>> javaRefClass(MethodHandles.Lookup lookup, JavaOp.InvokeOp op) {
+    public static Class<?> javaRefClassOrThrow(MethodHandles.Lookup lookup, JavaOp.InvokeOp op) {
         if (javaRefType(op) instanceof ClassType classType) {
-            return Optional.of((Class<?>) classTypeToType(lookup, classType));
+            return (Class<?>) classTypeToTypeOrThrow(lookup, classType);
         } else {
-            return Optional.empty();
+            throw new IllegalStateException(" javaRef class is null");
         }
     }
 
-    public static Optional<Class<?>> javaReturnClass(MethodHandles.Lookup lookup, JavaOp.InvokeOp op) {
-        if (javaReturnType(op) instanceof ClassType classType) {
-            return Optional.of((Class<?>) classTypeToType(lookup, classType));
-        } else {
-            return Optional.empty();
-        }
-    }
-
-
-    public static class ParamTable {
-        public static class Info {
-            public final int idx;
-            public final Block.Parameter parameter;
-            public final JavaType javaType;
-            public final CoreOp.VarOp varOp;
-            public GroupLayout layout = null;
-            public Class<?> clazz = null;
-
-            Info(int idx, Block.Parameter parameter, CoreOp.VarOp varOp) {
-                this.idx = idx;
-                this.parameter = parameter;
-                this.javaType = (JavaType) parameter.type();
-                this.varOp = varOp;
-            }
-
-            public boolean isPrimitive() {
-                return javaType instanceof PrimitiveType;
-            }
-
-            public void setLayout(GroupLayout layout) {
-                this.layout = layout;
-            }
-
-            public void setClass(Class<?> clazz) {
-                this.clazz = clazz;
-            }
-        }
-
-        final public BiMap<Block.Parameter, CoreOp.VarOp> parameterVarOpMap = new BiMap<>();
-        final public BiMap<Block.Parameter, JavaOp.InvokeOp> parameterInvokeOpMap = new BiMap<>();
-
-        final private Map<Block.Parameter, Info> parameterToInfo = new LinkedHashMap<>();
-        final private Map<CoreOp.VarOp, Info> varOpToInfo = new LinkedHashMap<>();
-
-        final private List<Info> list = new ArrayList<>();
-
-        public ParamTable.Info info(Block.Parameter parameter) {
-            return parameterToInfo.get(parameter);
-        }
-
-        void add(Map.Entry<Block.Parameter, CoreOp.VarOp> parameterToVarOp) {
-            //We add a new ParameterInfo to both maps using parameter and varOp as keys
-            varOpToInfo.put(parameterToVarOp.getValue(),
-                    // always called but convenient because computeIfAbsent returns what we added :)
-                    parameterToInfo.computeIfAbsent(parameterToVarOp.getKey(), (parameterKey) -> {
-                        var info = new ParamTable.Info(list.size(), parameterKey, parameterToVarOp.getValue());
-                        list.add(info);
-                        return info;
-                    })
-            );
-        }
-
-        public List<Info> list() {
-            return list;
-        }
-
-        public Stream<Info> stream() {
-            return list.stream();
-        }
-
-        final public CoreOp funcOp;
-
-        public ParamTable(CoreOp.FuncOp funcOp) {
-            this.funcOp = funcOp;
-            funcOp.parameters().forEach(parameter -> {
-                Optional<Op.Result> optionalResult = parameter.uses().stream().findFirst();
-                optionalResult.ifPresentOrElse(result -> {
-                    var resultOp = result.op();
-                    if (resultOp instanceof CoreOp.VarOp varOp) {
-                        parameterVarOpMap.add(parameter, varOp);
-                        add(Map.entry(parameter, varOp));
-                    } else if (resultOp instanceof JavaOp.InvokeOp invokeOp) {
-                        parameterInvokeOpMap.add(parameter, invokeOp);
-                    } else {
-                        //System.out.println("neither varOp or an invokeOp "+resultOp.getClass().getName());
-                    }
-                }, () -> {
-                    throw new IllegalStateException("no use of param");
-                });
-            });
-        }
-    }
 
     public record ParamVar(CoreOp.VarOp varOp, Block.Parameter parameter, CoreOp.FuncOp funcOp) {
     }

--- a/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
@@ -79,7 +79,7 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
                 commaSeparated(buildContext.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );
         braceNlIndented(_ ->
-                OpTk.rootOpStream(buildContext.lookup,funcOp)
+                OpTk.rootOpStream(funcOp)
                         .forEach(root ->
                                 recurse(buildContext, root).semicolonIf(!OpTk.isStructural(root)).nl()
                         )


### PR DESCRIPTION
After OpWrapper removal found some opportunities to simplify code. 

This PR just provides that cleanup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/544/head:pull/544` \
`$ git checkout pull/544`

Update a local copy of the PR: \
`$ git checkout pull/544` \
`$ git pull https://git.openjdk.org/babylon.git pull/544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 544`

View PR using the GUI difftool: \
`$ git pr show -t 544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/544.diff">https://git.openjdk.org/babylon/pull/544.diff</a>

</details>
