### PR TITLE
config now accessible from all backends

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -357,19 +357,13 @@ public class CudaBackend extends C99FFIBackend {
 
     final Set<String> usedMathFns = new HashSet<>();
 
-
-    public CudaBackend(String configSpec) {
-        this(Config.of(configSpec));
-    }
-
-    public CudaBackend() {
-        this(Config.of());
-    }
-
     public CudaBackend(Config config) {
         super("cuda_backend", config);
     }
 
+    public CudaBackend() {
+        this(Config.fromEnvOrProperty());
+    }
     @Override
     public void computeContextHandoff(ComputeContext computeContext) {
         injectBufferTracking(computeContext.computeCallGraph.entrypoint);
@@ -378,8 +372,8 @@ public class CudaBackend extends C99FFIBackend {
     @Override
     public void dispatchKernel(KernelCallGraph kernelCallGraph, NDRange ndRange, Object... args) {
         CompiledKernel compiledKernel = kernelCallGraphCompiledCodeMap.computeIfAbsent(kernelCallGraph, (_) -> {
-            String code = Config.PTX.isSet(config.bits()) ? createPTX(kernelCallGraph,  args) : createC99(kernelCallGraph, args);
-            if (Config.SHOW_CODE.isSet(config.bits())) {
+            String code = Config.PTX.isSet(config()) ? createPTX(kernelCallGraph,  args) : createC99(kernelCallGraph, args);
+            if (Config.SHOW_CODE.isSet(config())) {
                 System.out.println(code);
             }
             var compilationUnit = backendBridge.compile(code);
@@ -439,7 +433,7 @@ public class CudaBackend extends C99FFIBackend {
         out.append(invokedMethods);
 
         out.append(createFunction(builder.nl().nl(), lowered, true));
-        if (Config.SHOW_KERNEL_MODEL.isSet(config.bits())){
+        if (Config.SHOW_KERNEL_MODEL.isSet(config())){
             System.out.println("ptx follows\n"+out);
         }
 

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaDeviceInfo.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaDeviceInfo.java
@@ -24,9 +24,11 @@
  */
 package hat.backend.ffi;
 
+import hat.Config;
+
 public class CudaDeviceInfo {
     public static void main(String[] args) {
-        CudaBackend backend = new CudaBackend();
+        CudaBackend backend = new CudaBackend(Config.fromIntBits(0));
         backend.backendBridge.info();
     }
 }

--- a/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
+++ b/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
@@ -39,7 +39,7 @@ public class MockBackend extends FFIBackend {
 
 
     public MockBackend() {
-        super("mock_backend", Config.of(0));
+        super("mock_backend", Config.fromIntBits(0));
        // getBackend_MPtr  =  ffiLib.longIntFunc("getMockBackend");
        // getBackend(0);
     }

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLBackend.java
@@ -33,11 +33,11 @@ import hat.callgraph.KernelCallGraph;
 public class OpenCLBackend extends C99FFIBackend {
 
     public OpenCLBackend(String configSpec) {
-        this(Config.of(configSpec));
+        this(Config.fromSpec(configSpec));
     }
 
     public OpenCLBackend() {
-        this(Config.of());
+        this(Config.fromEnvOrProperty());
     }
 
     public OpenCLBackend(Config config) {
@@ -54,7 +54,7 @@ public class OpenCLBackend extends C99FFIBackend {
     public void dispatchKernel(KernelCallGraph kernelCallGraph, NDRange ndRange, Object... args) {
         CompiledKernel compiledKernel = kernelCallGraphCompiledCodeMap.computeIfAbsent(kernelCallGraph, (_) -> {
             String code = createC99(kernelCallGraph,  args);
-            if (Config.SHOW_CODE.isSet(config.bits())) {
+            if (Config.SHOW_CODE.isSet(config())) {
                 System.out.println(code);
             }
             var compilationUnit = backendBridge.compile(code);

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLDeviceInfo.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLDeviceInfo.java
@@ -24,6 +24,8 @@
  */
 package hat.backend.ffi;
 
+import hat.Config;
+
 public class OpenCLDeviceInfo {
     public static void main(String[] args) {
         OpenCLBackend backend = new OpenCLBackend();

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -261,7 +261,7 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
         buildContext.setFinals(hatFinalDetectionPhase.getFinalVars());
         builder.nl().kernelEntrypoint(buildContext, args).nl();
 
-        if (Config.SHOW_KERNEL_MODEL.isSet(config.bits())) {
+        if (Config.SHOW_KERNEL_MODEL.isSet(config())) {
             IO.println("Original");
             IO.println(kernelCallGraph.entrypoint.funcOp().toText());
             IO.println("Lowered");
@@ -278,18 +278,18 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
             case BufferState.NEW_STATE:
             case BufferState.HOST_OWNED:
             case BufferState.DEVICE_VALID_HOST_HAS_COPY: {
-                if (Config.SHOW_STATE.isSet(config.bits())) {
+                if (Config.SHOW_STATE.isSet(config())) {
                     System.out.println("in preMutate state = " + b.getStateString() + " no action to take");
                 }
                 break;
             }
             case BufferState.DEVICE_OWNED: {
                 backendBridge.getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
-                if (Config.SHOW_STATE.isSet(config.bits())) {
+                if (Config.SHOW_STATE.isSet(config())) {
                     System.out.print("in preMutate state = " + b.getStateString() + " we pulled from device ");
                 }
                 b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
-                if (Config.SHOW_STATE.isSet(config.bits())) {
+                if (Config.SHOW_STATE.isSet(config())) {
                     System.out.println("and switched to " + b.getStateString());
                 }
                 break;
@@ -301,13 +301,13 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
 
     @Override
     public void postMutate(Buffer b) {
-        if (Config.SHOW_STATE.isSet(config.bits())) {
+        if (Config.SHOW_STATE.isSet(config())) {
             System.out.print("in postMutate state = " + b.getStateString() + " no action to take ");
         }
         if (b.getState() != BufferState.NEW_STATE) {
             b.setState(BufferState.HOST_OWNED);
         }
-        if (Config.SHOW_STATE.isSet(config.bits())) {
+        if (Config.SHOW_STATE.isSet(config())) {
             System.out.println("and switched to (or stayed on) " + b.getStateString());
         }
     }
@@ -319,7 +319,7 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
             case BufferState.NEW_STATE:
             case BufferState.HOST_OWNED:
             case BufferState.DEVICE_VALID_HOST_HAS_COPY: {
-                if (Config.SHOW_STATE.isSet(config.bits())) {
+                if (Config.SHOW_STATE.isSet(config())) {
                     System.out.println("in preAccess state = " + b.getStateString() + " no action to take");
                 }
                 break;
@@ -327,11 +327,11 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
             case BufferState.DEVICE_OWNED: {
                 backendBridge.getBufferFromDeviceIfDirty(b);// calls through FFI and might block when fetching from device
 
-                if (Config.SHOW_STATE.isSet(config.bits())) {
+                if (Config.SHOW_STATE.isSet(config())) {
                     System.out.print("in preAccess state = " + b.getStateString() + " we pulled from device ");
                 }
                 b.setState(BufferState.DEVICE_VALID_HOST_HAS_COPY);
-                if (Config.SHOW_STATE.isSet(config.bits())) {
+                if (Config.SHOW_STATE.isSet(config())) {
                     System.out.println("and switched to " + b.getStateString());
                 }
                 break;
@@ -344,7 +344,7 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
 
     @Override
     public void postAccess(Buffer b) {
-        if (Config.SHOW_STATE.isSet(config.bits())) {
+        if (Config.SHOW_STATE.isSet(config())) {
             System.out.println("in postAccess state = " + b.getStateString());
         }
     }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackend.java
@@ -71,7 +71,7 @@ public abstract class FFIBackend extends FFIBackendDriver {
         }
 
         backendBridge.computeStart();
-        if (Config.INTERPRET.isSet(config.bits())) {
+        if (Config.INTERPRET.isSet(config())) {
             Interpreter.invoke(computeContext.accelerator.lookup, computeContext.computeCallGraph.entrypoint.lowered, args);
         } else {
             try {
@@ -129,8 +129,8 @@ public abstract class FFIBackend extends FFIBackendDriver {
     // This code should be common with jextracted-shared probably should be pushed down into another lib?
     protected CoreOp.FuncOp injectBufferTracking(CallGraph.ResolvedMethodCall computeMethod) {
         CoreOp.FuncOp transformedFuncOp = computeMethod.funcOp();
-        if (Config.MINIMIZE_COPIES.isSet(config.bits())) {
-            if (Config.SHOW_COMPUTE_MODEL.isSet(config.bits())) {
+        if (Config.MINIMIZE_COPIES.isSet(config())) {
+            if (Config.SHOW_COMPUTE_MODEL.isSet(config())) {
                 System.out.println("COMPUTE entrypoint before injecting buffer tracking...");
                 System.out.println(transformedFuncOp.toText());
             }
@@ -202,12 +202,12 @@ public abstract class FFIBackend extends FFIBackendDriver {
                 }
                 return bldr;
             });
-            if (Config.SHOW_COMPUTE_MODEL.isSet(config.bits())) {
+            if (Config.SHOW_COMPUTE_MODEL.isSet(config())) {
                 System.out.println("COMPUTE entrypoint after injecting buffer tracking...");
                 System.out.println(transformedFuncOp.toText());
             }
         }else{
-            if (Config.SHOW_COMPUTE_MODEL.isSet(config.bits())) {
+            if (Config.SHOW_COMPUTE_MODEL.isSet(config())) {
                 System.out.println("COMPUTE entrypoint (we will not be injecting buffer tracking...)...");
                 System.out.println(transformedFuncOp.toText());
             }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackendDriver.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/FFIBackendDriver.java
@@ -35,11 +35,10 @@ import java.lang.foreign.MemorySegment;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class FFIBackendDriver implements Backend {
+public abstract class FFIBackendDriver extends Backend {
     public boolean isAvailable() {
         return ffiLib.available;
     }
-    protected final Config config;
 
     public static class BackendBridge {
         // CUDA this combines Device+Stream+Context
@@ -165,8 +164,8 @@ public abstract class FFIBackendDriver implements Backend {
     public final BackendBridge backendBridge;
 
     public FFIBackendDriver(String libName, Config config) {
+        super(config);
         this.ffiLib = new FFILib(libName);
-        this.config = config;
         this.backendBridge = new BackendBridge(ffiLib, config);
     }
 

--- a/hat/backends/ffi/shared/src/main/native/include/config.h
+++ b/hat/backends/ffi/shared/src/main/native/include/config.h
@@ -24,7 +24,7 @@
 */
 /*
 You probably should not edit this this file!!!
-It was auto generated 2025-10-01 11:34:45.328 by hat.FFIConfigCreator
+It was auto generated 2025-10-02 14:07:12.618 by hat.FFIConfigCreator
 */
 #pragma once
 
@@ -47,6 +47,10 @@ struct BasicConfig{
     static constexpr int SHOW_STATE_BIT                   = 1<<0x14;
     static constexpr int PTX_BIT                          = 1<<0x15;
     static constexpr int INTERPRET_BIT                    = 1<<0x16;
+    static constexpr int NO_BUFFER_TAGGING_BIT            = 1<<0x17;
+    static constexpr int NO_DIALECT_BIT                   = 1<<0x18;
+    static constexpr int NO_MODULE_OP_BIT                 = 1<<0x19;
+    static constexpr int HEADLESS_BIT                     = 1<<0x1a;
     const static char *bitNames[]; // See below for initialization
     const static char *bitDescriptions[]; // See below for initialization
     int configBits;
@@ -65,6 +69,10 @@ struct BasicConfig{
     bool showState;
     bool ptx;
     bool interpret;
+    bool noBufferTagging;
+    bool noDialect;
+    bool noModuleOp;
+    bool headless;
     int platform;
     int device;
     bool alwaysCopy;
@@ -85,6 +93,10 @@ struct BasicConfig{
         showState((configBits & SHOW_STATE_BIT)==SHOW_STATE_BIT),
         ptx((configBits & PTX_BIT)==PTX_BIT),
         interpret((configBits & INTERPRET_BIT)==INTERPRET_BIT),
+        noBufferTagging((configBits & NO_BUFFER_TAGGING_BIT)==NO_BUFFER_TAGGING_BIT),
+        noDialect((configBits & NO_DIALECT_BIT)==NO_DIALECT_BIT),
+        noModuleOp((configBits & NO_MODULE_OP_BIT)==NO_MODULE_OP_BIT),
+        headless((configBits & HEADLESS_BIT)==HEADLESS_BIT),
         platform(configBits & 0xf),
         alwaysCopy(!minimizeCopies),
         device((configBits & 0xf0) >> 4){
@@ -104,6 +116,10 @@ struct BasicConfig{
                 std::cout << "native showState " << showState << std::endl;
                 std::cout << "native ptx " << ptx << std::endl;
                 std::cout << "native interpret " << interpret << std::endl;
+                std::cout << "native noBufferTagging " << noBufferTagging << std::endl;
+                std::cout << "native noDialect " << noDialect << std::endl;
+                std::cout << "native noModuleOp " << noModuleOp << std::endl;
+                std::cout << "native headless " << headless << std::endl;
                 std::cout << "native platform " << platform << std::endl;
                 std::cout << "native device " << device << std::endl;
             }
@@ -128,6 +144,10 @@ const char *BasicConfig::bitNames[]={
     "SHOW_STATE_BIT",
     "PTX_BIT",
     "INTERPRET_BIT",
+    "NO_BUFFER_TAGGING_BIT",
+    "NO_DIALECT_BIT",
+    "NO_MODULE_OP_BIT",
+    "HEADLESS_BIT",
 };
 const char *BasicConfig::bitDescriptions[]={
     "FFI ONLY Try to minimize copies",
@@ -145,5 +165,9 @@ const char *BasicConfig::bitDescriptions[]={
     "Show iface buffer state changes",
     "FFI (NVIDIA) ONLY pass PTX rather than C99 CUDA code",
     "Interpret the code model rather than converting to bytecode",
+    "Skip AUTO buffer tagging (rely on annotations)",
+    "Skip generating HAT dialect ops",
+    "Use original callgraph (not using Module Op)",
+    "Don't show UI",
 };
 #endif

--- a/hat/backends/java/seq/src/main/java/hat/backend/java/JavaSequentialBackend.java
+++ b/hat/backends/java/seq/src/main/java/hat/backend/java/JavaSequentialBackend.java
@@ -57,4 +57,6 @@ public class JavaSequentialBackend extends JavaBackend {
         }
     }
 
+
+
 }

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLBackend.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLBackend.java
@@ -27,6 +27,7 @@ package hat.backend.jextracted;
 
 import hat.Accelerator;
 import hat.ComputeContext;
+import hat.Config;
 import hat.NDRange;
 //import hat.backend.ffi.C99FFIBackend;
 import hat.callgraph.KernelCallGraph;
@@ -48,13 +49,15 @@ public class OpenCLBackend extends C99JExtractedBackend {
         return 0l;//backendHandle;
     }
 
-    public OpenCLBackend() {
-        super("opencl_backend");
+    public OpenCLBackend(Config config) {
+        super(config,"opencl_backend");
         getBackend_MH  = null;// nativeLibrary.longFunc("getBackend",JAVA_INT,JAVA_INT, JAVA_INT);
         getBackend(0,0,0);
         info();
     }
-
+    public OpenCLBackend() { // Ignore Intellij's no usages here, we load vai serviceloader!
+        this(Config.fromEnvOrProperty());
+    }
 
     @Override
     public void computeContextHandoff(ComputeContext computeContext) {

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -25,6 +25,7 @@
 
 package hat.backend.jextracted;
 
+import hat.Config;
 import hat.NDRange;
 import hat.codebuilders.C99HATKernelBuilder;
 import hat.buffer.ArgArray;
@@ -43,10 +44,9 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class C99JExtractedBackend extends JExtractedBackend {
-    public C99JExtractedBackend(String libName) {
-        super(libName);
+    public C99JExtractedBackend(Config config,String libName) {
+        super(config,libName);
     }
-
     public static class CompiledKernel {
         public final C99JExtractedBackend c99NativeBackend;
         public final KernelCallGraph kernelCallGraph;

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackend.java
@@ -26,6 +26,7 @@
 package hat.backend.jextracted;
 
 import hat.ComputeContext;
+import hat.Config;
 import hat.buffer.Buffer;
 import hat.callgraph.CallGraph;
 import hat.ifacemapper.BoundSchema;
@@ -54,8 +55,8 @@ public abstract class JExtractedBackend extends JExtractedBackendDriver {
         return segmentMapper.allocate(arena, boundSchema);
     }
 
-    public JExtractedBackend(String libName) {
-        super(libName);
+    public JExtractedBackend(Config config, String libName) {
+        super(config,libName);
     }
 
     public void dispatchCompute(ComputeContext computeContext, Object... args) {

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackendDriver.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/JExtractedBackendDriver.java
@@ -25,6 +25,7 @@
 package hat.backend.jextracted;
 
 
+import hat.Config;
 import hat.backend.Backend;
 import hat.buffer.ArgArray;
 import hat.buffer.Buffer;
@@ -36,7 +37,7 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
-public abstract class JExtractedBackendDriver implements Backend {
+public abstract class JExtractedBackendDriver extends Backend {
 /*
     public boolean isAvailable() {
         return nativeLibrary.available;
@@ -65,7 +66,8 @@ public abstract class JExtractedBackendDriver implements Backend {
 */
     //public final FFILib nativeLibrary;
 
-    public JExtractedBackendDriver(String libName) {
+    public JExtractedBackendDriver(Config config,String libName) {
+      super(config);
       /*  this.nativeLibrary = new FFILib(libName);
         this.dumpArgArray_MH = nativeLibrary.voidFunc("dumpArgArray", ADDRESS);
         this.getDevice_MH = nativeLibrary.longFunc("getDeviceHandle");

--- a/hat/core/src/main/java/hat/Accelerator.java
+++ b/hat/core/src/main/java/hat/Accelerator.java
@@ -49,6 +49,7 @@ import java.util.function.Predicate;
 
 import static hat.backend.Backend.FIRST;
 
+
 /**
  * This class provides the developer facing view of HAT, and wraps a <a href="backend/Backend.html">Backend</a> capable of
  * executing <b>NDRange</b> style execution.

--- a/hat/core/src/main/java/hat/ComputeContext.java
+++ b/hat/core/src/main/java/hat/ComputeContext.java
@@ -136,6 +136,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
     public void dispatchKernel(ComputeRange computeRange, QuotableKernelContextConsumer quotableKernelContextConsumer) {
         dispatchKernelWithComputeRange(computeRange, quotableKernelContextConsumer);
     }
+    /*
 
     private boolean isMethodFromHatKernelContext(JavaOp.InvokeOp invokeOp) {
         String kernelContextCanonicalName = hat.KernelContext.class.getName();
@@ -153,7 +154,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
         Op.Result outputResult = blockBuilder.op(hatBarrierOp);
         Op.Result inputResult = invokeOp.result();
         context.mapValue(inputResult, outputResult);
-    }
+    } */
 
     record CallGraph(Quoted quoted, JavaOp.LambdaOp lambdaOp, MethodRef methodRef, KernelCallGraph kernelCallGraph) {}
 
@@ -162,6 +163,9 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
         JavaOp.LambdaOp lambdaOp = (JavaOp.LambdaOp) quoted.op();
         MethodRef methodRef = OpTk.getQuotableTargetInvokeOpWrapper( lambdaOp).invokeDescriptor();
         KernelCallGraph kernelCallGraph = computeCallGraph.kernelCallGraphMap.get(methodRef);
+        if (kernelCallGraph == null){
+            throw new RuntimeException("Failed to create KernelCallGraph (did you miss @CodeReflection annotation?) ");
+        }
         // Analysis : dialect
         // NOTE: Keep the following boolean until we have the config available/reachable
         // from this class
@@ -238,20 +242,7 @@ public class ComputeContext implements BufferAllocator, BufferTracker {
         }
 
     }
-/*
-    @Override
-    public void preEscape(Buffer b) {
-        if (accelerator.backend instanceof BufferTracker bufferTracker) {
-            bufferTracker.preEscape(b);
-        }
-    }
 
-    @Override
-    public void postEscape(Buffer b) {
-        if (accelerator.backend instanceof BufferTracker bufferTracker) {
-            bufferTracker.postEscape(b);
-        }
-    } */
 
     @Override
     public <T extends Buffer> T allocate(SegmentMapper<T> segmentMapper, BoundSchema<T> boundSchema) {

--- a/hat/core/src/main/java/hat/FFIConfigCreator.java
+++ b/hat/core/src/main/java/hat/FFIConfigCreator.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package hat;
 
 import hat.codebuilders.CodeBuilder;
@@ -12,6 +36,7 @@ import java.util.Date;
 
 public class FFIConfigCreator {
     public static void main(String[] args) throws IOException {
+
         Path ffiInclude = Path.of("backends/ffi/shared/src/main/native/include");
         if (!Files.isDirectory(ffiInclude)) {
             System.out.println("No dir at " + ffiInclude);

--- a/hat/core/src/main/java/hat/backend/BackendAdaptor.java
+++ b/hat/core/src/main/java/hat/backend/BackendAdaptor.java
@@ -25,6 +25,7 @@
 package hat.backend;
 
 import hat.ComputeContext;
+import hat.Config;
 import hat.NDRange;
 import hat.buffer.Buffer;
 import hat.callgraph.KernelCallGraph;
@@ -35,7 +36,11 @@ import hat.ifacemapper.SegmentMapper;
 import java.lang.foreign.Arena;
 import java.lang.reflect.InvocationTargetException;
 
-public abstract class BackendAdaptor implements Backend {
+public abstract class BackendAdaptor extends Backend {
+    BackendAdaptor(Config config) {
+        super(config);
+    }
+
     @Override
     public void computeContextHandoff(ComputeContext computeContext) {
 

--- a/hat/core/src/main/java/hat/backend/DebugBackend.java
+++ b/hat/core/src/main/java/hat/backend/DebugBackend.java
@@ -25,6 +25,7 @@
 package hat.backend;
 
 import hat.ComputeContext;
+import hat.Config;
 import hat.NDRange;
 import hat.callgraph.KernelCallGraph;
 import hat.callgraph.KernelEntrypoint;
@@ -50,6 +51,7 @@ public class DebugBackend extends BackendAdaptor {
     }
 
     public DebugBackend(HowToRunCompute howToRunCompute, HowToRunKernel howToRunKernel){
+        super(Config.fromEnvOrProperty());
         this.howToRunCompute = howToRunCompute;
         this.howToRunKernel = howToRunKernel;
     }

--- a/hat/core/src/main/java/hat/backend/java/JavaBackend.java
+++ b/hat/core/src/main/java/hat/backend/java/JavaBackend.java
@@ -26,6 +26,7 @@
 package hat.backend.java;
 
 import hat.ComputeContext;
+import hat.Config;
 import hat.backend.Backend;
 import hat.buffer.Buffer;
 import hat.ifacemapper.BoundSchema;
@@ -35,7 +36,7 @@ import java.lang.foreign.Arena;
 import java.lang.reflect.InvocationTargetException;
 
 
-public abstract class JavaBackend implements Backend {
+public abstract class JavaBackend extends Backend {
 
     public final Arena arena = Arena.global();
 
@@ -55,6 +56,14 @@ public abstract class JavaBackend implements Backend {
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    JavaBackend(Config config){
+        super(config);
+    }
+
+    JavaBackend(){
+        this(Config.fromEnvOrProperty());
     }
 
 }

--- a/hat/core/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/core/src/main/java/hat/buffer/ArgArray.java
@@ -27,6 +27,7 @@ package hat.buffer;
 import hat.Accelerator;
 import hat.BufferTagger;
 import hat.ComputeContext;
+import hat.callgraph.CallGraph;
 import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.Schema;
 
@@ -293,8 +294,6 @@ public interface ArgArray extends Buffer {
     static void update(ArgArray argArray, KernelCallGraph kernelCallGraph, Object... args) {
         Annotation[][] parameterAnnotations = kernelCallGraph.entrypoint.getMethod().getParameterAnnotations();
         List<BufferTagger.AccessType> bufferAccessList = kernelCallGraph.bufferAccessList;
-        boolean bufferTagging = Boolean.getBoolean("bufferTagging");
-
         for (int i = 0; i < args.length; i++) {
             Object argObject = args[i];
             Arg arg = argArray.arg(i); // this should be invariant, but if we are called from create it will be 0 for all
@@ -331,7 +330,7 @@ public interface ArgArray extends Buffer {
                     buf.bytes(segment.byteSize());
                     buf.access(accessByte);
 
-                    if (bufferTagging) assert bufferAccessList.get(i).value == accessByte;
+                    if (CallGraph.bufferTagging) assert bufferAccessList.get(i).value == accessByte;
                 }
                 default -> throw new IllegalStateException("Unexpected value: " + argObject);
             }

--- a/hat/core/src/main/java/hat/callgraph/CallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/CallGraph.java
@@ -25,6 +25,7 @@
 package hat.callgraph;
 
 import hat.ComputeContext;
+import hat.Config;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.MethodRef;
@@ -42,8 +43,10 @@ public abstract class CallGraph<E extends Entrypoint> {
     public final Set<MethodCall> calls = new HashSet<>();
     public final Map<MethodRef, MethodCall> methodRefToMethodCallMap = new LinkedHashMap<>();
     public CoreOp.ModuleOp moduleOp;
-    public static boolean noModuleOp = Boolean.getBoolean("noModuleOp");
-    public static boolean bufferTagging = Boolean.getBoolean("bufferTagging");
+
+    // Todo: We should phase these out. We can also use Config.....
+    public final static boolean noModuleOp = Boolean.getBoolean("noModuleOp");
+    public final static boolean bufferTagging = Boolean.getBoolean("bufferTagging");
     public Stream<MethodCall> callStream() {
         return methodRefToMethodCallMap.values().stream();
     }

--- a/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
@@ -89,10 +89,11 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
     }
 
     static boolean isKernelDispatch(MethodHandles.Lookup lookup,Method calledMethod, CoreOp.FuncOp fow) {
-        if (fow.body().yieldType().equals(JavaType.VOID)) {
-            if (calledMethod.getParameterTypes() instanceof Class<?>[] parameterTypes && parameterTypes.length > 1) {
-                // We check that the proposed kernel first arg is an KernelContext and
-                // the only other args are primitive or ifacebuffers
+        if (fow.body().yieldType().equals(JavaType.VOID)
+                && calledMethod.getParameterTypes() instanceof Class<?>[] parameterTypes
+                && parameterTypes.length > 1) {
+                // We check that the proposed kernel returns void, the first arg is an KernelContext and we have more args
+                // We also check that other args are primitive or ifacebuffers  (or atomics?)...
                 var firstArgIsKid = StreamMutable.of(false);
                 var atLeastOneIfaceBufferParam = StreamMutable.of(false);
                 var hasOnlyPrimitiveAndIfaceBufferParams = StreamMutable.of(true);
@@ -113,9 +114,6 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
                 return true;
             }
             return false;
-        } else {
-            return false;
-        }
     }
 
     public final Map<MethodRef, KernelCallGraph> kernelCallGraphMap = new HashMap<>();

--- a/hat/core/src/main/java/hat/codebuilders/C99HATConfigBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATConfigBuilder.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package hat.codebuilders;
 
 import hat.Config;
@@ -66,7 +90,7 @@ public class C99HATConfigBuilder extends HATCodeBuilder<C99HATConfigBuilder> {
     }
 
     static public void main(){
-        var c = Config.of("INFO,SHOW_CODE,SHOW_KERNEL_MODEL,SHOW_COMPUTE_MODEL,PLATFORM:0,DEVICE:0");
+        var c = Config.fromSpec("INFO,SHOW_CODE,HEADLESS,NO_BUFFER_TAGGING,SHOW_KERNEL_MODEL,SHOW_COMPUTE_MODEL,PLATFORM:0,DEVICE:0");
         System.out.println(c);
         System.exit(1);
     }

--- a/hat/examples/experiments/src/main/java/experiments/Mesh.java
+++ b/hat/examples/experiments/src/main/java/experiments/Mesh.java
@@ -138,7 +138,7 @@ public class Mesh {
 
     public static void main(String[] args) {
         Accelerator accelerator = new Accelerator(MethodHandles.lookup()
-                ,new OpenCLBackend(of(Config.PROFILE,  Config.TRACE)));
+                ,new OpenCLBackend(fromBits(Config.PROFILE,  Config.TRACE)));
                 //,new DebugBackend(
                 //DebugBackend.HowToRunCompute.REFLECT,
                 //DebugBackend.HowToRunKernel.BABYLON_INTERPRETER));

--- a/hat/examples/experiments/src/main/java/experiments/MinBufferTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/MinBufferTest.java
@@ -59,11 +59,7 @@ public class MinBufferTest {
 
     public static void main(String[] args) {
         Accelerator accelerator = new Accelerator(MethodHandles.lookup(),
-                new OpenCLBackend(of(
-                        Config.TRACE_COPIES,
-                        Config.MINIMIZE_COPIES
-                ))
-
+                new OpenCLBackend(fromSpec("TRACE_COPIES,MINIMIZE_COPIES"))
         );
         int len = 10000000;
         int valueToAdd = 10;

--- a/hat/examples/mandel/src/main/java/mandel/Main.java
+++ b/hat/examples/mandel/src/main/java/mandel/Main.java
@@ -26,6 +26,7 @@ package mandel;
 
 import hat.Accelerator;
 import hat.ComputeContext;
+import hat.Config;
 import hat.KernelContext;
 import hat.backend.Backend;
 import hat.buffer.S32Array;
@@ -71,8 +72,6 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        boolean headless = Boolean.getBoolean("headless") ||( args.length>0 && args[0].equals("--headless"));
-
         final int width = 1024;
         final int height = 1024;
         final float defaultScale = 3f;
@@ -83,11 +82,10 @@ public class Main {
 
         Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);
 
+        // TODO: lets use Config going forward
+        boolean headless = Boolean.getBoolean("headless") ||( args.length>0 && args[0].equals("--headless"))
+                || Config.HEADLESS.isSet(accelerator.backend.config());
         S32Array2D s32Array2D = S32Array2D.create(accelerator, width, height);
-        //var s32Array2DState = SegmentMapper.BufferState.of(s32Array2D);
-        //System.out.println(s32Array2DState);
-
-
 
         int[] palletteArray = new int[maxIterations];
 

--- a/hat/examples/violajones/src/main/java/violajones/Main.java
+++ b/hat/examples/violajones/src/main/java/violajones/Main.java
@@ -25,6 +25,7 @@
 package violajones;
 
 import hat.Accelerator;
+import hat.Config;
 import hat.backend.Backend;
 import org.xml.sax.SAXException;
 import violajones.attic.ViolaJones;
@@ -43,28 +44,24 @@ import java.lang.invoke.MethodHandles;
 public class Main {
 
     public static void main(String[] args) throws IOException, ParserConfigurationException, SAXException {
-        boolean headless = Boolean.getBoolean("headless") ||( args.length>0 && args[0].equals("--headless"));
+
         String imageName = (args.length>2 && args[1].equals("--image"))?args[2]:System.getProperty("image", "Nasa1996");
-      //  System.out.println("Using image "+imageName+".jpg");
+
         BufferedImage nasa1996 = ImageIO.read(ViolaJones.class.getResourceAsStream("/images/"+imageName+".jpg"));
-               //"/images/team.jpg"
-              // "/images/eggheads.jpg"
-             // "/images/highett.jpg"
-        //     "/images/Nasa1996.jpg"
-      //  ));
+
         XMLHaarCascadeModel xmlCascade = XMLHaarCascadeModel.load(
                 ViolaJonesRaw.class.getResourceAsStream("/cascades/haarcascade_frontalface_default.xml"));
-        Accelerator accelerator = new Accelerator(MethodHandles.lookup(),
-              //  new JavaSequentialBackend()
-                Backend.FIRST
-        );
+        Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);
+
+        // TODO: lets use Config going forward
+        boolean headless = Boolean.getBoolean("headless") ||( args.length>0 && args[0].equals("--headless"))
+                || Config.HEADLESS.isSet(accelerator.backend.config());
 
         var cascade = Cascade.createFrom(accelerator,xmlCascade);
 
         S08x3RGBImage rgbImage = S08x3RGBImage.create(accelerator, nasa1996.getWidth(),nasa1996.getHeight());
         rgbImage.syncFromRaster(nasa1996);
         ResultTable resultTable = ResultTable.create(accelerator,1000);
-       // System.out.println("result table layout "+Buffer.getLayout(resultTable));
         Viewer viewer = null;
         if (!headless){
             viewer = new Viewer(accelerator, nasa1996, rgbImage, cascade, null, null);


### PR DESCRIPTION
Config now setup for all backends. 

This allows us to test capabilities (such as SHOW_CODE) in all backends

We should lean on this rather than Boolean.get(propName).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.org/babylon.git pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/597.diff">https://git.openjdk.org/babylon/pull/597.diff</a>

</details>
