### PR TITLE
The OpWrapper removal caused a regression extracting nested ifaces

### DIFF
--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
@@ -367,7 +367,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
                 case JavaOp.BinaryTestOp $ -> binaryTest(buildContext, $);
                 case JavaOp.BinaryOp $ -> binaryOperation(buildContext, $);
                 case JavaOp.JavaConditionalOp $ -> logical(buildContext, $);
-                // case UnaryArithmeticOrLogicOpWrapper $ -> unaryOperation(buildContext, $);
+                case JavaOp.UnaryOp $ -> unaryOperation(buildContext, $);
                 default -> throw new IllegalStateException("handle nesting of op " + op);
             }
             return (T) this;

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -183,6 +183,8 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     private void varDeclarationWithInitialization(HATCodeBuilderContext buildContext, CoreOp.VarOp varOp) {
         // if type is Buffer (iMappable), then we ignore it and pass it along to the methodCall
         if (isMappableIFace(buildContext, (JavaType) varOp.varValueType()) && (JavaType) varOp.varValueType() instanceof ClassType classType) {
+            type(buildContext, (JavaType) varOp.varValueType()).space().identifier(varOp.varName());
+            space().equals().space();
             annotateTypeAndName(buildContext, (JavaType) varOp.varValueType(), classType, varOp);
         } else {
             type(buildContext, (JavaType) varOp.varValueType()).space().identifier(varOp.varName());
@@ -650,7 +652,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                     boolean isLocal = false;
                     if (instanceResult.op() instanceof CoreOp.VarAccessOp.VarLoadOp varLoadOp) {
                         CoreOp.VarOp resolve = buildContext.scope.resolve(varLoadOp.operands().getFirst());
-                        if (privateAndLocalTypes.contains(resolve.varName())) {
+                        if (name.contains("create") && privateAndLocalTypes.contains(resolve.varName())) {
                             isLocal = true;
                         }
                     }


### PR DESCRIPTION
This fixes a codegen bug where the lhs var assignment from a rhs iface buffer access was not generating the var decl ;)

This only affected violajones and heal examples.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/550/head:pull/550` \
`$ git checkout pull/550`

Update a local copy of the PR: \
`$ git checkout pull/550` \
`$ git pull https://git.openjdk.org/babylon.git pull/550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 550`

View PR using the GUI difftool: \
`$ git pr show -t 550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/550.diff">https://git.openjdk.org/babylon/pull/550.diff</a>

</details>
