### PR TITLE
Hat cleanup codegen

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
@@ -130,19 +130,13 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
     }
 
     @Override
-    public CudaHATKernelBuilder emitPrivateDeclaration(String typeStructName, String varName) {
-        return suffix_t(typeStructName)
-                .space()
-                .emitText(varName).nl();
+    public CudaHATKernelBuilder privateDeclaration(String typeStructName, CoreOp.VarOp varOp) {
+        return suffix_t(typeStructName).space().identifier(varOp.varName()).nl();
     }
 
     @Override
-    public CudaHATKernelBuilder emitLocalDeclaration(String typeName, String varName) {
-        return localPtrPrefix()
-                .space()
-                .suffix_t(typeName)
-                .space()
-                .identifier(varName);
+    public CudaHATKernelBuilder localDeclaration(String typeName, CoreOp.VarOp varOp) {
+        return localPtrPrefix().space().suffix_t(typeName).space().identifier(varOp.varName());
     }
 
     @Override

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
@@ -41,8 +41,6 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
     @Override
     public OpenCLHATKernelBuilder defines() {
         hashDefine("NDRANGE_OPENCL");
-        pragma("OPENCL", "EXTENSION", "cl_khr_global_int32_base_atomics", ":", "enable");
-        pragma("OPENCL", "EXTENSION", "cl_khr_local_int32_base_atomics", ":", "enable");
         hashIfndef("NULL", _ -> hashDefine("NULL", "0"));
         return self();
     }
@@ -109,16 +107,6 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
           return identifier("atomic_inc").paren(_ ->
               ampersand().recurse(buildContext, instanceResult.op()).rarrow().identifier(name)
           );
-    }
-
-    @Override
-    public OpenCLHATKernelBuilder privateDeclaration(String typeStructName, CoreOp.VarOp varOp) {
-        return suffix_t(typeStructName).space().identifier(varOp.varName()).nl();
-    }
-
-    @Override
-    public OpenCLHATKernelBuilder localDeclaration(String typeName, CoreOp.VarOp varOp) {
-        return localPtrPrefix().space().suffix_t(typeName).space().identifier(varOp.varName());
     }
 
 }

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
@@ -112,19 +112,13 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
     }
 
     @Override
-    public OpenCLHATKernelBuilder emitPrivateDeclaration(String typeStructName, String varName) {
-        return suffix_t(typeStructName)
-                .space()
-                .emitText(varName).nl();
+    public OpenCLHATKernelBuilder privateDeclaration(String typeStructName, CoreOp.VarOp varOp) {
+        return suffix_t(typeStructName).space().identifier(varOp.varName()).nl();
     }
 
     @Override
-    public OpenCLHATKernelBuilder emitLocalDeclaration(String typeName, String varName) {
-        return localPtrPrefix()
-                .space()
-                .suffix_t(typeName)
-                .space()
-                .identifier(varName);
+    public OpenCLHATKernelBuilder localDeclaration(String typeName, CoreOp.VarOp varOp) {
+        return localPtrPrefix().space().suffix_t(typeName).space().identifier(varOp.varName());
     }
 
 }

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
@@ -39,9 +39,10 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
 
     @Override
     public OpenCLHatKernelBuilder defines() {
-        hashDefine("NDRANGE_OPENCL");
-        pragma("OPENCL", "EXTENSION", "cl_khr_global_int32_base_atomics", ":", "enable");
-        pragma("OPENCL", "EXTENSION", "cl_khr_local_int32_base_atomics", ":", "enable");
+        hashDefine("NDRANGE_OPENCL");  // dont' thnk we need this
+       // pragma("OPENCL", "EXTENSION", "cl_khr_global_int32_base_atomics", ":", "enable");
+        //pragma("OPENCL", "EXTENSION", "cl_khr_local_int32_base_atomics", ":", "enable");
+        pragmas();
         hashIfndef("NULL", _ -> hashDefine("NULL", "0"));
         return self();
     }
@@ -78,14 +79,16 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
         return identifier("get_group_id").oparen().literal(id).cparen();
     }
 
+
+
     @Override
     public OpenCLHatKernelBuilder kernelDeclaration(CoreOp.FuncOp funcOp) {
-        return keyword("__kernel").space().voidType().space().identifier(funcOp.funcName());
+        return keyword("__kernel").space().voidType().space().funcName(funcOp);
     }
 
     @Override
     public OpenCLHatKernelBuilder functionDeclaration(HATCodeBuilderContext codeBuilderContext, JavaType type, CoreOp.FuncOp funcOp) {
-        return keyword("inline").space().type(codeBuilderContext,type).space().identifier(funcOp.funcName());
+        return keyword("inline").space().type(codeBuilderContext,type).space().funcName(funcOp);
     }
 
     @Override
@@ -111,14 +114,6 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
         return identifier("barrier").oparen().identifier("CLK_LOCAL_MEM_FENCE").cparen().semicolon();
     }
 
-    @Override
-    public OpenCLHatKernelBuilder privateDeclaration(String typeStructName, CoreOp.VarOp varOp) {
-        return suffix_t(typeStructName).space().identifier(varOp.varName()).nl();
-    }
 
-    @Override
-    public OpenCLHatKernelBuilder localDeclaration(String typeName, CoreOp.VarOp varOp) {
-        return localPtrPrefix().space().suffix_t(typeName).space().identifier(varOp.varName());
-    }
 
 }

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
@@ -112,19 +112,13 @@ public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelB
     }
 
     @Override
-    public OpenCLHatKernelBuilder emitPrivateDeclaration(String typeStructName, String varName) {
-        return suffix_t(typeStructName)
-                .space()
-                .emitText(varName).nl();
+    public OpenCLHatKernelBuilder privateDeclaration(String typeStructName, CoreOp.VarOp varOp) {
+        return suffix_t(typeStructName).space().identifier(varOp.varName()).nl();
     }
 
     @Override
-    public OpenCLHatKernelBuilder emitLocalDeclaration(String typeName, String varName) {
-        return localPtrPrefix()
-                .space()
-                .suffix_t(typeName)
-                .space()
-                .identifier(varName);
+    public OpenCLHatKernelBuilder localDeclaration(String typeName, CoreOp.VarOp varOp) {
+        return localPtrPrefix().space().suffix_t(typeName).space().identifier(varOp.varName());
     }
 
 }

--- a/hat/core/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/core/src/main/java/hat/buffer/ArgArray.java
@@ -225,7 +225,7 @@ public interface ArgArray extends Buffer {
             .arrayLen("argc").pad(12).array("arg", arg->arg
                             .fields("idx", "variant")
                             .pad(11/*(int)(16 - JAVA_INT.byteSize() - JAVA_BYTE.byteSize())*/)
-                            .field("value", value->value
+                            .field("value", val->val
                                             .fields("z1","s8","u16","s16","s32","u32","f32","s64","u64","f64")
                                                     .field("buf", buf->buf
                                                             .fields("address","bytes",/*"vendorPtr",*/"access")

--- a/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATComputeBuilder.java
@@ -33,13 +33,13 @@ import jdk.incubator.code.dialect.java.JavaType;
 import java.lang.invoke.MethodHandles;
 
 
-public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HATCodeBuilderWithContext<T> {
+public  abstract class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HATCodeBuilderWithContext<T> {
 
     public T computeDeclaration(TypeElement typeElement, String name) {
         return typeName(typeElement.toString()).space().identifier(name);
     }
 
-    public T compute(MethodHandles.Lookup lookup,CoreOp.FuncOp funcOp) {
+     public T compute(MethodHandles.Lookup lookup,CoreOp.FuncOp funcOp) {
         HATCodeBuilderContext buildContext = new HATCodeBuilderContext(lookup,funcOp);
         computeDeclaration(funcOp.resultType(), funcOp.funcName());
         parenNlIndented(_ ->
@@ -53,24 +53,6 @@ public  class C99HATComputeBuilder<T extends C99HATComputeBuilder<T>> extends HA
                         )
         );
 
-        return self();
-    }
-
-    @Override
-    public T emitPrivateDeclaration(String typeName, String varName) {
-        // TODO: What would emit a Java backend
-        return self();
-    }
-
-    @Override
-    public T emitLocalDeclaration(String typeName, String varName) {
-        // TODO: What would emit a pure C99 backend?
-        return self();
-    }
-
-    @Override
-    public T syncBlockThreads() {
-        // TODO: What would emit a pure C99 backend?
         return self();
     }
 }

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -53,7 +53,9 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
     public T types() {
         return this
-                .charTypeDefs("s8_t", "byte", "boolean")
+
+                .charTypeDefs("byte", "boolean")
+                /*
                 .unsignedCharTypeDefs("u8_t")
                 .shortTypeDefs("s16_t")
                 .unsignedShortTypeDefs("u16_t")
@@ -62,7 +64,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
                 .floatTypeDefs("f32_t")
                 .longTypeDefs("s64_t")
                 .unsignedLongTypeDefs("u64_t")
-
+                */
                 // Another generic way of declaring the kernelContext is as follows:
                 // // It is reasonable to use hat.codebuilders.HATCodeBuilderWithContext.typedef()
                 // // But note that we pass null as first arg which is normally expected to be a bound schema
@@ -128,7 +130,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
         identifier("kc").rarrow().identifier("bix").equals().blockId(0).semicolon().nl();
 
 
-        if (ndRange.kid.getDimensions() > 1) {
+        if (ndRange.kid.getDimensions() > 1) { // do we need to guard this?
             identifier("kc").rarrow().identifier("y").equals().globalId(1).semicolon().nl();
             identifier("kc").rarrow().identifier("maxY").equals().identifier("global_kc").rarrow().identifier("maxY").semicolon().nl();
 
@@ -139,7 +141,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
             identifier("kc").rarrow().identifier("biy").equals().blockId(1).semicolon().nl();
         }
 
-        if (ndRange.kid.getDimensions() > 2) {
+        if (ndRange.kid.getDimensions() > 2) { // do we need to guard this
             identifier("kc").rarrow().identifier("z").equals().globalId(2).semicolon().nl();
             identifier("kc").rarrow().identifier("maxZ").equals().identifier("global_kc").rarrow().identifier("maxZ").semicolon().nl();
 
@@ -275,5 +277,12 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     public abstract T localSize(int id);
 
     public abstract T blockId(int id);
+    final  public T privateDeclaration(HATCodeBuilderWithContext.LocalArrayDeclaration localArrayDeclaration) {
+        return suffix_t(localArrayDeclaration.ifaceStruct().name()).space().varName(localArrayDeclaration.varOp()).nl();
+    }
 
+    final public T localDeclaration(HATCodeBuilderWithContext.LocalArrayDeclaration localArrayDeclaration) {
+        return localPtrPrefix().space() // we should be able to compose-call to privateDeclaration?
+                .suffix_t(localArrayDeclaration.ifaceStruct().name()).space().varName(localArrayDeclaration.varOp());
+    }
 }

--- a/hat/core/src/main/java/hat/codebuilders/CodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/CodeBuilder.java
@@ -320,7 +320,9 @@ public abstract class CodeBuilder<T extends CodeBuilder<T>> extends TextBuilder<
     public final T paren(Consumer<T> consumer) {
         return oparen().accept(consumer).cparen();
     }
-
+    public T ocparen() {
+        return oparen().cparen();
+    }
     public T parenWhen(boolean value, Consumer<T> consumer) {
         if (value) {
             oparen().accept(consumer).cparen();

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
@@ -292,11 +292,11 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
         T unaryOperation(HATCodeBuilderContext buildContext, JavaOp.UnaryOp unaryOp);
 
 
-        T binaryOperation(HATCodeBuilderContext buildContext, Op binaryOp);
+        T binaryOperation(HATCodeBuilderContext buildContext, JavaOp.BinaryOp binaryOp);
 
         T logical(HATCodeBuilderContext buildContext, JavaOp.JavaConditionalOp logicalOp);
 
-        T binaryTest(HATCodeBuilderContext buildContext, Op binaryTestOp);
+        T binaryTest(HATCodeBuilderContext buildContext, JavaOp.BinaryTestOp binaryTestOp);
 
         T conv(HATCodeBuilderContext buildContext, JavaOp.ConvOp convOp);
 
@@ -328,7 +328,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
 
          T ternary(HATCodeBuilderContext buildContext, JavaOp.ConditionalExpressionOp ternaryOp);
 
-         T parencedence(HATCodeBuilderContext buildContext, Op parent, Op child);
+         T parenthesisIfNeeded(HATCodeBuilderContext buildContext, Op parent, Op child);
 
        //  T parencedence(HATCodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child);
 
@@ -375,5 +375,30 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
 
 
     }
-
+    T symbol(Op op) {
+        return switch (op) {
+            case JavaOp.ModOp o -> percent();
+            case JavaOp.MulOp o -> mul();
+            case JavaOp.DivOp o -> div();
+            case JavaOp.AddOp o -> plus();
+            case JavaOp.SubOp o -> minus();
+            case JavaOp.LtOp o -> lt();
+            case JavaOp.GtOp o -> gt();
+            case JavaOp.LeOp o -> lte();
+            case JavaOp.GeOp o -> gte();
+            case JavaOp.AshrOp o -> cchevron().cchevron();
+            case JavaOp.LshlOp o -> ochevron().ochevron();
+            case JavaOp.LshrOp o -> cchevron().cchevron();
+            case JavaOp.NeqOp o -> pling().equals();
+            case JavaOp.NegOp o -> minus();
+            case JavaOp.EqOp o -> equals().equals();
+            case JavaOp.NotOp o -> pling();
+            case JavaOp.AndOp o -> ampersand();
+            case JavaOp.OrOp o -> bar();
+            case JavaOp.XorOp o -> hat();
+            case JavaOp.ConditionalAndOp o -> condAnd();
+            case JavaOp.ConditionalOrOp o -> condOr();
+            default -> throw new IllegalStateException("Unexpected value: " + op);
+        };
+    }
 }

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
@@ -131,12 +131,6 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
     protected T hashIfndef(String value, Consumer<T> consumer) {
         return hashIfndef(value).accept(consumer).hashEndif();
     }
-  /*  public T defonce(String name, Runnable r) {
-        return ifndef(name+"_ONCE_DEF",()->{
-            define(name+"_ONCE_DEF").nl();
-            r.run();
-        });
-    }*/
   public T varName(CoreOp.VarOp varOp) {
       identifier(varOp.varName());
       return self();
@@ -270,6 +264,18 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
             doubleDeclaration(varName);
         }
         return self();
+    }
+    public T funcName(CoreOp.FuncCallOp funcCallOp){
+        return identifier(funcCallOp.funcName());
+    }
+    public T funcName(CoreOp.FuncOp funcOp) {
+        return identifier(funcOp.funcName());
+    }
+    public T fieldName(JavaOp.FieldAccessOp fieldAccessOp) {
+        return identifier(OpTk.fieldName(fieldAccessOp));
+    }
+    public T funcName(JavaOp.InvokeOp invokeOp){
+        return identifier(invokeOp.invokeDescriptor().name());
     }
 
     /* this should not be too C99 specific */

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderContext.java
@@ -87,11 +87,6 @@ public class HATCodeBuilderContext {
 
     public static class ForScope extends LoopScope<JavaOp.ForOp> {
         Map<Block.Parameter, CoreOp.VarOp> blockParamToVarOpMap = new HashMap<>();
-
-        JavaOp.ForOp forOp() {
-            return op;
-        }
-
         ForScope(Scope<?> parent, JavaOp.ForOp forOp) {
             super(parent, forOp);
             var loopParams = forOp.loopBody().entryBlock().parameters().toArray(new Block.Parameter[0]);
@@ -218,6 +213,9 @@ public class HATCodeBuilderContext {
     }
 
     public Scope<?> scope = null;
+    final public MethodHandles.Lookup lookup;
+    final public CoreOp.FuncOp funcOp;
+    final public FuncOpParams paramTable;
 
     private void popScope() {
         scope = scope.parent;
@@ -238,13 +236,10 @@ public class HATCodeBuilderContext {
         r.run();
         popScope();
     }
-    final public MethodHandles.Lookup lookup;
-    final public CoreOp.FuncOp funcOp;
-    final public FuncOpParams paramTable;
+
     public HATCodeBuilderContext(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp) {
         this.lookup = lookup;
         this.funcOp = funcOp;
         this.paramTable = new FuncOpParams(funcOp);
     }
-
 }

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -39,7 +39,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
-import java.util.stream.Stream;
 
 import jdk.incubator.code.Op;
 import jdk.incubator.code.TypeElement;
@@ -52,65 +51,6 @@ import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.dialect.java.PrimitiveType;
 
 public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithContext<T>> extends HATCodeBuilder<T> implements HATCodeBuilder.CodeBuilderInterface<T> {
-    /*
-   0 =  ()[ ] . -> ++ --
-   1 = ++ --+ -! ~ (type) *(deref) &(addressof) sizeof
-   2 = * / %
-   3 = + -
-   4 = << >>
-   5 = < <= > >=
-   6 = == !=
-   7 = &
-   8 = ^
-   9 = |
-   10 = &&
-   11 = ||
-   12 = ()?:
-   13 = += -= *= /= %= &= ^= |= <<= >>=
-   14 = ,
-     */
-    public int precedenceOf(Op op) {
-        return switch (op) {
-            case CoreOp.YieldOp o -> 0;
-            case JavaOp.InvokeOp o -> 0;
-            case CoreOp.FuncCallOp o -> 0;
-            case CoreOp.VarOp o -> 13;
-            case CoreOp.VarAccessOp.VarStoreOp o -> 13;
-            case JavaOp.FieldAccessOp o -> 0;
-            case CoreOp.VarAccessOp.VarLoadOp o -> 0;
-            case CoreOp.ConstantOp o -> 0;
-            case JavaOp.LambdaOp o -> 0;
-            case CoreOp.TupleOp o -> 0;
-            case JavaOp.WhileOp o -> 0;
-            case JavaOp.ConvOp o -> 1;
-            case JavaOp.NegOp  o-> 1;
-            case JavaOp.ModOp o -> 2;
-            case JavaOp.MulOp o -> 2;
-            case JavaOp.DivOp o -> 2;
-            case JavaOp.NotOp o -> 2;
-            case JavaOp.AddOp o -> 3;
-            case JavaOp.SubOp o -> 3;
-            case JavaOp.AshrOp o -> 4;
-            case JavaOp.LshlOp o -> 4;
-            case JavaOp.LshrOp o -> 4;
-            case JavaOp.LtOp o -> 5;
-            case JavaOp.GtOp o -> 5;
-            case JavaOp.LeOp o -> 5;
-            case JavaOp.GeOp o -> 5;
-            case JavaOp.EqOp o -> 6;
-            case JavaOp.NeqOp o -> 6;
-
-            case JavaOp.AndOp o -> 11;
-            case JavaOp.XorOp o -> 12;
-            case JavaOp.OrOp o -> 13;
-            case JavaOp.ConditionalAndOp o -> 14;
-            case JavaOp.ConditionalOrOp o -> 15;
-            case JavaOp.ConditionalExpressionOp o -> 18;
-            case CoreOp.ReturnOp o -> 19;
-
-            default -> throw new IllegalStateException("precedence ");
-        };
-    }
 
     public T typedefStructOrUnion(MemoryLayout memoryLayout, String name) {
         return typedefKeyword().space().structOrUnion(memoryLayout).space().suffix_s(name);
@@ -122,8 +62,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
 
     public T type(HATCodeBuilderContext buildContext, JavaType javaType) {
-        if (OpTk.isAssignable(buildContext.lookup,javaType, MappableIface.class)
-                //isIfaceUsingLookup(buildContext.lookup,javaType)
+        if (OpTk.isAssignable(buildContext.lookup, javaType, MappableIface.class)
                         && javaType instanceof ClassType classType) {
             String name = classType.toClassName();
             int dotIdx = name.lastIndexOf('.');
@@ -150,53 +89,47 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     public T varStore(HATCodeBuilderContext buildContext, CoreOp.VarAccessOp.VarStoreOp varStoreOp) {
         CoreOp.VarOp varOp = buildContext.scope.resolve(varStoreOp.operands().getFirst());
         varName(varOp).equals();
-        parencedence(buildContext, varStoreOp, ((Op.Result)varStoreOp.operands().get(1)).op());
+        parenthesisIfNeeded(buildContext, varStoreOp, ((Op.Result)varStoreOp.operands().get(1)).op());
         return self();
     }
 
-    private String extractClassType(HATCodeBuilderContext buildContext, JavaType javaType, ClassType classType) {
-        String name = classType.toClassName();
-        int dotIdx = name.lastIndexOf('.');
-        int dollarIdx = name.lastIndexOf('$');
-        int idx = Math.max(dotIdx, dollarIdx);
-        if (idx > 0) {
-            name = name.substring(idx + 1);
-        }
-        return name;
-    }
 
-    record LocalArrayDeclaration(String typeStructName, String varName) {}
+    record IfaceStruct(ClassType classType){
+        String name(){
+            String name = classType.toClassName();
+            int dotIdx = name.lastIndexOf('.');
+            int dollarIdx = name.lastIndexOf('$');
+            int idx = Math.max(dotIdx, dollarIdx);
+            if (idx > 0) {
+                name = name.substring(idx + 1);
+            }
+            return name;
+        }
+    }
+    record LocalArrayDeclaration(IfaceStruct ifaceStruct, CoreOp.VarOp varOp) {}
     private final Stack<LocalArrayDeclaration> localArrayDeclarations = new Stack<>();
-    private final Set<String> localDataStructures = new HashSet<>();
+    private final Set<CoreOp.VarOp> localDataStructures = new HashSet<>();
 
     private boolean isMappableIFace(HATCodeBuilderContext buildContext, JavaType javaType) {
         return (OpTk.isAssignable(buildContext.lookup,javaType, MappableIface.class));
     }
 
-    private void annotateTypeAndName(HATCodeBuilderContext buildContext, JavaType javaType, ClassType classType, CoreOp.VarOp varOp) {
-        String typeName = extractClassType(buildContext, javaType, classType);
-        String variableName = varOp.varName();
-        //localDataStructures.add(variableName);
-        localArrayDeclarations.push(new LocalArrayDeclaration(typeName, variableName));
+    private void annotateTypeAndName( ClassType classType, CoreOp.VarOp varOp) {
+
+        localArrayDeclarations.push(new LocalArrayDeclaration(new IfaceStruct(classType), varOp));
     }
 
     private void varDeclarationWithInitialization(HATCodeBuilderContext buildContext, CoreOp.VarOp varOp) {
-        // if type is Buffer (iMappable), then we ignore it and pass it along to the methodCall
+        type(buildContext, (JavaType) varOp.varValueType()).space().identifier(varOp.varName()).space().equals().space();
         if (isMappableIFace(buildContext, (JavaType) varOp.varValueType()) && (JavaType) varOp.varValueType() instanceof ClassType classType) {
-            type(buildContext, (JavaType) varOp.varValueType()).space().identifier(varOp.varName());
-            space().equals().space();
-            annotateTypeAndName(buildContext, (JavaType) varOp.varValueType(), classType, varOp);
-        } else {
-            type(buildContext, (JavaType) varOp.varValueType()).space().identifier(varOp.varName());
-            space().equals().space();
+            annotateTypeAndName( classType, varOp);
         }
-        parencedence(buildContext, varOp, ((Op.Result)varOp.operands().getFirst()).op());
+        parenthesisIfNeeded(buildContext, varOp, ((Op.Result)varOp.operands().getFirst()).op());
     }
 
     @Override
     public T varDeclaration(HATCodeBuilderContext buildContext, CoreOp.VarOp varOp) {
         if (varOp.isUninitialized()) {
-            // Variable is uninitialized
             type(buildContext, (JavaType) varOp.varValueType()).space().identifier(varOp.varName());
         } else {
             varDeclarationWithInitialization(buildContext, varOp);
@@ -206,7 +139,6 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
     @Override
     public T varFuncDeclaration(HATCodeBuilderContext buildContext, CoreOp.VarOp varOp) {
-        // append("/* skipping ").type(varFuncDeclarationOpWrapper.javaType()).append(" param declaration  */");
         return self();
     }
 
@@ -225,70 +157,61 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
     @Override
     public T fieldStore(HATCodeBuilderContext buildContext, JavaOp.FieldAccessOp.FieldStoreOp fieldStoreOp) {
-      //  throw new IllegalStateException("What is this field store ?" + fieldStoreOp);
         return self();
     }
 
-    T symbol(Op op) {
-        return switch (op) {
-            case JavaOp.ModOp o -> percent();
-            case JavaOp.MulOp o -> mul();
-            case JavaOp.DivOp o -> div();
-            case JavaOp.AddOp o -> plus();
-            case JavaOp.SubOp o -> minus();
-            case JavaOp.LtOp o -> lt();
-            case JavaOp.GtOp o -> gt();
-            case JavaOp.LeOp o -> lte();
-            case JavaOp.GeOp o -> gte();
-            case JavaOp.AshrOp o -> cchevron().cchevron();
-            case JavaOp.LshlOp o -> ochevron().ochevron();
-            case JavaOp.LshrOp o -> cchevron().cchevron();
-            case JavaOp.NeqOp o -> pling().equals();
-            case JavaOp.NegOp o -> minus();
-            case JavaOp.EqOp o -> equals().equals();
-            case JavaOp.NotOp o -> pling();
-            case JavaOp.AndOp o -> ampersand();
-            case JavaOp.OrOp o -> bar();
-            case JavaOp.XorOp o -> hat();
-            case JavaOp.ConditionalAndOp o -> condAnd();
-            case JavaOp.ConditionalOrOp o -> condOr();
-            default -> throw new IllegalStateException("Unexpected value: " + op);
-        };
-    }
+
 
     @Override
     public T unaryOperation(HATCodeBuilderContext buildContext, JavaOp.UnaryOp unaryOp) {
-        symbol(unaryOp);
-        parencedence(buildContext, unaryOp, ((Op.Result)unaryOp.operands().getFirst()).op());
+        symbol(unaryOp).parenthesisIfNeeded(buildContext, unaryOp, ((Op.Result)unaryOp.operands().getFirst()).op());
         return self();
     }
 
     @Override
-    public T binaryOperation(HATCodeBuilderContext buildContext, Op binaryOp) {
-        parencedence(buildContext, binaryOp, ((Op.Result) binaryOp.operands().get(0)).op());
+    public T binaryOperation(HATCodeBuilderContext buildContext, JavaOp.BinaryOp binaryOp) {
+        parenthesisIfNeeded(buildContext, binaryOp, OpTk.lhsResult(binaryOp).op());
         symbol(binaryOp);
-        parencedence(buildContext, binaryOp, ((Op.Result) binaryOp.operands().get(1)).op());
+        parenthesisIfNeeded(buildContext, binaryOp, OpTk.rhsResult(binaryOp).op());
         return self();
     }
 
+
+    public static List<Op> ops(JavaOp.JavaConditionalOp javaConditionalOp, int idx){
+        return javaConditionalOp.bodies().get(idx).entryBlock().ops();
+    }
+    public static List<Op> lhsOps(JavaOp.JavaConditionalOp javaConditionalOp){
+        return ops(javaConditionalOp,0);
+    }
+    public static List<Op> rhsOps(JavaOp.JavaConditionalOp javaConditionalOp){
+        return ops(javaConditionalOp,1);
+    }
     @Override
     public T logical(HATCodeBuilderContext buildContext, JavaOp.JavaConditionalOp logicalOp) {
-        logicalOp.bodies().get(0).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp)
-                .forEach(o ->  recurse(buildContext, o));
+        lhsOps(logicalOp).stream().filter(o -> o instanceof CoreOp.YieldOp).forEach(o ->  recurse(buildContext, o));
         space().symbol(logicalOp).space();
-        logicalOp.bodies().get(1).entryBlock().ops().stream().filter(o -> o instanceof CoreOp.YieldOp)
-                .forEach(o-> recurse(buildContext, o));
+        rhsOps(logicalOp).stream().filter(o -> o instanceof CoreOp.YieldOp).forEach(o-> recurse(buildContext, o));
         return self();
     }
-
+    public static Op.Result result(JavaOp.BinaryTestOp binaryTestOp, int idx){
+        return (Op.Result)binaryTestOp.operands().get(idx);
+    }
+    public static Op.Result lhsResult(JavaOp.BinaryTestOp binaryTestOp){
+        return result(binaryTestOp,0);
+    }
+    public static Op.Result rhsResult(JavaOp.BinaryTestOp binaryTestOp){
+        return result(binaryTestOp,1);
+    }
     @Override
-    public T binaryTest(HATCodeBuilderContext buildContext, Op binaryTestOp) {
-        parencedence(buildContext, binaryTestOp, ((Op.Result) binaryTestOp.operands().get(0)).op());
+    public T binaryTest(HATCodeBuilderContext buildContext, JavaOp.BinaryTestOp binaryTestOp) {
+        parenthesisIfNeeded(buildContext, binaryTestOp, lhsResult(binaryTestOp).op());
         symbol(binaryTestOp);
-        parencedence(buildContext, binaryTestOp, ((Op.Result) binaryTestOp.operands().get(1)).op());
+        parenthesisIfNeeded(buildContext, binaryTestOp, rhsResult(binaryTestOp).op());
         return self();
     }
-
+    public static Op.Result result(JavaOp.ConvOp convOp){
+        return (Op.Result)convOp.operands().getFirst();
+    }
     @Override
     public T conv(HATCodeBuilderContext buildContext, JavaOp.ConvOp convOp) {
         if (convOp.resultType() == JavaType.DOUBLE) {
@@ -296,14 +219,13 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
         } else {
             paren(_ -> type(buildContext,(JavaType)convOp.resultType()));
         }
-        parencedence(buildContext, convOp, ((Op.Result)convOp.operands().getFirst()).op());
+        parenthesisIfNeeded(buildContext, convOp, result(convOp).op());
         return self();
     }
 
     @Override
     public T constant(HATCodeBuilderContext buildContext, CoreOp.ConstantOp constantOp) {
-        Object object = constantOp.value();
-        if (object == null) {
+        if (constantOp.value() == null) {
             nullKeyword();
         } else {
             literal(constantOp.value().toString());
@@ -342,15 +264,15 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     @Override
     public T funcCall(HATCodeBuilderContext buildContext, CoreOp.FuncCallOp funcCallOp) {
           identifier(funcCallOp.funcName());
-        paren(_ -> {
+        paren(_ ->
             commaSeparated(funcCallOp.operands(), (e) -> {
                 if (e instanceof Op.Result result) {
-                    parencedence(buildContext, funcCallOp, result.op());
+                    parenthesisIfNeeded(buildContext, funcCallOp, result.op());
                 } else {
                     throw new IllegalStateException("Value?");
                 }
-            });
-        });
+            })
+        );
         return self();
     }
 
@@ -468,7 +390,6 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     public T typedef(BoundSchema<?> boundSchema, Schema.IfaceType ifaceType) {
         typedefKeyword().space().structOrUnion(ifaceType instanceof Schema.IfaceType.Struct)
                 .space().suffix_s(ifaceType.iface.getSimpleName()).braceNlIndented(_ -> {
-                    //System.out.println(ifaceTypeNode);
                     int fieldCount = ifaceType.fields.size();
                     StreamCounter.of(ifaceType.fields, (c, field) -> {
                         nlIf(c.isNotFirst());
@@ -550,27 +471,19 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
     @Override
     public T methodCall(HATCodeBuilderContext buildContext, JavaOp.InvokeOp invokeOp) {
-        var name = invokeOp.invokeDescriptor().name();//OpTk.name(invokeOp);
-
         if (OpTk.isIfaceBufferMethod(buildContext.lookup, invokeOp)) {
-            var operandCount = invokeOp.operands().size();
-            var returnType = OpTk.javaReturnType(invokeOp);
+          //  var returnType = OpTk.javaReturnType(invokeOp);
 
-            if (operandCount == 1 && name.startsWith("atomic") && name.endsWith("Inc")
-                    && returnType instanceof PrimitiveType primitiveType && primitiveType.equals(JavaType.INT)) {
+            if (invokeOp.operands().size() == 1 && invokeOp.invokeDescriptor().name().startsWith("atomic") && invokeOp.invokeDescriptor().name().endsWith("Inc")
+                    && OpTk.javaReturnType(invokeOp) instanceof PrimitiveType primitiveType && primitiveType.equals(JavaType.INT)) {
                 // this is a bit of a hack for atomics.
                 if (invokeOp.operands().getFirst() instanceof Op.Result instanceResult) {
-                    atomicInc(buildContext, instanceResult, name.substring(0, name.length() - 3));
-                    //identifier("atomic_inc").paren(_ -> {
-                    //    ampersand().recurse(buildContext, OpWrapper.wrap(instanceResult.op()));
-                    //    rarrow().identifier(name.substring(0, name.length() - 3));
-                    //});
+                    atomicInc(buildContext, instanceResult, invokeOp.invokeDescriptor().name().substring(0, invokeOp.invokeDescriptor().name().length() - 3));
                 } else {
                     throw new IllegalStateException("bad atomic");
                 }
             } else {
-
-                if (name.equals("create")) {
+                if (invokeOp.invokeDescriptor().name().equals("create")) { // TODO:  only on iface buffers
                     // If we decide to keep the version in which we pass the enum with the memory space
                     // to allocate a particular data structure (E.g., shared, or private)
 
@@ -595,16 +508,16 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                             String spaceName = fieldLoadOp.fieldDescriptor().name();
                             LocalArrayDeclaration declaration = localArrayDeclarations.pop();
                             if (spaceName.equals(Space.PRIVATE.name())) {
-                                emitPrivateDeclaration(declaration.typeStructName, declaration.varName);
+                                privateDeclaration(declaration.ifaceStruct.name(), declaration.varOp);
                             } else if (spaceName.equals(Space.SHARED.name())) {
-                                emitLocalDeclaration(declaration.typeStructName, declaration.varName);
+                                localDeclaration(declaration.ifaceStruct.name(), declaration.varOp);
                             }
                         }
                     }
-                } else if (name.equals("createLocal")) {
+                } else if (invokeOp.invokeDescriptor().name().equals("createLocal")) { // TODO:  only on kernel iface buffers
                     LocalArrayDeclaration declaration = localArrayDeclarations.pop();
-                    emitLocalDeclaration(declaration.typeStructName, declaration.varName);
-                    localDataStructures.add(declaration.varName);
+                    localDeclaration(declaration.ifaceStruct.name(), declaration.varOp);
+                    localDataStructures.add(declaration.varOp);
                 } else if (invokeOp.operands().getFirst() instanceof Op.Result instanceResult) {
                 /*
                 We have three types of returned values from an ifaceBuffer
@@ -642,40 +555,33 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                  of course we could return
                           cascade->tree + treeIdx;
                  */
-                    if (returnType instanceof ClassType) {
+                    if (OpTk.javaReturnType(invokeOp) instanceof ClassType) {
                         ampersand();
                         /* This is way more complicated I think we need to determine the expression type.
                          * sumOfThisStage=sumOfThisStage+&left->anon->value; from    sumOfThisStage += left.anon().value();
                          */
                     }
 
+
+
+                    recurse(buildContext, instanceResult.op());
+
                     // Check if the varOpLoad that could follow corresponds to a local/private type
                     boolean isLocal = false;
                     if (instanceResult.op() instanceof CoreOp.VarAccessOp.VarLoadOp varLoadOp) {
                         CoreOp.VarOp resolve = buildContext.scope.resolve(varLoadOp.operands().getFirst());
-                        if (localDataStructures.contains(resolve.varName())) {
+                        if (localDataStructures.contains(resolve)) {
                             isLocal = true;
                         }
                     }
 
-                    recurse(buildContext, instanceResult.op());
+                    either(isLocal, CodeBuilder::dot, CodeBuilder::rarrow);
 
-                    if (!isLocal) {
-                        // If it is not local or private, it generates an arrow
-                        rarrow();
-                    } else {
-                        // Otherwise, it generates a do (access members without pointers)
-                        dot();
-                    }
-                    identifier(name);
+                    identifier(invokeOp.invokeDescriptor().name());
 
-
-                    //if (invokeOpWrapper.name().equals("value") || invokeOpWrapper.name().equals("anon")){
-                    //System.out.println("value|anon");
-                    // }
-                    if (returnType instanceof PrimitiveType primitiveType && primitiveType.isVoid()) {
+                    if (OpTk.javaReturnType(invokeOp) instanceof PrimitiveType primitiveType && primitiveType.isVoid()) {
                         //   setter
-                        switch (operandCount) {
+                        switch (invokeOp.operands().size()) {
                             case 2: {
                                 if (invokeOp.operands().get(1) instanceof Op.Result result1) {
                                     equals().recurse(buildContext, result1.op());
@@ -711,7 +617,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
             }
         } else {
             // Detect well-known constructs
-            if (name.equals("barrier")) {
+            if (invokeOp.invokeDescriptor().name().equals("barrier")) { // TODO:  only on kernel context?
                 List<Value> operands = invokeOp.operands();
                 for (Value value : operands) {
                     if (value instanceof Op.Result instanceResult) {
@@ -725,12 +631,10 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
                 }
             } else {
                 // General case
-                identifier(name).paren(_ ->
+                identifier(invokeOp.invokeDescriptor().name()).paren(_ ->
                         commaSeparated(invokeOp.operands(), (op) -> {
                             if (op instanceof Op.Result result) {
                                 recurse(buildContext, result.op());
-                            } else {
-                                throw new IllegalStateException("wtf?");
                             }
                         })
                 );
@@ -739,11 +643,13 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
         return self();
     }
 
-    public abstract T emitPrivateDeclaration(String typeName, String varName);
+    public abstract T privateDeclaration(String typeName, CoreOp.VarOp varOp);
 
-    public abstract T emitLocalDeclaration(String typeName, String varName);
+    public abstract T localDeclaration(String typeName, CoreOp.VarOp varOp);
 
     public abstract T syncBlockThreads();
+
+
 
     @Override
     public T ternary(HATCodeBuilderContext buildContext, JavaOp.ConditionalExpressionOp ternaryOp) {
@@ -763,39 +669,25 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
     /**
      * Wrap paren() of precedence of op is higher than parent.
-     * Parencedence is just a great name for this ;)
      *
      * @param buildContext
      * @param parent
      * @param child
      */
-  /*  @Override
-    public T parencedence(HATCodeBuilderContext buildContext, Op parent, OpWrapper<?> child) {
-        return parenWhen(precedenceOf(parent) < precedenceOf(child.op), _ -> recurse(buildContext, child));
+    @Override
+    public T parenthesisIfNeeded(HATCodeBuilderContext buildContext, Op parent, Op child) {
+        return parenWhen(OpTk.needsParenthesis(parent,child), _ -> recurse(buildContext, child));
     }
 
-    @Override
-    public T parencedence(HATCodeBuilderContext buildContext, OpWrapper<?> parent, OpWrapper<?> child) {
-        return parenWhen(precedenceOf(parent.op) < precedenceOf(child.op), _ -> recurse(buildContext, child));
-    } */
-
-    @Override
-    public T parencedence(HATCodeBuilderContext buildContext, Op parent, Op child) {
-        return parenWhen(precedenceOf(parent) < precedenceOf(child), _ -> recurse(buildContext, child));
+    public static Op.Result result( CoreOp.ReturnOp returnOp){
+       return (Op.Result)returnOp.operands().getFirst();
     }
-
-  /*  @Override
-    public T parencedence(HATCodeBuilderContext buildContext, OpWrapper<?> parent, Op child) {
-        return parenWhen(precedenceOf(parent.op) < precedenceOf(child), _ -> recurse(buildContext, child));
-    } */
-
 
     @Override
     public T ret(HATCodeBuilderContext buildContext, CoreOp.ReturnOp returnOp) {
-        returnKeyword();
-        if (!returnOp.operands().isEmpty()) {
-            space().parencedence(buildContext, returnOp, ((Op.Result)returnOp.operands().getFirst()).op());
-        }
+        returnKeyword().when(!returnOp.operands().isEmpty(),
+                        $-> $.space().parenthesisIfNeeded(buildContext, returnOp, result(returnOp).op())
+                );
         return self();
     }
 }

--- a/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
@@ -66,6 +66,7 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
         }
         dot().identifier(invokeOp.invokeDescriptor().name());
         paren(_ ->
+                // why the sublist? is this static vs instance?
             commaSeparated(  invokeOp.operands().subList(0,invokeOp.operands().size()-1), o->
                     recurse(buildContext,  ((Op.Result) o).op())
             )
@@ -74,20 +75,20 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
     }
 
     @Override
-    public T emitPrivateDeclaration(String typeName, String varName) {
-        // TODO: What would emit a Java backend
+    public T privateDeclaration(String typeName, CoreOp.VarOp varOp) {
+        blockComment("/* private declaration !! */");
         return self();
     }
 
     @Override
-    public T emitLocalDeclaration(String typeName, String varName) {
-        // TODO: What would emit a Java backend
+    public T localDeclaration(String typeName, CoreOp.VarOp varOp) {
+        blockComment("/* local declaration !! */");
         return self();
     }
 
     @Override
     public T syncBlockThreads() {
-        // TODO: What would emit a Java backend?
+        blockComment("/* group wide barrier!! */");
         return self();
     }
 

--- a/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
+++ b/hat/tools/src/main/java/hat/tools/text/JavaHATCodeBuilder.java
@@ -46,10 +46,11 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
         return self();
     }
 
+
     @Override
     public T fieldLoad(HATCodeBuilderContext buildContext, JavaOp.FieldAccessOp.FieldLoadOp fieldLoadOp) {
         if (OpTk.isKernelContextAccess(fieldLoadOp)) {
-            identifier("kc").dot().identifier(OpTk.fieldName(fieldLoadOp));
+            identifier("kc").dot().fieldName(fieldLoadOp);
         } else if (fieldLoadOp.operands().isEmpty() && fieldLoadOp.result().type() instanceof PrimitiveType) { // only primitve fields
             var value = OpTk.getStaticFinalPrimitiveValue(buildContext.lookup,fieldLoadOp);
             literal(value.toString());
@@ -75,13 +76,13 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
     }
 
     @Override
-    public T privateDeclaration(String typeName, CoreOp.VarOp varOp) {
+    public T privateDeclaration(LocalArrayDeclaration localArrayDeclaration) {
         blockComment("/* private declaration !! */");
         return self();
     }
 
     @Override
-    public T localDeclaration(String typeName, CoreOp.VarOp varOp) {
+    public T localDeclaration(LocalArrayDeclaration localArrayDeclaration) {
         blockComment("/* local declaration !! */");
         return self();
     }
@@ -94,7 +95,7 @@ public  class JavaHATCodeBuilder<T extends JavaHATCodeBuilder<T>> extends HATCod
 
     public T compute(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp) {
         HATCodeBuilderContext buildContext = new HATCodeBuilderContext(lookup,funcOp);
-        typeName(funcOp.resultType().toString()).space().identifier(funcOp.funcName());
+        typeName(funcOp.resultType().toString()).space().funcName(funcOp);
         parenNlIndented(_ ->
                 commaSeparated(buildContext.paramTable.list(), (info) -> type(buildContext,(JavaType) info.parameter.type()).space().varName(info.varOp))
         );


### PR DESCRIPTION
We have multiple tiers of c99 code gen.  

In this cleanup I moved common functionality down the class hierarchy as much as possible, to avoid duplications. 

Also preferring not to pass strings, but compuse using Core.Op and Java.Op types. 

I also separated out calls to identifer() to varName(), funcName(), keyword() ....

