### PR TITLE
Cleanups

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxPartialEvaluator.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxPartialEvaluator.java
@@ -375,7 +375,7 @@ final class OnnxPartialEvaluator {
                     }
                     return Array.newInstance(resolveToClass(l, nType), lengths);
                 } else {
-                    MethodHandle mh = constructorHandle(l, no.constructorReference().type());
+                    MethodHandle mh = constructorHandle(l, no.constructorReference().signature());
                     return invoke(mh, values);
                 }
             }

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/PartialEvaluator.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/PartialEvaluator.java
@@ -369,7 +369,7 @@ public final class PartialEvaluator {
                     }
                     return Array.newInstance(resolveToClass(l, nType), lengths);
                 } else {
-                    MethodHandle mh = constructorHandle(l, no.constructorReference().type());
+                    MethodHandle mh = constructorHandle(l, no.constructorReference().signature());
                     return invoke(mh, values);
                 }
             }

--- a/cr-examples/spirv/src/main/java/intel/code/spirv/SpirvOps.java
+++ b/cr-examples/spirv/src/main/java/intel/code/spirv/SpirvOps.java
@@ -125,7 +125,7 @@ public class SpirvOps {
         private MethodRef descriptor;
 
         public CallOp(MethodRef descriptor, List<Value> operands) {
-            super(nameString(descriptor), descriptor.type().returnType(), operands);
+            super(nameString(descriptor), descriptor.signature().returnType(), operands);
             this.descriptor = descriptor;
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/SwapMath.java
+++ b/hat/examples/experiments/src/main/java/experiments/SwapMath.java
@@ -76,7 +76,7 @@ public class SwapMath {
             if (invoke(lookup,op) instanceof Invoke.Static ih
                     && ih.named("sqrt") &&  ih.returns(double.class) && ih.receives(double.class)){
                 var absStaticMethod = MethodRef.method(Math.class, "abs", double.class, double.class);
-                var absInvoke =  JavaOp.invoke(InvokeKind.STATIC, false, absStaticMethod.type().returnType(), absStaticMethod,
+                var absInvoke =  JavaOp.invoke(InvokeKind.STATIC, false, absStaticMethod.signature().returnType(), absStaticMethod,
                         builder.context().getValue(op.operands().get(0)));
                 var absResult= builder.op(absInvoke);
                 builder.context().mapValue(op.result(), absResult);

--- a/hat/optkl/src/main/java/optkl/OpHelper.java
+++ b/hat/optkl/src/main/java/optkl/OpHelper.java
@@ -556,11 +556,11 @@ public sealed interface OpHelper<T extends Op> extends LookupCarrier
         }
 
         default boolean returnsVoid() {
-            return op().invokeReference().type().returnType().equals(JavaType.VOID);
+            return op().invokeReference().signature().returnType().equals(JavaType.VOID);
         }
 
         default CodeType returnType() {
-            return op().invokeReference().type().returnType();
+            return op().invokeReference().signature().returnType();
         }
 
         default boolean returnsInt() {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeType.java
@@ -14,7 +14,7 @@ import jdk.incubator.code.extern.ExternalizedCodeType;
  *
  * @apiNote
  * Code types enable reasoning statically about a code model, approximating
- * run time behaviour.
+ * run time behavior.
  *
  * @see Value
  * @see Block.Parameter
@@ -33,7 +33,7 @@ public non-sealed interface CodeType extends CodeItem {
     ExternalizedCodeType externalize();
 
     /**
-     * Return a string representation of this Java type.
+     * Return a string representation of this code type.
      */
     @Override
     String toString();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -52,11 +52,11 @@ import java.util.*;
 import java.util.function.BiFunction;
 
 /**
- * An operation modelling a unit of program behaviour.
+ * An operation modeling a unit of program behavior.
  * <p>
  * An operation might model the addition of two integers, or a method invocation expression.
  * Alternatively an operation may model something more complex like method declarations, lambda expressions, or
- * try statements. In such cases an operation will contain one or more bodies modelling the nested structure.
+ * try statements. In such cases an operation will contain one or more bodies modeling the nested structure.
  * <p>
  * An instance of an operation when initially constructed is referred to as an unbuilt operation.
  * An unbuilt operation's state and descendants are all immutable except for its {@link #result result} and

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
@@ -136,7 +136,7 @@ public final class Quoted<T extends Op> {
     }
 
     /**
-     * Embeds the given operation into a quoting code model whose behaviour quotes the operation.
+     * Embeds the given operation into a quoting code model whose behavior quotes the operation.
      * <p>
      * The result is a {@link jdk.incubator.code.dialect.core.CoreOp.FuncOp func operation}
      * that has one body with one block (<i>fblock</i>).
@@ -213,7 +213,7 @@ public final class Quoted<T extends Op> {
      * Extracts the quoted operation from a quoting code model with the given runtime arguments.
      * <p>
      * This method behaves as if the quoting code model is executed with the runtime arguments by interpreting the
-     * behaviour of the code elements, as specified, in the code model, but it may be implemented more efficiently.
+     * behavior of the code elements, as specified, in the code model, but it may be implemented more efficiently.
      *
      * @param funcOp the quoting code model
      * @param args   the runtime arguments

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Reflect.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Reflect.java
@@ -48,7 +48,7 @@ import java.lang.reflect.Method;
  * The code model of a reflectable lambda expression (or method reference) is accessed by invoking
  * {@link Op#ofLambda(Object)} with an argument that is an instance of a functional interface associated with the
  * reflectable lambda expression. The result is an optional value that contains a {@link Quoted quoted} instance, from
- * which may be retrieved the operation modelling the lambda expression. In addition, it is possible to retrieve
+ * which may be retrieved the operation modeling the lambda expression. In addition, it is possible to retrieve
  * a mapping from {@link Value values} in the code model that model final, or effectively final, variables used but not
  * declared in the lambda expression to their corresponding run time values. Such run time values are commonly referred
  * to as captured values. For example:

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -424,7 +424,7 @@ public final class BytecodeGenerator {
             // When there is no next operation
             case null -> false;
             // New object cannot use first operand from stack, new array fall through to the default
-            case NewOp op when !(op.constructorReference().type().returnType() instanceof ArrayType) ->
+            case NewOp op when !(op.constructorReference().signature().returnType() instanceof ArrayType) ->
                 false;
             // For lambda the effective operands are captured values
             case LambdaOp op ->
@@ -772,7 +772,7 @@ public final class BytecodeGenerator {
                         // Processing is deferred to the CondBrOp, do not process the op result
                     }
                     case NewOp op -> {
-                        switch (op.constructorReference().type().returnType()) {
+                        switch (op.constructorReference().signature().returnType()) {
                             case ArrayType at -> {
                                 processOperands(op);
                                 if (at.dimensions() == 1) {
@@ -793,12 +793,12 @@ public final class BytecodeGenerator {
                                 cob.invokespecial(
                                         ((JavaType) op.resultType()).toNominalDescriptor(),
                                         ConstantDescs.INIT_NAME,
-                                        MethodRef.toNominalDescriptor(op.constructorReference().type())
+                                        MethodRef.toNominalDescriptor(op.constructorReference().signature())
                                                  .changeReturnType(ConstantDescs.CD_void));
                             }
                             default ->
                                 throw new IllegalArgumentException("Invalid return type: "
-                                                                    + op.constructorReference().type().returnType());
+                                                                    + op.constructorReference().signature().returnType());
                         }
                         push(op.result());
                     }
@@ -807,7 +807,7 @@ public final class BytecodeGenerator {
                         MethodRef md = op.invokeReference();
                         JavaType refType = (JavaType)md.refType();
                         ClassDesc specialCaller = lookup.lookupClass().describeConstable().get();
-                        MethodTypeDesc mDesc = MethodRef.toNominalDescriptor(md.type());
+                        MethodTypeDesc mDesc = MethodRef.toNominalDescriptor(md.signature());
                         if (op.invokeKind() == InvokeOp.InvokeKind.SUPER) {
                             // constructs method handle via lookup.findSpecial using the lookup's class as the specialCaller
                             // original lookup is stored in class data
@@ -826,7 +826,7 @@ public final class BytecodeGenerator {
                             processOperands(op.argOperands());
                             var varArgOperands = op.varArgOperands();
                             cob.loadConstant(varArgOperands.size());
-                            var compType = ((ArrayType) op.invokeReference().type().parameterTypes().getLast()).componentType();
+                            var compType = ((ArrayType) op.invokeReference().signature().parameterTypes().getLast()).componentType();
                             var compTypeDesc = compType.toNominalDescriptor();
                             var typeKind = TypeKind.from(compTypeDesc);
                             if (compTypeDesc.isPrimitive()) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -89,12 +89,12 @@ public sealed abstract class CoreOp extends Op {
         public static class Builder {
             final Body.Builder ancestorBody;
             final String funcName;
-            final FunctionType funcType;
+            final FunctionType signature;
 
-            Builder(Body.Builder ancestorBody, String funcName, FunctionType funcType) {
+            Builder(Body.Builder ancestorBody, String funcName, FunctionType signature) {
                 this.ancestorBody = ancestorBody;
                 this.funcName = funcName;
-                this.funcType = funcType;
+                this.signature = signature;
             }
 
             /**
@@ -104,7 +104,7 @@ public sealed abstract class CoreOp extends Op {
              * @return the completed function operation
              */
             public FuncOp body(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, funcType);
+                Body.Builder body = Body.Builder.of(ancestorBody, signature);
                 c.accept(body.entryBlock());
                 return new FuncOp(funcName, body);
             }
@@ -1520,11 +1520,11 @@ public sealed abstract class CoreOp extends Op {
      * Creates a function operation builder.
      *
      * @param funcName the function name
-     * @param funcType the function type
+     * @param signature the function's signature, represented as a function type
      * @return the function operation builder
      */
-    public static FuncOp.Builder func(String funcName, FunctionType funcType) {
-        return new FuncOp.Builder(null, funcName, funcType);
+    public static FuncOp.Builder func(String funcName, FunctionType signature) {
+        return new FuncOp.Builder(null, funcName, signature);
     }
 
     /**
@@ -1542,24 +1542,24 @@ public sealed abstract class CoreOp extends Op {
      * Creates a function call operation.
      *
      * @param funcName the name of the target function
-     * @param funcType the type of the target function
+     * @param signature the signature of the target function, represented as a function type
      * @param args     the function arguments
      * @return the function call operation
      */
-    public static FuncCallOp funcCall(String funcName, FunctionType funcType, Value... args) {
-        return funcCall(funcName, funcType, List.of(args));
+    public static FuncCallOp funcCall(String funcName, FunctionType signature, Value... args) {
+        return funcCall(funcName, signature, List.of(args));
     }
 
     /**
      * Creates a function call operation.
      *
-     * @param funcName the name of the target function
-     * @param funcType the type of the target function
-     * @param args     the function arguments
+     * @param funcName  the name of the target function
+     * @param signature the signature of the target function, represented as a function type
+     * @param args      the function arguments
      * @return the function call operation
      */
-    public static FuncCallOp funcCall(String funcName, FunctionType funcType, List<Value> args) {
-        return new FuncCallOp(funcName, funcType.returnType(), args);
+    public static FuncCallOp funcCall(String funcName, FunctionType signature, List<Value> args) {
+        return new FuncCallOp(funcName, signature.returnType(), args);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -113,7 +113,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "func";
 
         /**
-         * The externalized attribute modelling the function name
+         * The externalized attribute modeling the function name
          */
         static final String ATTRIBUTE_FUNC_NAME = NAME + ".name";
 
@@ -232,7 +232,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "func.call";
 
         /**
-         * The externalized attribute modelling the name of the invoked function
+         * The externalized attribute modeling the name of the invoked function
          */
         static final String ATTRIBUTE_FUNC_NAME = NAME + ".name";
 
@@ -887,7 +887,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "constant";
 
         /**
-         * The externalized attribute modelling the constant value
+         * The externalized attribute modeling the constant value
          */
         static final String ATTRIBUTE_CONSTANT_VALUE = NAME + ".value";
 
@@ -1019,7 +1019,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "var";
 
         /**
-         * The externalized attribute modelling the variable name
+         * The externalized attribute modeling the variable name
          */
         static final String ATTRIBUTE_NAME = NAME + ".name";
 
@@ -1329,7 +1329,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "tuple.load";
 
         /**
-         * The externalized attribute modelling the tuple index
+         * The externalized attribute modeling the tuple index
          */
         static final String ATTRIBUTE_INDEX = NAME + ".index";
 
@@ -1409,7 +1409,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "tuple.with";
 
         /**
-         * The externalized attribute modelling the tuple index
+         * The externalized attribute modeling the tuple index
          */
         static final String ATTRIBUTE_INDEX = NAME + ".index";
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -61,7 +61,7 @@ import static jdk.incubator.code.internal.ArithmeticAndConvOpImpls.*;
  * operations. Such a model represents the same Java program and preserves the program meaning as defined by the
  * Java Language Specification.
  * <p>
- * Java operations model specific Java language constructs or Java program behaviour. Some Java operations model
+ * Java operations model specific Java language constructs or Java program behavior. Some Java operations model
  * structured control flow and nested code. These operations are transformable, commonly referred to as lowering, into
  * a sequence of other core or Java operations. Those that implement {@link Op.Lowerable} can transform themselves and
  * will transform associated operations that are not explicitly lowerable.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -408,21 +408,21 @@ public sealed abstract class JavaOp extends Op {
          */
         public static class Builder {
             final Body.Builder ancestorBody;
-            final FunctionType funcType;
+            final FunctionType signature;
             final CodeType functionalInterface;
             final boolean isReflectable;
 
-            Builder(Body.Builder ancestorBody, FunctionType funcType, CodeType functionalInterface) {
+            Builder(Body.Builder ancestorBody, FunctionType signature, CodeType functionalInterface) {
                 this.ancestorBody = ancestorBody;
-                this.funcType = funcType;
+                this.signature = signature;
                 this.functionalInterface = functionalInterface;
                 this.isReflectable = false;
             }
 
-            Builder(Body.Builder ancestorBody, FunctionType funcType, CodeType functionalInterface,
+            Builder(Body.Builder ancestorBody, FunctionType signature, CodeType functionalInterface,
                     boolean isReflectable) {
                 this.ancestorBody = ancestorBody;
-                this.funcType = funcType;
+                this.signature = signature;
                 this.functionalInterface = functionalInterface;
                 this.isReflectable = isReflectable;
             }
@@ -434,7 +434,7 @@ public sealed abstract class JavaOp extends Op {
              * @return the completed lambda operation
              */
             public LambdaOp body(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, funcType);
+                Body.Builder body = Body.Builder.of(ancestorBody, signature);
                 c.accept(body.entryBlock());
                 return new LambdaOp(functionalInterface, body, isReflectable);
             }
@@ -446,7 +446,7 @@ public sealed abstract class JavaOp extends Op {
              * @see Reflect
              */
             public Builder reflectable() {
-                return new Builder(ancestorBody, funcType, functionalInterface, true);
+                return new Builder(ancestorBody, signature, functionalInterface, true);
             }
         }
 
@@ -1000,7 +1000,7 @@ public sealed abstract class JavaOp extends Op {
                                 // If varargs then we cannot infer invoke kind
                                 throw new UnsupportedOperationException("Unsupported invoke kind value:" + v);
                             }
-                            int paramCount = invokeRef.type().parameterTypes().size();
+                            int paramCount = invokeRef.signature().parameterTypes().size();
                             int argCount = def.operands().size();
                             yield (argCount == paramCount + 1)
                                     ? InvokeKind.INSTANCE
@@ -1038,7 +1038,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         static void validateArgCount(InvokeKind invokeKind, boolean isVarArgs, MethodRef invokeRef, List<Value> operands) {
-            int paramCount = invokeRef.type().parameterTypes().size();
+            int paramCount = invokeRef.signature().parameterTypes().size();
             int argCount = operands.size() - (invokeKind == InvokeKind.STATIC ? 0 : 1);
             if ((!isVarArgs && argCount != paramCount)
                     || argCount < paramCount - 1) {
@@ -1109,7 +1109,7 @@ public sealed abstract class JavaOp extends Op {
 
             int operandCount = operands().size();
             int argCount = operandCount - (invokeKind == InvokeKind.STATIC ? 0 : 1);
-            int paramCount = invokeReference.type().parameterTypes().size();
+            int paramCount = invokeReference.signature().parameterTypes().size();
             int varArgCount = argCount - (paramCount - 1);
             return operands().subList(operandCount - varArgCount, operandCount);
         }
@@ -1121,7 +1121,7 @@ public sealed abstract class JavaOp extends Op {
             if (!isVarArgs) {
                 return operands();
             }
-            int paramCount = invokeReference().type().parameterTypes().size();
+            int paramCount = invokeReference().signature().parameterTypes().size();
             int argOperandsCount = paramCount - (invokeKind() == InvokeKind.STATIC ? 1 : 0);
             return operands().subList(0, argOperandsCount);
         }
@@ -1257,7 +1257,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         static void validateArgCount(boolean isVarArgs, MethodRef ctorRef, List<Value> operands) {
-            int paramCount = ctorRef.type().parameterTypes().size();
+            int paramCount = ctorRef.signature().parameterTypes().size();
             int argCount = operands.size();
             if ((!isVarArgs && argCount != paramCount)
                     || argCount < paramCount - 1) {
@@ -3275,9 +3275,9 @@ public sealed abstract class JavaOp extends Op {
     public static final class IfOp extends JavaOp
             implements Op.Nested, Op.Lowerable, JavaStatement {
 
-        static final FunctionType PREDICATE_TYPE = CoreType.functionType(BOOLEAN);
+        static final FunctionType PREDICATE_SIGNATURE = CoreType.functionType(BOOLEAN);
 
-        static final FunctionType ACTION_TYPE = CoreType.FUNCTION_TYPE_VOID;
+        static final FunctionType ACTION_SIGNATURE = CoreType.FUNCTION_TYPE_VOID;
 
         /**
          * Builder for the initial predicate body of an if operation.
@@ -3298,7 +3298,7 @@ public sealed abstract class JavaOp extends Op {
              * @return a builder to add an action body to the if operation
              */
             public ThenBuilder if_(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, PREDICATE_TYPE);
+                Body.Builder body = Body.Builder.of(ancestorBody, PREDICATE_SIGNATURE);
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -3325,7 +3325,7 @@ public sealed abstract class JavaOp extends Op {
              * @return a builder for further predicate and action bodies
              */
             public ElseIfBuilder then(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_TYPE);
+                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_SIGNATURE);
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -3337,7 +3337,7 @@ public sealed abstract class JavaOp extends Op {
              * @return a builder for further predicate and action bodies
              */
             public ElseIfBuilder then() {
-                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_TYPE);
+                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_SIGNATURE);
                 body.entryBlock().op(core_yield());
                 bodies.add(body);
 
@@ -3364,7 +3364,7 @@ public sealed abstract class JavaOp extends Op {
              * @return a builder to add an action body to the if operation
              */
             public ThenBuilder elseif(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, PREDICATE_TYPE);
+                Body.Builder body = Body.Builder.of(ancestorBody, PREDICATE_SIGNATURE);
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -3378,7 +3378,7 @@ public sealed abstract class JavaOp extends Op {
              * @return the completed if operation
              */
             public IfOp else_(Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_TYPE);
+                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_SIGNATURE);
                 c.accept(body.entryBlock());
                 bodies.add(body);
 
@@ -3390,7 +3390,7 @@ public sealed abstract class JavaOp extends Op {
              * @return the completed if operation
              */
             public IfOp else_() {
-                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_TYPE);
+                Body.Builder body = Body.Builder.of(ancestorBody, ACTION_SIGNATURE);
                 body.entryBlock().op(core_yield());
                 bodies.add(body);
 
@@ -6250,13 +6250,13 @@ public sealed abstract class JavaOp extends Op {
      * Creates a lambda operation.
      *
      * @param ancestorBody        the ancestor of the body of the lambda operation
-     * @param funcType            the lambda operation's function type
+     * @param signature           the lambda operation's signature, represented as a function type
      * @param functionalInterface the lambda operation's functional interface type
      * @return the lambda operation
      */
     public static LambdaOp.Builder lambda(Body.Builder ancestorBody,
-                                          FunctionType funcType, CodeType functionalInterface) {
-        return new LambdaOp.Builder(ancestorBody, funcType, functionalInterface);
+                                          FunctionType signature, CodeType functionalInterface) {
+        return new LambdaOp.Builder(ancestorBody, signature, functionalInterface);
     }
 
     /**
@@ -6409,7 +6409,7 @@ public sealed abstract class JavaOp extends Op {
      * @return the invoke operation
      */
     public static InvokeOp invoke(MethodRef invokeRef, List<Value> args) {
-        return invoke(invokeRef.type().returnType(), invokeRef, args);
+        return invoke(invokeRef.signature().returnType(), invokeRef, args);
     }
 
     /**
@@ -6449,7 +6449,7 @@ public sealed abstract class JavaOp extends Op {
      * @return the invoke super operation
      */
     public static InvokeOp invoke(CodeType returnType, MethodRef invokeRef, List<Value> args) {
-        int paramCount = invokeRef.type().parameterTypes().size();
+        int paramCount = invokeRef.signature().parameterTypes().size();
         int argCount = args.size();
         InvokeOp.InvokeKind ik = (argCount == paramCount + 1)
                 ? InvokeOp.InvokeKind.INSTANCE

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/MethodRef.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/MethodRef.java
@@ -51,7 +51,7 @@ import static jdk.incubator.code.dialect.core.CoreType.functionType;
  * <ul>
  *     <li>an <em>owner type</em>, the type of which the target method is a member;</li>
  *     <li>a <em>name</em>, the name of the target method.</li>
- *     <li>a <em>type</em>, the type of the target method.</li>
+ *     <li>a <em>signature</em>, representing the method type of the target method.</li>
  * </ul>
  * Some method references, called <em>constructor references</em> are used to model a Java constructor, called
  * the <em>target constructor</em>. The name of a constructor reference is always the special name {@code "<init>"}.
@@ -74,9 +74,9 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
     String name();
 
     /**
-     * {@return the type of this method reference}
+     * {@return the signature of this method reference, represented as a function type}
      */
-    FunctionType type();
+    FunctionType signature();
 
     /**
      * {@return {@code true}, if this method reference is a constructor reference}
@@ -138,7 +138,7 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
      * {@return a method reference obtained from the provided owner, name and type}
      * @param refType the reference owner type
      * @param name the reference name
-     * @param mt the reference type
+     * @param mt the reference method type
      */
     static MethodRef method(Class<?> refType, String name, MethodType mt) {
         return method(refType, name, mt.returnType(), mt.parameterList());
@@ -170,10 +170,10 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
      * {@return a method reference obtained from the provided owner, name and type}
      * @param refType the reference owner type
      * @param name the reference name
-     * @param type the reference type
+     * @param signature the reference signature, represented as a function type
      */
-    static MethodRef method(CodeType refType, String name, FunctionType type) {
-        return new MethodRefImpl(refType, name, type);
+    static MethodRef method(CodeType refType, String name, FunctionType signature) {
+        return new MethodRefImpl(refType, name, signature);
     }
 
     /**
@@ -201,7 +201,7 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
     // Constructor factories
 
     /**
-     * {@return a method reference obtained from the provided constructor}
+     * {@return a constructor method reference obtained from the provided constructor}
      * @param c a reflective constructor
      */
     static MethodRef constructor(Constructor<?> c) {
@@ -210,16 +210,16 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
     }
 
     /**
-     * {@return a method reference obtained from the provided type}
+     * {@return a constructor method reference obtained from the provided method type}
      * The owner type of the returned method reference is the return type of the provided type.
-     * @param mt the reference type
+     * @param mt the method type
      */
     static MethodRef constructor(MethodType mt) {
         return constructor(mt.returnType(), mt.parameterList());
     }
 
     /**
-     * {@return a method reference obtained from the provided owner and parameter types}
+     * {@return a constructor method reference obtained from the provided owner and parameter types}
      * @param refType the reference owner type
      * @param params the reference parameter types
      */
@@ -228,7 +228,7 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
     }
 
     /**
-     * {@return a method reference obtained from the provided owner and parameter types}
+     * {@return a constructor method reference obtained from the provided owner and parameter types}
      * @param refType the reference owner type
      * @param params the reference parameter types
      */
@@ -237,7 +237,7 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
     }
 
     /**
-     * {@return a method reference obtained from the provided owner and parameter types}
+     * {@return a constructor method reference obtained from the provided owner and parameter types}
      * @param refType the reference owner type
      * @param params the reference parameter types
      */
@@ -246,7 +246,7 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
     }
 
     /**
-     * {@return a method reference obtained from the provided owner and parameter types}
+     * {@return a constructor method reference obtained from the provided owner and parameter types}
      * @param refType the reference owner type
      * @param params the reference parameter types
      */
@@ -255,12 +255,12 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
     }
 
     /**
-     * {@return a method reference obtained from the provided type}
+     * {@return a constructor method reference obtained from the provided type}
      * The owner type of the returned method reference is the return type of the provided type.
-     * @param type the reference type
+     * @param signature the signature of the reference type, represented as a function type.
      */
-    static MethodRef constructor(FunctionType type) {
-        return new MethodRefImpl(type.returnType(), INIT_NAME, type);
+    static MethodRef constructor(FunctionType signature) {
+        return new MethodRefImpl(signature.returnType(), INIT_NAME, signature);
     }
 
     // MethodTypeDesc factories
@@ -278,12 +278,12 @@ public sealed interface MethodRef extends JavaRef, TypeVariableType.Owner
 
     /**
      * {@return a nominal method type descriptor representing the signature of the given function type}
-     * @param t the function type to convert
+     * @param signature the signature to convert, represented as a function type
      */
-    static MethodTypeDesc toNominalDescriptor(FunctionType t) {
+    static MethodTypeDesc toNominalDescriptor(FunctionType signature) {
         return MethodTypeDesc.of(
-                toClassDesc(t.returnType()),
-                t.parameterTypes().stream().map(MethodRef::toClassDesc).toList());
+                toClassDesc(signature.returnType()),
+                signature.parameterTypes().stream().map(MethodRef::toClassDesc).toList());
     }
 
     private static ClassDesc toClassDesc(CodeType e) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/impl/JavaTypeUtils.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/impl/JavaTypeUtils.java
@@ -66,7 +66,7 @@ public class JavaTypeUtils {
     public static final String JAVA_REF_FLAT_NAME_PREFIX = "java.ref:";
 
     /**
-     * An enum modelling the Java type form kind. Useful for switching.
+     * An enum modeling the Java type form kind. Useful for switching.
      */
     public enum Kind {
         /** A flattened type form */
@@ -83,7 +83,7 @@ public class JavaTypeUtils {
         /**
          * Constructs a new kind from an externalized type form
          * @param tree the externalized type form
-         * @return the kind modelling {@code tree}
+         * @return the kind modeling {@code tree}
          */
         public static Kind of(ExternalizedCodeType tree) {
             return switch (tree.identifier()) {
@@ -209,7 +209,7 @@ public class JavaTypeUtils {
     // From externalized Java types/refs into actual Java types/refs
 
     /**
-     * {@return a {@code JavaType} modelling the provided inflated Java type form}.
+     * {@return a {@code JavaType} modeling the provided inflated Java type form}.
      * @param tree the inflated Java type form
      */
     public static JavaType toJavaType(ExternalizedCodeType tree) {
@@ -254,7 +254,7 @@ public class JavaTypeUtils {
     }
 
     /**
-     * {@return a {@code JavaRef} modelling the provided inflated Java reference form}.
+     * {@return a {@code JavaRef} modeling the provided inflated Java reference form}.
      * @param tree the inflated Java reference form
      */
     public static JavaRef toJavaRef(ExternalizedCodeType tree) {
@@ -296,7 +296,7 @@ public class JavaTypeUtils {
     // From externalized Java types/refs into external type/refs strings
 
     /**
-     * {@return a flat string modelling the provided inflated Java type form}.
+     * {@return a flat string modeling the provided inflated Java type form}.
      * @param tree the inflated Java type form
      */
     public static String toExternalTypeString(ExternalizedCodeType tree) {
@@ -345,7 +345,7 @@ public class JavaTypeUtils {
     }
 
     /**
-     * {@return a flat string modelling the provided inflated Java reference form}.
+     * {@return a flat string modeling the provided inflated Java reference form}.
      * @param tree the inflated Java type form
      */
     public static String toExternalRefString(ExternalizedCodeType tree) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/impl/MethodRefImpl.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/impl/MethodRefImpl.java
@@ -39,7 +39,7 @@ import jdk.incubator.code.dialect.core.FunctionType;
 import jdk.incubator.code.CodeType;
 import jdk.incubator.code.extern.ExternalizedCodeType;
 
-public record MethodRefImpl(CodeType refType, String name, FunctionType type) implements MethodRef {
+public record MethodRefImpl(CodeType refType, String name, FunctionType signature) implements MethodRef {
 
     static final MethodHandle MULTI_NEW_ARRAY_MH;
 
@@ -89,14 +89,14 @@ public record MethodRefImpl(CodeType refType, String name, FunctionType type) im
     }
 
     private MethodHandle resolveToConstructorHandle(MethodHandles.Lookup l) throws ReflectiveOperationException {
-        Class<?> refC = ResolutionHelper.resolveClass(l, type.returnType());
-        if (type.returnType() instanceof ArrayType at) {
+        Class<?> refC = ResolutionHelper.resolveClass(l, signature.returnType());
+        if (signature.returnType() instanceof ArrayType at) {
             if (at.dimensions() == 1) {
                 return MethodHandles.arrayConstructor(refC);
             } else {
-                int dims = type.parameterTypes().size();
+                int dims = signature.parameterTypes().size();
                 Class<?> elementType = refC;
-                for (int i = 0 ; i < type.parameterTypes().size(); i++) {
+                for (int i = 0; i < signature.parameterTypes().size(); i++) {
                     elementType = elementType.componentType();
                 }
                 // only the use-site knows how many dimensions are specified
@@ -106,7 +106,7 @@ public record MethodRefImpl(CodeType refType, String name, FunctionType type) im
             }
         } else {
             // MH lookup wants a void-returning lookup type
-            MethodType mt = MethodRef.toNominalDescriptor(type).resolveConstantDesc(l).changeReturnType(void.class);
+            MethodType mt = MethodRef.toNominalDescriptor(signature).resolveConstantDesc(l).changeReturnType(void.class);
             return l.findConstructor(refC, mt);
         }
     }
@@ -115,11 +115,11 @@ public record MethodRefImpl(CodeType refType, String name, FunctionType type) im
     public ExternalizedCodeType externalize() {
         if (!isConstructor()) {
             return JavaTypeUtils.methodRef(name, refType.externalize(),
-                    type.returnType().externalize(),
-                    type.parameterTypes().stream().map(CodeType::externalize).toList());
+                    signature.returnType().externalize(),
+                    signature.parameterTypes().stream().map(CodeType::externalize).toList());
         } else {
-            return JavaTypeUtils.constructorRef(type.returnType().externalize(),
-                    type.parameterTypes().stream().map(CodeType::externalize).toList());
+            return JavaTypeUtils.constructorRef(signature.returnType().externalize(),
+                    signature.parameterTypes().stream().map(CodeType::externalize).toList());
         }
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/impl/ResolutionHelper.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/impl/ResolutionHelper.java
@@ -72,7 +72,7 @@ public class ResolutionHelper {
 
     public static MethodHandle resolveMethod(MethodHandles.Lookup l, MethodRef methodRef, InvokeKind kind) throws ReflectiveOperationException {
         Class<?> refC = resolveClass(l, methodRef.refType());
-        MethodType mt = resolveMethodType(l, methodRef.type());
+        MethodType mt = resolveMethodType(l, methodRef.signature());
         HandleResolver<MethodHandle, MethodType> resolver = switch (kind) {
             case INSTANCE -> HandleResolver.FIND_VIRTUAL;
             case STATIC -> HandleResolver.FIND_STATIC;
@@ -83,7 +83,7 @@ public class ResolutionHelper {
 
     public static MethodHandle resolveMethod(MethodHandles.Lookup l, MethodRef methodRef) throws ReflectiveOperationException {
         Class<?> refC = resolveClass(l, methodRef.refType());
-        MethodType mt = resolveMethodType(l, methodRef.type());
+        MethodType mt = resolveMethodType(l, methodRef.signature());
         return resolveHandle(HandleResolver.FIND_STATIC, l, refC, methodRef.name(), mt)
                 .orElse(() -> resolveHandle(HandleResolver.FIND_VIRTUAL, l, refC, methodRef.name(), mt))
                 .handle();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
@@ -523,7 +523,7 @@ public class OpBuilder {
             args.addAll(successorArgs);
             Value successor = builder.op(invoke(
                     InvokeOp.InvokeKind.INSTANCE, true,
-                    BLOCK_BUILDER_REFERENCE.type().returnType(),
+                    BLOCK_BUILDER_REFERENCE.signature().returnType(),
                     BLOCK_BUILDER_REFERENCE, args));
             successors.add(successor);
         }
@@ -597,7 +597,7 @@ public class OpBuilder {
         Value yieldType = buildType(inputBody.yieldType());
         Value bodyType = builder.op(invoke(
                 InvokeOp.InvokeKind.STATIC, true,
-                FUNCTION_TYPE_FUNCTION_TYPE.type().returnType(),
+                FUNCTION_TYPE_FUNCTION_TYPE.signature().returnType(),
                 FUNCTION_TYPE_FUNCTION_TYPE, List.of(yieldType)));
         Value body = builder.op(invoke(BODY_BUILDER_OF, ancestorBodyValue, bodyType));
 
@@ -609,7 +609,7 @@ public class OpBuilder {
             } else {
                 assert entryBlock != null;
                 block = builder.op(invoke(InvokeOp.InvokeKind.INSTANCE, true,
-                        BLOCK_BUILDER_BLOCK.type().returnType(),
+                        BLOCK_BUILDER_BLOCK.signature().returnType(),
                         BLOCK_BUILDER_BLOCK, List.of(entryBlock)));
             }
             blockMap.put(inputBlock, block);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -458,12 +458,12 @@ public class ReflectMethods extends TreeTranslatorPrev {
         // Label
         Map.Entry<String, Op.Result> label;
 
-        BodyStack(BodyStack parent, JCTree tree, FunctionType bodyType) {
+        BodyStack(BodyStack parent, JCTree tree, FunctionType bodySignature) {
             this.parent = parent;
 
             this.tree = tree;
 
-            this.body = Body.Builder.of(parent != null ? parent.body : null, bodyType);
+            this.body = Body.Builder.of(parent != null ? parent.body : null, bodySignature);
             this.block = body.entryBlock();
 
             this.localToOp = new LinkedHashMap<>(); // order is important for captured values
@@ -505,10 +505,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
             tree.sym.type.getParameterTypes().stream().map(ReflectMethods.this::typeToCodeType).forEach(parameters::add);
 
-            FunctionType bodyType = CoreType.functionType(
+            FunctionType bodySignature = CoreType.functionType(
                     typeToCodeType(tree.sym.type.getReturnType()), parameters);
 
-            this.stack = this.top = new BodyStack(null, tree.body, bodyType);
+            this.stack = this.top = new BodyStack(null, tree.body, bodySignature);
 
             // @@@ this as local variable? (it can never be stored to)
             for (int i = 0 ; i < tree.params.size() ; i++) {
@@ -635,8 +635,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
         }
 
-        void pushBody(JCTree tree, FunctionType bodyType) {
-            stack = new BodyStack(stack, tree, bodyType);
+        void pushBody(JCTree tree, FunctionType bodySignature) {
+            stack = new BodyStack(stack, tree, bodySignature);
             lastOp = null; // reset
         }
 
@@ -1441,11 +1441,11 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // as the signature of the constructor symbol is not augmented
             // with enclosing this and captured params.
             MethodRef methodRef = symbolToMethodRef(tree.constructor);
-            argtypes.addAll(methodRef.type().parameterTypes());
-            FunctionType constructorType = CoreType.functionType(
+            argtypes.addAll(methodRef.signature().parameterTypes());
+            FunctionType constructorSignature = CoreType.functionType(
                     symbolToErasedDesc(tree.constructor.owner),
                     argtypes);
-            MethodRef constructorRef = MethodRef.constructor(constructorType);
+            MethodRef constructorRef = MethodRef.constructor(constructorSignature);
 
             args.addAll(scanMethodArguments(tree.args, tree.constructorType, tree.varargsElement));
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -31,7 +31,7 @@
 /// This package documentation is organized into three parts. The first part introduces code reflection using
 /// examples and explains how code reflection extends the core reflection API. The second part builds on those examples
 /// and explains how code models can be traversed, executed, built, and transformed. The third part more formally
-/// explains code model structure, code model behaviour, dialects, and the use of `core` and `Java` dialects to define
+/// explains code model structure, code model behavior, dialects, and the use of `core` and `Java` dialects to define
 /// Java code models.
 ///
 /// ## Core reflection API

--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -420,11 +420,11 @@ public final class BytecodeLift {
                         case INVOKEVIRTUAL, INVOKEINTERFACE -> {
                             operands.add(stack.pop());
                             yield op(JavaOp.invoke(JavaOp.InvokeOp.InvokeKind.INSTANCE, false,
-                                    mDesc.type().returnType(), mDesc, operands.reversed()));
+                                    mDesc.signature().returnType(), mDesc, operands.reversed()));
                         }
                         case INVOKESTATIC ->
                                 op(JavaOp.invoke(JavaOp.InvokeOp.InvokeKind.STATIC, false,
-                                        mDesc.type().returnType(), mDesc, operands.reversed()));
+                                        mDesc.signature().returnType(), mDesc, operands.reversed()));
                         case INVOKESPECIAL -> {
                             if (inst.owner().asSymbol().equals(newStack.peek()) && inst.name().equalsString(ConstantDescs.INIT_NAME)) {
                                 newStack.pop();
@@ -436,7 +436,7 @@ public final class BytecodeLift {
                             } else {
                                 operands.add(stack.pop());
                                 yield op(JavaOp.invoke(JavaOp.InvokeOp.InvokeKind.SUPER, false,
-                                        mDesc.type().returnType(), mDesc, operands.reversed()));
+                                        mDesc.signature().returnType(), mDesc, operands.reversed()));
                             }
                         }
                         default ->

--- a/test/jdk/jdk/incubator/code/bytecode/lift/UnresolvedTypesTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/UnresolvedTypesTransformer.java
@@ -129,7 +129,7 @@ final class UnresolvedTypesTransformer {
                             if (i == 0) yield resolveTo(ut, id.refType());
                             i--;
                         }
-                        yield resolveTo(ut, id.type().parameterTypes().get(i));
+                        yield resolveTo(ut, id.signature().parameterTypes().get(i));
                     }
                     case JavaOp.FieldAccessOp fao ->
                         resolveTo(ut, fao.fieldReference().refType());
@@ -140,7 +140,7 @@ final class UnresolvedTypesTransformer {
                     case CoreOp.VarAccessOp.VarStoreOp vso ->
                         resolveTo(ut, vso.varType().valueType());
                     case JavaOp.NewOp no ->
-                        resolveTo(ut, no.constructorReference().type().parameterTypes().get(i));
+                        resolveTo(ut, no.constructorReference().signature().parameterTypes().get(i));
                     case JavaOp.ArrayAccessOp.ArrayLoadOp alo ->
                         resolveTo(ut, toArray(alo.resultType()));
                     case JavaOp.ArrayAccessOp.ArrayStoreOp aso ->

--- a/test/jdk/jdk/incubator/code/pe/PartialEvaluator.java
+++ b/test/jdk/jdk/incubator/code/pe/PartialEvaluator.java
@@ -365,7 +365,7 @@ final class PartialEvaluator {
                     }
                     return Array.newInstance(resolveToClass(l, nType), lengths);
                 } else {
-                    MethodHandle mh = constructorHandle(l, no.constructorReference().type());
+                    MethodHandle mh = constructorHandle(l, no.constructorReference().signature());
                     return invoke(mh, values);
                 }
             }


### PR DESCRIPTION
Fix various spelling/typo issues.

Consistently use the name signature when using a function type to represent the signature of a method, constructor, body etc.

`MethodRef.type` is renamed to `MethodRef.signature`.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1004/head:pull/1004` \
`$ git checkout pull/1004`

Update a local copy of the PR: \
`$ git checkout pull/1004` \
`$ git pull https://git.openjdk.org/babylon.git pull/1004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1004`

View PR using the GUI difftool: \
`$ git pr show -t 1004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1004.diff">https://git.openjdk.org/babylon/pull/1004.diff</a>

</details>
