### PR TITLE
[hat] Clean-up and formatting for HAT Dialect

### DIFF
--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -24,7 +24,6 @@
  */
 package hat.codebuilders;
 
-
 import hat.dialect.HatBarrierOp;
 import hat.dialect.HatLocalVarOp;
 import hat.dialect.HatMemoryOp;
@@ -36,8 +35,6 @@ import hat.optools.FuncOpParams;
 import hat.optools.OpTk;
 import hat.util.StreamMutable;
 
-import jdk.incubator.code.Block;
-import jdk.incubator.code.Body;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.ClassType;
@@ -61,8 +58,8 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
     public T varLoadOp(ScopedCodeBuilderContext buildContext, CoreOp.VarAccessOp.VarLoadOp varLoadOp) {
         Op resolve = buildContext.scope.resolve(varLoadOp.operands().getFirst());
         switch (resolve) {
-            case CoreOp.VarOp varOp -> varName(varOp);
-            case HatMemoryOp hatMemoryOp -> varName(hatMemoryOp);
+            case CoreOp.VarOp $ -> varName($);
+            case HatMemoryOp $ -> varName($);
             case null, default -> {
             }
         }

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilderWithContext.java
@@ -118,9 +118,7 @@ public abstract class HATCodeBuilderWithContext<T extends HATCodeBuilderWithCont
 
     @Override
     public T fieldLoadOp(ScopedCodeBuilderContext buildContext, JavaOp.FieldAccessOp.FieldLoadOp fieldLoadOp) {
-        if (OpTk.isKernelContextAccess(fieldLoadOp)) {
-            identifier("kc").rarrow().fieldName(fieldLoadOp);
-        } else if (fieldLoadOp.operands().isEmpty() && fieldLoadOp.result().type() instanceof PrimitiveType) {
+        if (fieldLoadOp.operands().isEmpty() && fieldLoadOp.result().type() instanceof PrimitiveType) {
             Object value = OpTk.getStaticFinalPrimitiveValue(buildContext.lookup,fieldLoadOp);
             literal(value.toString());
         } else {

--- a/hat/core/src/main/java/hat/dialect/HatBlockThreadIdOp.java
+++ b/hat/core/src/main/java/hat/dialect/HatBlockThreadIdOp.java
@@ -38,8 +38,8 @@ public class HatBlockThreadIdOp extends HatThreadOP {
     private final TypeElement resultType;
     private static final String NAME = "BlockThreadId";
 
-    public HatBlockThreadIdOp(int dimension, TypeElement resultType, List<Value> operands) {
-        super(dimension, operands);
+    public HatBlockThreadIdOp(int dimension, TypeElement resultType) {
+        super(dimension, List.of());
         this.resultType = resultType;
     }
 

--- a/hat/core/src/main/java/hat/dialect/HatGlobalSizeOp.java
+++ b/hat/core/src/main/java/hat/dialect/HatGlobalSizeOp.java
@@ -38,8 +38,8 @@ public class HatGlobalSizeOp extends HatThreadOP {
     private final TypeElement resultType;
     private static final String NAME = "GlobalThreadSize";
 
-    public HatGlobalSizeOp(int dimension, TypeElement resultType, List<Value> operands) {
-        super(dimension, operands);
+    public HatGlobalSizeOp(int dimension, TypeElement resultType) {
+        super(dimension, List.of());
         this.resultType = resultType;
     }
 

--- a/hat/core/src/main/java/hat/dialect/HatGlobalThreadIdOp.java
+++ b/hat/core/src/main/java/hat/dialect/HatGlobalThreadIdOp.java
@@ -38,8 +38,8 @@ public class HatGlobalThreadIdOp extends HatThreadOP {
     private final TypeElement resultType;
     private static final String NAME = "GlobalThreadId";
 
-    public HatGlobalThreadIdOp(int dimension, TypeElement resultType, List<Value> operands) {
-        super(dimension, operands);
+    public HatGlobalThreadIdOp(int dimension, TypeElement resultType) {
+        super(dimension, List.of());
         this.resultType = resultType;
     }
 

--- a/hat/core/src/main/java/hat/dialect/HatLocalSizeOp.java
+++ b/hat/core/src/main/java/hat/dialect/HatLocalSizeOp.java
@@ -38,8 +38,8 @@ public class HatLocalSizeOp extends HatThreadOP {
     private final TypeElement resultType;
     private static final String NAME = "GlobalThreadSize";
 
-    public HatLocalSizeOp(int dimension, TypeElement resultType, List<Value> operands) {
-        super(dimension, operands);
+    public HatLocalSizeOp(int dimension, TypeElement resultType) {
+        super(dimension, List.of());
         this.resultType = resultType;
     }
 

--- a/hat/core/src/main/java/hat/dialect/HatLocalThreadIdOp.java
+++ b/hat/core/src/main/java/hat/dialect/HatLocalThreadIdOp.java
@@ -38,8 +38,8 @@ public class HatLocalThreadIdOp extends HatThreadOP {
     private final TypeElement resultType;
     private static final String NAME = "LocalThreadId";
 
-    public HatLocalThreadIdOp(int dimension, TypeElement resultType, List<Value> operands) {
-        super(dimension, operands);
+    public HatLocalThreadIdOp(int dimension, TypeElement resultType) {
+        super(dimension, List.of());
         this.resultType = resultType;
     }
 

--- a/hat/core/src/main/java/hat/phases/HatDialectifyBarrierPhase.java
+++ b/hat/core/src/main/java/hat/phases/HatDialectifyBarrierPhase.java
@@ -55,11 +55,13 @@ public class HatDialectifyBarrierPhase implements HatDialectifyPhase {
         HatBarrierOp hatBarrierOp = new HatBarrierOp(outputOperands);
         Op.Result outputResult = blockBuilder.op(hatBarrierOp);
         Op.Result inputResult = invokeOp.result();
+        hatBarrierOp.setLocation(invokeOp.location());
         context.mapValue(inputResult, outputResult);
     }
 
     @Override
     public CoreOp.FuncOp run(CoreOp.FuncOp funcOp) {
+        //System.out.println("[INFO] Code model before HatDialectifyBarrierPhase: " + funcOp.toText());
         Stream<CodeElement<?, ?>> elements = funcOp
                 .elements()
                 .mapMulti((element, consumer) -> {
@@ -83,8 +85,7 @@ public class HatDialectifyBarrierPhase implements HatDialectifyPhase {
             }
             return blockBuilder;
         });
-        // System.out.println("[INFO] Code model: " + funcOp.toText());
-        //entrypoint.funcOp(funcOp);
+        //System.out.println("[INFO] Code model after HatDialectifyBarrierPhase: " + funcOp.toText());
         return funcOp;
     }
 

--- a/hat/core/src/main/java/hat/phases/HatDialectifyMemoryPhase.java
+++ b/hat/core/src/main/java/hat/phases/HatDialectifyMemoryPhase.java
@@ -68,7 +68,7 @@ public class HatDialectifyMemoryPhase implements HatDialectifyPhase {
                 case SHARED -> HatLocalVarOp.INTRINSIC_NAME;
             };
 
-            //IO.println("ORIGINAL: " + funcOp.toText());
+            // IO.println("[INFO] Code model before HatDialectifyMemoryPhase: " + funcOp.toText());
             Stream<CodeElement<?, ?>> elements = funcOp.elements()
                     .mapMulti((codeElement, consumer) -> {
                         if (codeElement instanceof CoreOp.VarOp varOp) {
@@ -112,7 +112,12 @@ public class HatDialectifyMemoryPhase implements HatDialectifyPhase {
                                 default ->
                                         new HatPrivateVarOp(varOp.varName(), (ClassType) varOp.varValueType(), varOp.resultType(), invokeOp.resultType(), outputOperandsVarOp);
                             };
+
                             Op.Result hatLocalResult = blockBuilder.op(memoryOp);
+
+                            // update location
+                            memoryOp.setLocation(varOp.location());
+
                             context.mapValue(invokeOp.result(), hatLocalResult);
                         }
                     }
@@ -122,8 +127,7 @@ public class HatDialectifyMemoryPhase implements HatDialectifyPhase {
                 }
                 return blockBuilder;
             });
-            // IO.println("[INFO] Code model: " + funcOp.toText());
-            //entrypoint.funcOp(funcOp);
+            // IO.println("[INFO] Code model after HatDialectifyMemoryPhase: " + funcOp.toText());
             return funcOp;
     }
 }

--- a/hat/core/src/main/java/hat/phases/HatDialectifyThreadsPhase.java
+++ b/hat/core/src/main/java/hat/phases/HatDialectifyThreadsPhase.java
@@ -42,17 +42,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class HatDilectifyThreadsPhase implements HatDialectifyPhase {
+public class HatDialectifyThreadsPhase implements HatDialectifyPhase {
 
     private final ThreadAccess threadAccess;
 
-    public HatDilectifyThreadsPhase(ThreadAccess threadAccess) {
+    public HatDialectifyThreadsPhase(ThreadAccess threadAccess) {
         this.threadAccess =  threadAccess;
     }
 
     @Override
     public CoreOp.FuncOp run(CoreOp.FuncOp funcOp) {
-        // IO.println("[INFO] Code model before HatDilectifyThreadsPhase: " + funcOp.toText());
+        // IO.println("[INFO] Code model before HatDialectifyThreadsPhase: " + funcOp.toText());
         Stream<CodeElement<?, ?>> elements = funcOp.elements()
                 .mapMulti((codeElement, consumer) -> {
                     if (codeElement instanceof JavaOp.FieldAccessOp.FieldLoadOp fieldLoadOp) {
@@ -118,7 +118,7 @@ public class HatDilectifyThreadsPhase implements HatDialectifyPhase {
             }
             return blockBuilder;
         });
-        // IO.println("[INFO] Code model after HatDilectifyThreadsPhase: " + funcOp.toText());
+        // IO.println("[INFO] Code model after HatDialectifyThreadsPhase: " + funcOp.toText());
         return funcOp;
     }
 

--- a/hat/core/src/main/java/hat/phases/HatDialectifyTier.java
+++ b/hat/core/src/main/java/hat/phases/HatDialectifyTier.java
@@ -44,8 +44,8 @@ public class HatDialectifyTier {
             hatPhases.add(new HatDialectifyMemoryPhase(space, lookup));
             hatPhases.add(new HatDialectifyMemoryPhase(space, lookup));
         }
-        for (HatDilectifyThreadsPhase.ThreadAccess threadAccess: HatDilectifyThreadsPhase.ThreadAccess.values()) {
-            hatPhases.add(new HatDilectifyThreadsPhase(threadAccess));
+        for (HatDialectifyThreadsPhase.ThreadAccess threadAccess: HatDialectifyThreadsPhase.ThreadAccess.values()) {
+            hatPhases.add(new HatDialectifyThreadsPhase(threadAccess));
         }
     }
 

--- a/hat/core/src/main/java/hat/phases/HatDilectifyThreadsPhase.java
+++ b/hat/core/src/main/java/hat/phases/HatDilectifyThreadsPhase.java
@@ -52,6 +52,7 @@ public class HatDilectifyThreadsPhase implements HatDialectifyPhase {
 
     @Override
     public CoreOp.FuncOp run(CoreOp.FuncOp funcOp) {
+        // IO.println("[INFO] Code model before HatDilectifyThreadsPhase: " + funcOp.toText());
         Stream<CodeElement<?, ?>> elements = funcOp.elements()
                 .mapMulti((codeElement, consumer) -> {
                     if (codeElement instanceof JavaOp.FieldAccessOp.FieldLoadOp fieldLoadOp) {
@@ -107,14 +108,17 @@ public class HatDilectifyThreadsPhase implements HatDialectifyPhase {
                             case BLOCK_ID -> new HatBlockThreadIdOp(dim, fieldLoadOp.resultType(), outputOperands);
                         };
                         Op.Result threadResult = blockBuilder.op(threadOP);
+
+                        // update location
+                        threadOP.setLocation(fieldLoadOp.location());
+
                         context.mapValue(fieldLoadOp.result(), threadResult);
                     }
                 }
             }
             return blockBuilder;
         });
-        //IO.println("[INFO] Code model: " + funcOp.toText());
-        //entrypoint.funcOp(funcOp);
+        // IO.println("[INFO] Code model after HatDilectifyThreadsPhase: " + funcOp.toText());
         return funcOp;
     }
 

--- a/hat/core/src/main/java/hat/phases/HatDilectifyThreadsPhase.java
+++ b/hat/core/src/main/java/hat/phases/HatDilectifyThreadsPhase.java
@@ -101,11 +101,11 @@ public class HatDilectifyThreadsPhase implements HatDialectifyPhase {
                             throw new IllegalStateException("Thread Access can't be below 0!");
                         }
                         HatThreadOP threadOP = switch (threadAccess) {
-                            case GLOBAL_ID -> new HatGlobalThreadIdOp(dim, fieldLoadOp.resultType(), outputOperands);
-                            case GLOBAL_SIZE -> new HatGlobalSizeOp(dim, fieldLoadOp.resultType(), outputOperands);
-                            case LOCAL_ID -> new HatLocalThreadIdOp(dim, fieldLoadOp.resultType(), outputOperands);
-                            case LOCAL_SIZE -> new HatLocalSizeOp(dim, fieldLoadOp.resultType(), outputOperands);
-                            case BLOCK_ID -> new HatBlockThreadIdOp(dim, fieldLoadOp.resultType(), outputOperands);
+                            case GLOBAL_ID -> new HatGlobalThreadIdOp(dim, fieldLoadOp.resultType());
+                            case GLOBAL_SIZE -> new HatGlobalSizeOp(dim, fieldLoadOp.resultType());
+                            case LOCAL_ID -> new HatLocalThreadIdOp(dim, fieldLoadOp.resultType());
+                            case LOCAL_SIZE -> new HatLocalSizeOp(dim, fieldLoadOp.resultType());
+                            case BLOCK_ID -> new HatBlockThreadIdOp(dim, fieldLoadOp.resultType());
                         };
                         Op.Result threadResult = blockBuilder.op(threadOP);
 


### PR DESCRIPTION
This PR:
- Propagates the `location` from the replaced Op to the new HAT OP.
- Removes the data dependency to the `kernelContext` for all HAT Thread Ops.
- It removed unnecessary checks for the codegen