### PR TITLE
Simplify op transformer and protect against reentrant calls

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -62,31 +62,24 @@ public interface CodeTransformer {
      * @return the code transformer that transforms operations.
      */
     static CodeTransformer opTransformer(OpTransformer opTransformer) {
-        final class CodeTransformerOfOps implements CodeTransformer, Function<Op, Op.Result> {
-            Block.Builder builder;
-            Op op;
-
-            @Override
-            public Block.Builder acceptOp(Block.Builder builder, Op op) {
-                this.builder = builder;
-                this.op = op;
-                // Use null if there is no mapping in the output
-                // This can happen if an operation is removed by not applying
-                // it to the builder
-                List<Value> operands = op.operands().stream()
-                        .map(v -> builder.context().getValueOrDefault(v, null)).toList();
-                opTransformer.acceptOp(this, op, operands);
-                return builder;
-            }
-
-            @Override
-            public Op.Result apply(Op op) {
-                Op.Result result = builder.op(op);
-                builder.context().mapValue(this.op.result(), result);
+        return (builder, inputOp) -> {
+            // Allocate op builder function capturing builder and inputOp
+            // This is simpler and safer that using fields holding the builder and inputOp
+            // and protecting use against reentry of calls to builder.op for an attached
+            // operation that is transformed and contains bodies
+            // @@@ If performance is an issue consider changing
+            Function<Op, Op.Result> opBuilder = outputOp -> {
+                Op.Result result = builder.op(outputOp);
+                builder.context().mapValue(inputOp.result(), result);
                 return result;
-            }
-        }
-        return new CodeTransformerOfOps();
+            };
+
+            List<Value> outputOperands = inputOp.operands().stream()
+                    .map(v -> builder.context().getValueOrDefault(v, null)).toList();
+
+            opTransformer.acceptOp(opBuilder, inputOp, outputOperands);
+            return builder;
+        };
     }
 
     /**

--- a/test/jdk/jdk/incubator/code/transform/TestTransform.java
+++ b/test/jdk/jdk/incubator/code/transform/TestTransform.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
 import java.util.function.IntBinaryOperator;
+import java.util.function.IntSupplier;
 
 /*
  * @test
@@ -171,7 +172,70 @@ public class TestTransform {
     }
 
 
-     void testTransformer(String methodName, String transformedMethodName, CodeTransformer codeTransformer) throws Exception {
+    @Reflect
+    static int nested() {
+        return (true ? 1 : 2) + (true ? 3 : 4);
+    }
+
+
+    @Reflect
+    static int nestedReentranceOtherModel() {
+        return (true ? 5 : 6) + (true ? 3 : 4);
+    }
+
+    @Test
+    public void testOpTransformer_nestedReentranceOtherModel() throws Exception {
+        var codeTransformer = CodeTransformer.opTransformer((builder, op, operands) -> {
+            switch (op) {
+                case JavaOp.ConditionalExpressionOp cop -> {
+                    // Replace first conditional expression with that from another model
+                    if (cop.parent().nextOp(cop) instanceof JavaOp.ConditionalExpressionOp _) {
+                        @Reflect
+                        IntSupplier r = () -> true ? 5 : 6;
+                        JavaOp.ConditionalExpressionOp other = Op.ofLambda(r).orElseThrow().op().elements()
+                                .filter(JavaOp.ConditionalExpressionOp.class::isInstance)
+                                .map(JavaOp.ConditionalExpressionOp.class::cast)
+                                .findFirst()
+                                .orElseThrow();
+                        builder.apply(other);
+                    } else {
+                        builder.apply(cop);
+                    }
+                }
+                default ->
+                        builder.apply(op);
+            }
+        });
+
+        testTransformer("nested", "nestedReentranceOtherModel", codeTransformer);
+    }
+
+    @Reflect
+    static int nestedReentranceSameModel() {
+        return (true ? 3 : 4) + (true ? 3 : 4);
+    }
+
+    @Test
+    public void testOpTransformer_nestedReentranceSameModel() throws Exception {
+        var codeTransformer = CodeTransformer.opTransformer((builder, op, operands) -> {
+            switch (op) {
+                case JavaOp.ConditionalExpressionOp cop -> {
+                    // Replace first conditional expression with that from same model
+                    if (cop.parent().nextOp(cop) instanceof JavaOp.ConditionalExpressionOp second) {
+                        builder.apply(second);
+                    } else {
+                        builder.apply(cop);
+                    }
+                }
+                default ->
+                        builder.apply(op);
+            }
+        });
+
+        testTransformer("nested", "nestedReentranceSameModel", codeTransformer);
+    }
+
+    void testTransformer(String methodName, String transformedMethodName, CodeTransformer codeTransformer) throws Exception {
         Method fMethod = this.getClass().getDeclaredMethod(methodName);
         var fModel = Op.ofMethod(fMethod).orElseThrow();
 


### PR DESCRIPTION
The `CodeTransformer.opTransformer` implementation optimized for performance but failed to protect the fields used to store the current operation and block builder against reentrant calls. Such calls can occur when an attached operation is appended to a block builder and its bodies are transformed.

The bug is subtle enough it is worth overriding the performance concerns to focus on safety and simplicity. If performance becomes a concern we can reconsider.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1010/head:pull/1010` \
`$ git checkout pull/1010`

Update a local copy of the PR: \
`$ git checkout pull/1010` \
`$ git pull https://git.openjdk.org/babylon.git pull/1010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1010`

View PR using the GUI difftool: \
`$ git pr show -t 1010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1010.diff">https://git.openjdk.org/babylon/pull/1010.diff</a>

</details>
