### PR TITLE
[hat] rollback CUDA specific scheduler

### DIFF
--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend_queue.cpp
@@ -137,8 +137,6 @@ void CudaBackend::CudaQueue::dispatch(KernelContext *kernelContext, CompilationU
     int threadsPerBlockY = 1;
     int threadsPerBlockZ = 1;
 
-    bool isSpecific = kernelContext->isSpecific;
-
     // The local and global mesh dimensions match by design from the Java APIs
     const int dimensions = kernelContext->dimensions;
     if (kernelContext->lsx > 0) {
@@ -165,12 +163,6 @@ void CudaBackend::CudaQueue::dispatch(KernelContext *kernelContext, CompilationU
     }
     if (dimensions > 2) {
         blocksPerGridZ = (kernelContext->maxZ + threadsPerBlockZ - 1) / threadsPerBlockZ;
-    }
-
-    if (isSpecific) {
-        blocksPerGridX = kernelContext->maxX;
-        blocksPerGridY = kernelContext->maxY;
-        blocksPerGridZ = kernelContext->maxZ;
     }
 
     // Enable debug information with trace. Use HAT=INFO

--- a/hat/backends/ffi/shared/src/main/native/include/shared.h
+++ b/hat/backends/ffi/shared/src/main/native/include/shared.h
@@ -393,8 +393,6 @@ public:
     int bix;
     int biy;
     int biz;
-
-    bool isSpecific;
 };
 
 class Backend {

--- a/hat/core/src/main/java/hat/buffer/KernelContext.java
+++ b/hat/core/src/main/java/hat/buffer/KernelContext.java
@@ -100,9 +100,6 @@ public interface KernelContext extends Buffer {
     int biz();
     void biz(int biz);
 
-    boolean isSpecific();
-    void isSpecific(boolean specific);
-
     Schema<KernelContext> schema = Schema.of(KernelContext.class,
             kernelContext -> kernelContext
                     .fields(
@@ -111,8 +108,7 @@ public interface KernelContext extends Buffer {
                             "gsx", "gsy", "gsz",  // global sizes
                             "lix", "liy", "liz",  // local (thread-ids)
                             "lsx", "lsy", "lsz",  // block size
-                            "bix", "biy", "biz",   // block id
-                            "isSpecific"
+                            "bix", "biy", "biz"   // block id
                     ));
 
     static KernelContext  createDefault(Accelerator accelerator) {
@@ -144,8 +140,6 @@ public interface KernelContext extends Buffer {
         kernelContext.bix(0);
         kernelContext.biy(0);
         kernelContext.biz(0);
-
-        kernelContext.isSpecific(false);
 
         return kernelContext;
     }


### PR DESCRIPTION
Remove the CUDA Specific scheduler from the kernel context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/592/head:pull/592` \
`$ git checkout pull/592`

Update a local copy of the PR: \
`$ git checkout pull/592` \
`$ git pull https://git.openjdk.org/babylon.git pull/592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 592`

View PR using the GUI difftool: \
`$ git pr show -t 592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/592.diff">https://git.openjdk.org/babylon/pull/592.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/592#issuecomment-3356533218)
</details>
