### PR TITLE
[hat] Fix cuda set context

### DIFF
--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
@@ -197,6 +197,7 @@ CudaBackend::CudaModule *CudaBackend::compile(const  PtxSource *ptx) {
         jitOptions[4] = CU_JIT_GENERATE_LINE_INFO;
         jitOptVals[4] = reinterpret_cast<void *>(1);
 
+        CUDA_CHECK(cuCtxSetCurrent(context), "cuCtxSetCurrent");
         CUDA_CHECK(cuModuleLoadDataEx(&module, ptx->text, optc, jitOptions, (void **) jitOptVals), "cuModuleLoadDataEx");
 
         if (*infLog->text!='\0'){

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
@@ -49,7 +49,7 @@ void CudaBackend::CudaQueue::init(){
                   << " custream=" <<std::hex<<streamCreationThread <<std::dec
                   << std::endl;
     }
-    }
+}
 
 void CudaBackend::CudaQueue::wait(){
     CUDA_CHECK(cuStreamSynchronize(cuStream), "cuStreamSynchronize");
@@ -107,7 +107,7 @@ void CudaBackend::CudaQueue::copyFromDevice(Buffer *buffer) {
                   << std::hex<<cudaBuffer->bufferState->length<<std::dec << "/"
                   << cudaBuffer->bufferState->length << " "
                   << "devptr=" << std::hex<<  static_cast<long>(cudaBuffer->devicePtr) <<std::dec
-                << " thread=" <<thread_id
+                  << " thread=" <<thread_id
                   << std::endl;
     }
 

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackendDriver.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackendDriver.java
@@ -125,7 +125,6 @@ public abstract class FFIBackendDriver implements Backend {
             this.getBufferFromDeviceIfDirty_MPtr = ffiLib.booleanHandleAddressLongFunc("getBufferFromDeviceIfDirty");
         }
 
-
         void release() {}
 
         public long getBackend(int configBits) {


### PR DESCRIPTION
When running Java multi-threaded applications with the HAT CUDA Backend we need to set the current context before building the kernel. This patch fixes this. 

Heal application should work now for the CUDA backend.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/591/head:pull/591` \
`$ git checkout pull/591`

Update a local copy of the PR: \
`$ git checkout pull/591` \
`$ git pull https://git.openjdk.org/babylon.git pull/591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 591`

View PR using the GUI difftool: \
`$ git pr show -t 591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/591.diff">https://git.openjdk.org/babylon/pull/591.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/591#issuecomment-3356342803)
</details>
