### PR TITLE
Improve specification for building models

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -109,9 +109,6 @@ public final class Block implements CodeElement<Block, Op> {
      * When control is passed from a block to a successor block the values of the block reference's arguments are
      * assigned, in order, to the successor block's parameters.
      * <p>
-     * A block reference is considered unbuilt if it's {@link #targetBlock() target block} is unbuilt and
-     * is therefore in accessible. A block reference is considered built when the target block is built
-     * and therefore is accessible.
      */
     public static final class Reference implements CodeItem {
         final Block target;
@@ -130,11 +127,11 @@ public final class Block implements CodeElement<Block, Op> {
 
         /**
          * {@return the target block.}
-         * @throws IllegalStateException if this block reference is unbuilt because its target block is unbuilt.
+         * @throws IllegalStateException if the target block is being built and is not observable.
          */
         public Block targetBlock() {
             if (!isBuilt()) {
-                throw new IllegalStateException("Target block is unbuilt");
+                throw new IllegalStateException("Target block is being built and is not observable");
             }
 
             return target;
@@ -472,6 +469,10 @@ public final class Block implements CodeElement<Block, Op> {
      * <p>
      * A block builder is built when its {@link #parent() parent} body builder is {@link Body.Builder#build(Op) built}.
      * <p>
+     * A block is not observable while it is being built. Attempts to access a block being built through appended
+     * operations, their operation results, or created block references, result in an exception.
+     *
+     * <p>
      * If a built builder is operated on to append a block parameter, append an operation, build a sibling block,
      * then an {@code IllegalStateException} is thrown.
      */
@@ -581,7 +582,7 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Appends an unbuilt block parameter to the block's parameters.
+         * Appends a block parameter to the block's parameters.
          *
          * @param p the parameter type
          * @return the appended block parameter
@@ -592,24 +593,30 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Creates an unbuilt block reference to this block that can be used as a successor of a terminating operation.
+         * Creates a block reference to this block that can be used as a successor of a terminating operation.
+         * <p>
+         * A reference can only be constructed with block arguments whose declaring block is being built, otherwise
+         * construction fails with an exception.
          *
-         * @param args the unbuilt block arguments
+         * @param args the block arguments
          * @return the reference to this block
          * @throws IllegalStateException if this block builder is associated with the entry block.
-         * @throws IllegalArgumentException if a block argument is built because its declaring block is built.
+         * @throws IllegalArgumentException if a block argument's declaring block is built.
          */
         public Reference reference(Value... args) {
             return reference(List.of(args));
         }
 
         /**
-         * Creates an unbuilt block reference to this block that can be used as a successor of a terminating operation.
+         * Creates a block reference to this block that can be used as a successor of a terminating operation.
+         * <p>
+         * A reference can only be constructed with block arguments whose declaring block is being built, otherwise
+         * construction fails with an exception.
          *
-         * @param args the unbuilt block arguments
+         * @param args the block arguments
          * @return the reference to this block
          * @throws IllegalStateException if this block builder is associated with the entry block.
-         * @throws IllegalArgumentException if a block argument is built because its declaring block is built.
+         * @throws IllegalArgumentException if a block argument's declaring block is built.
          */
         public Reference reference(List<? extends Value> args) {
             if (isEntryBlock()) {
@@ -617,7 +624,7 @@ public final class Block implements CodeElement<Block, Op> {
             }
             for (Value operand : args) {
                 if (operand.isBuilt()) {
-                    throw new IllegalArgumentException("Operand's declaring block is built: " + operand);
+                    throw new IllegalArgumentException("Argument's declaring block is built: " + operand);
                 }
             }
 
@@ -676,16 +683,18 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Appends an operation to this block builder, first transforming the operation if it is built or unbuilt-bound.
+         * Appends an operation to this block builder, first transforming the operation if it is attached to a block,
+         * or a root operation.
          * <p>
-         * If the operation is unbuilt, then the operation is appended and bound to this block to become unbuilt-bound.
-         * Otherwise, if the operation is built or unbuilt-bound, the operation is first
+         * If the operation is unattached, then the operation is appended and attached to this block, and the operation
+         * is assigned an operation result.
+         * Otherwise, the operation (an attached or root operation) is first
          * {@link Op#transform(CodeContext, CodeTransformer) transformed} with this builder's context and
-         * code transformer, the resulting transformed unbuilt operation is appended, and the
-         * operation's result mapped to the transformed operation's unbuilt result, using the builder's context.
+         * code transformer, the resulting transformed and unattached operation is attached and appended, and the
+         * operation's result mapped to the transformed operation's result, using the builder's context.
          * <p>
-         * If the unbuilt operation (transformed, or otherwise) is structurally invalid then an
-         * {@code IllegalStateException} is thrown. An unbuilt operation is structurally invalid if:
+         * If the operation (transformed, or otherwise) is structurally invalid then an
+         * {@code IllegalStateException} is thrown. An operation is structurally invalid if:
          * <ul>
          * <li>any of its bodies does not have the same ancestor body as this block's parent body.
          * <li>any of its operands (values) is not reachable from this block.
@@ -699,7 +708,7 @@ public final class Block implements CodeElement<Block, Op> {
          * dominance check that can only be performed when the parent body is built.)
          *
          * @param op the operation to append
-         * @return the unbuilt operation result of the appended operation
+         * @return the operation result of the appended operation
          * @throws IllegalStateException if the operation is structurally invalid
          */
         public Op.Result op(Op op) {
@@ -774,7 +783,7 @@ public final class Block implements CodeElement<Block, Op> {
 
         for (Body b : op.bodies()) {
             if (b.ancestorBody != null && b.ancestorBody != this.parentBody) {
-                throw new IllegalStateException("Body of operation is bound to a different ancestor body: ");
+                throw new IllegalStateException("Body of operation is connected to a different ancestor body: ");
             }
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -469,9 +469,8 @@ public final class Block implements CodeElement<Block, Op> {
      * <p>
      * A block builder is built when its {@link #parent() parent} body builder is {@link Body.Builder#build(Op) built}.
      * <p>
-     * A block is not observable while it is being built. Attempts to access a block being built through appended
-     * operations, their operation results, or created block references, result in an exception.
-     *
+     * A block is not observable while it is being built. Attempts to access a block being built through the block's
+     * parameters, appended operations, their operation results, or created block references, result in an exception.
      * <p>
      * If a built builder is operated on to append a block parameter, append an operation, build a sibling block,
      * then an {@code IllegalStateException} is thrown.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -32,7 +32,7 @@ import java.util.*;
 /**
  * A body containing a sequence of (basic) blocks.
  * <p>
- * The sequence of blocks form a graph topologically sorted in reserve postorder.
+ * The sequence of blocks form a graph topologically sorted in reverse postorder.
  * The first block in the sequence is the entry block, and no other blocks refer to it as a successor.
  * The last operation in a block, a terminating operation, may refer to other blocks in the sequence as successors,
  * thus forming the graph. Otherwise, the last operation defines how the body passes control back to the parent
@@ -49,9 +49,8 @@ import java.util.*;
  * {@link Block.Builder#block(CodeType...) built}. A block builder can also be used to
  * {@link Block.Builder#reference(Value...) create} references to non-entry sibling blocks that can be used as
  * successors of terminal operations.
- *
- * When a body is {@link Body.Builder#build(Op) built} all blocks
- * in the body are also built.
+ * When a body completes {@link Body.Builder#build(Op) building} with a given operation all blocks in the body are also
+ * built. The given operation becomes the body's {@link #parent()}.
  */
 public final class Body implements CodeElement<Body, Block> {
     // @Stable?
@@ -87,9 +86,7 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * Returns this body's parent operation.
-     *
-     * @return the body's parent operation.
+     * {@return the body's parent operation.}
      */
     @Override
     public Op parent() {
@@ -434,7 +431,7 @@ public final class Body implements CodeElement<Body, Block> {
      */
     public final class Builder {
         /**
-         * Creates a body build with a new context, and a copying transformer.
+         * Creates a body builder with a new context, and a copying transformer.
          *
          * @param ancestorBody  the nearest ancestor body builder, may be null if isolated
          * @param bodySignature the body's signature
@@ -448,7 +445,7 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * Creates a body build with a copying transformer.
+         * Creates a body builder with a copying transformer.
          *
          * @param ancestorBody  the nearest ancestor body builder, may be null if isolated
          * @param bodySignature the body's signature
@@ -534,7 +531,7 @@ public final class Body implements CodeElement<Body, Block> {
          * a non-entry block with no predecessors.
          *
          * @param op the parent operation
-         * @return the build body
+         * @return the built body
          * @throws IllegalStateException if this body builder is built
          * @throws IllegalStateException if any descendant body builders are not built
          * @throws IllegalStateException if a block has no terminal operation, unless unreferenced and empty
@@ -551,6 +548,8 @@ public final class Body implements CodeElement<Body, Block> {
         //     Since blocks are already sorted in reverse postorder the work to compute the immediate dominator map
         //     is incremental and can it be represented efficiently as an integer array of block indexes.
         public Body build(Op op) {
+            Objects.requireNonNull(op);
+
             // Structural check
             // This body should not be closed
             check();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -42,11 +42,10 @@ import static java.util.stream.Collectors.toList;
  * implicitly when an operation is transformed by copying, and can be explicitly defined when a transformation
  * removes operations or adds new operations.
  * <p>
- * Associating an input code item to its corresponding output requires that the output be unbuilt, specifically blocks
- * connected to the output are unbuilt. An output value is an unbuilt value whose declaring block is
- * unbuilt. An output block builder is a block builder that is unbuilt and therefore its block is unbuilt. An
- * output block reference is an unbuilt block reference whose target block is unbuilt with unbuilt arguments whose
- * declaring blocks are unbuilt.
+ * Associating an input code item to its corresponding output requires that an output's blocks are being built. An
+ * output value requires that its declaring block is being built. An output block builder requires that its block is
+ * being built. An output block reference requires that its target block is being built and all arguments declaring
+ * blocks are being built.
  * <p>
  * Unless otherwise specified the passing of a {@code null} argument to the methods of this interface results in a
  * {@code NullPointerException}.
@@ -157,7 +156,7 @@ public final class CodeContext {
         Objects.requireNonNull(output);
 
         if (output.isBuilt()) {
-            throw new IllegalArgumentException("Output value bound: " + output);
+            throw new IllegalArgumentException("Output value's declaring block is built: " + output);
         }
 
         if (valueMap == EMPTY_MAP) {
@@ -182,7 +181,7 @@ public final class CodeContext {
         Objects.requireNonNull(output);
 
         if (output.isBuilt()) {
-            throw new IllegalArgumentException("Output value is bound: " + output);
+            throw new IllegalArgumentException("Output value's declaring block is built: " + output);
         }
 
         if (valueMap == EMPTY_MAP) {
@@ -277,12 +276,12 @@ public final class CodeContext {
         Objects.requireNonNull(output);
 
         if (output.target.isBuilt()) {
-            throw new IllegalArgumentException("Output block reference target is built: " + output);
+            throw new IllegalArgumentException("Output block reference's target block is built: " + output);
         }
 
         for (Value outputArgument : output.arguments()) {
             if (outputArgument.isBuilt()) {
-                throw new IllegalArgumentException("Output block reference argument is bound: " + outputArgument);
+                throw new IllegalArgumentException("Output block reference argument's declaring block is built: " + outputArgument);
             }
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
@@ -78,7 +78,7 @@ public sealed interface CodeElement<
      * Returns the parent element, otherwise {@code null} if this element is an operation that has no parent block.
      *
      * @return the parent code element.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     CodeElement<?, E> parent();
 
@@ -88,7 +88,7 @@ public sealed interface CodeElement<
      * Finds the nearest ancestor operation, otherwise {@code null} if there is no nearest ancestor.
      *
      * @return the nearest ancestor operation.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     default Op ancestorOp() {
         return switch (this) {
@@ -98,7 +98,7 @@ public sealed interface CodeElement<
             case Body body -> body.parent();
             // op -> block? -> body -> op~
             case Op op -> {
-                // Throws ISE if op is not bound
+                // Throws ISE if encountering block being built
                 Block parent = op.parent();
                 yield parent == null ? null : parent.parent().parent();
             }
@@ -109,7 +109,7 @@ public sealed interface CodeElement<
      * Finds the nearest ancestor body, otherwise {@code null} if there is no nearest ancestor.
      *
      * @return the nearest ancestor body.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     default Body ancestorBody() {
         return switch (this) {
@@ -123,7 +123,7 @@ public sealed interface CodeElement<
             }
             // op~ -> block? -> body
             case Op op -> {
-                // Throws ISE if op is not bound
+                // Throws ISE if encountering block being built
                 Block parent = op.parent();
                 yield parent == null ? null : parent.parent();
             }
@@ -134,18 +134,18 @@ public sealed interface CodeElement<
      * Finds the nearest ancestor block, otherwise {@code null} if there is no nearest ancestor.
      *
      * @return the nearest ancestor block.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     default Block ancestorBlock() {
         return switch (this) {
             // block -> body -> op~ -> block?
-            // Throws ISE if op is not bound
+            // Throws ISE if encountering block being built
             case Block block -> block.parent().parent().parent();
             // body -> op~ -> block?
-            // Throws ISE if op is not bound
+            // Throws ISE if encountering block being built
             case Body body -> body.parent().parent();
             // op~ -> block?
-            // Throws ISE if op is not bound
+            // Throws ISE if encountering block being built
             case Op op -> op.parent();
         };
     }
@@ -155,7 +155,7 @@ public sealed interface CodeElement<
      *
      * @param descendant the descendant element.
      * @return true if this element is an ancestor of the descendant element.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see #isDescendantOf
      */
     default boolean isAncestorOf(CodeElement<?, ?> descendant) {
@@ -173,7 +173,7 @@ public sealed interface CodeElement<
      *
      * @param ancestor the ancestor element.
      * @return true if this element is a descendant of the ancestor element.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see #isAncestorOf
      */
     default boolean isDescendantOf(CodeElement<?, ?> ancestor) {
@@ -201,7 +201,7 @@ public sealed interface CodeElement<
      * is less than {@code b}'s position; and {@code 1} if {@code a}'s pre-order traversal position
      * is greater than {@code b}'s position
      * @throws IllegalArgumentException if {@code a} and {@code b} are not present in the same code model
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     static int compare(CodeElement<?, ?> a, CodeElement<?, ?> b) {
         if (a == b) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -58,33 +58,24 @@ import java.util.function.BiFunction;
  * Alternatively an operation may model something more complex like method declarations, lambda expressions, or
  * try statements. In such cases an operation will contain one or more bodies modeling the nested structure.
  * <p>
- * An instance of an operation when initially constructed is referred to as an unbuilt operation.
- * An unbuilt operation's state and descendants are all immutable except for its {@link #result result} and
- * {@link #parent parent}, which are initially set to {@code null}.
+ * An operation when initially constructed is unattached from any parent block.
+ * An unattached operation's state and descendant elements are all immutable except for the operation's
+ * {@link #result result}, {@link #parent parent} block, and {@link #location}, which are all initially {@code null}.
  * <p>
- * An unbuilt operation transitions to a built operation in one of two ways:
- * <ol>
- * <li>
- * {@link #buildAsRoot() building} the unbuilt operation to become a built {@link #isRoot() root} operation. The
- * operation's {@link #result result} and {@link #parent parent} are always {@code null}.
- * </li>
- * <li>
- * {@link Block.Builder#op(Op) appending} the unbuilt operation to a block builder to first become an unbuilt-bound
- * operation that is bound to an operation result and parent block.
- * The unbuilt-bound operation has a non-{@code null} unbuilt {@link #result result} that never changes, an unbuilt
- * value that can be used by subsequent constructed operations.
- * An unbuilt-bound operation transitions to a built bound operation when the block builder it was appended to builds
- * the block, after which the built bound operation has a non-{@code null} {@link #parent parent} that never changes and
- * a built {@link #result}.
- * Before then the unbuilt-bound operation's {@link #parent parent} is inaccessible, as is unbuilt result's
- * {@link Value#declaringBlock() declaring block}) (since both refer to the same block).
- * </li>
- * </ol>
- * A built operation is fully immutable either as a root operation, the root of a code model, or as a bound operation
- * within a code model.
+ * An unattached operation can be attached to a block by {@link Block.Builder#op(Op) appending} it to a block that is
+ * being built. Once attached the operation has a permanently non-{@code null} operation {@link #result} that can be
+ * used as an operand of subsequent constructed operations.
+ * After the block is built the operation has a permanently non-{@code null} {@link #parent}. Before then, the block
+ * being built is not observable through this operation and any attempt to access the block results in an exception.
  * <p>
- * An operation can only be constructed with unbuilt values as operands (if any) and unbuilt block references as
- * successors (if any), otherwise construction fails with an exception.
+ * An unattached operation can be built as a {@link #isRoot() root} operation. Once built the operation's
+ * {@link #result result} and {@link #parent parent} are always {@code null}.
+ * <p>
+ * The {@link #location} may be {@link #setLocation set} while the operation is unattached or attached to a block being
+ * built.
+ * <p>
+ * An operation can only be constructed with operands whose declaring block is being built, otherwise construction fails
+ * with an exception.
  */
 public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
@@ -335,7 +326,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
     }
 
-    // Set when op is unbuilt-bound or root, otherwise null when unbuilt
+    // Set when op is attached to a block or root, otherwise null when unattached
     // @@@ stable value?
     Result result;
 
@@ -357,7 +348,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     protected Op(Op that, CodeContext cc) {
         List<Value> outputOperands = cc.getValues(that.operands);
-        // Values should be guaranteed to connect to unbuilt blocks since
+        // Values should be guaranteed to connect to blocks being built since
         // the context only allows such mappings, assert for clarity
         assert outputOperands.stream().noneMatch(Value::isBuilt);
         this.operands = List.copyOf(outputOperands);
@@ -383,7 +374,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * Constructs an operation with a list of operands.
      *
      * @param operands the list of operands, a copy of the list is performed if required.
-     * @throws IllegalArgumentException if an operand is built because its declaring block is built.
+     * @throws IllegalArgumentException if an operand's declaring block is built.
      */
     protected Op(List<? extends Value> operands) {
         for (Value operand : operands) {
@@ -417,12 +408,14 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Returns this operation's parent block, otherwise {@code null} if this operation is unbuilt or a root.
+     * Returns this operation's parent block, otherwise {@code null} if this operation is unattached to a block or a
+     * root operation.
      * <p>
      * The operation's parent block is the same as the operation result's {@link Value#declaringBlock declaring block}.
      *
-     * @return operation's parent block, or {@code null} if this operation is unbuilt or a root.
-     * @throws IllegalStateException if this operation is unbuilt-bound.
+     * @return operation's parent block, or {@code null} if this operation is unattached or a root operation.
+     * @throws IllegalStateException if this operation is attached and the parent block is being built and is not
+     * observable.
      * @see Value#declaringBlock()
      */
     @Override
@@ -432,7 +425,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
 
         if (!result.block.isBuilt()) {
-            throw new IllegalStateException("Unbuilt-bound operation");
+            throw new IllegalStateException("Parent block is being built and is not observable");
         }
 
         return result.block;
@@ -459,10 +452,8 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
 
     /**
-     * Returns the operation's result, otherwise {@code null} if this operation is unbuilt or a
-     * root.
-     *
-     * @return the operation's result, or {@code null} if this operation is unbuilt or a root.
+     * {@return the operation's result, or {@code null} if this operation is unattached or a
+     * root operation.}
      */
     public final Result result() {
         return result == Result.ROOT_RESULT ? null : result;
@@ -504,6 +495,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * first search of this operation's descendant operations.
      *
      * @return the list of captured values, modifiable
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see Body#capturedValues()
      */
     public final List<Value> capturedValues() {
@@ -522,7 +514,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * <p>
      * This method is idempotent.
      *
-     * @throws IllegalStateException if this operation is unbuilt-bound.
+     * @throws IllegalStateException if this operation is attached to a block.
      * @see #isRoot()
      */
     public final void buildAsRoot() {
@@ -530,7 +522,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
             return;
         }
         if (result != null) {
-            throw new IllegalStateException("Operation is unbuilt-bound to a parent block");
+            throw new IllegalStateException("Operation is attached to a block");
         }
         result = Result.ROOT_RESULT;
     }
@@ -538,18 +530,18 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     /**
      * {@return {@code true} if this operation is a root operation.}
      * @see #buildAsRoot()
-     * @see #isBound()
+     * @see #isAttached()
      * */
     public final boolean isRoot() {
         return result == Result.ROOT_RESULT;
     }
 
     /**
-     * {@return {@code true} if this operation is a bound to a result and parent block.}
+     * {@return {@code true} if this operation is attached to a block.}
      * @see #buildAsRoot()
      * @see #isRoot()
      * */
-    public final boolean isBound() {
+    public final boolean isAttached() {
         return !isRoot() && result != null;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
@@ -158,11 +158,12 @@ public final class Quoted<T extends Op> {
      *
      * @param op the operation
      * @return the quoting code model.
-     * @throws IllegalArgumentException if {@code op} is unbuilt.
+     * @throws IllegalArgumentException if {@code op} is unattached or a root operation.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     public static CoreOp.FuncOp embedOp(Op op) {
         if (op.result() == null) {
-            throw new IllegalArgumentException("Op is unbuilt");
+            throw new IllegalArgumentException("Operation is unattached or a root operation");
         }
 
         // if we don't remove duplicate operands we will have unused params in the new model

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
@@ -30,9 +30,6 @@ import java.util.*;
 /**
  * A value, that is the result of an operation or a block parameter.
  * <p>
- * A value is considered unbuilt if it's {@link #declaringBlock() declaring block} is unbuilt and
- * therefore is inaccessible. A value is considered built when the declaring block is built and
- * therefore is accessible.
  * @sealedGraph
  */
 public sealed abstract class Value implements CodeItem
@@ -55,11 +52,11 @@ public sealed abstract class Value implements CodeItem
      * If the value is a block parameter then the declaring block is the block declaring the parameter.
      *
      * @return the value's declaring block.
-     * @throws IllegalStateException if this value is unbuilt because its declaring block is unbuilt.
+     * @throws IllegalStateException if the declaring block is being built and is not observable.
      */
     public Block declaringBlock() {
         if (!isBuilt()) {
-            throw new IllegalStateException("Declaring block is unbuilt");
+            throw new IllegalStateException("Declaring block is being built and is not observable");
         }
         return block;
     }
@@ -70,8 +67,8 @@ public sealed abstract class Value implements CodeItem
      * If the value is a block parameter then the declaring code element is this value's declaring block.
      *
      * @return the value's declaring code element.
-     * @throws IllegalStateException if this value is a a block parameter and is unbuilt because its declaring block is
-     * unbuilt.
+     * @throws IllegalStateException if this value is a block parameter and its declaring block is being built and is
+     * not observable.
      */
     public CodeElement<?, ?> declaringElement() {
         return switch (this) {
@@ -133,11 +130,11 @@ public sealed abstract class Value implements CodeItem
      *
      * @return the uses of this value, as an unmodifiable sequenced set. The encouncter order is unspecified
      * and determined by the order in which operations are built into blocks.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if this value's declaring block is being built and is not observable.
      */
     public SequencedSet<Op.Result> uses() {
         if (!isBuilt()) {
-            throw new IllegalStateException("Users are unbuilt");
+            throw new IllegalStateException("Declaring block is being built and is not observable");
         }
 
         return Collections.unmodifiableSequencedSet(uses);
@@ -161,7 +158,7 @@ public sealed abstract class Value implements CodeItem
      *
      * @param dom the dominating value
      * @return {@code true} if this value is dominated by the given value {@code dom}.
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see Block#isDominatedBy
      */
     public boolean isDominatedBy(Value dom) {
@@ -200,7 +197,7 @@ public sealed abstract class Value implements CodeItem
      * @return the value {@code 0} if {@code a == b}; {@code -1} if {@code a} is less than {@code b}; and {@code -1}
      * if {@code a} is greater than {@code b}.
      * @throws IllegalArgumentException if {@code a} and {@code b} are not present in the same code model
-     * @throws IllegalStateException if an unbuilt block is encountered.
+     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see CodeElement#compare
      */
     public static int compare(Value a, Value b) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
@@ -474,7 +474,7 @@ public class OpBuilder {
         // check if java version at compile time matches the java version at runtime
         builder.op(funcCall(JAVA_VERSION_CHECKER_F_NAME, FunctionType.FUNCTION_TYPE_VOID));
         Value result = buildOp(null, ancestorBody, op);
-        // bind as bound root op
+        // build as root op
         builder.op(invoke(MethodRef.method(Op.class, "buildAsRoot", void.class), result));
         builder.op(return_(result));
 

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -58,7 +58,7 @@ public class TestBuild {
 
         var a = f.body().entryBlock().parameters().get(0);
         var b = f.body().entryBlock().parameters().get(1);
-        // Passing built values as operands to a new unbound operation
+        // Passing built values as operands to a new unattached operation
         Assertions.assertThrows(IllegalArgumentException.class, () -> JavaOp.add(a, b));
     }
 
@@ -120,7 +120,7 @@ public class TestBuild {
     }
 
     @Test
-    public void testUnbuiltValueAccess() {
+    public void testUnbuiltBlocksViaValue() {
         var body = Body.Builder.of(null, functionType(INT, INT, INT));
         var block = body.entryBlock();
 
@@ -128,13 +128,13 @@ public class TestBuild {
         Block.Parameter b = block.parameters().get(1);
         Op.Result result = block.op(JavaOp.add(a, b));
 
-        // Access the declaring block of unbuilt values before the blocks are built
+        // Declaring block is being built
         Assertions.assertThrows(IllegalStateException.class, a::declaringBlock);
         Assertions.assertThrows(IllegalStateException.class, result::declaringBlock);
         // Access to parent block/body of operation result before they are built
         Assertions.assertThrows(IllegalStateException.class, result.op()::ancestorBlock);
         Assertions.assertThrows(IllegalStateException.class, result.op()::ancestorBody);
-        // Access to set of users before built
+        // Access to set of users while declaring block is being built
         Assertions.assertThrows(IllegalStateException.class, a::uses);
 
         block.op(return_(result));
@@ -149,7 +149,7 @@ public class TestBuild {
     }
 
     @Test
-    public void testUnbuiltReferenceAccess() {
+    public void testUnbuiltBlocksViaReference() {
         var body = Body.Builder.of(null, functionType(INT, INT, INT));
         var block = body.entryBlock();
         var anotherBlock = block.block(INT, INT);
@@ -157,7 +157,7 @@ public class TestBuild {
         var a = block.parameters().get(0);
         var b = block.parameters().get(1);
         Block.Reference successor = anotherBlock.reference(a, b);
-        // Access to target block before built
+        // Target block is being built
         Assertions.assertThrows(IllegalStateException.class, successor::targetBlock);
         block.op(branch(anotherBlock.reference(a, b)));
 

--- a/test/jdk/jdk/incubator/code/TestBuildOp.java
+++ b/test/jdk/jdk/incubator/code/TestBuildOp.java
@@ -56,11 +56,11 @@ public class TestBuildOp {
         });
 
         Assertions.assertFalse(funcOp.isRoot());
-        Assertions.assertFalse(funcOp.isBound());
+        Assertions.assertFalse(funcOp.isAttached());
         funcOp.buildAsRoot();
 
         Assertions.assertTrue(funcOp.isRoot());
-        Assertions.assertFalse(funcOp.isBound());
+        Assertions.assertFalse(funcOp.isAttached());
         funcOp.buildAsRoot();
     }
 
@@ -73,7 +73,7 @@ public class TestBuildOp {
         CoreOp.FuncOp funcOp = (CoreOp.FuncOp) quotedOp.ancestorOp();
 
         Assertions.assertTrue(funcOp.isRoot());
-        Assertions.assertFalse(funcOp.isBound());
+        Assertions.assertFalse(funcOp.isAttached());
     }
 
     @Test
@@ -83,11 +83,11 @@ public class TestBuildOp {
         body.entryBlock().op(CoreOp.return_());
 
         Assertions.assertThrows(IllegalStateException.class, () -> r.op().buildAsRoot());
-        Assertions.assertTrue(r.op().isBound());
+        Assertions.assertTrue(r.op().isAttached());
         Assertions.assertFalse(r.op().isRoot());
 
         CoreOp.func("f", body);
-        Assertions.assertTrue(r.op().isBound());
+        Assertions.assertTrue(r.op().isAttached());
     }
 
     @Test

--- a/test/jdk/jdk/incubator/code/TestLiveness.java
+++ b/test/jdk/jdk/incubator/code/TestLiveness.java
@@ -349,7 +349,7 @@ public class TestLiveness {
          * @param descendant the descendant element
          * @return the child that is an ancestor of the given descendant element, otherwise the descendant
          * element if a child of this element, otherwise {@code null}.
-         * @throws IllegalStateException if an operation with unbuilt parent block is encountered.
+         * @throws IllegalStateException if an encountered block is being built and is not observable.
          */
         private static <C extends CodeElement<C, ?>> C findChildAncestor(CodeElement<?, C> parent, CodeElement<?, ?> descendant) {
             Objects.requireNonNull(descendant);


### PR DESCRIPTION
The specification for the state of an operation was awkward. This is now simplified.

When an operation is initially constructed it is unattached. It is attached to a block by appending to the block's builder, which assigns an operation result to the operation. Otherwise, it is built as a root operation.

This also narrows the focus of building to blocks and bodies, the only things which have builders. While a block is being built it is not observable and access to it through a block parameter, an attached operation, its operation result, or a block reference, result in an exception. After a block is built it becomes observable so an attached operation's parent block becomes accessible.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1005/head:pull/1005` \
`$ git checkout pull/1005`

Update a local copy of the PR: \
`$ git checkout pull/1005` \
`$ git pull https://git.openjdk.org/babylon.git pull/1005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1005`

View PR using the GUI difftool: \
`$ git pr show -t 1005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1005.diff">https://git.openjdk.org/babylon/pull/1005.diff</a>

</details>
