### PR TITLE
Cleanups

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/PartialEvaluator.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/PartialEvaluator.java
@@ -273,7 +273,7 @@ public final class PartialEvaluator {
 
                         processBlock(bc, inBlock, nextInBlock, outBlock);
 
-                        outBlock.op(CoreOp.branch(outBlock.context().getSuccessorOrCreate(nextInBlockRef)));
+                        outBlock.op(CoreOp.branch(outBlock.context().getReferenceOrCreate(nextInBlockRef)));
                     } else {
                         // @@@ might be non-constant latch to loop
                         processBlock(bc, inBlock, cb.falseBranch().targetBlock(), outBlock);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -650,7 +650,6 @@ public final class Block implements CodeElement<Block, Op> {
             check();
 
             body(body, values, CodeContext.create(cc), ct);
-//            ct.acceptBody(rebind(CodeContext.create(cc), ct), body, values);
         }
 
         /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -108,7 +108,6 @@ public final class Block implements CodeElement<Block, Op> {
      * A terminating operation may refer, via a block reference, to one or more blocks as its successors.
      * When control is passed from a block to a successor block the values of the block reference's arguments are
      * assigned, in order, to the successor block's parameters.
-     * <p>
      */
     public static final class Reference implements CodeItem {
         final Block target;
@@ -468,22 +467,29 @@ public final class Block implements CodeElement<Block, Op> {
      * A builder of a block.
      * <p>
      * A block builder is built when its {@link #parent() parent} body builder is {@link Body.Builder#build(Op) built}.
-     * <p>
-     * A block is not observable while it is being built. Attempts to access a block being built through the block's
-     * parameters, appended operations, their operation results, or created block references, result in an exception.
-     * <p>
      * If a built builder is operated on to append a block parameter, append an operation, build a sibling block,
      * then an {@code IllegalStateException} is thrown.
+     * <p>
+     * A block is not observable while it is being built. Attempts to access a block being built through the block's
+     * parameters, appended operations, their operation results, or block references, result in an exception.
+     * <p>
+     * A block builder has a code {@link #context() context} and code {@link #transformer() transformer} which are used
+     * to transform an attached or root operation that is {@link #op appended}. Any sibling block builder
+     * {@link #block(List) created} from a block builder will have the same code context and code transformer.
+     * <p>
+     * A block builder may be {@link #rebind rebound} to new block builder that builds the same block but with a
+     * different code context and code transformer. The rebound block builder can be used to apply alternative
+     * transformations to attached or root operations that are appended.
      */
     public final class Builder {
         final Body.Builder parentBody;
         final CodeContext cc;
-        final CodeTransformer ot;
+        final CodeTransformer ct;
 
-        Builder(Body.Builder parentBody, CodeContext cc, CodeTransformer ot) {
+        Builder(Body.Builder parentBody, CodeContext cc, CodeTransformer ct) {
             this.parentBody = parentBody;
             this.cc = cc;
-            this.ot = ot;
+            this.ct = ct;
         }
 
         void check() {
@@ -495,10 +501,10 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * {@return the block builder's operation transformer}
+         * {@return the block builder's code transformer}
          */
         public CodeTransformer transformer() {
-            return ot;
+            return ct;
         }
 
         /**
@@ -524,7 +530,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the entry block builder for parent body builder
          */
         public Block.Builder entryBlock() {
-            return parentBody.entryBlock.rebind(cc, ot);
+            return parentBody.entryBlock.rebind(cc, ct);
         }
 
         /**
@@ -535,24 +541,24 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Rebinds this block builder with the given context and operation transformer.
+         * Rebinds this block builder to a new block builder with the given context and code transformer.
          *
-         * <p>Either this block builder and the returned block builder may be operated on to build
+         * <p>Either this block builder and the rebound block builder may be operated on to build
          * the same block.
          * Both are equal to each other, and both are closed when the parent body builder is closed.
          *
          * @param cc the context
-         * @param ot the operation transformer
+         * @param ct the code transformer
          * @return the rebound block builder
          */
-        public Block.Builder rebind(CodeContext cc, CodeTransformer ot) {
-            return this.cc == cc && this.ot == ot
+        public Block.Builder rebind(CodeContext cc, CodeTransformer ct) {
+            return this.cc == cc && this.ct == ct
                     ? this
-                    : this.target().new Builder(parentBody(), cc, ot);
+                    : this.target().new Builder(parentBody(), cc, ct);
         }
 
         /**
-         * Creates a new sibling block in the same parent body as this block.
+         * Creates a new sibling block builder in the same parent body as this block builder.
          *
          * @param params the block's parameter types
          * @return the new block builder
@@ -562,13 +568,13 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Creates a new sibling block in the same parent body as this block.
+         * Creates a new sibling block builder in the same parent body as this block builder.
          *
          * @param params the block's parameter types
          * @return the new block builder
          */
         public Block.Builder block(List<CodeType> params) {
-            return parentBody.block(params, cc, ot);
+            return parentBody.block(params, cc, ct);
         }
 
         /**
@@ -631,36 +637,27 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Transforms a body starting from this block builder, using a code transformer.
-         * <p>
-         * This method first rebinds this builder with a child context created from
-         * this builder's context and the given operation transformer, and then
-         * transforms the body using the code transformer by
-         * {@link CodeTransformer#acceptBody(Builder, Body, List) accepting}
-         * the rebound builder, the body, and the values.
-         *
-         * @apiNote
-         * Creation of a child context ensures block and value mappings produced by
-         * the transformation do not affect this builder's context.
+         * Transforms a body starting from this block builder, using a {@link CodeContext#create(CodeContext) child}
+         * context of this builder's context and a given code transformer.
          *
          * @param body the body to transform
          * @param values the output values to map to the input parameters of the body's entry block
-         * @param ot the operation transformer
-         * @see CodeTransformer#acceptBody(Builder, Body, List)
+         * @param ct the code transformer
+         * @see #body(Body, List, CodeContext, CodeTransformer)
          */
         public void body(Body body, List<? extends Value> values,
-                         CodeTransformer ot) {
+                         CodeTransformer ct) {
             check();
 
-            ot.acceptBody(rebind(CodeContext.create(cc), ot), body, values);
+            body(body, values, CodeContext.create(cc), ct);
+//            ct.acceptBody(rebind(CodeContext.create(cc), ct), body, values);
         }
 
         /**
-         * Transforms a body starting from this block builder, using a given operation transformer.
+         * Transforms a body starting from this block builder, using a given context and code transformer.
          * <p>
-         * This method first rebinds this builder with the given context
-         * and the given operation transformer, and then
-         * transforms the body using the operation transformer by
+         * This method first {@link #rebind rebinds} this builder with the given context
+         * and code transformer, and then transforms the body using the code transformer by
          * {@link CodeTransformer#acceptBody(Builder, Body, List) accepting}
          * the rebound builder, the body, and the values.
          *
@@ -671,26 +668,27 @@ public final class Block implements CodeElement<Block, Op> {
          * @param body the body to transform
          * @param values the output values to map to the input parameters of the body's entry block
          * @param cc the code context
-         * @param ot the operation transformer
+         * @param ct the code transformer
+         * @see #rebind(CodeContext, CodeTransformer)
          * @see CodeTransformer#acceptBody(Builder, Body, List)
          */
         public void body(Body body, List<? extends Value> values,
-                         CodeContext cc, CodeTransformer ot) {
+                         CodeContext cc, CodeTransformer ct) {
             check();
 
-            ot.acceptBody(rebind(cc, ot), body, values);
+            ct.acceptBody(rebind(cc, ct), body, values);
         }
 
         /**
-         * Appends an operation to this block builder, first transforming the operation if it is attached to a block,
-         * or a root operation.
+         * Appends an operation to the sequence of operations of this block builder, first transforming the operation
+         * if it is attached to a block, or a root operation.
          * <p>
          * If the operation is unattached, then the operation is appended and attached to this block, and the operation
          * is assigned an operation result.
          * Otherwise, the operation (an attached or root operation) is first
-         * {@link Op#transform(CodeContext, CodeTransformer) transformed} with this builder's context and
-         * code transformer, the resulting transformed and unattached operation is attached and appended, and the
-         * operation's result mapped to the transformed operation's result, using the builder's context.
+         * {@link Op#transform(CodeContext, CodeTransformer) transformed} with this builder's code context and
+         * code transformer, the resulting transformed and unattached operation is appended and attached, and the
+         * operation's result mapped to the transformed operation's result, using the builder's code context.
          * <p>
          * If the operation (transformed, or otherwise) is structurally invalid then an
          * {@code IllegalStateException} is thrown. An operation is structurally invalid if:
@@ -699,7 +697,7 @@ public final class Block implements CodeElement<Block, Op> {
          * <li>any of its operands (values) is not reachable from this block.
          * <li>any of its successors is not a sibling of this block.
          * <li>any of its successors arguments (values) is not reachable from this block.
-         * <li>it's a terminating operation and a terminating operation is already appended.
+         * <li>a terminating operation is already appended as the last operation.
          * </ul>
          * A value is reachable from this block if there is a path from this block's parent body,
          * via its ancestor bodies, to the value's declaring block's parent body. (Note this structural check
@@ -718,7 +716,7 @@ public final class Block implements CodeElement<Block, Op> {
             Op transformedOp = op;
             if (op.isRoot() || oprToTransform != null) {
                 // If operation is assigned to block, or it's sealed, then copy it and transform its contents
-                transformedOp = op.transform(cc, ot);
+                transformedOp = op.transform(cc, ct);
                 assert transformedOp.result == null;
             }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -434,7 +434,7 @@ public final class Body implements CodeElement<Body, Block> {
      */
     public final class Builder {
         /**
-         * Creates a body builder, with entry block {@link #entryBlock builder} that has a
+         * Creates a body builder, with an entry block {@link #entryBlock builder} that has a
          * {@link CodeContext#create() new} code context and a {@link CodeTransformer#COPYING_TRANSFORMER copying}
          * code transformer.
          *
@@ -450,7 +450,7 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * Creates a body builder, with entry block {@link #entryBlock builder} that has the given code context
+         * Creates a body builder, with an entry block {@link #entryBlock builder} that has the given code context
          * and a {@link CodeTransformer#COPYING_TRANSFORMER copying} code transformer.
          *
          * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -428,12 +428,17 @@ public final class Body implements CodeElement<Body, Block> {
      * <p>
      * When the body builder is {@link Body.Builder#build(Op) built} all associated {@link Block.Builder block builders}
      * are also built and their blocks become children of the body.
+     * <p>
+     * A body builder has an entry block {@link #entryBlock builder} from which sibling block builders may be
+     * {@link Block.Builder#block(List) created}.
      */
     public final class Builder {
         /**
-         * Creates a body builder with a new context, and a copying transformer.
+         * Creates a body builder, with entry block {@link #entryBlock builder} that has a
+         * {@link CodeContext#create() new} code context and a {@link CodeTransformer#COPYING_TRANSFORMER copying}
+         * code transformer.
          *
-         * @param ancestorBody  the nearest ancestor body builder, may be null if isolated
+         * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
          * @param bodySignature the body's signature
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is built
@@ -445,11 +450,12 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * Creates a body builder with a copying transformer.
+         * Creates a body builder, with entry block {@link #entryBlock builder} that has the given code context
+         * and a {@link CodeTransformer#COPYING_TRANSFORMER copying} code transformer.
          *
-         * @param ancestorBody  the nearest ancestor body builder, may be null if isolated
+         * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
          * @param bodySignature the body's signature
-         * @param cc            the context
+         * @param cc            the code context
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is built
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
@@ -459,7 +465,8 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * Creates a body builder.
+         * Creates a body builder, with entry block {@link #entryBlock builder} that has the given code context
+         * and code transformer.
          * <p>
          * Structurally, the created body builder must be built before its ancestor body builder (if non-null) is built,
          * otherwise an {@code IllegalStateException} will occur.
@@ -470,22 +477,23 @@ public final class Body implements CodeElement<Body, Block> {
          * An entry block builder is created with appended block parameters corresponding, in order, to
          * the function type's parameter types.
          * <p>
-         * If the ancestor body is null then the created body builder is isolated and descendant operations may only
-         * use values declared within the created body builder. Otherwise, operations
-         * may use reachable values declared in the ancestor body builders (outside the created body builder).
+         * If the ancestor body is {@code null} then the created body builder is isolated and descendant operations may
+         * only use values declared within the created body builder. Otherwise, operations may use reachable values
+         * declared in the ancestor body builders (outside the created body builder).
+         * <p>
+         * The entry block {@link #entryBlock builder}
          *
-         * @param ancestorBody  the nearest ancestor body builder, may be null if isolated
+         * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
          * @param bodySignature the body's signature
-         * @param cc            the context
-         * @param ot            the transformer
+         * @param cc            the code context
+         * @param ct            the code transformer
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is built
-         * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
          */
         public static Builder of(Builder ancestorBody, FunctionType bodySignature,
-                                 CodeContext cc, CodeTransformer ot) {
+                                 CodeContext cc, CodeTransformer ct) {
             Body body = new Body(ancestorBody != null ? ancestorBody.target() : null, bodySignature.returnType());
-            return body.new Builder(ancestorBody, bodySignature, cc, ot);
+            return body.new Builder(ancestorBody, bodySignature, cc, ct);
         }
 
         // The ancestor body, may be null
@@ -501,7 +509,7 @@ public final class Body implements CodeElement<Body, Block> {
         boolean closed;
 
         Builder(Builder ancestorBody, FunctionType bodySignature,
-                CodeContext cc, CodeTransformer ot) {
+                CodeContext cc, CodeTransformer ct) {
             // Structural check
             // The ancestor body should not be built before this body is created
             if (ancestorBody != null) {
@@ -512,7 +520,7 @@ public final class Body implements CodeElement<Body, Block> {
             this.ancestorBody = ancestorBody;
             // Create entry block from the body's function type
             Block eb = Body.this.createBlock(bodySignature.parameterTypes());
-            this.entryBlock = eb.new Builder(this, cc, ot);
+            this.entryBlock = eb.new Builder(this, cc, ct);
         }
 
         void addGreatgrandchild(Builder greatgrandchild) {
@@ -644,11 +652,11 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         // Build new block in body
-        Block.Builder block(List<CodeType> params, CodeContext cc, CodeTransformer ot) {
+        Block.Builder block(List<CodeType> params, CodeContext cc, CodeTransformer ct) {
             check();
             Block block = Body.this.createBlock(params);
 
-            return block.new Builder(this, cc, ot);
+            return block.new Builder(this, cc, ct);
         }
     }
 
@@ -659,6 +667,7 @@ public final class Body implements CodeElement<Body, Block> {
      * @return the builder of a body containing the copied body
      * @see #transform(CodeContext, CodeTransformer)
      */
+    // @@@ Remove
     public Builder copy(CodeContext cc) {
         return transform(cc, CodeTransformer.COPYING_TRANSFORMER);
     }
@@ -666,16 +675,26 @@ public final class Body implements CodeElement<Body, Block> {
     /**
      * Transforms this body.
      * <p>
-     * A new body builder is created with the same function type as this body.
-     * Then, this body is {@link Block.Builder#body(Body, java.util.List, CodeContext, CodeTransformer) transformed}
-     * into the body builder's entry block builder with the given code context, operation transformer, and arguments
-     * that are the entry block builder's parameters.
+     * A new body builder is first {@link Body.Builder#of(Builder, FunctionType, CodeContext, CodeTransformer) created}
+     * with the following arguments:
+     * <ul>
+     * <li>an ancestor body builder that is the {@link Block.Builder#parentBody parent} body builder of the entry block
+     * builder {@link CodeContext#getBlock(Block) associated} with this body's ancestor entry block in the parent code
+     * context, otherwise {@code null} if this body has no ancestor entry block or there is no associated entry block
+     * builder.
+     * <li>this body's signature.
+     * <li>a {@link CodeContext#create(CodeContext) child} code context of the given parent code context.
+     * <li>the given code transformer.
+     * </ul>
+     * Then the given code transformer is used to transform this body by
+     * {@link CodeTransformer#acceptBody accepting} the new body builder's entry block builder, this body, and the entry
+     * block builder's parameters.
      *
-     * @param cc the code context
-     * @param ot the operation transformer
+     * @param cc the parent code context
+     * @param ct the code transformer
      * @return a body builder containing the transformed body
      */
-    public Builder transform(CodeContext cc, CodeTransformer ot) {
+    public Builder transform(CodeContext cc, CodeTransformer ct) {
         Block.Builder ancestorBlockBuilder = ancestorBody != null
                 ? cc.getBlock(ancestorBody.entryBlock()) : null;
         Builder ancestorBodyBuilder = ancestorBlockBuilder != null
@@ -684,10 +703,10 @@ public final class Body implements CodeElement<Body, Block> {
                 bodySignature(),
                 // Create child context for mapped code items contained in this body
                 // thereby not polluting the given context
-                CodeContext.create(cc), ot);
+                CodeContext.create(cc), ct);
 
         // Transform body starting from the entry block builder
-        ot.acceptBody(bodyBuilder.entryBlock, this, bodyBuilder.entryBlock.parameters());
+        ct.acceptBody(bodyBuilder.entryBlock, this, bodyBuilder.entryBlock.parameters());
         return bodyBuilder;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -62,14 +62,14 @@ public final class CodeContext {
     private final CodeContext parent;
     private Map<Value, Value> valueMap;
     private Map<Block, Block.Builder> blockMap;
-    private Map<Block.Reference, Block.Reference> successorMap;
+    private Map<Block.Reference, Block.Reference> referenceMap;
     private Map<Object, Object> propertiesMap;
 
     private CodeContext(CodeContext that) {
         this.parent = that;
         this.blockMap = emptyMap();
         this.valueMap = emptyMap();
-        this.successorMap = emptyMap();
+        this.referenceMap = emptyMap();
         this.propertiesMap = emptyMap();
     }
 
@@ -91,6 +91,7 @@ public final class CodeContext {
      *
      * @param input the input value
      * @throws IllegalArgumentException if there is no mapping
+     * @see #mapValue(Value, Value)
      */
     public Value getValue(Value input) {
         Value output = getValueOrNull(input);
@@ -105,6 +106,7 @@ public final class CodeContext {
      *
      * @param input the input value
      * @param defaultValue the default value to return if no mapping
+     * @see #getValue(Value)
      */
     public Value getValueOrDefault(Value input, Value defaultValue) {
         Value output = getValueOrNull(input);
@@ -121,6 +123,7 @@ public final class CodeContext {
      * @param inputs the list of input values
      * @return a modifiable list of output values
      * @throws IllegalArgumentException if an input value has no mapping
+     * @see #getValue(Value)
      */
     // @@@ If getValue is modified to return null then this method should fail on null
     public List<Value> getValues(List<? extends Value> inputs) {
@@ -150,6 +153,7 @@ public final class CodeContext {
      * @param input the input value
      * @param output the output value
      * @throws IllegalArgumentException if the output value's declaring block is built
+     * @see #getValue(Value)
      */
     public void mapValue(Value input, Value output) {
         Objects.requireNonNull(input);
@@ -174,6 +178,7 @@ public final class CodeContext {
      * @param output the output value
      * @return the previous mapped value, or null of there was no mapping.
      * @throws IllegalArgumentException if the output value's declaring block is built
+     * @see #mapValue(Value, Value)
      */
     // @@@ Is this needed?
     public Value mapValueIfAbsent(Value input, Value output) {
@@ -199,6 +204,7 @@ public final class CodeContext {
      * @param inputs the input values
      * @param outputs the output values.
      * @throws IllegalArgumentException if an output value's declaring block is built
+     * @see #mapValue(Value, Value)
      */
     public void mapValues(List<? extends Value> inputs, List<? extends Value> outputs) {
         // @@@ sizes should be the same?
@@ -214,6 +220,7 @@ public final class CodeContext {
      * {@return the output block builder mapped to the input block, otherwise null if no mapping}
      *
      * @param input the input block
+     * @see #getBlock(Block)
      */
     // @@@ throw IllegalArgumentException if there is no mapping?
     public Block.Builder getBlock(Block input) {
@@ -230,6 +237,7 @@ public final class CodeContext {
      * @param input the input block
      * @param output the output block builder
      * @throws IllegalArgumentException if the output block builder's block is built
+     * @see #getBlock(Block)
      */
     public void mapBlock(Block input, Block.Builder output) {
         Objects.requireNonNull(input);
@@ -246,19 +254,20 @@ public final class CodeContext {
     }
 
 
-    // Successor mappings
+    // Reference mappings
 
     /**
      * {@return the output block reference mapped to the input block reference,
      * otherwise null if no mapping}
      *
      * @param input the input reference
+     * @see #mapReference(Block.Reference, Block.Reference)
      */
     // @@@ throw IllegalArgumentException if there is no mapping?
-    public Block.Reference getSuccessor(Block.Reference input) {
+    public Block.Reference getReference(Block.Reference input) {
         Objects.requireNonNull(input);
 
-        return successorMap.get(input);
+        return referenceMap.get(input);
     }
 
     /**
@@ -270,8 +279,9 @@ public final class CodeContext {
      * @param output the output block reference
      * @throws IllegalArgumentException if the output block reference's target block is built or any of the
      * reference's arguments declaring blocks are built.
+     * @see #getReference(Block.Reference)
      */
-    public void mapSuccessor(Block.Reference input, Block.Reference output) {
+    public void mapReference(Block.Reference input, Block.Reference output) {
         Objects.requireNonNull(input);
         Objects.requireNonNull(output);
 
@@ -285,10 +295,10 @@ public final class CodeContext {
             }
         }
 
-        if (successorMap == EMPTY_MAP) {
-            successorMap = new HashMap<>();
+        if (referenceMap == EMPTY_MAP) {
+            referenceMap = new HashMap<>();
         }
-        successorMap.put(input, output);
+        referenceMap.put(input, output);
     }
 
     /**
@@ -296,21 +306,22 @@ public final class CodeContext {
      * block reference.
      * <p>
      * A new, unmapped reference, is created by obtaining the mapped output block builder from the input reference's
-     * target block, and creating a successor from the output block builder with arguments that is the result of
+     * target block, and creating a reference from the output block builder with arguments that is the result of
      * obtaining the mapped values from the input reference's arguments.
      *
      * @param input the input block reference
      * @return the output block reference, if present, otherwise a created block reference
      * @throws IllegalArgumentException if a new reference is to be created and there is no block mapping for the
      * input's target block or there is no value mapping for an input's argument
+     * @see #getReference(Block.Reference)
      */
-    public Block.Reference getSuccessorOrCreate(Block.Reference input) {
-        Block.Reference successor = getSuccessor(input);
-        if (successor != null) {
-            return successor;
+    public Block.Reference getReferenceOrCreate(Block.Reference input) {
+        Block.Reference reference = getReference(input);
+        if (reference != null) {
+            return reference;
         }
 
-        // Create successor
+        // Create reference
         Block.Builder outputBlock = getBlock(input.targetBlock());
         if (outputBlock == null) {
             throw new IllegalArgumentException("No mapping for input reference target block" + input.targetBlock());
@@ -325,6 +336,7 @@ public final class CodeContext {
      * {@return an object associated with a property key, or null if not associated.}
      *
      * @param key the property key
+     * @see #putProperty(Object, Object)
      */
     public Object getProperty(Object key) {
         CodeContext p = this;
@@ -345,6 +357,7 @@ public final class CodeContext {
      * @param key the property key
      * @param value the associated object
      * @return the current associated object, or null if not associated
+     * @see #getProperty(Object)
      */
     public Object putProperty(Object key, Object value) {
         if (propertiesMap == EMPTY_MAP) {
@@ -361,6 +374,8 @@ public final class CodeContext {
      * @param mappingFunction the mapping function
      * @return the current (existing or computed) object associated with the property key,
      * or null if the computed object is null
+     * @see #getProperty(Object)
+     * @see #putProperty(Object, Object)
      */
     public Object computePropertyIfAbsent(Object key, Function<Object, Object> mappingFunction) {
         if (propertiesMap == EMPTY_MAP) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -364,11 +364,11 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * To copy an operation use the {@link CodeTransformer#COPYING_TRANSFORMER copying transformer}.
      *
      * @param cc the code context.
-     * @param ot the code transformer.
+     * @param ct the code transformer.
      * @return the transformed operation.
      * @see CodeTransformer#COPYING_TRANSFORMER
      */
-    public abstract Op transform(CodeContext cc, CodeTransformer ot);
+    public abstract Op transform(CodeContext cc, CodeTransformer ct);
 
     /**
      * Constructs an operation with a list of operands.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
@@ -29,7 +29,7 @@ import java.util.*;
 
 /**
  * A value, that is the result of an operation or a block parameter.
- * <p>
+ *
  * @sealedGraph
  */
 public sealed abstract class Value implements CodeItem

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/ConstantLabelSwitchOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/ConstantLabelSwitchOp.java
@@ -59,11 +59,11 @@ public final class ConstantLabelSwitchOp extends Op implements Op.BlockTerminati
     ConstantLabelSwitchOp(ConstantLabelSwitchOp that, CodeContext cc) {
         super(that, cc);
         this.labels = that.labels;
-        this.targets = that.targets.stream().map(cc::getSuccessorOrCreate).toList();
+        this.targets = that.targets.stream().map(cc::getReferenceOrCreate).toList();
     }
 
     @Override
-    public ConstantLabelSwitchOp transform(CodeContext cc, CodeTransformer ot) {
+    public ConstantLabelSwitchOp transform(CodeContext cc, CodeTransformer ct) {
         return new ConstantLabelSwitchOp(this, cc);
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -134,44 +134,44 @@ public sealed abstract class CoreOp extends Op {
             this(funcName, def.bodyDefinitions().get(0));
         }
 
-        FuncOp(FuncOp that, CodeContext cc, CodeTransformer ot) {
+        FuncOp(FuncOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             this.funcName = that.funcName;
-            this.body = that.body.transform(cc, ot).build(this);
+            this.body = that.body.transform(cc, ct).build(this);
         }
 
-        FuncOp(FuncOp that, String funcName, CodeContext cc, CodeTransformer ot) {
+        FuncOp(FuncOp that, String funcName, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             this.funcName = funcName;
-            this.body = that.body.transform(cc, ot).build(this);
+            this.body = that.body.transform(cc, ct).build(this);
         }
 
         @Override
-        public FuncOp transform(CodeContext cc, CodeTransformer ot) {
-            return new FuncOp(this, cc, ot);
+        public FuncOp transform(CodeContext cc, CodeTransformer ct) {
+            return new FuncOp(this, cc, ct);
         }
 
         /**
          * Transforms a function operation using the given code transformer and a new context.
          *
-         * @param ot code transformer to apply to this function operation
+         * @param ct code transformer to apply to this function operation
          * @return the transformed function operation
          */
-        public FuncOp transform(CodeTransformer ot) {
-            return new FuncOp(this, CodeContext.create(), ot);
+        public FuncOp transform(CodeTransformer ct) {
+            return new FuncOp(this, CodeContext.create(), ct);
         }
 
         /**
          * Transforms a function operation using the given function name, code transformer and a new context.
          *
          * @param funcName the new function name
-         * @param ot code transformer to apply to this function operation
+         * @param ct code transformer to apply to this function operation
          * @return the transformed function operation
          */
-        public FuncOp transform(String funcName, CodeTransformer ot) {
-            return new FuncOp(this, funcName, CodeContext.create(), ot);
+        public FuncOp transform(String funcName, CodeTransformer ct) {
+            return new FuncOp(this, funcName, CodeContext.create(), ct);
         }
 
         FuncOp(String funcName, Body.Builder bodyBuilder) {
@@ -257,7 +257,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public FuncCallOp transform(CodeContext cc, CodeTransformer ot) {
+        public FuncCallOp transform(CodeContext cc, CodeTransformer ct) {
             return new FuncCallOp(this, cc);
         }
 
@@ -314,10 +314,10 @@ public sealed abstract class CoreOp extends Op {
             this(def.bodyDefinitions().get(0));
         }
 
-        ModuleOp(ModuleOp that, CodeContext cc, CodeTransformer ot) {
+        ModuleOp(ModuleOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
-            this.body = that.body.transform(cc, ot).build(this);
+            this.body = that.body.transform(cc, ct).build(this);
             this.table = createTable(body);
         }
 
@@ -334,18 +334,18 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public ModuleOp transform(CodeContext cc, CodeTransformer ot) {
-            return new ModuleOp(this, cc, ot);
+        public ModuleOp transform(CodeContext cc, CodeTransformer ct) {
+            return new ModuleOp(this, cc, ct);
         }
 
         /**
          * Transforms a module operation using the given code transformer and a new context.
          *
-         * @param ot code transformer to apply to the module operation
+         * @param ct code transformer to apply to the module operation
          * @return the transformed module operation
          */
-        public ModuleOp transform(CodeTransformer ot) {
-            return new ModuleOp(this, CodeContext.create(), ot);
+        public ModuleOp transform(CodeTransformer ct) {
+            return new ModuleOp(this, CodeContext.create(), ct);
         }
 
         ModuleOp(Body.Builder bodyBuilder) {
@@ -529,16 +529,16 @@ public sealed abstract class CoreOp extends Op {
             this(def.bodyDefinitions().get(0));
         }
 
-        QuotedOp(QuotedOp that, CodeContext cc, CodeTransformer ot) {
+        QuotedOp(QuotedOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
-            this.quotedBody = that.quotedBody.transform(cc, ot).build(this);
+            this.quotedBody = that.quotedBody.transform(cc, ct).build(this);
             this.quotedOp = getQuotedOp(quotedBody);
         }
 
         @Override
-        public QuotedOp transform(CodeContext cc, CodeTransformer ot) {
-            return new QuotedOp(this, cc, ot);
+        public QuotedOp transform(CodeContext cc, CodeTransformer ct) {
+            return new QuotedOp(this, cc, ct);
         }
 
         QuotedOp(Body.Builder bodyC) {
@@ -613,7 +613,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public ReturnOp transform(CodeContext cc, CodeTransformer ot) {
+        public ReturnOp transform(CodeContext cc, CodeTransformer ct) {
             return new ReturnOp(this, cc);
         }
 
@@ -666,7 +666,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public UnreachableOp transform(CodeContext cc, CodeTransformer ot) {
+        public UnreachableOp transform(CodeContext cc, CodeTransformer ct) {
             return new UnreachableOp(this, cc);
         }
 
@@ -706,7 +706,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public YieldOp transform(CodeContext cc, CodeTransformer ot) {
+        public YieldOp transform(CodeContext cc, CodeTransformer ct) {
             return new YieldOp(this, cc);
         }
 
@@ -762,11 +762,11 @@ public sealed abstract class CoreOp extends Op {
         BranchOp(BranchOp that, CodeContext cc) {
             super(that, cc);
 
-            this.branch = cc.getSuccessorOrCreate(that.branch);
+            this.branch = cc.getReferenceOrCreate(that.branch);
         }
 
         @Override
-        public BranchOp transform(CodeContext cc, CodeTransformer ot) {
+        public BranchOp transform(CodeContext cc, CodeTransformer ct) {
             return new BranchOp(this, cc);
         }
 
@@ -824,12 +824,12 @@ public sealed abstract class CoreOp extends Op {
         ConditionalBranchOp(ConditionalBranchOp that, CodeContext cc) {
             super(that, cc);
 
-            this.trueBranch = cc.getSuccessorOrCreate(that.trueBranch);
-            this.falseBranch = cc.getSuccessorOrCreate(that.falseBranch);
+            this.trueBranch = cc.getReferenceOrCreate(that.trueBranch);
+            this.falseBranch = cc.getReferenceOrCreate(that.falseBranch);
         }
 
         @Override
-        public ConditionalBranchOp transform(CodeContext cc, CodeTransformer ot) {
+        public ConditionalBranchOp transform(CodeContext cc, CodeTransformer ct) {
             return new ConditionalBranchOp(this, cc);
         }
 
@@ -943,7 +943,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public ConstantOp transform(CodeContext cc, CodeTransformer ot) {
+        public ConstantOp transform(CodeContext cc, CodeTransformer ct) {
             return new ConstantOp(this, cc);
         }
 
@@ -1058,7 +1058,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public VarOp transform(CodeContext cc, CodeTransformer ot) {
+        public VarOp transform(CodeContext cc, CodeTransformer ct) {
             return new VarOp(this, cc);
         }
 
@@ -1203,7 +1203,7 @@ public sealed abstract class CoreOp extends Op {
             }
 
             @Override
-            public VarLoadOp transform(CodeContext cc, CodeTransformer ot) {
+            public VarLoadOp transform(CodeContext cc, CodeTransformer ct) {
                 return new VarLoadOp(this, cc);
             }
 
@@ -1251,7 +1251,7 @@ public sealed abstract class CoreOp extends Op {
             }
 
             @Override
-            public VarStoreOp transform(CodeContext cc, CodeTransformer ot) {
+            public VarStoreOp transform(CodeContext cc, CodeTransformer ct) {
                 return new VarStoreOp(this, cc);
             }
 
@@ -1300,7 +1300,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public TupleOp transform(CodeContext cc, CodeTransformer ot) {
+        public TupleOp transform(CodeContext cc, CodeTransformer ct) {
             return new TupleOp(this, cc);
         }
 
@@ -1356,7 +1356,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public TupleLoadOp transform(CodeContext cc, CodeTransformer ot) {
+        public TupleLoadOp transform(CodeContext cc, CodeTransformer ct) {
             return new TupleLoadOp(this, cc);
         }
 
@@ -1436,7 +1436,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public TupleWithOp transform(CodeContext cc, CodeTransformer ot) {
+        public TupleWithOp transform(CodeContext cc, CodeTransformer ct) {
             return new TupleWithOp(this, cc);
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
@@ -29,17 +29,17 @@ public final class Inliner {
      * continue building.
      * <p>
      * This method {@link Block.Builder#body(Body, List, CodeContext, CodeTransformer) transforms} the
-     * body of the invokable operation with the given arguments, a new context, and an operation transformer that
+     * body of the invokable operation with the given arguments, a new context, and an code transformer that
      * replaces return operations by applying the given consumer to a block builder and a return value.
      * <p>
-     * The operation transformer copies all operations except return operations whose nearest invokable operation
+     * The code transformer copies all operations except return operations whose nearest invokable operation
      * ancestor is the given the invokable operation. When such a return operation is encountered, then on
      * first encounter of its grandparent body a return block builder is computed and used for this return operation
      * and encounters of subsequent return operations with the same grandparent body.
      * <p>
-     * If the grandparent body has only one block then operation transformer's block builder is the return
+     * If the grandparent body has only one block then code transformer's block builder is the return
      * block builder. Otherwise, if the grandparent body has one or more blocks then the return block builder is
-     * created from the operation transformer's block builder. The created return block builder will have a block
+     * created from the code transformer's block builder. The created return block builder will have a block
      * parameter whose type corresponds to the return type, or will have no parameter for void return.
      * The computation finishes by applying the return block builder and a return value to the inlining consumer.
      * If the grandparent body has only one block then the return value is the value mapped from the return
@@ -47,8 +47,8 @@ public final class Inliner {
      * then the value is the block parameter of the created return block builder, or is null for void return.
      * <p>
      * For every encounter of a return operation the associated return block builder is compared against the
-     * operation transformer's block builder. If they are not equal then a branch operation is added to the
-     * operation transformer's block builder whose successor is the return block builder with a block argument
+     * code transformer's block builder. If they are not equal then a branch operation is added to the
+     * code transformer's block builder whose successor is the return block builder with a block argument
      * that is the value mapped from the return operation's operand, or with no block argument for void return.
      * @apiNote
      * It is easier to inline an invokable op if its body is in lowered form (there are no operations in the blocks

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
@@ -91,7 +91,7 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
                     // Merge the successor's target block with this block
                     mergeBlock(b, br.targetBlock());
                 } else {
-                    b.op(CoreOp.branch(b.context().getSuccessorOrCreate(br)));
+                    b.op(CoreOp.branch(b.context().getReferenceOrCreate(br)));
                 }
 
                 // Remove the conditional dispatching block if all predecessor reference args are constants
@@ -189,7 +189,7 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
         }
         Block.Reference adjustedSuccessor = b.context().getBlock(successor.targetBlock())
                 .reference(arguments);
-        b.context().mapSuccessor(successor, adjustedSuccessor);
+        b.context().mapReference(successor, adjustedSuccessor);
     }
 
     void mergeBlock(Block.Builder b, CoreOp.BranchOp bop) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/SSA.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/SSA.java
@@ -267,7 +267,7 @@ public final class SSA {
                         List<Value> values = context.getValues(successor.arguments());
                         values.addAll(additionalParams);
                         Block.Builder successorBlockBuilder = context.getBlock(successorBlock);
-                        context.mapSuccessor(successor, successorBlockBuilder.reference(values));
+                        context.mapReference(successor, successorBlockBuilder.reference(values));
                     }
                     block.op(op);
                 }
@@ -447,7 +447,7 @@ public final class SSA {
                             List<Value> toArgs = cc.getValues(s.arguments());
                             toArgs.addAll(values);
                             Block.Reference toS = cc.getBlock(s.targetBlock()).reference(toArgs);
-                            cc.mapSuccessor(s, toS);
+                            cc.mapReference(s, toS);
                         }
                     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -467,17 +467,17 @@ public sealed abstract class JavaOp extends Op {
             this(def.resultType(), def.bodyDefinitions().get(0), isReflectable);
         }
 
-        LambdaOp(LambdaOp that, CodeContext cc, CodeTransformer ot) {
+        LambdaOp(LambdaOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             this.functionalInterface = that.functionalInterface;
-            this.body = that.body.transform(cc, ot).build(this);
+            this.body = that.body.transform(cc, ct).build(this);
             this.isReflectable = that.isReflectable;
         }
 
         @Override
-        public LambdaOp transform(CodeContext cc, CodeTransformer ot) {
-            return new LambdaOp(this, cc, ot);
+        public LambdaOp transform(CodeContext cc, CodeTransformer ct) {
+            return new LambdaOp(this, cc, ct);
         }
 
         LambdaOp(CodeType functionalInterface, Body.Builder bodyC, boolean isReflectable) {
@@ -751,7 +751,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public ThrowOp transform(CodeContext cc, CodeTransformer ot) {
+        public ThrowOp transform(CodeContext cc, CodeTransformer ct) {
             return new ThrowOp(this, cc);
         }
 
@@ -806,14 +806,14 @@ public sealed abstract class JavaOp extends Op {
             this.bodies = bodies.stream().map(b -> b.build(this)).toList();
         }
 
-        AssertOp(AssertOp that, CodeContext cc, CodeTransformer ot) {
+        AssertOp(AssertOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
-            this.bodies = that.bodies.stream().map(b -> b.transform(cc, ot).build(this)).toList();
+            this.bodies = that.bodies.stream().map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
-            return new AssertOp(this, cc, ot);
+        public Op transform(CodeContext cc, CodeTransformer ct) {
+            return new AssertOp(this, cc, ct);
         }
 
         @Override
@@ -885,7 +885,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public MonitorEnterOp transform(CodeContext cc, CodeTransformer ot) {
+            public MonitorEnterOp transform(CodeContext cc, CodeTransformer ct) {
                 return new MonitorEnterOp(this, cc);
             }
 
@@ -914,7 +914,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public MonitorExitOp transform(CodeContext cc, CodeTransformer ot) {
+            public MonitorExitOp transform(CodeContext cc, CodeTransformer ct) {
                 return new MonitorExitOp(this, cc);
             }
 
@@ -1022,7 +1022,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public InvokeOp transform(CodeContext cc, CodeTransformer ot) {
+        public InvokeOp transform(CodeContext cc, CodeTransformer ct) {
             return new InvokeOp(this, cc);
         }
 
@@ -1160,7 +1160,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
+        public Op transform(CodeContext cc, CodeTransformer ct) {
             return new ConvOp(this, cc);
         }
 
@@ -1239,7 +1239,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public NewOp transform(CodeContext cc, CodeTransformer ot) {
+        public NewOp transform(CodeContext cc, CodeTransformer ct) {
             return new NewOp(this, cc);
         }
 
@@ -1383,7 +1383,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public FieldLoadOp transform(CodeContext cc, CodeTransformer ot) {
+            public FieldLoadOp transform(CodeContext cc, CodeTransformer ct) {
                 return new FieldLoadOp(this, cc);
             }
 
@@ -1440,7 +1440,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public FieldStoreOp transform(CodeContext cc, CodeTransformer ot) {
+            public FieldStoreOp transform(CodeContext cc, CodeTransformer ct) {
                 return new FieldStoreOp(this, cc);
             }
 
@@ -1491,7 +1491,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public ArrayLengthOp transform(CodeContext cc, CodeTransformer ot) {
+        public ArrayLengthOp transform(CodeContext cc, CodeTransformer ct) {
             return new ArrayLengthOp(this, cc);
         }
 
@@ -1577,7 +1577,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public ArrayLoadOp transform(CodeContext cc, CodeTransformer ot) {
+            public ArrayLoadOp transform(CodeContext cc, CodeTransformer ct) {
                 return new ArrayLoadOp(this, cc);
             }
 
@@ -1623,7 +1623,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public ArrayStoreOp transform(CodeContext cc, CodeTransformer ot) {
+            public ArrayStoreOp transform(CodeContext cc, CodeTransformer ct) {
                 return new ArrayStoreOp(this, cc);
             }
 
@@ -1684,7 +1684,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public InstanceOfOp transform(CodeContext cc, CodeTransformer ot) {
+        public InstanceOfOp transform(CodeContext cc, CodeTransformer ct) {
             return new InstanceOfOp(this, cc);
         }
 
@@ -1759,7 +1759,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public CastOp transform(CodeContext cc, CodeTransformer ot) {
+        public CastOp transform(CodeContext cc, CodeTransformer ct) {
             return new CastOp(this, cc);
         }
 
@@ -1819,11 +1819,11 @@ public sealed abstract class JavaOp extends Op {
         ExceptionRegionEnter(ExceptionRegionEnter that, CodeContext cc) {
             super(that, cc);
 
-            this.references = that.references.stream().map(cc::getSuccessorOrCreate).toList();
+            this.references = that.references.stream().map(cc::getReferenceOrCreate).toList();
         }
 
         @Override
-        public ExceptionRegionEnter transform(CodeContext cc, CodeTransformer ot) {
+        public ExceptionRegionEnter transform(CodeContext cc, CodeTransformer ct) {
             return new ExceptionRegionEnter(this, cc);
         }
 
@@ -1884,11 +1884,11 @@ public sealed abstract class JavaOp extends Op {
         ExceptionRegionExit(ExceptionRegionExit that, CodeContext cc) {
             super(that, cc);
 
-            this.references = that.references.stream().map(cc::getSuccessorOrCreate).toList();
+            this.references = that.references.stream().map(cc::getReferenceOrCreate).toList();
         }
 
         @Override
-        public ExceptionRegionExit transform(CodeContext cc, CodeTransformer ot) {
+        public ExceptionRegionExit transform(CodeContext cc, CodeTransformer ct) {
             return new ExceptionRegionExit(this, cc);
         }
 
@@ -1958,7 +1958,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
+        public Op transform(CodeContext cc, CodeTransformer ct) {
             return new ConcatOp(this, cc);
         }
 
@@ -2112,7 +2112,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public AddOp transform(CodeContext cc, CodeTransformer ot) {
+        public AddOp transform(CodeContext cc, CodeTransformer ct) {
             return new AddOp(this, cc);
         }
 
@@ -2139,7 +2139,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public SubOp transform(CodeContext cc, CodeTransformer ot) {
+        public SubOp transform(CodeContext cc, CodeTransformer ct) {
             return new SubOp(this, cc);
         }
 
@@ -2166,7 +2166,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public MulOp transform(CodeContext cc, CodeTransformer ot) {
+        public MulOp transform(CodeContext cc, CodeTransformer ct) {
             return new MulOp(this, cc);
         }
 
@@ -2193,7 +2193,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public DivOp transform(CodeContext cc, CodeTransformer ot) {
+        public DivOp transform(CodeContext cc, CodeTransformer ct) {
             return new DivOp(this, cc);
         }
 
@@ -2220,7 +2220,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public ModOp transform(CodeContext cc, CodeTransformer ot) {
+        public ModOp transform(CodeContext cc, CodeTransformer ct) {
             return new ModOp(this, cc);
         }
 
@@ -2248,7 +2248,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public OrOp transform(CodeContext cc, CodeTransformer ot) {
+        public OrOp transform(CodeContext cc, CodeTransformer ct) {
             return new OrOp(this, cc);
         }
 
@@ -2276,7 +2276,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public AndOp transform(CodeContext cc, CodeTransformer ot) {
+        public AndOp transform(CodeContext cc, CodeTransformer ct) {
             return new AndOp(this, cc);
         }
 
@@ -2304,7 +2304,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public XorOp transform(CodeContext cc, CodeTransformer ot) {
+        public XorOp transform(CodeContext cc, CodeTransformer ct) {
             return new XorOp(this, cc);
         }
 
@@ -2331,7 +2331,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public LshlOp transform(CodeContext cc, CodeTransformer ot) {
+        public LshlOp transform(CodeContext cc, CodeTransformer ct) {
             return new LshlOp(this, cc);
         }
 
@@ -2358,7 +2358,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public AshrOp transform(CodeContext cc, CodeTransformer ot) {
+        public AshrOp transform(CodeContext cc, CodeTransformer ct) {
             return new AshrOp(this, cc);
         }
 
@@ -2385,7 +2385,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public LshrOp transform(CodeContext cc, CodeTransformer ot) {
+        public LshrOp transform(CodeContext cc, CodeTransformer ct) {
             return new LshrOp(this, cc);
         }
 
@@ -2412,7 +2412,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public NegOp transform(CodeContext cc, CodeTransformer ot) {
+        public NegOp transform(CodeContext cc, CodeTransformer ct) {
             return new NegOp(this, cc);
         }
 
@@ -2439,7 +2439,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public ComplOp transform(CodeContext cc, CodeTransformer ot) {
+        public ComplOp transform(CodeContext cc, CodeTransformer ct) {
             return new ComplOp(this, cc);
         }
 
@@ -2466,7 +2466,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public NotOp transform(CodeContext cc, CodeTransformer ot) {
+        public NotOp transform(CodeContext cc, CodeTransformer ct) {
             return new NotOp(this, cc);
         }
 
@@ -2494,7 +2494,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public EqOp transform(CodeContext cc, CodeTransformer ot) {
+        public EqOp transform(CodeContext cc, CodeTransformer ct) {
             return new EqOp(this, cc);
         }
 
@@ -2522,7 +2522,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public NeqOp transform(CodeContext cc, CodeTransformer ot) {
+        public NeqOp transform(CodeContext cc, CodeTransformer ct) {
             return new NeqOp(this, cc);
         }
 
@@ -2549,7 +2549,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public GtOp transform(CodeContext cc, CodeTransformer ot) {
+        public GtOp transform(CodeContext cc, CodeTransformer ct) {
             return new GtOp(this, cc);
         }
 
@@ -2577,7 +2577,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public GeOp transform(CodeContext cc, CodeTransformer ot) {
+        public GeOp transform(CodeContext cc, CodeTransformer ct) {
             return new GeOp(this, cc);
         }
 
@@ -2605,7 +2605,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public LtOp transform(CodeContext cc, CodeTransformer ot) {
+        public LtOp transform(CodeContext cc, CodeTransformer ct) {
             return new LtOp(this, cc);
         }
 
@@ -2633,7 +2633,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public LeOp transform(CodeContext cc, CodeTransformer ot) {
+        public LeOp transform(CodeContext cc, CodeTransformer ct) {
             return new LeOp(this, cc);
         }
 
@@ -2761,7 +2761,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public BreakOp transform(CodeContext cc, CodeTransformer ot) {
+        public BreakOp transform(CodeContext cc, CodeTransformer ct) {
             return new BreakOp(this, cc);
         }
 
@@ -2795,7 +2795,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public ContinueOp transform(CodeContext cc, CodeTransformer ot) {
+        public ContinueOp transform(CodeContext cc, CodeTransformer ct) {
             return new ContinueOp(this, cc);
         }
 
@@ -2836,7 +2836,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public YieldOp transform(CodeContext cc, CodeTransformer ot) {
+        public YieldOp transform(CodeContext cc, CodeTransformer ct) {
             return new YieldOp(this, cc);
         }
 
@@ -2916,16 +2916,16 @@ public sealed abstract class JavaOp extends Op {
             this(def.bodyDefinitions().get(0));
         }
 
-        BlockOp(BlockOp that, CodeContext cc, CodeTransformer ot) {
+        BlockOp(BlockOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             // Copy body
-            this.body = that.body.transform(cc, ot).build(this);
+            this.body = that.body.transform(cc, ct).build(this);
         }
 
         @Override
-        public BlockOp transform(CodeContext cc, CodeTransformer ot) {
-            return new BlockOp(this, cc, ot);
+        public BlockOp transform(CodeContext cc, CodeTransformer ct) {
+            return new BlockOp(this, cc, ct);
         }
 
         BlockOp(Body.Builder bodyC) {
@@ -2999,17 +2999,17 @@ public sealed abstract class JavaOp extends Op {
             this(def.bodyDefinitions().get(0), def.bodyDefinitions().get(1));
         }
 
-        SynchronizedOp(SynchronizedOp that, CodeContext cc, CodeTransformer ot) {
+        SynchronizedOp(SynchronizedOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             // Copy bodies
-            this.exprBody = that.exprBody.transform(cc, ot).build(this);
-            this.blockBody = that.blockBody.transform(cc, ot).build(this);
+            this.exprBody = that.exprBody.transform(cc, ct).build(this);
+            this.blockBody = that.blockBody.transform(cc, ct).build(this);
         }
 
         @Override
-        public SynchronizedOp transform(CodeContext cc, CodeTransformer ot) {
-            return new SynchronizedOp(this, cc, ot);
+        public SynchronizedOp transform(CodeContext cc, CodeTransformer ct) {
+            return new SynchronizedOp(this, cc, ct);
         }
 
         // @@@: builder?
@@ -3167,16 +3167,16 @@ public sealed abstract class JavaOp extends Op {
             this(def.bodyDefinitions().get(0));
         }
 
-        LabeledOp(LabeledOp that, CodeContext cc, CodeTransformer ot) {
+        LabeledOp(LabeledOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             // Copy body
-            this.body = that.body.transform(cc, ot).build(this);
+            this.body = that.body.transform(cc, ct).build(this);
         }
 
         @Override
-        public LabeledOp transform(CodeContext cc, CodeTransformer ot) {
-            return new LabeledOp(this, cc, ot);
+        public LabeledOp transform(CodeContext cc, CodeTransformer ct) {
+            return new LabeledOp(this, cc, ct);
         }
 
         LabeledOp(Body.Builder bodyC) {
@@ -3410,17 +3410,17 @@ public sealed abstract class JavaOp extends Op {
             this(def.bodyDefinitions());
         }
 
-        IfOp(IfOp that, CodeContext cc, CodeTransformer ot) {
+        IfOp(IfOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             // Copy body
             this.bodies = that.bodies.stream()
-                    .map(b -> b.transform(cc, ot).build(this)).toList();
+                    .map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
         @Override
-        public IfOp transform(CodeContext cc, CodeTransformer ot) {
-            return new IfOp(this, cc, ot);
+        public IfOp transform(CodeContext cc, CodeTransformer ct) {
+            return new IfOp(this, cc, ct);
         }
 
         IfOp(List<Body.Builder> bodyCs) {
@@ -3542,12 +3542,12 @@ public sealed abstract class JavaOp extends Op {
 
         final List<Body> bodies;
 
-        JavaSwitchOp(JavaSwitchOp that, CodeContext cc, CodeTransformer ot) {
+        JavaSwitchOp(JavaSwitchOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             // Copy body
             this.bodies = that.bodies.stream()
-                    .map(b -> b.transform(cc, ot).build(this)).toList();
+                    .map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
         JavaSwitchOp(Value target, List<Body.Builder> bodyCs) {
@@ -3738,15 +3738,15 @@ public sealed abstract class JavaOp extends Op {
             this(def.resultType(), def.operands().get(0), def.bodyDefinitions());
         }
 
-        SwitchExpressionOp(SwitchExpressionOp that, CodeContext cc, CodeTransformer ot) {
-            super(that, cc, ot);
+        SwitchExpressionOp(SwitchExpressionOp that, CodeContext cc, CodeTransformer ct) {
+            super(that, cc, ct);
 
             this.resultType = that.resultType;
         }
 
         @Override
-        public SwitchExpressionOp transform(CodeContext cc, CodeTransformer ot) {
-            return new SwitchExpressionOp(this, cc, ot);
+        public SwitchExpressionOp transform(CodeContext cc, CodeTransformer ct) {
+            return new SwitchExpressionOp(this, cc, ct);
         }
 
         SwitchExpressionOp(CodeType resultType, Value target, List<Body.Builder> bodyCs) {
@@ -3779,13 +3779,13 @@ public sealed abstract class JavaOp extends Op {
             this(def.operands().get(0), def.bodyDefinitions());
         }
 
-        SwitchStatementOp(SwitchStatementOp that, CodeContext cc, CodeTransformer ot) {
-            super(that, cc, ot);
+        SwitchStatementOp(SwitchStatementOp that, CodeContext cc, CodeTransformer ct) {
+            super(that, cc, ct);
         }
 
         @Override
-        public SwitchStatementOp transform(CodeContext cc, CodeTransformer ot) {
-            return new SwitchStatementOp(this, cc, ot);
+        public SwitchStatementOp transform(CodeContext cc, CodeTransformer ct) {
+            return new SwitchStatementOp(this, cc, ct);
         }
 
         SwitchStatementOp(Value target, List<Body.Builder> bodyCs) {
@@ -3818,7 +3818,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public SwitchFallthroughOp transform(CodeContext cc, CodeTransformer ot) {
+        public SwitchFallthroughOp transform(CodeContext cc, CodeTransformer ct) {
             return new SwitchFallthroughOp(this, cc);
         }
 
@@ -4011,18 +4011,18 @@ public sealed abstract class JavaOp extends Op {
                     def.bodyDefinitions().get(3));
         }
 
-        ForOp(ForOp that, CodeContext cc, CodeTransformer ot) {
+        ForOp(ForOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
-            this.initBody = that.initBody.transform(cc, ot).build(this);
-            this.condBody = that.condBody.transform(cc, ot).build(this);
-            this.updateBody = that.updateBody.transform(cc, ot).build(this);
-            this.loopBody = that.loopBody.transform(cc, ot).build(this);
+            this.initBody = that.initBody.transform(cc, ct).build(this);
+            this.condBody = that.condBody.transform(cc, ct).build(this);
+            this.updateBody = that.updateBody.transform(cc, ct).build(this);
+            this.loopBody = that.loopBody.transform(cc, ct).build(this);
         }
 
         @Override
-        public ForOp transform(CodeContext cc, CodeTransformer ot) {
-            return new ForOp(this, cc, ot);
+        public ForOp transform(CodeContext cc, CodeTransformer ct) {
+            return new ForOp(this, cc, ct);
         }
 
         ForOp(Body.Builder initC,
@@ -4284,17 +4284,17 @@ public sealed abstract class JavaOp extends Op {
                     def.bodyDefinitions().get(2));
         }
 
-        EnhancedForOp(EnhancedForOp that, CodeContext cc, CodeTransformer ot) {
+        EnhancedForOp(EnhancedForOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
-            this.exprBody = that.exprBody.transform(cc, ot).build(this);
-            this.initBody = that.initBody.transform(cc, ot).build(this);
-            this.loopBody = that.loopBody.transform(cc, ot).build(this);
+            this.exprBody = that.exprBody.transform(cc, ct).build(this);
+            this.initBody = that.initBody.transform(cc, ct).build(this);
+            this.loopBody = that.loopBody.transform(cc, ct).build(this);
         }
 
         @Override
-        public EnhancedForOp transform(CodeContext cc, CodeTransformer ot) {
-            return new EnhancedForOp(this, cc, ot);
+        public EnhancedForOp transform(CodeContext cc, CodeTransformer ct) {
+            return new EnhancedForOp(this, cc, ct);
         }
 
         EnhancedForOp(Body.Builder expressionC, Body.Builder initC, Body.Builder bodyC) {
@@ -4539,16 +4539,16 @@ public sealed abstract class JavaOp extends Op {
             }
         }
 
-        WhileOp(WhileOp that, CodeContext cc, CodeTransformer ot) {
+        WhileOp(WhileOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             this.bodies = that.bodies.stream()
-                    .map(b -> b.transform(cc, ot).build(this)).toList();
+                    .map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
         @Override
-        public WhileOp transform(CodeContext cc, CodeTransformer ot) {
-            return new WhileOp(this, cc, ot);
+        public WhileOp transform(CodeContext cc, CodeTransformer ct) {
+            return new WhileOp(this, cc, ct);
         }
 
         @Override
@@ -4701,16 +4701,16 @@ public sealed abstract class JavaOp extends Op {
             }
         }
 
-        DoWhileOp(DoWhileOp that, CodeContext cc, CodeTransformer ot) {
+        DoWhileOp(DoWhileOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             this.bodies = that.bodies.stream()
-                    .map(b -> b.transform(cc, ot).build(this)).toList();
+                    .map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
         @Override
-        public DoWhileOp transform(CodeContext cc, CodeTransformer ot) {
-            return new DoWhileOp(this, cc, ot);
+        public DoWhileOp transform(CodeContext cc, CodeTransformer ct) {
+            return new DoWhileOp(this, cc, ct);
         }
 
         @Override
@@ -4773,11 +4773,11 @@ public sealed abstract class JavaOp extends Op {
             implements Op.Nested, Op.Lowerable, JavaExpression {
         final List<Body> bodies;
 
-        JavaConditionalOp(JavaConditionalOp that, CodeContext cc, CodeTransformer ot) {
+        JavaConditionalOp(JavaConditionalOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             // Copy body
-            this.bodies = that.bodies.stream().map(b -> b.transform(cc, ot).build(this)).toList();
+            this.bodies = that.bodies.stream().map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
         JavaConditionalOp(List<Body.Builder> bodyCs) {
@@ -4909,13 +4909,13 @@ public sealed abstract class JavaOp extends Op {
             this(def.bodyDefinitions());
         }
 
-        ConditionalAndOp(ConditionalAndOp that, CodeContext cc, CodeTransformer ot) {
-            super(that, cc, ot);
+        ConditionalAndOp(ConditionalAndOp that, CodeContext cc, CodeTransformer ct) {
+            super(that, cc, ct);
         }
 
         @Override
-        public ConditionalAndOp transform(CodeContext cc, CodeTransformer ot) {
-            return new ConditionalAndOp(this, cc, ot);
+        public ConditionalAndOp transform(CodeContext cc, CodeTransformer ct) {
+            return new ConditionalAndOp(this, cc, ct);
         }
 
         ConditionalAndOp(List<Body.Builder> bodyCs) {
@@ -4978,13 +4978,13 @@ public sealed abstract class JavaOp extends Op {
             this(def.bodyDefinitions());
         }
 
-        ConditionalOrOp(ConditionalOrOp that, CodeContext cc, CodeTransformer ot) {
-            super(that, cc, ot);
+        ConditionalOrOp(ConditionalOrOp that, CodeContext cc, CodeTransformer ct) {
+            super(that, cc, ct);
         }
 
         @Override
-        public ConditionalOrOp transform(CodeContext cc, CodeTransformer ot) {
-            return new ConditionalOrOp(this, cc, ot);
+        public ConditionalOrOp transform(CodeContext cc, CodeTransformer ct) {
+            return new ConditionalOrOp(this, cc, ct);
         }
 
         ConditionalOrOp(List<Body.Builder> bodyCs) {
@@ -5025,18 +5025,18 @@ public sealed abstract class JavaOp extends Op {
             this(def.resultType(), def.bodyDefinitions());
         }
 
-        ConditionalExpressionOp(ConditionalExpressionOp that, CodeContext cc, CodeTransformer ot) {
+        ConditionalExpressionOp(ConditionalExpressionOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             // Copy body
             this.bodies = that.bodies.stream()
-                    .map(b -> b.transform(cc, ot).build(this)).toList();
+                    .map(b -> b.transform(cc, ct).build(this)).toList();
             this.resultType = that.resultType;
         }
 
         @Override
-        public ConditionalExpressionOp transform(CodeContext cc, CodeTransformer ot) {
-            return new ConditionalExpressionOp(this, cc, ot);
+        public ConditionalExpressionOp transform(CodeContext cc, CodeTransformer ct) {
+            return new ConditionalExpressionOp(this, cc, ct);
         }
 
         ConditionalExpressionOp(CodeType expressionType, List<Body.Builder> bodyCs) {
@@ -5265,28 +5265,28 @@ public sealed abstract class JavaOp extends Op {
             this(resources, body, catchers, finalizer);
         }
 
-        TryOp(TryOp that, CodeContext cc, CodeTransformer ot) {
+        TryOp(TryOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             if (that.resourcesBody != null) {
-                this.resourcesBody = that.resourcesBody.transform(cc, ot).build(this);
+                this.resourcesBody = that.resourcesBody.transform(cc, ct).build(this);
             } else {
                 this.resourcesBody = null;
             }
-            this.body = that.body.transform(cc, ot).build(this);
+            this.body = that.body.transform(cc, ct).build(this);
             this.catchBodies = that.catchBodies.stream()
-                    .map(b -> b.transform(cc, ot).build(this))
+                    .map(b -> b.transform(cc, ct).build(this))
                     .toList();
             if (that.finallyBody != null) {
-                this.finallyBody = that.finallyBody.transform(cc, ot).build(this);
+                this.finallyBody = that.finallyBody.transform(cc, ct).build(this);
             } else {
                 this.finallyBody = null;
             }
         }
 
         @Override
-        public TryOp transform(CodeContext cc, CodeTransformer ot) {
-            return new TryOp(this, cc, ot);
+        public TryOp transform(CodeContext cc, CodeTransformer ct) {
+            return new TryOp(this, cc, ct);
         }
 
         TryOp(Body.Builder resourcesC,
@@ -5730,7 +5730,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public TypePatternOp transform(CodeContext cc, CodeTransformer ot) {
+            public TypePatternOp transform(CodeContext cc, CodeTransformer ct) {
                 return new TypePatternOp(this, cc);
             }
 
@@ -5803,7 +5803,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public RecordPatternOp transform(CodeContext cc, CodeTransformer ot) {
+            public RecordPatternOp transform(CodeContext cc, CodeTransformer ct) {
                 return new RecordPatternOp(this, cc);
             }
 
@@ -5866,7 +5866,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public Op transform(CodeContext cc, CodeTransformer ot) {
+            public Op transform(CodeContext cc, CodeTransformer ct) {
                 return new MatchAllPatternOp(this, cc);
             }
 
@@ -5906,16 +5906,16 @@ public sealed abstract class JavaOp extends Op {
                         def.bodyDefinitions().get(0), def.bodyDefinitions().get(1));
             }
 
-            MatchOp(MatchOp that, CodeContext cc, CodeTransformer ot) {
+            MatchOp(MatchOp that, CodeContext cc, CodeTransformer ct) {
                 super(that, cc);
 
-                this.patternBody = that.patternBody.transform(cc, ot).build(this);
-                this.matchBody = that.matchBody.transform(cc, ot).build(this);
+                this.patternBody = that.patternBody.transform(cc, ct).build(this);
+                this.matchBody = that.matchBody.transform(cc, ct).build(this);
             }
 
             @Override
-            public MatchOp transform(CodeContext cc, CodeTransformer ot) {
-                return new MatchOp(this, cc, ot);
+            public MatchOp transform(CodeContext cc, CodeTransformer ct) {
+                return new MatchOp(this, cc, ct);
             }
 
             MatchOp(Value target, Body.Builder patternC, Body.Builder matchC) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/ExternalizedOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/ExternalizedOp.java
@@ -99,7 +99,7 @@ public record ExternalizedOp(String name,
                 op.externalizeOpName(),
                 op.location(),
                 cc.getValues(op.operands()),
-                op.successors().stream().map(cc::getSuccessorOrCreate).toList(),
+                op.successors().stream().map(cc::getReferenceOrCreate).toList(),
                 op.resultType(),
                 op.externalize(),
                 op.bodies().stream().map(b -> b.copy(cc)).toList()

--- a/test/jdk/jdk/incubator/code/ad/ForwardDifferentiation.java
+++ b/test/jdk/jdk/incubator/code/ad/ForwardDifferentiation.java
@@ -224,7 +224,7 @@ public final class ForwardDifferentiation {
 
             // Map successor with appended arguments
             Block.Reference to = cc.getBlock(from.targetBlock()).reference(outputArgs);
-            cc.mapSuccessor(from, to);
+            cc.mapReference(from, to);
         }
     }
 

--- a/test/jdk/jdk/incubator/code/anf/AnfDialect.java
+++ b/test/jdk/jdk/incubator/code/anf/AnfDialect.java
@@ -71,8 +71,8 @@ public final class AnfDialect {
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
-            return new AnfLetOp(this, cc, ot);
+        public Op transform(CodeContext cc, CodeTransformer ct) {
+            return new AnfLetOp(this, cc, ct);
         }
 
         public AnfLetOp(Body.Builder bodyBuilder) {
@@ -128,8 +128,8 @@ public final class AnfDialect {
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
-            return new AnfLetRecOp(this, cc, ot);
+        public Op transform(CodeContext cc, CodeTransformer ct) {
+            return new AnfLetRecOp(this, cc, ct);
         }
 
         public AnfLetRecOp(Body.Builder bodyBuilder) {
@@ -216,8 +216,8 @@ public final class AnfDialect {
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
-            return new AnfIfOp(this, cc, ot);
+        public Op transform(CodeContext cc, CodeTransformer ct) {
+            return new AnfIfOp(this, cc, ct);
         }
 
         AnfIfOp(Value test, Body.Builder thenBodyBuilder, Body.Builder elseBodyBuilder) {
@@ -301,8 +301,8 @@ public final class AnfDialect {
         }
 
         @Override
-        public AnfFuncOp transform(CodeContext cc, CodeTransformer ot) {
-            return new AnfFuncOp(this, cc, ot);
+        public AnfFuncOp transform(CodeContext cc, CodeTransformer ct) {
+            return new AnfFuncOp(this, cc, ct);
         }
 
         AnfFuncOp(String funcName, Body.Builder bodyBuilder) {
@@ -353,7 +353,7 @@ public final class AnfDialect {
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
+        public Op transform(CodeContext cc, CodeTransformer ct) {
             return new AnfApply(this, cc);
         }
 
@@ -409,7 +409,7 @@ public final class AnfDialect {
         }
 
         @Override
-        public Op transform(CodeContext cc, CodeTransformer ot) {
+        public Op transform(CodeContext cc, CodeTransformer ct) {
             return new AnfApplyStub(this, cc);
         }
 

--- a/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
@@ -102,7 +102,7 @@ sealed abstract class SlotOp extends Op {
         }
 
         @Override
-        public SlotLoadOp transform(CodeContext cc, CodeTransformer ot) {
+        public SlotLoadOp transform(CodeContext cc, CodeTransformer ct) {
             return new SlotLoadOp(this, cc);
         }
 
@@ -151,7 +151,7 @@ sealed abstract class SlotOp extends Op {
         }
 
         @Override
-        public SlotStoreOp transform(CodeContext cc, CodeTransformer ot) {
+        public SlotStoreOp transform(CodeContext cc, CodeTransformer ct) {
             return new SlotStoreOp(this, cc);
         }
 

--- a/test/jdk/jdk/incubator/code/pe/PartialEvaluator.java
+++ b/test/jdk/jdk/incubator/code/pe/PartialEvaluator.java
@@ -269,7 +269,7 @@ final class PartialEvaluator {
 
                         processBlock(bc, inBlock, nextInBlock, outBlock);
 
-                        outBlock.op(CoreOp.branch(outBlock.context().getSuccessorOrCreate(nextInBlockRef)));
+                        outBlock.op(CoreOp.branch(outBlock.context().getReferenceOrCreate(nextInBlockRef)));
                     } else {
                         // @@@ might be non-constant latch to loop
                         processBlock(bc, inBlock, cb.falseBranch().targetBlock(), outBlock);

--- a/test/jdk/jdk/incubator/code/writer/TestAttributeSerialization.java
+++ b/test/jdk/jdk/incubator/code/writer/TestAttributeSerialization.java
@@ -52,7 +52,7 @@ public class TestAttributeSerialization {
         }
 
         @Override
-        public TestOp transform(CodeContext cc, CodeTransformer ot) {
+        public TestOp transform(CodeContext cc, CodeTransformer ct) {
             return new TestOp(this, cc);
         }
 


### PR DESCRIPTION
Doc updates.

Use reference instead of successor in documentation and API of `CodeContext`. (Successor refers to the block references of an operation.)

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1008/head:pull/1008` \
`$ git checkout pull/1008`

Update a local copy of the PR: \
`$ git checkout pull/1008` \
`$ git pull https://git.openjdk.org/babylon.git pull/1008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1008`

View PR using the GUI difftool: \
`$ git pr show -t 1008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1008.diff">https://git.openjdk.org/babylon/pull/1008.diff</a>

</details>
