### PR TITLE
Fixup maven, hat.java and hat/bld.java to include arrayview example

### DIFF
--- a/hat/examples/arrayview/pom.xml
+++ b/hat/examples/arrayview/pom.xml
@@ -26,7 +26,7 @@ questions.
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <groupId>oracle.code</groupId>
-    <artifactId>hat-example-squares</artifactId>
+    <artifactId>hat-example-arrayview</artifactId>
     <version>1.0</version>
     <parent>
         <groupId>oracle.code</groupId>

--- a/hat/hat.java
+++ b/hat/hat.java
@@ -109,23 +109,32 @@ public static void main(String[] argArr) throws IOException, InterruptedExceptio
         var backend_ffi_cuda = Jar.of(project.id("backend{s}-ffi-cuda"), ffiSharedBackend);
         var backend_ffi_opencl = Jar.of(project.id("backend{s}-ffi-opencl"), ffiSharedBackend);
         var backend_ffi_mock = Jar.of(project.id("backend{s}-ffi-mock"), ffiSharedBackend);
+
+        // These examples just rely on core
         var backend_mt_java = Jar.of(project.id("backend{s}-java-mt"), core);
         var backend_seq_java = Jar.of(project.id("backend{s}-java-seq"), core);
-        var example_shared = Jar.of(project.id("example{s}-shared"), ui, core);
-        var example_blackscholes = Jar.of(project.id("example{s}-blackscholes"), example_shared);
-        var example_mandel = Jar.of(project.id("example{s}-mandel"), example_shared);
-        var example_life = Jar.of(project.id("example{s}-life"), example_shared);
         var example_squares = Jar.of(project.id("example{s}-squares"), core);
         var example_matmul = Jar.of(project.id("example{s}-matmul"), core);
-        var example_heal = Jar.of(project.id("example{s}-heal"), example_shared);
-        var example_normmap = Jar.of(project.id("example{s}-normmap"), example_shared);
-        var example_violajones = Jar.of(project.id("example{s}-violajones"), example_shared);
-        var example_experiments = Jar.of(project.id("example{s}-experiments"), backend_ffi_opencl); //experiments have some code that expect opencl backend
+        var example_arrayview = Jar.of(project.id("example{s}-arrayview"), core);
+        var example_blackscholes = Jar.of(project.id("example{s}-blackscholes"), core);
+        var example_normmap = Jar.of(project.id("example{s}-normmap"), core); // will probabvly need shared when we hatify
 
+        // example_shared allows us to break out common UI functions, views, even loops etc
+        var example_shared = Jar.of(project.id("example{s}-shared"), ui, core);
+
+        // These examples use example_shared, so they are UI based
+        var example_mandel = Jar.of(project.id("example{s}-mandel"), example_shared);
+        var example_life = Jar.of(project.id("example{s}-life"), example_shared);
+        var example_heal = Jar.of(project.id("example{s}-heal"), example_shared);
+        var example_violajones = Jar.of(project.id("example{s}-violajones"), example_shared);
+
+        // experiments include code that expects an opencl backend, this is not idea, but we can accomodate
+        var example_experiments = Jar.of(project.id("example{s}-experiments"), backend_ffi_opencl);
+
+        // Now we have the more complex nonsense for nbody (which needs opengl and opencl extracted)
         var wrapped_shared = Jar.of(project.id("wrap{s}-shared"));
         var jextracted_opencl = JExtract.extract(project.id("extract{ions|ed}-opencl"), jextract, openclCmakeInfo, core);
         var wrapped_jextracted_opencl = Jar.of(project.id("wrap{s}-opencl"), jextracted_opencl, wrapped_shared);
-
         var jextracted_opengl = JExtract.extract(project.id("extract{ions|ed}-opengl"), jextract, ui, openglCmakeInfo, core);
 
         // Sigh... We have different src exclusions for wrapped opengl depending on the OS
@@ -134,6 +143,7 @@ public static void main(String[] argArr) throws IOException, InterruptedExceptio
 
         var wrapped_jextracted_opengl = Jar.of(project.id("wrap{s}-opengl"), Set.of(excludedOpenGLWrapSrc), jextracted_opengl, wrapped_shared);
 
+        // Finally we have everything needed for nbody
         var example_nbody = Jar.of(project.id("example{s}-nbody"), ui, wrapped_jextracted_opengl, wrapped_jextracted_opencl);
 
         while (!args.isEmpty()) {

--- a/hat/hat/bld.java
+++ b/hat/hat/bld.java
@@ -311,11 +311,8 @@ void main(String[] args) {
 
     var examplesDir = dir.existingDir("examples");
 
-    Artifacts.example_shared = buildDir.mavenStyleBuild(
-            examplesDir.existingDir("shared"), "hat-example-shared-1.0.jar", Artifacts.core
-    );
 
-    Stream.of( "blackscholes", "squares", "matmul")
+    Stream.of( "blackscholes", "squares", "matmul", "arrayview")
             .parallel()
             .map(examplesDir::existingDir)
             .forEach(exampleDir->buildDir.mavenStyleBuild(
@@ -330,7 +327,11 @@ void main(String[] args) {
                     Artifacts.core, Artifacts.backend_ffi_shared, Artifacts.backend_ffi_opencl
             ));
 
-    Stream.of( "heal", "life", "mandel", "violajones", "arrayview")   // these require example_shared ui stuff
+    Artifacts.example_shared = buildDir.mavenStyleBuild(
+            examplesDir.existingDir("shared"), "hat-example-shared-1.0.jar", Artifacts.core
+    );
+
+    Stream.of( "heal", "life", "mandel", "violajones")   // these require example_shared ui stuff
             .parallel()
             .map(examplesDir::existingDir)
             .forEach(exampleDir->buildDir.mavenStyleBuild(


### PR DESCRIPTION
The arrayview (squares copy) had an incorrect pom id (copy of squares id). Which meant we had dupliicate id's

I added arrayview to hat.java (for the `java -cp hat/job.jar hat.java bld` to work 

I also removed some unnecessary deps between a few examples that really only depended on hat core. 