### PR TITLE
Remove noModuleOp and bufferTagging flags

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -408,22 +408,11 @@ public class CudaBackend extends C99FFIBackend {
         out.append(builder.getText());
         builder.clear();
 
-        if (CallGraph.noModuleOp) {
-            System.out.println("NOT using ModuleOp for CudaBackend");
-            for (KernelCallGraph.KernelReachableResolvedMethodCall k : kernelCallGraph.kernelReachableResolvedStream().toList()) {
-                CoreOp.FuncOp calledFunc = k.funcOp();
-                CoreOp.FuncOp loweredFunc = OpTk.lower(calledFunc);
-                loweredFunc = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,loweredFunc, argsMap, usedMathFns);
-                invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
-            }
-        } else {
-            System.out.println("Using ModuleOp for CudaBackend");
-            kernelCallGraph.moduleOp.functionTable().forEach((_, funcOp) -> {
-                CoreOp.FuncOp loweredFunc = OpTk.lower(funcOp);
-                loweredFunc = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,loweredFunc, argsMap, usedMathFns);
-                invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
-            });
-        }
+        kernelCallGraph.moduleOp.functionTable().forEach((_, funcOp) -> {
+            CoreOp.FuncOp loweredFunc = OpTk.lower(funcOp);
+            loweredFunc = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,loweredFunc, argsMap, usedMathFns);
+            invokedMethods.append(createFunction(new PTXHATKernelBuilder(addressSize).nl().nl(), loweredFunc, false));
+        });
 
         lowered = transformPTXPtrs(kernelCallGraph.computeContext.accelerator.lookup,lowered, argsMap, usedMathFns);
         for (String s : usedMathFns) {

--- a/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
+++ b/hat/backends/ffi/mock/src/main/java/hat/backend/ffi/MockBackend.java
@@ -57,15 +57,7 @@ public class MockBackend extends FFIBackend {
         // Here we receive a callgraph from the kernel entrypoint
         // The first time we see this we need to convert the kernel entrypoint
         // and rechable methods to a form that our mock backend can execute.
-        if (CallGraph.noModuleOp) {
-            System.out.println("NOT using ModuleOp for MockBackend");
-            kernelCallGraph.kernelReachableResolvedStream().forEach(kr -> {
-
-            });
-        } else {
-            System.out.println("Using ModuleOp for MockBackend");
-            kernelCallGraph.moduleOp.functionTable().forEach((_, funcOp) -> {
-            });
-        }
+        kernelCallGraph.moduleOp.functionTable().forEach((_, funcOp) -> {
+        });
     }
 }

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -231,29 +231,16 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
                         kernelCallGraph.entrypoint.funcOp());
 
         // Sorting by rank ensures we don't need forward declarations
-        if (CallGraph.noModuleOp) {
-            IO.println("NOT using ModuleOp for C99FFIBackend");
-            kernelCallGraph.kernelReachableResolvedStream().sorted((lhs, rhs) -> rhs.rank - lhs.rank)
-                    .forEach(kernelReachableResolvedMethod -> {
-                                HatFinalDetectionPhase finals = new HatFinalDetectionPhase();
-                                finals.apply(kernelReachableResolvedMethod.funcOp());
-                                // Update the build context for this method to use the right constants-map
-                                buildContext.setFinals(finals.getFinalVars());
-                                builder.nl().kernelMethod(buildContext, kernelReachableResolvedMethod.funcOp()).nl();
-                    });
-        } else {
-            IO.println("Using ModuleOp for C99FFIBackend");
-            kernelCallGraph.moduleOp.functionTable()
-                    .forEach((_, funcOp) -> {
+        kernelCallGraph.moduleOp.functionTable()
+                .forEach((_, funcOp) -> {
 
-                        HatFinalDetectionPhase finals = new HatFinalDetectionPhase();
-                        finals.apply(funcOp);
+                    HatFinalDetectionPhase finals = new HatFinalDetectionPhase();
+                    finals.apply(funcOp);
 
-                        // Update the build context for this method to use the right constants-map
-                        buildContext.setFinals(finals.getFinalVars());
-                        builder.nl().kernelMethod(buildContext, funcOp).nl();
-                    });
-        }
+                    // Update the build context for this method to use the right constants-map
+                    buildContext.setFinals(finals.getFinalVars());
+                    builder.nl().kernelMethod(buildContext, funcOp).nl();
+                });
 
         // Update the constants-map for the main kernel
         HatFinalDetectionPhase hatFinalDetectionPhase = new HatFinalDetectionPhase();

--- a/hat/core/src/main/java/hat/BufferTagger.java
+++ b/hat/core/src/main/java/hat/BufferTagger.java
@@ -57,6 +57,17 @@ public class BufferTagger {
         }
     }
 
+    public static String convertAccessType(int i) {
+        switch (i) {
+            case 0 -> {return "NOT_BUFFER";}
+            case 1 -> {return "NA";}
+            case 2 -> {return "RO";}
+            case 4 -> {return "WO";}
+            case 6 -> {return "RW";}
+            default -> {return "";}
+        }
+    }
+
     // generates a list of AccessTypes matching the given FuncOp's parameter order
     public static ArrayList<AccessType> getAccessList(MethodHandles.Lookup l, CoreOp.FuncOp f) {
         CoreOp.FuncOp inlinedFunc = inlineLoop(l, f);

--- a/hat/core/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/core/src/main/java/hat/buffer/ArgArray.java
@@ -27,7 +27,6 @@ package hat.buffer;
 import hat.Accelerator;
 import hat.BufferTagger;
 import hat.ComputeContext;
-import hat.callgraph.CallGraph;
 import hat.callgraph.KernelCallGraph;
 import hat.ifacemapper.Schema;
 
@@ -330,7 +329,11 @@ public interface ArgArray extends Buffer {
                     buf.bytes(segment.byteSize());
                     buf.access(accessByte);
 
-                    if (CallGraph.bufferTagging) assert bufferAccessList.get(i).value == accessByte;
+                    assert bufferAccessList.get(i).value == accessByte: "buffer tagging mismatch: "
+                            + kernelCallGraph.entrypoint.getMethod().getParameters()[i].toString()
+                            + " in " + kernelCallGraph.entrypoint.getMethod().getName()
+                            + " annotated as " + BufferTagger.convertAccessType(accessByte)
+                            + " but tagged as " + bufferAccessList.get(i).name();
                 }
                 default -> throw new IllegalStateException("Unexpected value: " + argObject);
             }

--- a/hat/core/src/main/java/hat/callgraph/CallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/CallGraph.java
@@ -43,10 +43,6 @@ public abstract class CallGraph<E extends Entrypoint> {
     public final Set<MethodCall> calls = new HashSet<>();
     public final Map<MethodRef, MethodCall> methodRefToMethodCallMap = new LinkedHashMap<>();
     public CoreOp.ModuleOp moduleOp;
-
-    // Todo: We should phase these out. We can also use Config.....
-    public final static boolean noModuleOp = Boolean.getBoolean("noModuleOp");
-    public final static boolean bufferTagging = Boolean.getBoolean("bufferTagging");
     public Stream<MethodCall> callStream() {
         return methodRefToMethodCallMap.values().stream();
     }

--- a/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/ComputeCallGraph.java
@@ -214,11 +214,7 @@ public class ComputeCallGraph extends CallGraph<ComputeEntrypoint> {
     }
 
     public void close() {
-        if (CallGraph.noModuleOp) {
-            updateDag(entrypoint);
-        } else {
-            closeWithModuleOp(entrypoint);
-        }
+        closeWithModuleOp(entrypoint);
     }
 
     public void closeWithModuleOp(ComputeReachableResolvedMethodCall computeReachableResolvedMethodCall) {

--- a/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -82,9 +82,7 @@ public class KernelCallGraph extends CallGraph<KernelEntrypoint> {
         super(computeCallGraph.computeContext, new KernelEntrypoint(null, methodRef, method, funcOp));
         entrypoint.callGraph = this;
         this.computeCallGraph = computeCallGraph;
-        System.out.println("-DbufferTagging="+CallGraph.bufferTagging);
-        System.out.println("-DnoModuleOp="+CallGraph.noModuleOp);
-        bufferAccessList = CallGraph.bufferTagging?BufferTagger.getAccessList(computeContext.accelerator.lookup, entrypoint.funcOp()):List.of();
+        bufferAccessList = BufferTagger.getAccessList(computeContext.accelerator.lookup, entrypoint.funcOp());
         usesArrayView = false;
     }
 

--- a/hat/hat.java
+++ b/hat/hat.java
@@ -188,9 +188,7 @@ public static void main(String[] argArr) throws IOException, InterruptedExceptio
                 case "run" -> {
                     if (args.size() > 1) {
                         var backendName = args.removeFirst();
-                        var vmOpts = new ArrayList<String>(List.of(
-                            "-DbufferTagging=true"
-                        ));
+                        var vmOpts = new ArrayList<String>(List.of());
                         while (args.getFirst() instanceof String  possibleVmOpt &&  possibleVmOpt.startsWith("-")){
                             vmOpts.add(args.removeFirst());
                         }
@@ -257,9 +255,7 @@ public static void main(String[] argArr) throws IOException, InterruptedExceptio
                     if (args.size() > 1) {
                         var backendName = args.removeFirst();
                         var runnableName = "experiments";
-                        var vmOpts = new ArrayList<String>(List.of(
-                            "-DbufferTagging=true"
-                        ));
+                        var vmOpts = new ArrayList<String>(List.of());
                         while (args.getFirst() instanceof String  possibleVmOpt &&  possibleVmOpt.startsWith("-")){
                             vmOpts.add(args.removeFirst());
                         }

--- a/hat/hat/Script.java
+++ b/hat/hat/Script.java
@@ -1284,8 +1284,6 @@ public class Script {
         public StringList args = new StringList();
         public StringList nativeAccessModules = new StringList();
         private boolean headless;
-        public boolean noModuleOp;
-        public boolean bufferTagging;
 
 
         public JavaBuilder enable_native_access(String module) {
@@ -1344,14 +1342,6 @@ public class Script {
         public void headless() {
             this.headless = true;
         }
-
-        public void noModuleOp() {
-            this.noModuleOp = true;
-        }
-
-        public void bufferTagging() {
-            this.bufferTagging = true;
-        }
     }
 
     public static final class JavaResult extends Result<JavaBuilder> {
@@ -1382,12 +1372,6 @@ public class Script {
         }
         if (javaBuilder.headless) {
             result.opts.add("-Dheadless=true");
-        }
-        if (javaBuilder.noModuleOp) {
-            result.opts.add("-DnoModuleOp=true");
-        }
-        if (javaBuilder.bufferTagging) {
-            result.opts.add("-DbufferTagging=true");
         }
         if (javaBuilder.startOnFirstThread) {
             result.opts.add("-XstartOnFirstThread");

--- a/hat/hat/run.java
+++ b/hat/hat/run.java
@@ -28,8 +28,6 @@ import static java.lang.IO.println;
 
 class Config{
      boolean headless=false;
-     boolean noModuleOp = false;
-     boolean bufferTagging = false;
      boolean verbose = false;
      boolean startOnFirstThread = false;
      boolean justShowCommandline = false;
@@ -73,8 +71,6 @@ class Config{
             }else{
                 switch (args[arg]) {
                    case "headless" -> headless = true;
-                   case "noModuleOp" -> noModuleOp = true;
-                   case "bufferTagging" -> bufferTagging = true;
                    case "verbose" -> verbose = true;
                    case "justShowCommandLine" -> justShowCommandline = true;
                    case "startOnFirstThread" -> startOnFirstThread = true;
@@ -174,7 +170,6 @@ void main(String[] argv) {
               }
               default -> {}
           }
-          if (config.noModuleOp) System.out.println("NOT using ModuleOp for CallGraphs");
       }
       Script.java(java -> java
               .enable_preview()
@@ -182,8 +177,6 @@ void main(String[] argv) {
               .enable_native_access("ALL-UNNAMED")
               .library_path(buildDir)
               .when(config.headless, Script.JavaBuilder::headless)
-              .when(config.noModuleOp, Script.JavaBuilder::noModuleOp)
-              .when(config.bufferTagging, Script.JavaBuilder::bufferTagging)
               .when(config.startOnFirstThread, Script.JavaBuilder::start_on_first_thread)
               .class_path(config.classpath)
               .vmargs(config.vmargs)

--- a/hat/hat/test.java
+++ b/hat/hat/test.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 
 class Config {
     boolean headless = false;
-    boolean noModuleOp = false;
     boolean verbose = false;
     boolean startOnFirstThread = false;
     boolean justShowCommandline = false;
@@ -78,7 +77,6 @@ class Config {
             } else {
                 switch (args[arg]) {
                     case "headless" -> headless = true;
-                    case "noModuleOp" -> noModuleOp = true;
                     case "verbose" -> verbose = true;
                     case "justShowCommandLine" -> justShowCommandline = true;
                     case "startOnFirstThread" -> startOnFirstThread = true;
@@ -148,9 +146,6 @@ void main(String[] argv) {
             default -> {
             }
         }
-        if (config.noModuleOp) {
-            System.out.println("NOT using ModuleOp for CallGraphs");
-        }
     }
 
     // Remove the previous report file:
@@ -185,7 +180,6 @@ void main(String[] argv) {
                     .enable_native_access("ALL-UNNAMED")
                     .library_path(buildDir)
                     .when(config.headless, Script.JavaBuilder::headless)
-                    .when(config.noModuleOp, Script.JavaBuilder::noModuleOp)
                     .when(config.startOnFirstThread, Script.JavaBuilder::start_on_first_thread)
                     .class_path(config.classpath)
                     .vmargs(config.vmargs)
@@ -228,7 +222,6 @@ void main(String[] argv) {
                 .enable_native_access("ALL-UNNAMED")
                 .library_path(buildDir)
                 .when(config.headless, Script.JavaBuilder::headless)
-                .when(config.noModuleOp, Script.JavaBuilder::noModuleOp)
                 .when(config.startOnFirstThread, Script.JavaBuilder::start_on_first_thread)
                 .class_path(config.classpath)
                 .vmargs(config.vmargs)


### PR DESCRIPTION
Phase out the backend that doesn't use `ModuleOp`. Also make `bufferTagging` run by default.