### PR TITLE
More codegen tweaks

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
@@ -457,7 +457,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
                 floatVal(Integer.toHexString(Float.floatToIntBits(Float.parseFloat(op.value().toString()))).toUpperCase());
             }
         } else {
-            append(op.value().toString());
+            constant(op.value().toString());
         }
     }
 
@@ -505,7 +505,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
                     st().dot().param().paramType(op.operands().get(i).type()).space().osbrace().param().intVal(i).csbrace().commaSpace().reg(op.operands().get(i)).ptxNl();
                 }
                 dot().param().space().paramType(op.resultType()).space().retVal().ptxNl();
-                call().uni().space().oparen().retVal().cparen().commaSpace().append(OpTk.methodOrThrow(MethodHandles.lookup(),op).getName()).commaSpace();
+                call().uni().space().oparen().retVal().cparen().commaSpace().identifier(OpTk.methodOrThrow(MethodHandles.lookup(),op).getName()).commaSpace();
                 final int[] counter = {0};
                 paren(_ ->
                         separated(op.operands(),(_)->commaSpace(),
@@ -574,7 +574,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     }
 
     public PTXHATKernelBuilder block(Block block) {
-        return append("block_").intVal(block.index());
+        return typeName("block_").intVal(block.index());
     }
 
     public PTXHATKernelBuilder fieldReg(Field ref) {
@@ -610,14 +610,14 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     }
 
     public PTXHATKernelBuilder resultReg(Op op, PTXRegister.Type type) {
-        return append(addReg(op.result(), type));
+        return identifier(addReg(op.result(), type));
     }
 
     public PTXHATKernelBuilder reg(Value val, PTXRegister.Type type) {
         if (varToRegMap.containsKey(val)) {
             return regName(getReg(val));
         } else {
-            return append(addReg(val, type));
+            return identifier(addReg(val, type));
         }
     }
 
@@ -667,14 +667,14 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     public PTXHATKernelBuilder resultType(TypeElement type, boolean signedResult) {
         PTXRegister.Type res = getResultType(type);
         if (signedResult && (res == PTXRegister.Type.U32)) return s32();
-        return dot().append(getResultType(type).getName());
+        return dot().typeName(getResultType(type).getName());
     }
 
     public PTXHATKernelBuilder paramType(TypeElement type) {
         PTXRegister.Type res = getResultType(type);
         if (res == PTXRegister.Type.U32) return b32();
         if (res == PTXRegister.Type.U64) return b64();
-        return dot().append(getResultType(type).getName());
+        return dot().typeName(getResultType(type).getName());
     }
 
     public PTXRegister.Type getResultType(TypeElement type) {
@@ -716,11 +716,11 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     }
 */
     public PTXHATKernelBuilder address(String address) {
-        return osbrace().append(address).csbrace();
+        return osbrace().constant(address).csbrace();
     }
 
     public PTXHATKernelBuilder address(String address, int offset) {
-        osbrace().append(address);
+        osbrace().constant(address);
         if (offset == 0) {
             return csbrace();
         } else if (offset > 0) {
@@ -735,243 +735,243 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
 
 
     public PTXHATKernelBuilder param() {
-        return append("param");
+        return keyword("param");
     }
 
     public PTXHATKernelBuilder global() {
-        return dot().append("global");
+        return dot().keyword("global");
     }
 
     public PTXHATKernelBuilder rn() {
-        return dot().append("rn");
+        return dot().keyword("rn");
     }
 
     public PTXHATKernelBuilder rm() {
-        return dot().append("rm");
+        return dot().keyword("rm");
     }
 
     public PTXHATKernelBuilder rzi() {
-        return dot().append("rzi");
+        return dot().keyword("rzi");
     }
 
     public PTXHATKernelBuilder to() {
-        return dot().append("to");
+        return dot().keyword("to");
     }
 
     public PTXHATKernelBuilder lo() {
-        return dot().append("lo");
+        return dot().keyword("lo");
     }
 
     public PTXHATKernelBuilder wide() {
-        return dot().append("wide");
+        return dot().keyword("wide");
     }
 
     public PTXHATKernelBuilder uni() {
-        return dot().append("uni");
+        return dot().keyword("uni");
     }
 
     public PTXHATKernelBuilder sat() {
-        return dot().append("sat");
+        return dot().keyword("sat");
     }
 
     public PTXHATKernelBuilder ftz() {
-        return dot().append("ftz");
+        return dot().keyword("ftz");
     }
 
     public PTXHATKernelBuilder approx() {
-        return dot().append("approx");
+        return dot().keyword("approx");
     }
 
     public PTXHATKernelBuilder mov() {
-        return append("mov");
+        return keyword("mov");
     }
 
     public PTXHATKernelBuilder setp() {
-        return append("setp");
+        return keyword("setp");
     }
 
     public PTXHATKernelBuilder selp() {
-        return append("selp");
+        return keyword("selp");
     }
 
     public PTXHATKernelBuilder ld() {
-        return append("ld");
+        return keyword("ld");
     }
 
     public PTXHATKernelBuilder st() {
-        return append("st");
+        return keyword("st");
     }
 
     public PTXHATKernelBuilder cvt() {
-        return append("cvt");
+        return keyword("cvt");
     }
 
     public PTXHATKernelBuilder bra() {
-        return append("bra");
+        return keyword("bra");
     }
 
     public PTXHATKernelBuilder ret() {
-        return append("ret");
+        return keyword("ret");
     }
 
     public PTXHATKernelBuilder rem() {
-        return append("rem");
+        return keyword("rem");
     }
 
     public PTXHATKernelBuilder mul() {
-        return append("mul");
+        return keyword("mul");
     }
 
     public PTXHATKernelBuilder div() {
-        return append("div");
+        return keyword("div");
     }
 
     public PTXHATKernelBuilder rcp() {
-        return append("rcp");
+        return keyword("rcp");
     }
 
     public PTXHATKernelBuilder add() {
-        return append("add");
+        return keyword("add");
     }
 
     public PTXHATKernelBuilder sub() {
-        return append("sub");
+        return keyword("sub");
     }
 
     public PTXHATKernelBuilder lt() {
-        return append("lt");
+        return keyword("lt");
     }
 
     public PTXHATKernelBuilder gt() {
-        return append("gt");
+        return keyword("gt");
     }
 
     public PTXHATKernelBuilder le() {
-        return append("le");
+        return keyword("le");
     }
 
     public PTXHATKernelBuilder ge() {
-        return append("ge");
+        return keyword("ge");
     }
 
     public PTXHATKernelBuilder geu() {
-        return append("geu");
+        return keyword("geu");
     }
 
     public PTXHATKernelBuilder ne() {
-        return append("ne");
+        return keyword("ne");
     }
 
     public PTXHATKernelBuilder eq() {
-        return append("eq");
+        return keyword("eq");
     }
 
     public PTXHATKernelBuilder xor() {
-        return append("xor");
+        return keyword("xor");
     }
 
     public PTXHATKernelBuilder or() {
-        return append("or");
+        return keyword("or");
     }
 
     public PTXHATKernelBuilder and() {
-        return append("and");
+        return keyword("and");
     }
 
     public PTXHATKernelBuilder cvta() {
-        return append("cvta");
+        return keyword("cvta");
     }
 
     public PTXHATKernelBuilder mad() {
-        return append("mad");
+        return keyword("mad");
     }
 
     public PTXHATKernelBuilder fma() {
-        return append("fma");
+        return keyword("fma");
     }
 
     public PTXHATKernelBuilder sqrt() {
-        return append("sqrt");
+        return keyword("sqrt");
     }
 
     public PTXHATKernelBuilder abs() {
-        return append("abs");
+        return keyword("abs");
     }
 
     public PTXHATKernelBuilder ex2() {
-        return append("ex2");
+        return keyword("ex2");
     }
 
     public PTXHATKernelBuilder shl() {
-        return append("shl");
+        return keyword("shl");
     }
 
     public PTXHATKernelBuilder shr() {
-        return append("shr");
+        return keyword("shr");
     }
 
     public PTXHATKernelBuilder neg() {
-        return append("neg");
+        return keyword("neg");
     }
 
     public PTXHATKernelBuilder call() {
-        return append("call");
+        return keyword("call");
     }
 
     public PTXHATKernelBuilder exit() {
-        return append("exit");
+        return keyword("exit");
     }
 
     public PTXHATKernelBuilder brkpt() {
-        return append("brkpt");
+        return keyword("brkpt");
     }
 
     public PTXHATKernelBuilder ptxIndent() {
-        return append("    ");
+        return space().space().space().space();
     }
 
     public PTXHATKernelBuilder u32() {
-        return dot().append(PTXRegister.Type.U32.getName());
+        return dot().typeName(PTXRegister.Type.U32.getName());
     }
 
     public PTXHATKernelBuilder s32() {
-        return dot().append(PTXRegister.Type.S32.getName());
+        return dot().typeName(PTXRegister.Type.S32.getName());
     }
 
     public PTXHATKernelBuilder f32() {
-        return dot().append(PTXRegister.Type.F32.getName());
+        return dot().typeName(PTXRegister.Type.F32.getName());
     }
 
     public PTXHATKernelBuilder b32() {
-        return dot().append(PTXRegister.Type.B32.getName());
+        return dot().typeName(PTXRegister.Type.B32.getName());
     }
 
     public PTXHATKernelBuilder u64() {
-        return dot().append(PTXRegister.Type.U64.getName());
+        return dot().typeName(PTXRegister.Type.U64.getName());
     }
 
     public PTXHATKernelBuilder s64() {
-        return dot().append(PTXRegister.Type.S64.getName());
+        return dot().typeName(PTXRegister.Type.S64.getName());
     }
 
     public PTXHATKernelBuilder f64() {
-        return dot().append(PTXRegister.Type.F64.getName());
+        return dot().typeName(PTXRegister.Type.F64.getName());
     }
 
     public PTXHATKernelBuilder b64() {
-        return dot().append(PTXRegister.Type.B64.getName());
+        return dot().typeName(PTXRegister.Type.B64.getName());
     }
 
     public PTXHATKernelBuilder version() {
-        return dot().append("version");
+        return dot().keyword("version");
     }
 
     public PTXHATKernelBuilder target() {
-        return dot().append("target");
+        return dot().keyword("target");
     }
 
     public PTXHATKernelBuilder addressSize() {
-        return dot().append("address_size");
+        return dot().keyword("address_size");
     }
 
     public PTXHATKernelBuilder major(int major) {
@@ -983,7 +983,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     }
 
     public PTXHATKernelBuilder target(String target) {
-        return append(target);
+        return keyword(target);
     }
 
     public PTXHATKernelBuilder size(int addressSize) {
@@ -991,70 +991,66 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
     }
 
     public PTXHATKernelBuilder funcName(String funcName) {
-        return append(funcName);
+        return identifier(funcName);
     }
 
     public PTXHATKernelBuilder visible() {
-        return dot().append("visible");
+        return dot().keyword("visible");
     }
 
     public PTXHATKernelBuilder entry() {
-        return dot().append("entry");
+        return dot().keyword("entry");
     }
 
     public PTXHATKernelBuilder func() {
-        return dot().append("func");
+        return dot().keyword("func");
     }
 
     public PTXHATKernelBuilder oabrace() {
-        return append("<");
+        return symbol("<");
     }
 
     public PTXHATKernelBuilder cabrace() {
-        return append(">");
+        return symbol(">");
     }
 
     public PTXHATKernelBuilder regName(PTXRegister reg) {
-        return append(reg.name());
+        return identifier(reg.name());
     }
 
     public PTXHATKernelBuilder regName(String regName) {
-        return append(regName);
+        return identifier(regName);
     }
 
     public PTXHATKernelBuilder regType(Value val) {
-        return append(getReg(val).type().getName());
+        return keyword(getReg(val).type().getName());
     }
 
     public PTXHATKernelBuilder regType(PTXRegister.Type t) {
-        return append(t.getName());
+        return keyword(t.getName());
     }
 
     public PTXHATKernelBuilder regTypePrefix(PTXRegister.Type t) {
-        return append(t.getRegPrefix());
+        return keyword(t.getRegPrefix());
     }
 
     public PTXHATKernelBuilder reg() {
-        return dot().append("reg");
+        return dot().keyword("reg");
     }
 
     public PTXHATKernelBuilder retVal() {
-        return append("retval");
-    }
-
-    public PTXHATKernelBuilder temp() {
-        return append("temp");
+        return keyword("retval");
     }
 
     public PTXHATKernelBuilder intVal(int i) {
-        return append(String.valueOf(i));
+        return constant(String.valueOf(i));
     }
 
     public PTXHATKernelBuilder floatVal(String s) {
-        return append("0f").append(s);
+        return constant("0f").constant(s);
     }
 
     public PTXHATKernelBuilder doubleVal(String s) {
-        return append("0d").append(s);
+        return constant("0d").constant(s);
     }
 }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/Config.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/Config.java
@@ -341,7 +341,7 @@ public record Config(int bits) {
             }
 
             ConfigBuilder stdCout(String s) {
-                return std("cout").space().leftShift().space().dquote().emitText(s).dquote();
+                return std("cout").space().leftShift().space().dquote().literal(s).dquote();
             }
         }
 

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -42,7 +42,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
         return this
                 .charTypeDefs("byte", "boolean")
                 .typedefStructOrUnion(true, "KernelContext", _ -> {
-                    intDeclaration("dimensions").semicolonNl();
+                    intDeclaration("dimensions").semicolon().nl();
                 });
     }
     @Override

--- a/hat/core/src/main/java/hat/codebuilders/CodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/CodeBuilder.java
@@ -24,15 +24,13 @@
  */
 package hat.codebuilders;
 
-import hat.optools.OpTk;
 import hat.util.StreamMutable;
-import jdk.incubator.code.Op;
 
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 /**
- * Extends the base TextBuilder to add common constructs/keywords for generating code.
+ * Extends the base TextBuilder to add common constructs/keywords for generating C99/Java style code.
  *
  * @author Gary Frost
  */
@@ -41,11 +39,6 @@ public abstract class CodeBuilder<T extends CodeBuilder<T>> extends TextBuilder<
     public T semicolon() {
         return symbol(";");
     }
-
-    public T semicolonNl() {
-        return semicolon().nl();
-    }
-
 
     public T comma() {
         return symbol(",");
@@ -86,16 +79,21 @@ public abstract class CodeBuilder<T extends CodeBuilder<T>> extends TextBuilder<
     }
 
     public T lineComment(String line) {
-        return symbol("//").space().commented(line).nl();
+        return comment("//").space().comment(line).nl();
+    }
+
+    @Override
+    public T constant(String text ){
+       return emitText(text);
     }
 
 
     public T blockComment(String block) {
-        return symbol("/*").nl().commented(block).nl().symbol("*/").nl();
+        return comment("/*").nl().comment(block).nl().symbol("*/").nl();
     }
 
     public T blockInlineComment(String block) {
-        return symbol("/*").space().commented(block).space().symbol("*/").space();
+        return comment("/*").space().comment(block).space().comment("*/");
     }
 
     public T newKeyword() {
@@ -398,7 +396,7 @@ public abstract class CodeBuilder<T extends CodeBuilder<T>> extends TextBuilder<
     }
 
     public T squote(String txt) {
-        return osquote().append(txt).csquote();
+        return osquote().escaped(txt).csquote();
     }
 
     public T rarrow() {
@@ -460,11 +458,11 @@ public abstract class CodeBuilder<T extends CodeBuilder<T>> extends TextBuilder<
         return self();
     }
     public final T intType() {
-        return append("int");
+        return typeName("int");
     }
 
     public final T intConstZero() {
-        return append("0");
+        return constant("0");
     }
 
 

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
@@ -116,11 +116,11 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
     }
 
     protected T hashIfdef(String value) {
-        return hashIfdefKeyword().space().append(value).nl();
+        return hashIfdefKeyword().space().constant(value).nl();
     }
 
     protected T hashIfndef(String value) {
-        return hashIfndefKeyword().space().append(value).nl();
+        return hashIfndefKeyword().space().constant(value).nl();
     }
 
     public T hashIfdef(String value, Consumer<T> consumer) {
@@ -145,7 +145,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
     public T hashDefine(String name, String... values) {
         hashDefineKeyword().space().identifier(name);
         for (String value : values) {
-            space().append(value);
+            space().constant(value);
         }
         return nl();
     }
@@ -153,7 +153,7 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
     public T pragma(String name, String... values) {
         hash().pragmaKeyword().space().identifier(name);
         for (String value : values) {
-            space().append(value);
+            space().constant(value);
         }
         return nl();
     }

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -193,7 +193,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
     @Override
     public T lambdaOp(ScopedCodeBuilderContext buildContext, JavaOp.LambdaOp lambdaOp) {
-        return commented("/*LAMBDA*/");
+        return comment("/*LAMBDA*/");
     }
 
     @Override
@@ -202,7 +202,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
             if (operand instanceof Op.Result result) {
                 recurse(buildContext, result.op());
             } else {
-                commented("/*nothing to tuple*/");
+                comment("/*nothing to tuple*/");
             }
         });
         return self();

--- a/hat/core/src/main/java/hat/codebuilders/TextRenderer.java
+++ b/hat/core/src/main/java/hat/codebuilders/TextRenderer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hat.codebuilders;
+
+public interface TextRenderer<T extends TextBuilder<T>>{
+    T identifier(String text);
+    T symbol(String text);
+    T typeName(String text);
+    T label(String text);
+    T keyword(String text);
+    T constant(String text);
+    T literal(String text);
+    T reserved(String text);
+    T nl();
+    T space();
+    T comment(String text);
+}


### PR DESCRIPTION
Cleaned up codegen where we were generating 'raw' append(str) and emiText(str).

We should always call one of the methods in the TextRenderer iface. ... identifier,label,literal etc 

This helps when styling/colorizing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/562/head:pull/562` \
`$ git checkout pull/562`

Update a local copy of the PR: \
`$ git checkout pull/562` \
`$ git pull https://git.openjdk.org/babylon.git pull/562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 562`

View PR using the GUI difftool: \
`$ git pr show -t 562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/562.diff">https://git.openjdk.org/babylon/pull/562.diff</a>

</details>
