### PR TITLE
Fix bug in QuotedOp.transform

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -480,28 +480,19 @@ public sealed abstract class CoreOp extends Op {
             super(that, cc);
 
             this.quotedBody = that.quotedBody.transform(cc, ot).build(this);
-            this.quotedOp = that.quotedOp;
+            this.quotedOp = getQuotedOp(quotedBody);
         }
 
         @Override
-        public QuotedOp transform(CodeContext cc, CodeTransformer ot) {
-            return new QuotedOp(this, cc, ot);
+        public QuotedOp transform(CodeContext cc, CodeTransformer _ignored) {
+            return new QuotedOp(this, cc, CodeTransformer.COPYING_TRANSFORMER);
         }
 
         QuotedOp(Body.Builder bodyC) {
             super(List.of());
 
             this.quotedBody = bodyC.build(this);
-            if (quotedBody.blocks().size() > 1) {
-                throw new IllegalArgumentException();
-            }
-            if (!(quotedBody.entryBlock().terminatingOp() instanceof YieldOp yop)) {
-                throw new IllegalArgumentException();
-            }
-            if (!(yop.yieldValue() instanceof Result r)) {
-                throw new IllegalArgumentException();
-            }
-            this.quotedOp = r.op();
+            this.quotedOp = getQuotedOp(quotedBody);
         }
 
         @Override
@@ -527,6 +518,19 @@ public sealed abstract class CoreOp extends Op {
         @Override
         public TypeElement resultType() {
             return QUOTED_OP_TYPE;
+        }
+
+        private Op getQuotedOp(Body quotedBody) {
+            if (quotedBody.blocks().size() > 1) {
+                throw new IllegalArgumentException();
+            }
+            if (!(quotedBody.entryBlock().terminatingOp() instanceof YieldOp yop)) {
+                throw new IllegalArgumentException();
+            }
+            if (!(yop.yieldValue() instanceof Result r)) {
+                throw new IllegalArgumentException();
+            }
+            return r.op();
         }
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -484,8 +484,8 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public QuotedOp transform(CodeContext cc, CodeTransformer _ignored) {
-            return new QuotedOp(this, cc, CodeTransformer.COPYING_TRANSFORMER);
+        public QuotedOp transform(CodeContext cc, CodeTransformer ot) {
+            return new QuotedOp(this, cc, ot);
         }
 
         QuotedOp(Body.Builder bodyC) {

--- a/test/jdk/jdk/incubator/code/TestTransformQuotedOp.java
+++ b/test/jdk/jdk/incubator/code/TestTransformQuotedOp.java
@@ -1,0 +1,58 @@
+import jdk.incubator.code.Block;
+import jdk.incubator.code.CodeTransformer;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.java.JavaOp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.IntUnaryOperator;
+
+import static jdk.incubator.code.dialect.core.CoreOp.*;
+import static jdk.incubator.code.dialect.core.CoreOp.return_;
+import static jdk.incubator.code.dialect.core.CoreType.functionType;
+import static jdk.incubator.code.dialect.java.JavaType.INT;
+import static jdk.incubator.code.dialect.java.JavaType.type;
+
+/*
+ * @test
+ * @modules jdk.incubator.code
+ * @library lib
+ * @run junit TestTransformQuotedOp
+ */
+public class TestTransformQuotedOp {
+    @Test
+    void test() {
+        // functional type = (int)int
+        CoreOp.FuncOp f = func("f", functionType(CoreOp.QuotedOp.QUOTED_OP_TYPE, INT))
+                .body(block -> {
+                    Block.Parameter i = block.parameters().get(0);
+
+                    // functional type = (int)int
+                    // op type = ()Quoted<LambdaOp>
+                    CoreOp.QuotedOp qop = quoted(block.parentBody(), qblock -> {
+                        return JavaOp.lambda(qblock.parentBody(),
+                                        functionType(INT, INT), type(IntUnaryOperator.class))
+                                .body(lblock -> {
+                                    Block.Parameter li = lblock.parameters().get(0);
+
+                                    lblock.op(return_(
+                                            // capture i from function's body
+                                            lblock.op(JavaOp.add(i, li))
+                                    ));
+                                });
+                    });
+                    Op.Result lquoted = block.op(qop);
+
+                    block.op(return_(lquoted));
+                });
+
+        System.out.println(f.toText());
+
+        FuncOp tf = f.transform(CodeTransformer.COPYING_TRANSFORMER);
+
+        QuotedOp qop = (QuotedOp) tf.body().entryBlock().firstOp();
+
+        Assertions.assertEquals(qop.bodies().getFirst().entryBlock().firstOp(), qop.quotedOp());
+    }
+}


### PR DESCRIPTION
There's a bug in `QuotedOp.transform`, it copies the value of `quotedOp`, making `quotedOp` field value different from the op inside `quotedBody`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/990/head:pull/990` \
`$ git checkout pull/990`

Update a local copy of the PR: \
`$ git checkout pull/990` \
`$ git pull https://git.openjdk.org/babylon.git pull/990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 990`

View PR using the GUI difftool: \
`$ git pr show -t 990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/990.diff">https://git.openjdk.org/babylon/pull/990.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/990#issuecomment-4180659890)
</details>
