### PR TITLE
implemented preprocessor hook for OpenCL code gen

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
@@ -37,12 +37,7 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
 
     @Override
     public CudaHATKernelBuilder defines() {
-        return hashDefine("__global");  // nor this
-    }
-
-    @Override
-    public CudaHATKernelBuilder pragmas() {
-        return self();
+        return self();  // nor this
     }
 
     private CudaHATKernelBuilder threadDimId(int id) {

--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -150,7 +150,7 @@ public abstract class C99FFIBackend extends FFIBackend  implements BufferTracker
 
     public <T extends C99HATKernelBuilder<T>> String createCode(KernelCallGraph kernelCallGraph, T builder, Object... args) {
 
-        builder.defines().pragmas().types();
+        builder.defines().types();
         Set<Schema.IfaceType> already = new LinkedHashSet<>();
         Arrays.stream(args)
                 .filter(arg -> arg instanceof Buffer)

--- a/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
+++ b/hat/backends/jextracted/opencl/src/main/java/hat/backend/jextracted/OpenCLHatKernelBuilder.java
@@ -34,15 +34,10 @@ import jdk.incubator.code.dialect.java.JavaType;
 public class OpenCLHatKernelBuilder extends C99HATKernelBuilder<OpenCLHatKernelBuilder> {
 
     @Override
-    public OpenCLHatKernelBuilder defines() {
-        return pragmas().hashIfndef("NULL", _ -> hashDefine("NULL", "0"));
-    }
-
-    @Override
-    public OpenCLHatKernelBuilder pragmas() {
-        return self().
-                pragma("OPENCL", "EXTENSION", "cl_khr_global_int32_base_atomics", ":", "enable").
-                pragma("OPENCL", "EXTENSION", "cl_khr_local_int32_base_atomics", ":", "enable");
+    public OpenCLHatKernelBuilder defines(){
+        return hashIfndef("NULL", _ -> hashDefine("NULL", "0"))
+                .pragma("OPENCL", "EXTENSION", "cl_khr_global_int32_base_atomics", ":", "enable")
+                .pragma("OPENCL", "EXTENSION", "cl_khr_local_int32_base_atomics", ":", "enable");
     }
 
     @Override

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -76,7 +76,7 @@ public abstract class C99JExtractedBackend extends JExtractedBackend {
     public Map<KernelCallGraph, CompiledKernel> kernelCallGraphCompiledCodeMap = new HashMap<>();
 
     public <T extends C99HATKernelBuilder<T>> String createCode(KernelCallGraph kernelCallGraph, T builder, Object[] args) {
-        builder.defines().pragmas().types();
+        builder.defines().types();
         Set<Schema.IfaceType> already = new LinkedHashSet<>();
         Arrays.stream(args)
                 .filter(arg -> arg instanceof Buffer)

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -168,8 +168,6 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
 
     public abstract T defines();
 
-    public abstract T pragmas();
-
     public abstract T kernelDeclaration(CoreOp.FuncOp funcOp);
 
     public abstract T functionDeclaration(ScopedCodeBuilderContext codeBuilderContext, JavaType javaType, CoreOp.FuncOp funcOp);

--- a/hat/core/src/main/java/hat/codebuilders/CodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/CodeBuilder.java
@@ -470,7 +470,12 @@ public abstract class CodeBuilder<T extends CodeBuilder<T>> extends TextBuilder<
     public final T intConstZero() {
         return constant("0");
     }
-
+    public final T intConstOne() {
+        return constant("1");
+    }
+    public final T intConstTwo() {
+        return constant("2");
+    }
 
     public final T voidType() {
         return typeName("void");

--- a/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/HATCodeBuilder.java
@@ -188,6 +188,13 @@ public abstract class HATCodeBuilder<T extends HATCodeBuilder<T>> extends CodeBu
         return nl();
     }
 
+    public T hashDefine(String name, Consumer<T> consumer) {
+        hashDefineKeyword().space().identifier(name);
+        space();
+        consumer.accept(self());
+        return nl();
+    }
+
     public T pragma(String name, String... values) {
         hash().pragmaKeyword().space().identifier(name);
         for (String value : values) {

--- a/hat/examples/nbody/src/main/java/nbody/opencl/OpenCLNBodyGLWindow.java
+++ b/hat/examples/nbody/src/main/java/nbody/opencl/OpenCLNBodyGLWindow.java
@@ -238,6 +238,27 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
 
                         }
                         """;
+                /* Aspirational Java code
+                     void nbody(KernelContext kc, F32Arr xyzPosFloats ,F32Arr xyzVelFloats, float mass, float delT, float espSqr ){
+                                float4 acc = float4.of(0.0,0.0,0.0,0.0);
+                                float4[] xyzPos = xyzPosFloats.float4ArrayView();
+                                float4[] xyzVel = xyzVelFloats.float4ArrayView();
+                                float4 myPos = xyzPos[kc.gix];
+                                float4 myVel = xyzVel[kc.gix];
+                                for (int i = 0; i < kc.gsx; i++) {
+                                       float4 delta =  xyzPos[i].sub(myPos); // xyzPos[i] - myPos
+                                       float invDist =  (float) 1.0/sqrt((float)((delta.x * delta.x) + (delta.y * delta.y) + (delta.z * delta.z) + espSqr));
+                                       float s = mass * invDist * invDist * invDist;
+                                       acc  = acc.plus(delta.mul(s)); //  acc= acc + (s * delta);
+                                }
+                                acc = acc.mul(delT); //acc = acc*delT;
+                                myPos = myPos.plus(myVel.mul(delT)).plus(acc.mul(delT/2); //  myPos = myPos + (myVel * delT) + (acc * delT)/2;
+                                myVel = myVel.plus(acc)//   myVel = myVel + acc;
+                                xyzPos[kc.gix] = myPos;
+                                xyzVel[kc.gix] = myVel;
+
+                            }
+                 */
                 default -> throw new IllegalStateException();
             };
             var program = context.buildProgram(code);


### PR DESCRIPTION
Here we leverage OpenCL's ability to lean on the C99 preprocessor to generate C99 code. 

Instead of having OpenCL generator differentiate, we get the OpenCL code builder to define a set of #defines and generate backend 'neutral' C99 code (common between Cuda and OpenCL). 

This PR just has the OpenCL changes.  Cuda changes will be next  