### PR TITLE
Remove op name state from Op

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxOp.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxOp.java
@@ -223,6 +223,7 @@ public abstract class OnnxOp extends Op {
     static final String ATTRIBUTE_OPTIONAL_INPUTS = "optional_inputs";
     static final String ATTRIBUTE_OPTIONAL_OUTPUTS = "optional_outputs";
 
+    final OnnxSchema schema;
     final Map<String, Object> onnxAttributes;
     final TypeElement resultType;
     final List<OnnxParameter> optionalInputArguments;
@@ -230,8 +231,9 @@ public abstract class OnnxOp extends Op {
 
     @SuppressWarnings("unchecked")
     OnnxOp(OnnxSchema schema, ExternalizedOp def) {
-        super(def.name(), def.operands());
+        super(def.operands());
 
+        this.schema = schema;
         this.onnxAttributes = schema.attributes().isEmpty()
                 ? Map.of()
                 : OnnxAttribute.process(def, schema.attributes());
@@ -257,6 +259,7 @@ public abstract class OnnxOp extends Op {
     OnnxOp(OnnxOp that, CopyContext cc) {
         super(that, cc);
 
+        this.schema = that.schema;
         this.onnxAttributes = Map.copyOf(that.onnxAttributes);
         this.resultType = that.resultType;
         this.optionalInputArguments = List.copyOf(that.optionalInputArguments);
@@ -267,8 +270,9 @@ public abstract class OnnxOp extends Op {
            Set<? extends OnnxParameter> optionalOutputParameters,
            List<Object> inputArguments,
            List<Object> attributeValues) {
-        super(schema.name(), concatValues(inputArguments));
+        super(concatValues(inputArguments));
 
+        this.schema = schema;
         this.resultType = resultType;
 
         // Optional output parameters
@@ -329,6 +333,11 @@ public abstract class OnnxOp extends Op {
     @Override
     public TypeElement resultType() {
         return resultType;
+    }
+
+    @Override
+    public String opName() {
+        return schema.name();
     }
 
     @Override

--- a/cr-examples/samples/src/main/java/oracle/code/samples/DialectFMAOp.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/DialectFMAOp.java
@@ -75,12 +75,12 @@ public class DialectFMAOp {
 
     // Custom Node inherits from Op
     private static class FMA extends Op {
-
-        private final TypeElement typeElement;
         private static final String NAME = "fma";
 
+        private final TypeElement typeElement;
+
         FMA(List<Value> operands, TypeElement typeElement) {
-            super(NAME, operands);
+            super(operands);
             this.typeElement = typeElement;
         }
 
@@ -100,8 +100,8 @@ public class DialectFMAOp {
         }
 
         @Override
-        public Map<String, Object> externalize() {
-            return Map.of("", this.typeElement);
+        public String opName() {
+            return NAME;
         }
     }
 

--- a/cr-examples/samples/src/main/java/oracle/code/samples/DialectWithInvoke.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/DialectWithInvoke.java
@@ -71,8 +71,8 @@ public class DialectWithInvoke {
 
         private final TypeElement typeDescriptor;
 
-        FMAIntrinsicOp(String opName, TypeElement typeDescriptor, List<Value> operands) {
-            super(opName, operands);
+        FMAIntrinsicOp(TypeElement typeDescriptor, List<Value> operands) {
+            super(operands);
             this.typeDescriptor = typeDescriptor;
         }
 
@@ -92,8 +92,8 @@ public class DialectWithInvoke {
         }
 
         @Override
-        public Map<String, Object> externalize() {
-            return Map.of("", "dialect." + this.opName());
+        public String opName() {
+            return "intrinsicsFMA";
         }
     }
 
@@ -120,7 +120,7 @@ public class DialectWithInvoke {
                 List<Value> outputOperands = context.getValues(inputOperands);
 
                 // Create new node
-                FMAIntrinsicOp myCustomFunction = new FMAIntrinsicOp("intrinsicsFMA", invokeOp.resultType(), outputOperands);
+                FMAIntrinsicOp myCustomFunction = new FMAIntrinsicOp(invokeOp.resultType(), outputOperands);
 
                 // Add the new node to the code builder
                 Op.Result outputResult = blockBuilder.op(myCustomFunction);

--- a/cr-examples/spirv/src/main/java/intel/code/spirv/SpirvOp.java
+++ b/cr-examples/spirv/src/main/java/intel/code/spirv/SpirvOp.java
@@ -34,25 +34,30 @@ import jdk.incubator.code.TypeElement;
 import jdk.incubator.code.dialect.java.JavaType;
 
 public abstract class SpirvOp extends Op {
+    private final String opName;
     private final TypeElement type;
 
     SpirvOp(String opName) {
-        super(opName, List.of());
+        super(List.of());
+        this.opName = opName;
         this.type = JavaType.VOID;
     }
 
     SpirvOp(String opName, TypeElement type, List<Value> operands) {
-        super(opName, operands);
+        super(operands);
+        this.opName = opName;
         this.type = type;
     }
 
     SpirvOp(String opName, TypeElement type, List<Value> operands, Map<String, Object> attributes) {
-        super(opName, operands);
+        super(operands);
+        this.opName = opName;
         this.type = type;
     }
 
     SpirvOp(SpirvOp that, CopyContext cc) {
         super(that, cc);
+        this.opName = that.opName;
         this.type = that.type;
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
@@ -37,29 +37,38 @@ import java.util.Map;
 public class ArithMathOps {
 
     static abstract class ArithMathOp extends Op {
+        final String opName;
         final TypeElement resultType;
 
         public ArithMathOp(ExternalizedOp def) {
-            super(def.name(), def.operands());;
+            super(def.operands());
 
+            this.opName = def.name();
             this.resultType = def.resultType();
         }
 
         ArithMathOp(ArithMathOp that, CopyContext cc) {
             super(that, cc);
 
+            this.opName = that.opName;
             this.resultType = that.resultType;
         }
 
         ArithMathOp(String name, TypeElement resultType, List<? extends Value> operands) {
-            super(name, operands);
+            super(operands);
 
+            this.opName = name;
             this.resultType = resultType;
         }
 
         @Override
         public TypeElement resultType() {
             return resultType;
+        }
+
+        @Override
+        public String opName() {
+            return opName;
         }
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
@@ -70,7 +70,7 @@ public class SCFOps {
         final Body body;
 
         public ForOp(ExternalizedOp def) {
-            super(def.name(), def.operands());;
+            super(def.operands());;
 
             this.body = def.bodyDefinitions().get(0).build(this);
         }
@@ -87,7 +87,7 @@ public class SCFOps {
         }
 
         ForOp(List<Value> range, Body.Builder bodyBuilder) {
-            super(NAME, range);
+            super(range);
 
             this.body = bodyBuilder.build(this);
         }
@@ -113,7 +113,7 @@ public class SCFOps {
         public static final String NAME = "scf.yield";
 
         public YieldOp(ExternalizedOp def) {
-            super(def.name(), def.operands());
+            super(def.operands());
         }
 
         YieldOp(YieldOp that, CopyContext cc) {
@@ -126,7 +126,7 @@ public class SCFOps {
         }
 
         YieldOp(List<Value> values) {
-            super(NAME, values);
+            super(values);
         }
 
         @Override

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -42,7 +42,7 @@ public class TritonOps {
         final TypeElement resultType;
 
         public TritonOp(ExternalizedOp def) {
-            super(def.name(), def.operands());
+            super(def.operands());
 
             this.resultType = def.resultType();
         }
@@ -53,8 +53,8 @@ public class TritonOps {
             this.resultType = that.resultType;
         }
 
-        TritonOp(String name, TypeElement resultType, List<? extends Value> operands) {
-            super(name, operands);
+        TritonOp(TypeElement resultType, List<? extends Value> operands) {
+            super(operands);
 
             this.resultType = resultType;
         }
@@ -62,6 +62,13 @@ public class TritonOps {
         @Override
         public TypeElement resultType() {
             return resultType;
+        }
+
+        @Override
+        public String opName() {
+            OpFactoryHelper.OpDeclaration opDecl = this.getClass().getDeclaredAnnotation(OpFactoryHelper.OpDeclaration.class);
+            assert opDecl != null : this.getClass().getName();
+            return opDecl.value();
         }
     }
 
@@ -110,7 +117,7 @@ public class TritonOps {
         }
 
         ModuleOp(List<FuncOp> functions) {
-            super(NAME, JavaType.VOID,
+            super(JavaType.VOID,
                     List.of());
 
             Body.Builder bodyC = Body.Builder.of(null, CoreType.FUNCTION_TYPE_VOID);
@@ -207,7 +214,7 @@ public class TritonOps {
         }
 
         FuncOp(String funcName, Body.Builder bodyBuilder) {
-            super(NAME, JavaType.VOID,
+            super(JavaType.VOID,
                     List.of());
 
             this.funcName = funcName;
@@ -282,7 +289,7 @@ public class TritonOps {
         }
 
         CallOp(String funcName, TypeElement resultType, List<Value> args) {
-            super(NAME, resultType, args);
+            super(resultType, args);
 
             this.funcName = funcName;
         }
@@ -357,7 +364,7 @@ public class TritonOps {
         }
 
         ReduceOp(int axis, Value tensor, Body.Builder reducerBuilder) {
-            super(NAME, reducerBuilder.bodyType().returnType(), List.of(tensor));
+            super(reducerBuilder.bodyType().returnType(), List.of(tensor));
 
             this.axis = axis;
             this.reducer = reducerBuilder.build(this);
@@ -400,7 +407,7 @@ public class TritonOps {
         }
 
         ReduceReturnOp(Value r) {
-            super(NAME, JavaType.VOID, List.of(r));
+            super(JavaType.VOID, List.of(r));
         }
     }
 
@@ -438,7 +445,7 @@ public class TritonOps {
         }
 
         GetProgramIdOp(int axis) {
-            super(NAME, JavaType.INT, List.of());
+            super(JavaType.INT, List.of());
 
             this.axis = axis;
         }
@@ -496,7 +503,7 @@ public class TritonOps {
         }
 
         MakeRangeOp(int start, int end) {
-            super(NAME, tensorType(start, end), List.of());
+            super(tensorType(start, end), List.of());
 
             this.start = start;
             this.end = end;
@@ -548,7 +555,7 @@ public class TritonOps {
         }
 
         ExpandOp(int axis, TypeElement tensorType, Value v) {
-            super(NAME, tensorType, List.of(v));
+            super(tensorType, List.of(v));
 
             this.axis = axis;
         }
@@ -581,7 +588,7 @@ public class TritonOps {
         }
 
         SplatOp(TypeElement tensorType, Value v) {
-            super(NAME, tensorType, List.of(v));
+            super(tensorType, List.of(v));
         }
     }
 
@@ -603,7 +610,7 @@ public class TritonOps {
         }
 
         BroadcastOp(TypeElement tensorType, Value v) {
-            super(NAME, tensorType, List.of(v));
+            super(tensorType, List.of(v));
         }
     }
 
@@ -625,7 +632,7 @@ public class TritonOps {
         }
 
         AddPtrOp(Value ptr, Value offset) {
-            super(NAME, ptr.type(), List.of(ptr, offset));
+            super(ptr.type(), List.of(ptr, offset));
         }
     }
 
@@ -647,11 +654,11 @@ public class TritonOps {
         }
 
         LoadOp(TypeElement tensorType, Value ptr, Value mask) {
-            super(NAME, tensorType, List.of(ptr, mask));
+            super(tensorType, List.of(ptr, mask));
         }
 
         LoadOp(TypeElement tensorType, Value ptr, Value mask, Value other) {
-            super(NAME, tensorType, List.of(ptr, mask, other));
+            super(tensorType, List.of(ptr, mask, other));
         }
     }
 
@@ -673,7 +680,7 @@ public class TritonOps {
         }
 
         StoreOp(Value ptr, Value v, Value mask) {
-            super(NAME, JavaType.VOID, List.of(ptr, v, mask));
+            super(JavaType.VOID, List.of(ptr, v, mask));
         }
     }
 
@@ -695,11 +702,11 @@ public class TritonOps {
         }
 
         ReturnOp() {
-            super(NAME, JavaType.VOID, List.of());
+            super(JavaType.VOID, List.of());
         }
 
         ReturnOp(Value v) {
-            super(NAME, JavaType.VOID, List.of(v));
+            super(JavaType.VOID, List.of(v));
         }
     }
 
@@ -721,7 +728,7 @@ public class TritonOps {
         }
 
         DotOp(TypeElement tensorType, Value a, Value b, Value c) {
-            super(NAME, tensorType, List.of(a, b, c));
+            super(tensorType, List.of(a, b, c));
         }
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTestOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTestOps.java
@@ -39,7 +39,7 @@ public class TritonTestOps {
         public static final String NAME = "tt.consume";
 
         public ConsumeOp(ExternalizedOp def) {
-            super(def.name(), def.operands());
+            super(def.operands());
         }
 
         ConsumeOp(ConsumeOp that, CopyContext cc) {
@@ -52,12 +52,17 @@ public class TritonTestOps {
         }
 
         ConsumeOp(List<Value> values) {
-            super(NAME, values);
+            super(values);
         }
 
         @Override
         public TypeElement resultType() {
             return JavaType.VOID;
+        }
+
+        @Override
+        public String opName() {
+            return NAME;
         }
     }
 

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXHATKernelBuilder.java
@@ -170,7 +170,7 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
         public BoundSchema<?> boundSchema;
 
         PTXPtrOp(TypeElement resultType, String fieldName, List<Value> operands, BoundSchema<?> boundSchema) {
-            super(NAME, operands);
+            super(operands);
             this.resultType = resultType;
             this.fieldName = fieldName;
             this.boundSchema = boundSchema;
@@ -191,6 +191,11 @@ public class PTXHATKernelBuilder extends CodeBuilder<PTXHATKernelBuilder> {
         @Override
         public TypeElement resultType() {
             return resultType;
+        }
+
+        @Override
+        public String opName() {
+            return NAME;
         }
     }
 

--- a/hat/examples/experiments/src/main/java/experiments/DNA.java
+++ b/hat/examples/experiments/src/main/java/experiments/DNA.java
@@ -48,10 +48,12 @@ public class DNA {
     }
 
     public static class DNAOp extends Op { // externalized
+        private final String opName;
         private final TypeElement type;
 
         DNAOp(String opName, TypeElement type, List<Value> operands) {
-            super(opName, operands);
+            super(operands);
+            this.opName = opName;
             this.type = type;
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
+++ b/hat/examples/experiments/src/main/java/experiments/LayoutExample.java
@@ -289,7 +289,7 @@ public class LayoutExample {
         }
 
         public PtrToMember(Value ptr, String simpleMemberName) {
-            super(NAME, List.of(ptr));
+            super(List.of(ptr));
             this.simpleMemberName = simpleMemberName;
 
             if (!(ptr.type() instanceof PtrType ptrType)) {
@@ -343,6 +343,11 @@ public class LayoutExample {
         }
 
         @Override
+        public String opName() {
+            return NAME;
+        }
+
+        @Override
         public Map<String, Object> externalize() {
             return Map.of(
                     "", simpleMemberName,
@@ -376,7 +381,7 @@ public class LayoutExample {
         }
 
         public PtrAddOffset(Value ptr, Value offset) {
-            super(NAME, List.of(ptr, offset));
+            super(List.of(ptr, offset));
 
             if (!(ptr.type() instanceof PtrType)) {
                 throw new IllegalArgumentException("Pointer value is not of pointer type: " + ptr.type());
@@ -389,6 +394,11 @@ public class LayoutExample {
         @Override
         public TypeElement resultType() {
             return ptrValue().type();
+        }
+
+        @Override
+        public String opName() {
+            return NAME;
         }
 
         public Value ptrValue() {
@@ -416,7 +426,7 @@ public class LayoutExample {
         }
 
         public PtrLoadValue(Value ptr) {
-            super(NAME, List.of(ptr));
+            super(List.of(ptr));
 
             if (!(ptr.type() instanceof PtrType ptrType)) {
                 throw new IllegalArgumentException("Pointer value is not of pointer type: " + ptr.type());
@@ -430,6 +440,11 @@ public class LayoutExample {
         @Override
         public TypeElement resultType() {
             return resultType;
+        }
+
+        @Override
+        public String opName() {
+            return NAME;
         }
 
         public Value ptrValue() {
@@ -450,7 +465,7 @@ public class LayoutExample {
         }
 
         public PtrStoreValue(Value ptr, Value v) {
-            super(NAME, List.of(ptr));
+            super(List.of(ptr));
 
             if (!(ptr.type() instanceof PtrType ptrType)) {
                 throw new IllegalArgumentException("Pointer value is not of pointer type: " + ptr.type());
@@ -467,6 +482,11 @@ public class LayoutExample {
         @Override
         public TypeElement resultType() {
             return JavaType.VOID;
+        }
+
+        @Override
+        public String opName() {
+            return NAME;
         }
 
         public Value ptrValue() {

--- a/hat/examples/experiments/src/main/java/experiments/RawLayout.java
+++ b/hat/examples/experiments/src/main/java/experiments/RawLayout.java
@@ -307,7 +307,7 @@ public class RawLayout {
         }
 
         public PtrToMember(Value ptr, String simpleMemberName) {
-            super(NAME, List.of(ptr));
+            super(List.of(ptr));
             this.simpleMemberName = simpleMemberName;
 
             if (!(ptr.type() instanceof PtrType ptrType)) {
@@ -361,6 +361,11 @@ public class RawLayout {
         }
 
         @Override
+        public String opName() {
+            return NAME;
+        }
+
+        @Override
         public Map<String, Object> externalize() {
             return Map.of(
                     "", simpleMemberName,
@@ -395,7 +400,7 @@ public class RawLayout {
         }
 
         public PtrAddOffset(Value ptr, Value offset) {
-            super(NAME, List.of(ptr, offset));
+            super(List.of(ptr, offset));
 
             if (!(ptr.type() instanceof PtrType)) {
                 throw new IllegalArgumentException("Pointer value is not of pointer type: " + ptr.type());
@@ -417,6 +422,11 @@ public class RawLayout {
         public Value offsetValue() {
             return operands().get(1);
         }
+
+        @Override
+        public String opName() {
+            return NAME;
+        }
     }
 
   //  @OpFactory.OpDeclaration(PtrToMember.NAME)
@@ -436,7 +446,7 @@ public class RawLayout {
         }
 
         public PtrLoadValue(Value ptr) {
-            super(NAME, List.of(ptr));
+            super(List.of(ptr));
 
             if (!(ptr.type() instanceof PtrType ptrType)) {
                 throw new IllegalArgumentException("Pointer value is not of pointer type: " + ptr.type());
@@ -450,6 +460,11 @@ public class RawLayout {
         @Override
         public TypeElement resultType() {
             return resultType;
+        }
+
+        @Override
+        public String opName() {
+            return NAME;
         }
 
         public Value ptrValue() {
@@ -471,7 +486,7 @@ public class RawLayout {
         }
 
         public PtrStoreValue(Value ptr, Value v) {
-            super(NAME, List.of(ptr));
+            super(List.of(ptr));
 
             if (!(ptr.type() instanceof PtrType ptrType)) {
                 throw new IllegalArgumentException("Pointer value is not of pointer type: " + ptr.type());
@@ -488,6 +503,11 @@ public class RawLayout {
         @Override
         public TypeElement resultType() {
             return JavaType.VOID;
+        }
+
+        @Override
+        public String opName() {
+            return NAME;
         }
 
         public Value ptrValue() {

--- a/hat/examples/experiments/src/main/java/experiments/Transform.java
+++ b/hat/examples/experiments/src/main/java/experiments/Transform.java
@@ -65,25 +65,30 @@ public class Transform {
         }
 
         public static abstract class MyOp extends Op {
+            private final String opName;
             private final TypeElement type;
 
             MyOp(String opName) {
-                super(opName, List.of());
+                super(List.of());
+                this.opName = opName;
                 this.type = FUNCTION_TYPE_VOID;
             }
 
             MyOp(String opName, TypeElement type, List<Value> operands) {
-                super(opName, operands);
+                super(operands);
+                this.opName = opName;
                 this.type = type;
             }
 
             MyOp(String opName, TypeElement type, List<Value> operands, Map<String, Object> attributes) {
-                super(opName, operands);
+                super(operands);
+                this.opName = opName;
                 this.type = type;
             }
 
             MyOp(MyOp that, CopyContext cc) {
                 super(that, cc);
+                this.opName = that.opName;
                 this.type = that.type;
             }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -269,12 +269,12 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     // Set when op is bound to block, otherwise null when unbound
+    // @@@ stable value?
     Result result;
 
     // null if not specified
+    // @@@ stable value?
     Location location;
-
-    final String name;
 
     final List<Value> operands;
 
@@ -287,7 +287,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * values computed, in order, by mapping the operation's operands using the copy context.
      */
     protected Op(Op that, CopyContext cc) {
-        this(that.name, cc.getValues(that.operands));
+        this(cc.getValues(that.operands));
         this.location = that.location;
     }
 
@@ -331,11 +331,9 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     /**
      * Constructs an operation with a name and list of operands.
      *
-     * @param name       the operation name.
-     * @param operands   the list of operands, a copy of the list is performed if required.
+     * @param operands the list of operands, a copy of the list is performed if required.
      */
-    protected Op(String name, List<? extends Value> operands) {
-        this.name = name;
+    protected Op(List<? extends Value> operands) {
         this.operands = List.copyOf(operands);
     }
 
@@ -402,21 +400,15 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * {@return the operation name}
-     */
-    public String opName() {
-        return name;
-    }
-
-    /**
      * {@return the operation's operands, as an unmodifiable list}
      */
-    public List<Value> operands() {
+    public final List<Value> operands() {
         return operands;
     }
 
     /**
      * {@return the operation's successors, as an unmodifiable list}
+     * @implSpec this implementation returns an unmodifiable empty list.
      */
     public List<Block.Reference> successors() {
         return List.of();
@@ -435,9 +427,17 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      *
      * @return the function type
      */
-    public FunctionType opType() {
+    public final FunctionType opType() {
         List<TypeElement> operandTypes = operands.stream().map(Value::type).toList();
         return CoreType.functionType(resultType(), operandTypes);
+    }
+
+    /**
+     * {@return the operation name}
+     * @implSpec this implementation returns the result of the expression {@code this.getClass().getName()}.
+     */
+    public String opName() {
+        return this.getClass().getName();
     }
 
     /**
@@ -445,6 +445,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      *
      * <p>A null attribute value is represented by the constant
      * value {@link jdk.incubator.code.extern.ExternalizedOp#NULL_ATTRIBUTE_VALUE}.
+     * @implSpec this implementation returns an unmodifiable empty map.
      *
      * @return the operation's externalized state, as an unmodifiable map
      */
@@ -462,7 +463,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @return the list of captured values, modifiable
      * @see Body#capturedValues()
      */
-    public List<Value> capturedValues() {
+    public final List<Value> capturedValues() {
         Set<Value> cvs = new LinkedHashSet<>();
 
         capturedValues(cvs, new ArrayDeque<>(), this);
@@ -480,7 +481,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      *
      * @return the textual form of this operation.
      */
-    public String toText() {
+    public final String toText() {
         return OpWriter.toText(this);
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -1149,17 +1149,17 @@ public final class BytecodeGenerator {
                         case LtOp _ -> Opcode.IFGE;
                         case LeOp _ -> Opcode.IFGT;
                         default ->
-                            throw new UnsupportedOperationException(op.opName() + " on int");
+                            throw new UnsupportedOperationException(op + " on int");
                     };
                 case REFERENCE ->
                     switch (op) {
                         case EqOp _ -> Opcode.IFNONNULL;
                         case NeqOp _ -> Opcode.IFNULL;
                         default ->
-                            throw new UnsupportedOperationException(op.opName() + " on Object");
+                            throw new UnsupportedOperationException(op + " on Object");
                     };
                 default ->
-                    throw new UnsupportedOperationException(op.opName() + " on " + op.operands().get(0).type());
+                    throw new UnsupportedOperationException(op + " on " + op.operands().get(0).type());
             };
         }
         processOperand(secondOperand);
@@ -1173,14 +1173,14 @@ public final class BytecodeGenerator {
                     case LtOp _ -> Opcode.IF_ICMPGE;
                     case LeOp _ -> Opcode.IF_ICMPGT;
                     default ->
-                        throw new UnsupportedOperationException(op.opName() + " on int");
+                        throw new UnsupportedOperationException(op + " on int");
                 };
             case REFERENCE ->
                 switch (op) {
                     case EqOp _ -> Opcode.IF_ACMPNE;
                     case NeqOp _ -> Opcode.IF_ACMPEQ;
                     default ->
-                        throw new UnsupportedOperationException(op.opName() + " on Object");
+                        throw new UnsupportedOperationException(op + " on Object");
                 };
             case FLOAT -> {
                 cob.fcmpg(); // FCMPL?
@@ -1195,7 +1195,7 @@ public final class BytecodeGenerator {
                 yield reverseIfOpcode(op);
             }
             default ->
-                throw new UnsupportedOperationException(op.opName() + " on " + op.operands().get(0).type());
+                throw new UnsupportedOperationException(op + " on " + op.operands().get(0).type());
         };
     }
 
@@ -1222,7 +1222,7 @@ public final class BytecodeGenerator {
             case LtOp _ -> Opcode.IFGE;
             case LeOp _ -> Opcode.IFGT;
             default ->
-                throw new UnsupportedOperationException(op.opName());
+                throw new UnsupportedOperationException(op.toString());
         };
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/SlotOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/SlotOp.java
@@ -60,8 +60,8 @@ sealed abstract class SlotOp extends Op {
         this.slot = that.slot;
     }
 
-    protected SlotOp(String name, List<? extends Value> operands, int slot) {
-        super(name, operands);
+    protected SlotOp(List<? extends Value> operands, int slot) {
+        super(operands);
         this.slot = slot;
     }
 
@@ -79,6 +79,11 @@ sealed abstract class SlotOp extends Op {
     @OpDeclaration(SlotLoadOp.NAME)
     public static final class SlotLoadOp extends SlotOp {
         public static final String NAME = "slot.load";
+
+        @Override
+        public String opName() {
+            return NAME;
+        }
 
         final TypeElement resultType;
 
@@ -103,7 +108,7 @@ sealed abstract class SlotOp extends Op {
         }
 
         SlotLoadOp(int slot, TypeElement resultType) {
-            super(NAME, List.of(), slot);
+            super(List.of(), slot);
             this.resultType = resultType;
         }
 
@@ -127,6 +132,11 @@ sealed abstract class SlotOp extends Op {
     public static final class SlotStoreOp extends SlotOp {
         public static final String NAME = "slot.store";
 
+        @Override
+        public String opName() {
+            return NAME;
+        }
+
         public SlotStoreOp(ExternalizedOp def) {
             int slot = def.extractAttributeValue(ATTRIBUTE_SLOT, true,
                     v -> switch (v) {
@@ -147,7 +157,7 @@ sealed abstract class SlotOp extends Op {
         }
 
         SlotStoreOp(int slot, Value v) {
-            super(NAME, List.of(v), slot);
+            super(List.of(v), slot);
         }
 
         @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -48,8 +48,15 @@ public sealed abstract class CoreOp extends Op {
         super(that, cc);
     }
 
-    protected CoreOp(String name, List<? extends Value> operands) {
-        super(name, operands);
+    protected CoreOp(List<? extends Value> operands) {
+        super(operands);
+    }
+
+    @Override
+    public String opName() {
+        OpDeclaration opDecl = this.getClass().getDeclaredAnnotation(OpDeclaration.class);
+        assert opDecl != null : this.getClass().getName();
+        return opDecl.value();
     }
 
     /**
@@ -121,7 +128,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         FuncOp(String funcName, Body.Builder bodyBuilder) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.funcName = funcName;
             this.body = bodyBuilder.build(this);
@@ -200,7 +207,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         FuncCallOp(String funcName, TypeElement resultType, List<Value> args) {
-            super(NAME, args);
+            super(args);
 
             this.funcName = funcName;
             this.resultType = resultType;
@@ -271,7 +278,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         ModuleOp(Body.Builder bodyBuilder) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.body = bodyBuilder.build(this);
             this.table = createTable(body);
@@ -340,7 +347,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         QuotedOp(Body.Builder bodyC) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.quotedBody = bodyC.build(this);
             if (quotedBody.blocks().size() > 1) {
@@ -362,11 +369,6 @@ public sealed abstract class CoreOp extends Op {
 
         public Op quotedOp() {
             return quotedOp;
-        }
-
-        @Override
-        public List<Value> capturedValues() {
-            return quotedBody.capturedValues();
         }
 
         @Override
@@ -427,7 +429,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         ClosureOp(Body.Builder bodyC) {
-            super(NAME,
+            super(
                     List.of());
 
             this.body = bodyC.build(this);
@@ -446,11 +448,6 @@ public sealed abstract class CoreOp extends Op {
         @Override
         public Body body() {
             return body;
-        }
-
-        @Override
-        public List<Value> capturedValues() {
-            return body.capturedValues();
         }
 
         @Override
@@ -489,7 +486,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         ClosureCallOp(List<Value> args) {
-            super(NAME, args);
+            super(args);
         }
 
         @Override
@@ -527,7 +524,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         ReturnOp(Value operand) {
-            super(NAME, operand == null ? List.of() : List.of(operand));
+            super(operand == null ? List.of() : List.of(operand));
         }
 
         public Value returnValue() {
@@ -573,7 +570,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         UnreachableOp() {
-            super(NAME, List.of());
+            super(List.of());
         }
 
         @Override
@@ -611,11 +608,11 @@ public sealed abstract class CoreOp extends Op {
         }
 
         YieldOp() {
-            super(NAME, List.of());
+            super(List.of());
         }
 
         YieldOp(List<Value> operands) {
-            super(NAME, operands);
+            super(operands);
         }
 
         public Value yieldValue() {
@@ -665,7 +662,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         BranchOp(Block.Reference successor) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.b = successor;
         }
@@ -721,7 +718,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         ConditionalBranchOp(Value p, Block.Reference t, Block.Reference f) {
-            super(NAME, List.of(p));
+            super(List.of(p));
 
             this.t = t;
             this.f = f;
@@ -816,7 +813,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         ConstantOp(TypeElement type, Object value) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.type = type;
             this.value = value;
@@ -891,7 +888,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         VarOp(ExternalizedOp def, String varName) {
-            super(NAME, def.operands());
+            super(def.operands());
 
             this.varName = varName;
             this.resultType = (VarType) def.resultType();
@@ -915,7 +912,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         VarOp(String varName, TypeElement type, Value init) {
-            super(NAME, init == null ? List.of() : List.of(init));
+            super(init == null ? List.of() : List.of(init));
 
             this.varName =  varName == null ? "" : varName;
             this.resultType = CoreType.varType(type);
@@ -965,8 +962,8 @@ public sealed abstract class CoreOp extends Op {
             super(that, cc);
         }
 
-        VarAccessOp(String name, List<Value> operands) {
-            super(name, operands);
+        VarAccessOp(List<Value> operands) {
+            super(operands);
         }
 
         public Value varOperand() {
@@ -1022,7 +1019,7 @@ public sealed abstract class CoreOp extends Op {
 
             // (Variable)VarType
             VarLoadOp(Value varValue) {
-                super(NAME, List.of(varValue));
+                super(List.of(varValue));
             }
 
             @Override
@@ -1053,8 +1050,7 @@ public sealed abstract class CoreOp extends Op {
             }
 
             VarStoreOp(List<Value> values) {
-                super(NAME,
-                        values);
+                super(values);
             }
 
             @Override
@@ -1064,7 +1060,7 @@ public sealed abstract class CoreOp extends Op {
 
             // (Variable, VarType)void
             VarStoreOp(Value varValue, Value v) {
-                super(NAME, List.of(varValue, v));
+                super(List.of(varValue, v));
             }
 
             public Value storeOperand() {
@@ -1092,7 +1088,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleOp(TupleOp that, CopyContext cc) {
-            this(cc.getValues(that.operands()));
+            super(that, cc);
         }
 
         @Override
@@ -1101,7 +1097,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleOp(List<? extends Value> componentValues) {
-            super(NAME, componentValues);
+            super(componentValues);
         }
 
         @Override
@@ -1134,11 +1130,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleLoadOp(TupleLoadOp that, CopyContext cc) {
-            this(that, cc.getValues(that.operands()));
-        }
-
-        TupleLoadOp(TupleLoadOp that, List<Value> values) {
-            super(NAME, values);
+            super(that, cc);
 
             this.index = that.index;
         }
@@ -1149,7 +1141,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleLoadOp(Value tupleValue, int index) {
-            super(NAME, List.of(tupleValue));
+            super(List.of(tupleValue));
 
             this.index = index;
         }
@@ -1195,11 +1187,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleWithOp(TupleWithOp that, CopyContext cc) {
-            this(that, cc.getValues(that.operands()));
-        }
-
-        TupleWithOp(TupleWithOp that, List<Value> values) {
-            super(NAME, values);
+            super(that, cc);
 
             this.index = that.index;
         }
@@ -1210,7 +1198,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleWithOp(Value tupleValue, int index, Value value) {
-            super(NAME, List.of(tupleValue, value));
+            super(List.of(tupleValue, value));
 
             // @@@ Validate tuple type and index
             this.index = index;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -69,8 +69,15 @@ public sealed abstract class JavaOp extends Op {
         super(that, cc);
     }
 
-    protected JavaOp(String name, List<? extends Value> operands) {
-        super(name, operands);
+    protected JavaOp(List<? extends Value> operands) {
+        super(operands);
+    }
+
+    @Override
+    public String opName() {
+        OpDeclaration opDecl = this.getClass().getDeclaredAnnotation(OpDeclaration.class);
+        assert opDecl != null : this.getClass().getName();
+        return opDecl.value();
     }
 
     /**
@@ -216,7 +223,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         LambdaOp(TypeElement functionalInterface, Body.Builder bodyC, boolean isQuotable) {
-            super(NAME,
+            super(
                     List.of());
 
             this.functionalInterface = functionalInterface;
@@ -241,11 +248,6 @@ public sealed abstract class JavaOp extends Op {
         @Override
         public Body body() {
             return body;
-        }
-
-        @Override
-        public List<Value> capturedValues() {
-            return body.capturedValues();
         }
 
         @Override
@@ -429,7 +431,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ThrowOp(Value e) {
-            super(NAME, List.of(e));
+            super(List.of(e));
         }
 
         public Value argument() {
@@ -456,7 +458,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         public AssertOp(List<Body.Builder> bodies) {
-            super(NAME, List.of());
+            super(List.of());
 
             if (bodies.size() != 1 && bodies.size() != 2) {
                 throw new IllegalArgumentException("Assert must have one or two bodies.");
@@ -493,8 +495,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        MonitorOp(String name, Value monitor) {
-            super(name, List.of(monitor));
+        MonitorOp(Value monitor) {
+            super(List.of(monitor));
         }
 
         public Value monitorValue() {
@@ -531,7 +533,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             MonitorEnterOp(Value monitor) {
-                super(NAME, monitor);
+                super(monitor);
             }
         }
 
@@ -560,7 +562,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             MonitorExitOp(Value monitor) {
-                super(NAME, monitor);
+                super(monitor);
             }
         }
     }
@@ -654,7 +656,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         InvokeOp(InvokeKind invokeKind, boolean isVarArgs, TypeElement resultType, MethodRef invokeDescriptor, List<Value> args) {
-            super(NAME, args);
+            super(args);
 
             validateArgCount(invokeKind, isVarArgs, invokeDescriptor, args);
 
@@ -761,7 +763,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConvOp(TypeElement resultType, Value arg) {
-            super(NAME, List.of(arg));
+            super(List.of(arg));
 
             this.resultType = resultType;
         }
@@ -820,7 +822,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         NewOp(boolean isVarargs, TypeElement resultType, ConstructorRef constructorDescriptor, List<Value> args) {
-            super(NAME, args);
+            super(args);
 
             validateArgCount(isVarargs, constructorDescriptor, args);
 
@@ -881,9 +883,9 @@ public sealed abstract class JavaOp extends Op {
             this.fieldDescriptor = that.fieldDescriptor;
         }
 
-        FieldAccessOp(String name, List<Value> operands,
+        FieldAccessOp(List<Value> operands,
                       FieldRef fieldDescriptor) {
-            super(name, operands);
+            super(operands);
 
             this.fieldDescriptor = fieldDescriptor;
         }
@@ -939,14 +941,14 @@ public sealed abstract class JavaOp extends Op {
 
             // instance
             FieldLoadOp(TypeElement resultType, FieldRef descriptor, Value receiver) {
-                super(NAME, List.of(receiver), descriptor);
+                super(List.of(receiver), descriptor);
 
                 this.resultType = resultType;
             }
 
             // static
             FieldLoadOp(TypeElement resultType, FieldRef descriptor) {
-                super(NAME, List.of(), descriptor);
+                super(List.of(), descriptor);
 
                 this.resultType = resultType;
             }
@@ -995,12 +997,12 @@ public sealed abstract class JavaOp extends Op {
 
             // instance
             FieldStoreOp(FieldRef descriptor, Value receiver, Value v) {
-                super(NAME, List.of(receiver, v), descriptor);
+                super(List.of(receiver, v), descriptor);
             }
 
             // static
             FieldStoreOp(FieldRef descriptor, Value v) {
-                super(NAME, List.of(v), descriptor);
+                super(List.of(v), descriptor);
             }
 
             @Override
@@ -1033,7 +1035,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ArrayLengthOp(Value array) {
-            super(NAME, List.of(array));
+            super(List.of(array));
         }
 
         @Override
@@ -1049,16 +1051,11 @@ public sealed abstract class JavaOp extends Op {
             implements AccessOp, ReflectiveOp {
 
         ArrayAccessOp(ArrayAccessOp that, CopyContext cc) {
-            this(that, cc.getValues(that.operands()));
+            super(that, cc);
         }
 
-        ArrayAccessOp(ArrayAccessOp that, List<Value> operands) {
-            super(that.opName(), operands);
-        }
-
-        ArrayAccessOp(String name,
-                      Value array, Value index, Value v) {
-            super(name, operands(array, index, v));
+        ArrayAccessOp(Value array, Value index, Value v) {
+            super(operands(array, index, v));
         }
 
         static List<Value> operands(Value array, Value index, Value v) {
@@ -1101,7 +1098,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             ArrayLoadOp(Value array, Value index, TypeElement componentType) {
-                super(NAME, array, index, null);
+                super(array, index, null);
                 this.componentType = componentType;
             }
 
@@ -1138,7 +1135,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             ArrayStoreOp(Value array, Value index, Value v) {
-                super(NAME, array, index, v);
+                super(array, index, v);
             }
 
             @Override
@@ -1185,7 +1182,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         InstanceOfOp(TypeElement t, Value v) {
-            super(NAME, List.of(v));
+            super(List.of(v));
 
             this.typeDescriptor = t;
         }
@@ -1243,7 +1240,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         CastOp(TypeElement resultType, TypeElement t, Value v) {
-            super(NAME, List.of(v));
+            super(List.of(v));
 
             this.resultType = resultType;
             this.typeDescriptor = t;
@@ -1294,10 +1291,10 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ExceptionRegionEnter(List<Block.Reference> s) {
-            super(NAME, List.of());
+            super(List.of());
 
             if (s.size() < 2) {
-                throw new IllegalArgumentException("Operation must have two or more successors" + opName());
+                throw new IllegalArgumentException("Operation must have two or more successors " + this);
             }
 
             this.s = List.copyOf(s);
@@ -1350,10 +1347,10 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ExceptionRegionExit(List<Block.Reference> s) {
-            super(NAME, List.of());
+            super(List.of());
 
             if (s.size() < 2) {
-                throw new IllegalArgumentException("Operation must have two or more successors" + opName());
+                throw new IllegalArgumentException("Operation must have two or more successors " + this);
             }
 
             this.s = List.copyOf(s);
@@ -1400,7 +1397,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         public ConcatOp(Value lhs, Value rhs) {
-            super(ConcatOp.NAME, List.of(lhs, rhs));
+            super(List.of(lhs, rhs));
         }
 
         @Override
@@ -1423,8 +1420,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        protected ArithmeticOperation(String name, List<Value> operands) {
-            super(name, operands);
+        protected ArithmeticOperation(List<Value> operands) {
+            super(operands);
         }
     }
 
@@ -1437,8 +1434,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        protected TestOperation(String name, List<Value> operands) {
-            super(name, operands);
+        protected TestOperation(List<Value> operands) {
+            super(operands);
         }
     }
 
@@ -1450,8 +1447,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        protected BinaryOp(String name, Value lhs, Value rhs) {
-            super(name, List.of(lhs, rhs));
+        protected BinaryOp(Value lhs, Value rhs) {
+            super(List.of(lhs, rhs));
         }
 
         @Override
@@ -1468,8 +1465,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        protected UnaryOp(String name, Value v) {
-            super(name, List.of(v));
+        protected UnaryOp(Value v) {
+            super(List.of(v));
         }
 
         @Override
@@ -1486,8 +1483,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        protected BinaryTestOp(String name, Value lhs, Value rhs) {
-            super(name, List.of(lhs, rhs));
+        protected BinaryTestOp(Value lhs, Value rhs) {
+            super(List.of(lhs, rhs));
         }
 
         @Override
@@ -1517,7 +1514,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         AddOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1542,7 +1539,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         SubOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1567,7 +1564,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         MulOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1592,7 +1589,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         DivOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1617,7 +1614,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ModOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1643,7 +1640,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         OrOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1669,7 +1666,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         AndOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1695,7 +1692,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         XorOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1720,7 +1717,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         LshlOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1745,7 +1742,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         AshrOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1770,7 +1767,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         LshrOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1795,7 +1792,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         NegOp(Value v) {
-            super(NAME, v);
+            super(v);
         }
     }
 
@@ -1820,7 +1817,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ComplOp(Value v) {
-            super(NAME, v);
+            super(v);
         }
     }
 
@@ -1845,7 +1842,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         NotOp(Value v) {
-            super(NAME, v);
+            super(v);
         }
     }
 
@@ -1871,7 +1868,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         EqOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1897,7 +1894,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         NeqOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1922,7 +1919,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         GtOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1948,7 +1945,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         GeOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -1974,7 +1971,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         LtOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -2000,7 +1997,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         LeOp(Value lhs, Value rhs) {
-            super(NAME, lhs, rhs);
+            super(lhs, rhs);
         }
     }
 
@@ -2013,8 +2010,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        JavaLabelOp(String name, Value label) {
-            super(name, checkLabel(label));
+        JavaLabelOp(Value label) {
+            super(checkLabel(label));
         }
 
         static List<Value> checkLabel(Value label) {
@@ -2109,7 +2106,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         BreakOp(Value label) {
-            super(NAME, label);
+            super(label);
         }
 
         @Override
@@ -2139,7 +2136,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ContinueOp(Value label) {
-            super(NAME, label);
+            super(label);
         }
 
         @Override
@@ -2195,7 +2192,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         YieldOp(Value operand) {
-            super(NAME, operand == null ? List.of() : List.of(operand));
+            super(operand == null ? List.of() : List.of(operand));
         }
 
         public Value yieldValue() {
@@ -2278,7 +2275,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         BlockOp(Body.Builder bodyC) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.body = bodyC.build(this);
             if (!body.bodyType().returnType().equals(VOID)) {
@@ -2350,7 +2347,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         SynchronizedOp(Body.Builder exprC, Body.Builder bodyC) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.expr = exprC.build(this);
             if (expr.bodyType().returnType().equals(VOID)) {
@@ -2500,7 +2497,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         LabeledOp(Body.Builder bodyC) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.body = bodyC.build(this);
             if (!body.bodyType().returnType().equals(VOID)) {
@@ -2669,7 +2666,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         IfOp(List<Body.Builder> bodyCs) {
-            super(NAME, List.of());
+            super(List.of());
 
             // Normalize by adding an empty else action
             // @@@ Is this needed?
@@ -2781,8 +2778,8 @@ public sealed abstract class JavaOp extends Op {
                     .map(b -> b.transform(cc, ot).build(this)).toList();
         }
 
-        JavaSwitchOp(String name, Value target, List<Body.Builder> bodyCs) {
-            super(name, List.of(target));
+        JavaSwitchOp(Value target, List<Body.Builder> bodyCs) {
+            super(List.of(target));
 
             // Each case is modelled as a contiguous pair of bodies
             // The first body models the case labels, and the second models the case statements
@@ -2938,7 +2935,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         SwitchExpressionOp(TypeElement resultType, Value target, List<Body.Builder> bodyCs) {
-            super(NAME, target, bodyCs);
+            super(target, bodyCs);
 
             this.resultType = resultType == null ? bodies.get(1).yieldType() : resultType;
         }
@@ -2971,7 +2968,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         SwitchStatementOp(Value target, List<Body.Builder> bodyCs) {
-            super(NAME, target, bodyCs);
+            super(target, bodyCs);
         }
 
         @Override
@@ -3003,7 +3000,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         SwitchFallthroughOp() {
-            super(NAME, List.of());
+            super(List.of());
         }
 
         @Override
@@ -3162,7 +3159,7 @@ public sealed abstract class JavaOp extends Op {
               Body.Builder condC,
               Body.Builder updateC,
               Body.Builder bodyC) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.init = initC.build(this);
 
@@ -3378,7 +3375,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         EnhancedForOp(Body.Builder expressionC, Body.Builder initC, Body.Builder bodyC) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.expression = expressionC.build(this);
             if (expression.bodyType().returnType().equals(VOID)) {
@@ -3559,13 +3556,13 @@ public sealed abstract class JavaOp extends Op {
         }
 
         WhileOp(List<Body.Builder> bodyCs) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
         }
 
         WhileOp(Body.Builder predicate, Body.Builder body) {
-            super(NAME, List.of());
+            super(List.of());
 
             Objects.requireNonNull(body);
 
@@ -3691,13 +3688,13 @@ public sealed abstract class JavaOp extends Op {
         }
 
         DoWhileOp(List<Body.Builder> bodyCs) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
         }
 
         DoWhileOp(Body.Builder body, Body.Builder predicate) {
-            super(NAME, List.of());
+            super(List.of());
 
             Objects.requireNonNull(body);
 
@@ -3787,8 +3784,8 @@ public sealed abstract class JavaOp extends Op {
             this.bodies = that.bodies.stream().map(b -> b.transform(cc, ot).build(this)).toList();
         }
 
-        JavaConditionalOp(String name, List<Body.Builder> bodyCs) {
-            super(name, List.of());
+        JavaConditionalOp(List<Body.Builder> bodyCs) {
+            super(List.of());
 
             if (bodyCs.isEmpty()) {
                 throw new IllegalArgumentException();
@@ -3912,7 +3909,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConditionalAndOp(List<Body.Builder> bodyCs) {
-            super(NAME, bodyCs);
+            super(bodyCs);
         }
 
         @Override
@@ -3967,7 +3964,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConditionalOrOp(List<Body.Builder> bodyCs) {
-            super(NAME, bodyCs);
+            super(bodyCs);
         }
 
         @Override
@@ -4012,7 +4009,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConditionalExpressionOp(TypeElement expressionType, List<Body.Builder> bodyCs) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
             // @@@ when expressionType is null, we assume truepart and falsepart have the same yieldType
@@ -4199,7 +4196,7 @@ public sealed abstract class JavaOp extends Op {
               Body.Builder bodyC,
               List<Body.Builder> catchersC,
               Body.Builder finalizerC) {
-            super(NAME, List.of());
+            super(List.of());
 
             if (resourcesC != null) {
                 this.resources = resourcesC.build(this);
@@ -4550,8 +4547,8 @@ public sealed abstract class JavaOp extends Op {
                 super(that, cc);
             }
 
-            PatternOp(String name, List<Value> operands) {
-                super(name, operands);
+            PatternOp(List<Value> operands) {
+                super(operands);
             }
         }
 
@@ -4568,7 +4565,7 @@ public sealed abstract class JavaOp extends Op {
             final String bindingName;
 
             TypePatternOp(ExternalizedOp def) {
-                super(NAME, List.of());
+                super(List.of());
 
                 this.bindingName = def.extractAttributeValue(ATTRIBUTE_BINDING_NAME, true,
                         v -> switch (v) {
@@ -4593,7 +4590,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             TypePatternOp(TypeElement targetType, String bindingName) {
-                super(NAME, List.of());
+                super(List.of());
 
                 this.bindingName = bindingName;
                 this.resultType = Pattern.bindingType(targetType);
@@ -4654,7 +4651,7 @@ public sealed abstract class JavaOp extends Op {
             RecordPatternOp(RecordTypeRef recordDescriptor, List<Value> nestedPatterns) {
                 // The type of each value is a subtype of Pattern
                 // The number of values corresponds to the number of components of the record
-                super(NAME, List.copyOf(nestedPatterns));
+                super(List.copyOf(nestedPatterns));
 
                 this.recordDescriptor = recordDescriptor;
             }
@@ -4695,7 +4692,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             MatchAllPatternOp() {
-                super(NAME, List.of());
+                super(List.of());
             }
 
             @Override
@@ -4737,8 +4734,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             MatchOp(Value target, Body.Builder patternC, Body.Builder matchC) {
-                super(NAME,
-                        List.of(target));
+                super(List.of(target));
 
                 this.pattern = patternC.build(this);
                 this.match = matchC.build(this);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
@@ -179,7 +179,8 @@ public class OpBuilder {
         builder.op(invoke(MethodRef.method(Op.class, "seal", void.class), result));
         builder.op(return_(result));
 
-        return func("builder." + op.opName(), builder.parentBody());
+        // @@@ avoid use of opName
+        return func("builder." + op.getClass().getName(), builder.parentBody());
     }
 
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/interpreter/Interpreter.java
@@ -341,7 +341,7 @@ public final class Interpreter {
             try {
                 for (int i = 0; i < nops - 1; i++) {
                     Op op = bc.b.ops().get(i);
-                    assert !(op instanceof Op.Terminating) : op.opName();
+                    assert !(op instanceof Op.Terminating) : op;
 
                     Object result = interpretOp(l, oc, op);
                     oc.setValue(op.result(), result);
@@ -404,7 +404,7 @@ public final class Interpreter {
                 oc.successor(ere.end());
             } else {
                 throw interpreterException(
-                        new UnsupportedOperationException("Unsupported terminating operation: " + to.opName()));
+                        new UnsupportedOperationException("Unsupported terminating operation: " + to));
             }
         }
     }
@@ -599,10 +599,12 @@ public final class Interpreter {
             Array.set(a, (int) index, v);
             return null;
         } else if (o instanceof JavaOp.ArithmeticOperation || o instanceof JavaOp.TestOperation) {
+            // @@@ avoid use of opName
             MethodHandle mh = opHandle(l, o.opName(), o.opType());
             Object[] values = o.operands().stream().map(oc::getValue).toArray();
             return invoke(mh, values);
         } else if (o instanceof JavaOp.ConvOp) {
+            // @@@ avoid use of opName
             MethodHandle mh = opHandle(l, o.opName() + "_" + o.opType().returnType(), o.opType());
             Object[] values = o.operands().stream().map(oc::getValue).toArray();
             return invoke(mh, values);
@@ -645,7 +647,7 @@ public final class Interpreter {
             return null;
         } else {
             throw interpreterException(
-                    new UnsupportedOperationException("Unsupported operation: " + o.opName()));
+                    new UnsupportedOperationException("Unsupported operation: " + o));
         }
     }
 

--- a/test/jdk/java/lang/reflect/code/ad/ForwardDifferentiation.java
+++ b/test/jdk/java/lang/reflect/code/ad/ForwardDifferentiation.java
@@ -191,7 +191,7 @@ public final class ForwardDifferentiation {
                     Op.Result cosx = block.op(JavaOp.invoke(J_L_MATH_COS, outputA));
                     yield block.op(JavaOp.mul(cosx, da));
                 } else {
-                    throw new UnsupportedOperationException("Operation not supported: " + op.opName());
+                    throw new UnsupportedOperationException("Operation not supported: " + op);
                 }
             }
             case CoreOp.ReturnOp _ -> {
@@ -205,7 +205,7 @@ public final class ForwardDifferentiation {
                 op.successors().forEach(s -> adaptSuccessor(block.context(), s));
                 yield block.op(op);
             }
-            default -> throw new UnsupportedOperationException("Operation not supported: " + op.opName());
+            default -> throw new UnsupportedOperationException("Operation not supported: " + op);
         };
     }
 

--- a/test/jdk/java/lang/reflect/code/anf/AnfDialect.java
+++ b/test/jdk/java/lang/reflect/code/anf/AnfDialect.java
@@ -76,7 +76,7 @@ public final class AnfDialect {
         }
 
         public AnfLetOp(Body.Builder bodyBuilder) {
-            super(NAME, List.of());
+            super(List.of());
 
             this.bindings = bodyBuilder.build(this);
         }
@@ -133,7 +133,7 @@ public final class AnfDialect {
         }
 
         public AnfLetRecOp(Body.Builder bodyBuilder) {
-            super(AnfLetRecOp.NAME, List.of());
+            super(List.of());
 
             this.bindings = bodyBuilder.build(this);
         }
@@ -221,7 +221,7 @@ public final class AnfDialect {
         }
 
         AnfIfOp(Value test, Body.Builder thenBodyBuilder, Body.Builder elseBodyBuilder) {
-            super(NAME, List.of(test));
+            super(List.of(test));
 
             this.then_ = thenBodyBuilder.build(this);
             this.else_ = elseBodyBuilder.build(this);
@@ -306,7 +306,7 @@ public final class AnfDialect {
         }
 
         AnfFuncOp(String funcName, Body.Builder bodyBuilder) {
-            super(NAME,
+            super(
                     List.of());
 
             this.funcName = funcName;
@@ -364,7 +364,7 @@ public final class AnfDialect {
         }
 
         public AnfApply(List<Value> arguments) {
-            super(AnfApply.NAME, arguments);
+            super(arguments);
 
             // First argument is func value
             // Subsequent arguments are func arguments
@@ -414,7 +414,7 @@ public final class AnfDialect {
         }
 
         public AnfApplyStub(String callSiteName, List<Value> arguments, TypeElement resultType) {
-            super(AnfApplyStub.NAME, arguments);
+            super(arguments);
             this.resultType = resultType;
             this.callSiteName = callSiteName;
 

--- a/test/jdk/java/lang/reflect/code/anf/AnfTransformer.java
+++ b/test/jdk/java/lang/reflect/code/anf/AnfTransformer.java
@@ -180,7 +180,7 @@ public class AnfTransformer {
                     } else if (o instanceof CoreOp.YieldOp yo) {
                         return yo.yieldValue().type();
                     } else {
-                        throw new UnsupportedOperationException("Unsupported terminator encountered: " + o.opName());
+                        throw new UnsupportedOperationException("Unsupported terminator encountered: " + o);
                     }
                 } else {
                     visitedBlocks.add(block);
@@ -191,7 +191,7 @@ public class AnfTransformer {
 
         }
 
-        throw new RuntimeException("Encountered Block with no return " + op.opName());
+        throw new RuntimeException("Encountered Block with no return " + op);
     }
 
     private Block.Builder transformEndOp(Block.Builder b, Op op) {

--- a/test/jdk/java/lang/reflect/code/pe/PartialEvaluator.java
+++ b/test/jdk/java/lang/reflect/code/pe/PartialEvaluator.java
@@ -298,7 +298,7 @@ final class PartialEvaluator {
                 }
                 case CoreOp.ReturnOp _ -> outBlock.op(to);
                 default -> throw evaluationException(
-                        new UnsupportedOperationException("Unsupported terminating operation: " + to.opName()));
+                        new UnsupportedOperationException("Unsupported terminating operation: " + to));
             }
         }
     }
@@ -455,16 +455,19 @@ final class PartialEvaluator {
                 return null;
             }
             case JavaOp.ArithmeticOperation arithmeticOperation -> {
+                // @@@ TODO avoid use of opName
                 MethodHandle mh = opHandle(l, o.opName(), o.opType());
                 Object[] values = o.operands().stream().map(bc::getValue).toArray();
                 return invoke(mh, values);
             }
             case JavaOp.TestOperation testOperation -> {
+                // @@@ TODO avoid use of opName
                 MethodHandle mh = opHandle(l, o.opName(), o.opType());
                 Object[] values = o.operands().stream().map(bc::getValue).toArray();
                 return invoke(mh, values);
             }
             case JavaOp.ConvOp convOp -> {
+                // @@@ TODO avoid use of opName
                 MethodHandle mh = opHandle(l, o.opName() + "_" + o.opType().returnType(), o.opType());
                 Object[] values = o.operands().stream().map(bc::getValue).toArray();
                 return invoke(mh, values);
@@ -487,7 +490,7 @@ final class PartialEvaluator {
 //                return null;
 //            }
             case null, default -> throw evaluationException(
-                    new UnsupportedOperationException("Unsupported operation: " + o.opName()));
+                    new UnsupportedOperationException("Unsupported operation: " + o));
         }
     }
 

--- a/test/jdk/java/lang/reflect/code/writer/TestAttributeSerialization.java
+++ b/test/jdk/java/lang/reflect/code/writer/TestAttributeSerialization.java
@@ -57,7 +57,7 @@ public class TestAttributeSerialization {
         }
 
         TestOp(Object attributeValue) {
-            super("test-op", List.of());
+            super(List.of());
             this.attributeValue = attributeValue;
         }
 


### PR DESCRIPTION
Op no longer has a field holding the operation name. By default the method `opName` returns `this.getClass().getName()`, which may be overridden.