### PR TITLE
[hat][java-mt] Fixed KernelContext init per thread in WorkStealer

### DIFF
--- a/hat/core/src/main/java/hat/backend/java/WorkStealer.java
+++ b/hat/core/src/main/java/hat/backend/java/WorkStealer.java
@@ -66,6 +66,7 @@ public class WorkStealer {
                         rendezvous(startBarrier);
                         //  System.out.println("Thread #"+Thread.currentThread()+" started");
 
+                        // The range should be initialised by now.
                         var ndRange1D = NDRange.of1D(range);
                         hat.KernelContext kernelContext = new KernelContext(ndRange1D);
                         try {

--- a/hat/core/src/main/java/hat/backend/java/WorkStealer.java
+++ b/hat/core/src/main/java/hat/backend/java/WorkStealer.java
@@ -46,7 +46,6 @@ public class WorkStealer {
     volatile int range;
     volatile boolean running = true;
     final int chunkSize = 1024;
-    private KernelContext[] ranges;
 
     public WorkStealer(int threadCount) {
         super();
@@ -55,32 +54,32 @@ public class WorkStealer {
         if (threadCount > 1) {
             taskCount = new AtomicInteger(0);
             threads = new Thread[threadCount];
-            this.ranges = new KernelContext[threadCount];
             setupBarrier = new CyclicBarrier(threadCount + 1);
             startBarrier = new CyclicBarrier(threadCount + 1);
             doneBarrier = new CyclicBarrier(threadCount + 1);
             for (int i = 0; i < threadCount; i++) {
                 final int fini = i;
-                var ndRange1D = NDRange.of1D(range);
-                ranges[fini] = new KernelContext(ndRange1D);
                 threads[fini] = new Thread(() -> {
-
-                    hat.KernelContext kernelContext = ranges[fini];
                     while (running) {
                         rendezvous(setupBarrier);
                         //  System.out.println("Thread #"+Thread.currentThread()+" waiting start");
                         rendezvous(startBarrier);
                         //  System.out.println("Thread #"+Thread.currentThread()+" started");
 
-                        int myChunk;
-                        while ((myChunk = taskCount.getAndIncrement()) < (range / chunkSize) + 1) {
-                            for (kernelContext.gix = myChunk * chunkSize; kernelContext.gix < (myChunk + 1) * chunkSize && kernelContext.gix < range; kernelContext.gix++) {
-                                rangeConsumer.accept(kernelContext);
+                        var ndRange1D = NDRange.of1D(range);
+                        hat.KernelContext kernelContext = new KernelContext(ndRange1D);
+                        try {
+                            int myChunk;
+                            while ((myChunk = taskCount.getAndIncrement()) < (range / chunkSize) + 1) {
+                                for (kernelContext.gix = myChunk * chunkSize; kernelContext.gix < (myChunk + 1) * chunkSize && kernelContext.gix < range; kernelContext.gix++) {
+                                    rangeConsumer.accept(kernelContext);
+                                }
                             }
+                        } finally {
+                            //  System.out.println("Thread #"+Thread.currentThread()+" done");
+                            rendezvous(doneBarrier);
+                            //  System.out.println("Thread #"+Thread.currentThread()+" pastDone");
                         }
-                        //  System.out.println("Thread #"+Thread.currentThread()+" done");
-                        rendezvous(doneBarrier);
-                        //  System.out.println("Thread #"+Thread.currentThread()+" pastDone");
                     }
                 });
                 threads[i].setDaemon(true);


### PR DESCRIPTION
Cause: Previous fixes to WorkStealer removed the Accelerator from the constructor which provided the range. However, the KernelContext creation was done before the startBarrier leading to the use of an uninitialized range, typically 0.

Fixes:
1. Moved the KernelContext construction for each worker thread after the startBarrier so that the range gets initialized prior to it.
2. Moved the doneBarrier in the worker threads to a finally block so that any exceptions thrown from the rangeConsumer do not leave the backend blocked.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Juan Fumero](https://openjdk.org/census#jfumero) (@jjfumero - **Reviewer**) ⚠️ Review applies to [16bcc51d](https://git.openjdk.org/babylon/pull/955/files/16bcc51d5e6fb96e2fb86e22dd4b6a2b071b36d1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/955/head:pull/955` \
`$ git checkout pull/955`

Update a local copy of the PR: \
`$ git checkout pull/955` \
`$ git pull https://git.openjdk.org/babylon.git pull/955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 955`

View PR using the GUI difftool: \
`$ git pr show -t 955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/955.diff">https://git.openjdk.org/babylon/pull/955.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/955#issuecomment-4041163410)
</details>
