### PR TITLE
BytecodeGenerator constructor with varargs fix + test

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -789,7 +789,16 @@ public final class BytecodeGenerator {
                             case JavaType jt -> {
                                 cob.new_(jt.toNominalDescriptor())
                                     .dup();
-                                processOperands(op);
+                                if (op.isVarargs()) {
+                                    int varargIndex = op.constructorReference().signature().parameterTypes().size() - 1;
+                                    var argOperands = op.operands().subList(0, varargIndex);
+                                    processOperands(argOperands);
+                                    var compType = ((ArrayType) op.constructorReference().signature().parameterTypes().getLast()).componentType();
+                                    var varArgOperands = op.operands().subList(varargIndex, op.operands().size());
+                                    loadArray(compType, varArgOperands);
+                                } else {
+                                    processOperands(op);
+                                }
                                 cob.invokespecial(
                                         ((JavaType) op.resultType()).toNominalDescriptor(),
                                         ConstantDescs.INIT_NAME,
@@ -825,23 +834,8 @@ public final class BytecodeGenerator {
                         if (op.isVarArgs()) {
                             processOperands(op.argOperands());
                             var varArgOperands = op.varArgOperands();
-                            cob.loadConstant(varArgOperands.size());
                             var compType = ((ArrayType) op.invokeReference().signature().parameterTypes().getLast()).componentType();
-                            var compTypeDesc = compType.toNominalDescriptor();
-                            var typeKind = TypeKind.from(compTypeDesc);
-                            if (compTypeDesc.isPrimitive()) {
-                                cob.newarray(typeKind);
-                            } else {
-                                cob.anewarray(compTypeDesc);
-                            }
-                            for (int j = 0; j < varArgOperands.size(); j++) {
-                                // we duplicate array value on the stack to be consumed by arrayStore
-                                // after completion of this loop the array value will be on top of the stack
-                                cob.dup();
-                                cob.loadConstant(j);
-                                load(varArgOperands.get(j));
-                                cob.arrayStore(typeKind);
-                            }
+                            loadArray(compType, varArgOperands);
                         } else {
                             processOperands(op);
                         }
@@ -1080,6 +1074,25 @@ public final class BytecodeGenerator {
             }
         }
         exceptionRegionsChange(new Block[0]);
+    }
+
+    private void loadArray(JavaType compType, List<Value> array) {
+        cob.loadConstant(array.size());
+        var compTypeDesc = compType.toNominalDescriptor();
+        var typeKind = TypeKind.from(compTypeDesc);
+        if (compTypeDesc.isPrimitive()) {
+            cob.newarray(typeKind);
+        } else {
+            cob.anewarray(compTypeDesc);
+        }
+        for (int j = 0; j < array.size(); j++) {
+            // we duplicate array value on the stack to be consumed by arrayStore
+            // after completion of this loop the array value will be on top of the stack
+            cob.dup();
+            cob.loadConstant(j);
+            load(array.get(j));
+            cob.arrayStore(typeKind);
+        }
     }
 
     private void exceptionRegionsChange(Block[] newCatchBlocks) {

--- a/test/jdk/jdk/incubator/code/bytecode/TestVarArg.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestVarArg.java
@@ -53,6 +53,8 @@ public class TestVarArg {
 
         r += ls + j("s1", "s2", "s3");
 
+        r += ls + new V("s4", "s5");
+
         r += ls + w(8, 9);
 
         r += k();
@@ -86,6 +88,13 @@ public class TestVarArg {
 
     static String d(double... a) {
         return Arrays.toString(a);
+    }
+
+    record V(String i, Object... s) {
+        @Override
+        public String toString() {
+            return i + " " + Arrays.toString(s);
+        }
     }
 
     private CoreOp.FuncOp getFuncOp(String name) {


### PR DESCRIPTION
BytecodeGenerator mishandled constructors with varargs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1011/head:pull/1011` \
`$ git checkout pull/1011`

Update a local copy of the PR: \
`$ git checkout pull/1011` \
`$ git pull https://git.openjdk.org/babylon.git pull/1011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1011`

View PR using the GUI difftool: \
`$ git pr show -t 1011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1011.diff">https://git.openjdk.org/babylon/pull/1011.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1011#issuecomment-4297478150)
</details>
