### PR TITLE
Fixes for cuda codegen issues

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -377,7 +377,7 @@ public class CudaBackend extends C99FFIBackend {
     @Override
     public void dispatchKernel(KernelCallGraph kernelCallGraph, NDRange ndRange, Object... args) {
         CompiledKernel compiledKernel = kernelCallGraphCompiledCodeMap.computeIfAbsent(kernelCallGraph, (_) -> {
-            String code = config.isPTX() ? createPTX(kernelCallGraph,  ndRange, args) : createC99(kernelCallGraph,  ndRange, args);
+            String code = config.isPTX() ? createPTX(kernelCallGraph,  args) : createC99(kernelCallGraph,  ndRange, args);
             if (config.isSHOW_CODE()) {
                 System.out.println(code);
             }

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
@@ -56,7 +56,7 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
 
     @Override
     public CudaHATKernelBuilder globalId(int id) {
-        return blockId(id).asterisk().localSize(id).plus().localId(id);
+        return paren(_->blockId(id).asterisk().localSize(id).plus().localId(id));
     }
 
     @Override

--- a/hat/core/src/main/java/hat/BufferTagger.java
+++ b/hat/core/src/main/java/hat/BufferTagger.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package hat;
 
 import hat.buffer.Buffer;

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -38,10 +38,6 @@ import jdk.incubator.code.dialect.java.PrimitiveType;
 import java.util.function.Consumer;
 
 public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> extends HATCodeBuilderWithContext<T> {
-   // protected final NDRange ndRange; // Should be in the context ?
-   // public C99HATKernelBuilder(NDRange ndRange) {
-       // this.ndRange = ndRange;
-   // }
     public T types() {
         return this
                 .charTypeDefs("byte", "boolean")


### PR DESCRIPTION
Juan and I found some CUDA code gen issues. 

This PR addresses them.  

Also added Copyright to  BufferTagger.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/557/head:pull/557` \
`$ git checkout pull/557`

Update a local copy of the PR: \
`$ git checkout pull/557` \
`$ git pull https://git.openjdk.org/babylon.git pull/557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 557`

View PR using the GUI difftool: \
`$ git pr show -t 557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/557.diff">https://git.openjdk.org/babylon/pull/557.diff</a>

</details>
