### PR TITLE
Add IsQuotable attribute to LambdaOp

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -884,7 +884,7 @@ public final class BytecodeGenerator {
                             ClassDesc[] captureTypes = op.capturedValues().stream()
                                     .map(Value::type).map(BytecodeGenerator::toClassDesc).toArray(ClassDesc[]::new);
                             int lambdaIndex = lambdaSink.size();
-                            if (Quotable.class.isAssignableFrom(intfClass)) {
+                            if (op.isQuotable()) {
                                 cob.invokedynamic(DynamicCallSiteDesc.of(
                                         DMHD_LAMBDA_ALT_METAFACTORY,
                                         funcIntfMethodName(intfClass),

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeLift.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeLift.java
@@ -471,6 +471,8 @@ public final class BytecodeLift {
                         }
                         FunctionType lambdaFunc = CoreType.functionType(JavaType.type(mt.returnType()),
                                                                             mt.parameterList().stream().map(JavaType::type).toList());
+                        // how to know if lambda is Quotable ?
+                        // if the last bsm arg is a MH to a an opMethod ?
                         JavaOp.LambdaOp.Builder lambda = JavaOp.lambda(currentBlock.parentBody(),
                                                                        lambdaFunc,
                                                                        JavaType.type(inst.typeSymbol().returnType()));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -158,6 +158,7 @@ public sealed abstract class JavaOp extends Op {
             final Body.Builder ancestorBody;
             final FunctionType funcType;
             final TypeElement functionalInterface;
+            boolean quotable = false;
 
             Builder(Body.Builder ancestorBody, FunctionType funcType, TypeElement functionalInterface) {
                 this.ancestorBody = ancestorBody;
@@ -168,17 +169,29 @@ public sealed abstract class JavaOp extends Op {
             public LambdaOp body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(ancestorBody, funcType);
                 c.accept(body.entryBlock());
-                return new LambdaOp(functionalInterface, body);
+                return new LambdaOp(functionalInterface, body, quotable);
+            }
+
+            public Builder quotable() {
+                this.quotable = true;
+                return this;
             }
         }
 
         static final String NAME = "lambda";
+        static final String ATTRIBUTE_LAMBDA_IS_QUOTABLE = NAME + ".isQuotable";
 
         final TypeElement functionalInterface;
         final Body body;
+        final boolean isQuotable;
 
-        LambdaOp(ExternalizedOp def) {
-            this(def.resultType(), def.bodyDefinitions().get(0));
+        static LambdaOp create(ExternalizedOp def) {
+            boolean isQuotable = def.extractAttributeValue(ATTRIBUTE_LAMBDA_IS_QUOTABLE,
+                    false, v -> switch (v) {
+                        case Boolean b -> b;
+                        case null, default -> false;
+                    });
+            return new LambdaOp(def.resultType(), def.bodyDefinitions().get(0), isQuotable);
         }
 
         LambdaOp(LambdaOp that, CopyContext cc, OpTransformer ot) {
@@ -186,6 +199,7 @@ public sealed abstract class JavaOp extends Op {
 
             this.functionalInterface = that.functionalInterface;
             this.body = that.body.transform(cc, ot).build(this);
+            this.isQuotable = that.isQuotable;
         }
 
         @Override
@@ -193,12 +207,13 @@ public sealed abstract class JavaOp extends Op {
             return new LambdaOp(this, cc, ot);
         }
 
-        LambdaOp(TypeElement functionalInterface, Body.Builder bodyC) {
+        LambdaOp(TypeElement functionalInterface, Body.Builder bodyC, boolean isQuotable) {
             super(NAME,
                     List.of());
 
             this.functionalInterface = functionalInterface;
             this.body = bodyC.build(this);
+            this.isQuotable = isQuotable;
         }
 
         @Override
@@ -235,6 +250,17 @@ public sealed abstract class JavaOp extends Op {
         @Override
         public TypeElement resultType() {
             return functionalInterface();
+        }
+
+        public boolean isQuotable() {
+            return isQuotable;
+        }
+
+        @Override
+        public Map<String, Object> externalize() {
+            Map<String, Object> m = new HashMap<>();
+            m.put(ATTRIBUTE_LAMBDA_IS_QUOTABLE, isQuotable);
+            return Collections.unmodifiableMap(m);
         }
 
         /**
@@ -4975,7 +5001,7 @@ public sealed abstract class JavaOp extends Op {
             case "java.try" -> TryOp.create(def);
             case "java.while" -> new WhileOp(def);
             case "java.yield" -> new YieldOp(def);
-            case "lambda" -> new LambdaOp(def);
+            case "lambda" -> LambdaOp.create(def);
             case "le" -> new LeOp(def);
             case "lshl" -> new LshlOp(def);
             case "lshr" -> new LshrOp(def);
@@ -5039,7 +5065,19 @@ public sealed abstract class JavaOp extends Op {
      * @return the lambda operation
      */
     public static LambdaOp lambda(TypeElement functionalInterface, Body.Builder body) {
-        return new LambdaOp(functionalInterface, body);
+        return new LambdaOp(functionalInterface, body, false);
+    }
+
+    /**
+     * Creates a lambda operation.
+     *
+     * @param functionalInterface the lambda operation's functional interface type
+     * @param body                the body of the lambda operation
+     * @param isQuotable          true if the lambda is quotable
+     * @return the lambda operation
+     */
+    public static LambdaOp lambda(TypeElement functionalInterface, Body.Builder body, boolean isQuotable) {
+        return new LambdaOp(functionalInterface, body, isQuotable);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1526,7 +1526,7 @@ public class ReflectMethods extends TreeTranslator {
                     // Get the functional interface type
                     JavaType fiType = typeToTypeElement(tree.target);
                     // build functional lambda
-                    yield JavaOp.lambda(fiType, stack.body);
+                    yield JavaOp.lambda(fiType, stack.body, kind == FunctionalExpressionKind.QUOTABLE);
                 }
             };
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
@@ -499,7 +499,7 @@ public final class Interpreter {
             Object fiInstance = MethodHandleProxies.asInterfaceInstance(fi, fProxy);
 
             // If a quotable lambda proxy again to add method Quoted quoted()
-            if (Quotable.class.isAssignableFrom(fi)) {
+            if (lo.isQuotable()) {
                 return Proxy.newProxyInstance(l.lookupClass().getClassLoader(), new Class<?>[]{fi},
                         new InvocationHandler() {
                             private final Quoted quoted = new Quoted(lo, capturedValuesAndArguments);


### PR DESCRIPTION
In the `interpreter` and `ByteCodeGenerator` we detect if a lambda is quotable based on its functional interface. This approach will not work if intersection type is used e.g. `Runnable r = (Runnable & Quotable) () -> {};` This PR adds a flag to LambdaOp that will be set by the `javac` for quotable lambdas.