### PR TITLE
Add local array support to BufferTagger

### DIFF
--- a/hat/core/src/main/java/hat/BufferTagger.java
+++ b/hat/core/src/main/java/hat/BufferTagger.java
@@ -197,15 +197,13 @@ public class BufferTagger {
         } else if (op.operands().getFirst() instanceof Block.Parameter param) {
             return param;
         }
-        Value val = op.operands().getFirst();
-        while (!(val instanceof Block.Parameter)) {
-            Op root = ((Op.Result) val).op();
-            if (root.operands().isEmpty()) { // if the "root op" is an invoke
-                return root.result();
+        while (op.operands().getFirst() instanceof Op.Result r) {
+            op = r.op();
+            if (op.operands().isEmpty()) { // if the "root op" is an invoke
+                return op.result();
             }
-            val = root.operands().getFirst();
         }
-        return val;
+        return op.operands().getFirst();
     }
 
     // retrieves accessType based on return value of InvokeOp

--- a/hat/core/src/main/java/hat/BufferTagger.java
+++ b/hat/core/src/main/java/hat/BufferTagger.java
@@ -194,17 +194,16 @@ public class BufferTagger {
     public static Value getRootValue(Op op) {
         if (op.operands().isEmpty()) {
             return op.result();
-        }
-        if (op.operands().getFirst() instanceof Block.Parameter param) {
+        } else if (op.operands().getFirst() instanceof Block.Parameter param) {
             return param;
         }
         Value val = op.operands().getFirst();
         while (!(val instanceof Block.Parameter)) {
-            // or if the "root VarOp" is an invoke (not sure how to tell)
-            // if (tempOp instanceof JavaOp.InvokeOp iop
-            //        && ((TypeElement) iop.resultType()) instanceof ClassType classType
-            //        && !hasOperandType(iop, classType)) return ((CoreOp.VarOp) op);
-            val = ((Op.Result) val).op().operands().getFirst();
+            Op root = ((Op.Result) val).op();
+            if (root.operands().isEmpty()) { // if the "root op" is an invoke
+                return root.result();
+            }
+            val = root.operands().getFirst();
         }
         return val;
     }

--- a/hat/core/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/core/src/main/java/hat/buffer/ArgArray.java
@@ -36,6 +36,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.List;
 
 import static hat.buffer.ArgArray.Arg.Value.Buf.UNKNOWN_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
@@ -291,7 +292,8 @@ public interface ArgArray extends Buffer {
 
     static void update(ArgArray argArray, KernelCallGraph kernelCallGraph, Object... args) {
         Annotation[][] parameterAnnotations = kernelCallGraph.entrypoint.getMethod().getParameterAnnotations();
-        ArrayList<BufferTagger.AccessType> bufferAccessList = kernelCallGraph.bufferAccessList;
+        List<BufferTagger.AccessType> bufferAccessList = kernelCallGraph.bufferAccessList;
+        boolean bufferTagging = Boolean.getBoolean("bufferTagging");
 
         for (int i = 0; i < args.length; i++) {
             Object argObject = args[i];
@@ -329,7 +331,7 @@ public interface ArgArray extends Buffer {
                     buf.bytes(segment.byteSize());
                     buf.access(accessByte);
 
-                    assert bufferAccessList.get(i).value == accessByte;
+                    if (bufferTagging) assert bufferAccessList.get(i).value == accessByte;
                 }
                 default -> throw new IllegalStateException("Unexpected value: " + argObject);
             }

--- a/hat/core/src/main/java/hat/callgraph/CallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/CallGraph.java
@@ -43,6 +43,7 @@ public abstract class CallGraph<E extends Entrypoint> {
     public final Map<MethodRef, MethodCall> methodRefToMethodCallMap = new LinkedHashMap<>();
     public CoreOp.ModuleOp moduleOp;
     public static boolean noModuleOp = Boolean.getBoolean("noModuleOp");
+    public static boolean bufferTagging = Boolean.getBoolean("bufferTagging");
     public Stream<MethodCall> callStream() {
         return methodRefToMethodCallMap.values().stream();
     }

--- a/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
     public final ComputeCallGraph computeCallGraph;
     public final Map<MethodRef, MethodCall> bufferAccessToMethodCallMap = new LinkedHashMap<>();
-    public final ArrayList<BufferTagger.AccessType> bufferAccessList;
+    public final List<BufferTagger.AccessType> bufferAccessList;
 
     public interface KernelReachable {
     }
@@ -79,7 +79,9 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
         super(computeCallGraph.computeContext, new KernelEntrypoint(null, methodRef, method, funcOp));
         entrypoint.callGraph = this;
         this.computeCallGraph = computeCallGraph;
-        bufferAccessList = BufferTagger.getAccessList(computeContext.accelerator.lookup, entrypoint.funcOp());
+        System.out.println("-DbufferTagging="+CallGraph.bufferTagging);
+        System.out.println("-DnoModuleOp="+CallGraph.noModuleOp);
+        bufferAccessList = CallGraph.bufferTagging?BufferTagger.getAccessList(computeContext.accelerator.lookup, entrypoint.funcOp()):List.of();
     }
 
     void updateDag(KernelReachableResolvedMethodCall kernelReachableResolvedMethodCall) {

--- a/hat/hat/Script.java
+++ b/hat/hat/Script.java
@@ -1285,6 +1285,7 @@ public class Script {
         public StringList nativeAccessModules = new StringList();
         private boolean headless;
         public boolean noModuleOp;
+        public boolean bufferTagging;
 
 
         public JavaBuilder enable_native_access(String module) {
@@ -1347,6 +1348,10 @@ public class Script {
         public void noModuleOp() {
             this.noModuleOp = true;
         }
+
+        public void bufferTagging() {
+            this.bufferTagging = true;
+        }
     }
 
     public static final class JavaResult extends Result<JavaBuilder> {
@@ -1380,6 +1385,9 @@ public class Script {
         }
         if (javaBuilder.noModuleOp) {
             result.opts.add("-DnoModuleOp=true");
+        }
+        if (javaBuilder.bufferTagging) {
+            result.opts.add("-DbufferTagging=true");
         }
         if (javaBuilder.startOnFirstThread) {
             result.opts.add("-XstartOnFirstThread");

--- a/hat/hat/run.java
+++ b/hat/hat/run.java
@@ -29,6 +29,7 @@ import static java.lang.IO.println;
 class Config{
      boolean headless=false;
      boolean noModuleOp = false;
+     boolean bufferTagging = false;
      boolean verbose = false;
      boolean startOnFirstThread = false;
      boolean justShowCommandline = false;
@@ -73,6 +74,7 @@ class Config{
                 switch (args[arg]) {
                    case "headless" -> headless = true;
                    case "noModuleOp" -> noModuleOp = true;
+                   case "bufferTagging" -> bufferTagging = true;
                    case "verbose" -> verbose = true;
                    case "justShowCommandLine" -> justShowCommandline = true;
                    case "startOnFirstThread" -> startOnFirstThread = true;
@@ -181,6 +183,7 @@ void main(String[] argv) {
               .library_path(buildDir)
               .when(config.headless, Script.JavaBuilder::headless)
               .when(config.noModuleOp, Script.JavaBuilder::noModuleOp)
+              .when(config.bufferTagging, Script.JavaBuilder::bufferTagging)
               .when(config.startOnFirstThread, Script.JavaBuilder::start_on_first_thread)
               .class_path(config.classpath)
               .vmargs(config.vmargs)


### PR DESCRIPTION
Add support for local arrays that are initialized in a kernel rather than passed as a parameter to the kernel.

Also add opt-in for buffer tagging: add `-DbufferTagging=true` to enable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/559/head:pull/559` \
`$ git checkout pull/559`

Update a local copy of the PR: \
`$ git checkout pull/559` \
`$ git pull https://git.openjdk.org/babylon.git pull/559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 559`

View PR using the GUI difftool: \
`$ git pr show -t 559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/559.diff">https://git.openjdk.org/babylon/pull/559.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/559#issuecomment-3271728212)
</details>
