### PR TITLE
OpWriter.ColoringOption proposal

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpParser.java
@@ -186,6 +186,7 @@ public final class OpParser {
     }
 
     static List<Op> parse(OpFactory opFactory, TypeElementFactory typeFactory, String in) {
+        in = in.replaceAll("\\033\\[\\d+m", ""); // remove ANSI coloring
         Lexer lexer = Scanner.factory().newScanner(in);
         lexer.nextToken();
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
@@ -338,43 +338,12 @@ public final class OpWriter {
         }
     }
 
-    /**
-     * An option describing how to color the output.
-     */
-    public enum ColoringOption implements Option {
-        /** Performs no coloring. */
-        NONE((_, text) -> text),
-
-        /** Uses ANSI codes to color the output. */
-        ANSI((itemType, text) -> "\033[3" +
+    static BiFunction<Class<? extends CodeItem>, String, String> getDyer() {
+        return Boolean.getBoolean("jdk.incubator.code.extern.OpWriter.COLOR") ? (itemType, text) -> "\033[3" +
                 (itemType == Op.class ? '4' : // blue
                 itemType == Block.class ? '5': // purple
                 itemType == TypeElement.class ? '2': '1') // green : red
-                + "m" + text + "\033[0m"),
-
-        /** Uses ANSI high intensity codes to color the output. */
-        ANSI_HI((itemType, text) -> "\033[9" +
-                (itemType == Op.class ? '4' : // blue
-                itemType == Block.class ? '5': // purple
-                itemType == TypeElement.class ? '2': '1') // green : red
-                + "m" + text + "\033[0m"),
-
-        /** Uses HTML elements to color the output */
-        HTML((itemType, text) -> "<font color=\"" +
-                (itemType == Op.class ? "blue" :
-                itemType == Block.class ? "purple":
-                itemType == TypeElement.class ? "green" : "red")
-                + "\">" + text + "</font>");
-
-        public static ColoringOption defaultValue() {
-            return NONE;
-        }
-
-        final BiFunction<Class<? extends CodeItem>, String, String> dyer;
-
-        ColoringOption(BiFunction<Class<? extends CodeItem>, String, String> dyer) {
-            this.dyer = dyer;
-        }
+                + "m" + text + "\033[0m" : (_, text) -> text;
     }
 
     final Function<CodeItem, String> namer;
@@ -395,7 +364,7 @@ public final class OpWriter {
         this.dropLocation = false;
         this.dropOpDescendants = false;
         this.writeVoidOpResult = false;
-        this.dyer = ColoringOption.NONE.dyer;
+        this.dyer = getDyer();
     }
 
     /**
@@ -409,7 +378,6 @@ public final class OpWriter {
         boolean dropLocation = false;
         boolean dropOpDescendants = false;
         boolean writeVoidOpResult = false;
-        var dyer = ColoringOption.NONE.dyer;
         for (Option option : options) {
             switch (option) {
                 case CodeItemNamerOption namerOption -> {
@@ -426,9 +394,6 @@ public final class OpWriter {
                 case VoidOpResultOption voidOpResultOption -> {
                     writeVoidOpResult = voidOpResultOption == VoidOpResultOption.WRITE_VOID;
                 }
-                case ColoringOption colorSchemaOption -> {
-                    dyer = colorSchemaOption.dyer;
-                }
             }
         }
 
@@ -437,7 +402,7 @@ public final class OpWriter {
         this.dropLocation = dropLocation;
         this.dropOpDescendants = dropOpDescendants;
         this.writeVoidOpResult = writeVoidOpResult;
-        this.dyer = dyer;
+        this.dyer = getDyer();
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
@@ -345,8 +345,15 @@ public final class OpWriter {
         /** Performs no coloring. */
         NONE((_, text) -> text),
 
-        /** Uses ANSI codes to color the output */
+        /** Uses ANSI codes to color the output. */
         ANSI((itemType, text) -> "\033[3" +
+                (itemType == Op.class ? '4' : // blue
+                itemType == Block.class ? '5': // purple
+                itemType == TypeElement.class ? '2': '1') // green : red
+                + "m" + text + "\033[0m"),
+
+        /** Uses ANSI high intensity codes to color the output. */
+        ANSI_HI((itemType, text) -> "\033[9" +
                 (itemType == Op.class ? '4' : // blue
                 itemType == Block.class ? '5': // purple
                 itemType == TypeElement.class ? '2': '1') // green : red

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpWriter.java
@@ -51,6 +51,11 @@ public final class OpWriter {
      */
     static final String ATTRIBUTE_LOCATION = "loc";
 
+    /**
+     * Boolean property to provide ANSI-colored output.
+     */
+    static final boolean COLOR = Boolean.getBoolean("jdk.incubator.code.extern.OpWriter.COLOR");
+
     static final class GlobalValueBlockNaming implements Function<CodeItem, String> {
         final Map<CodeItem, String> gn;
         int valueOrdinal = 0;
@@ -339,11 +344,14 @@ public final class OpWriter {
     }
 
     static BiFunction<Class<? extends CodeItem>, String, String> getDyer() {
-        return Boolean.getBoolean("jdk.incubator.code.extern.OpWriter.COLOR") ? (itemType, text) -> "\033[3" +
-                (itemType == Op.class ? '4' : // blue
-                itemType == Block.class ? '5': // purple
-                itemType == TypeElement.class ? '2': '1') // green : red
-                + "m" + text + "\033[0m" : (_, text) -> text;
+        return COLOR
+                ? (itemType, text) ->
+                        (itemType == Op.class ? "\033[34m" : // blue
+                         itemType == Block.class ? "\033[35m": // purple
+                         itemType == TypeElement.class ? "\033[32m": "\033[31m") // green : red
+                        + text
+                        + "\033[0m" // reset
+                : (_, text) -> text;
     }
 
     final Function<CodeItem, String> namer;


### PR DESCRIPTION
I propose `OpWriter` enables simple ANSI coloring based on `jdk.incubator.code.extern.OpWriter.COLOR` system property.

ANSI coloring sample:
<img width="989" height="746" alt="ansi-coloring" src="https://github.com/user-attachments/assets/2025bcbe-6c6c-48ab-8ed5-67ff88b47fe6" />

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/546/head:pull/546` \
`$ git checkout pull/546`

Update a local copy of the PR: \
`$ git checkout pull/546` \
`$ git pull https://git.openjdk.org/babylon.git pull/546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 546`

View PR using the GUI difftool: \
`$ git pr show -t 546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/546.diff">https://git.openjdk.org/babylon/pull/546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/546#issuecomment-3253440996)
</details>
