### PR TITLE
Updates to specification and API

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -249,7 +249,7 @@ public class TritonOps {
         public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
             // Isolate body with respect to ancestor transformations
             // and copy directly without lowering descendant operations
-            b.rebind(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);
             return b;
         }
     }

--- a/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -105,7 +105,7 @@ public class KernelCallGraph implements LookupCarrier {
                         blockbuilder.context().mapValue(invoke.op().result(), exitBlockBuilder.parameters().getFirst());
                     }
                     changed.set(true);
-                    return exitBlockBuilder.rebind(blockbuilder.context(), blockbuilder.transformer());
+                    return exitBlockBuilder.withContextAndTransformer(blockbuilder.context(), blockbuilder.transformer());
                 }
                 blockbuilder.op(op);
                 return blockbuilder;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -709,7 +709,7 @@ public final class Block implements CodeElement<Block, Op> {
          * </ul>
          * <a id="reachable-value"></a>A value is reachable if this block builder's {@link #parentBody() parent} body
          * builder is the same as or is connected, directly or indirectly through its
-         * {@link Body.Builder#ancestorBody() nearest ancestor} body builder and so on, to the body builder for the
+         * {@link Body.Builder#connectedAncestorBody() nearest ancestor} body builder and so on, to the body builder for the
          * value's declaring block's parent body. A value is not reachable if an isolated body builder is encountered
          * (the isolated body builder's nearest ancestor body builder is {@code null} and therefore there is no
          * connection, directly or indirectly).
@@ -791,7 +791,7 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         for (Body b : op.bodies()) {
-            if (b.ancestorBody != null && b.ancestorBody != this.parentBody) {
+            if (b.connectedAncestorBody != null && b.connectedAncestorBody != this.parentBody) {
                 throw new IllegalStateException("Body of operation is connected to a different ancestor body: ");
             }
         }
@@ -840,7 +840,7 @@ public final class Block implements CodeElement<Block, Op> {
     private boolean isReachable(Value v) {
         Body b = parentBody;
         while (b != null && b != v.block.parentBody) {
-            b = b.ancestorBody;
+            b = b.connectedAncestorBody;
         }
         return b != null;
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -38,8 +38,8 @@ import java.util.stream.Collectors;
  * <p>
  * Blocks declare zero or more block parameters.
  * <p>
- * A block is built using a {@link Block.Builder block builder} that is used to append operations to the block
- * being built.
+ * A block is built using a {@link Block.Builder}, as part of the
+ * <a href="Body.Builder.html#body-building-process">process of building</a> its parent body.
  */
 public final class Block implements CodeElement<Block, Op> {
 
@@ -467,26 +467,17 @@ public final class Block implements CodeElement<Block, Op> {
     /**
      * A builder for a block.
      * <p>
-     * A block builder defines the structure of the block that is being built. It is used to {@link #op(Op) append}
-     * operations to its block. It can also be used to {@link Block.Builder#block(List) create} block builders for
-     * sibling blocks.
+     * A block builder builds one block as part of the <a href="Body.Builder.html#body-building-process">building process</a>
+     * of building its parent body. The block is not <a href="Body.Builder.html#body-building-observability">observable</a>
+     * until the parent body builder <a href="Body.Builder.html#body-building-finishing">finishes</a>.
      * <p>
-     * A block builder has a {@link Block.Builder#parentBody() parent body builder}.
-     * <p>
-     * A block builder is operable while its parent body builder is building the parent body.
-     * After the parent body is {@link Body.Builder#build(Op) built}, further attempts to operate on the block builder
-     * throw an exception.
-     * <p>
-     * The block being built is not observable while building is in progress. Attempts to observe it through its
-     * parameters, appended operations, their operation results, or block references, throw an exception.
-     * <p>
-     * A block builder always has a code {@link #context() context} and code {@link #transformer() transformer}. These
-     * are used when {@link #op appending} an attached or root operation. Any sibling block builder
-     * {@link #block(List) created} from a block builder will have the same code context and code transformer.
+     * A block builder has a code {@link #context() context} and code {@link #transformer() transformer}. These are used
+     * when {@link #op appending} an attached or root operation, to <i>transform-on-append</i>. Any sibling block
+     * builder {@link #block(List) created} from a block builder will have the same code context and code transformer.
      * <p>
      * A block builder may be obtained with a different code context and code transformer by calling
-     * {@link #withContextAndTransformer(CodeContext, CodeTransformer)}. Such a block builder can be used to apply
-     * alternative transformations to attached or root operations that are appended.
+     * {@link #withContextAndTransformer(CodeContext, CodeTransformer)}. Such a block builder builds the same block, and
+     * can be used to apply alternative transformations to attached or root operations that are appended.
      * <p>
      * During {@link CodeTransformer code transformation}, a block builder may also serve as the current output block
      * builder.
@@ -532,11 +523,11 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Returns the entry block builder of this builder's parent body.
+         * Returns the entry block builder of this builder's parent body builder.
          * <p>
          * The returned block builder has this block builder's code context and code transformer.
          *
-         * @return the entry block builder of this builder's parent body
+         * @return the entry block builder of this builder's parent body builder
          */
         public Block.Builder entryBlock() {
             return parentBody.entryBlock.withContextAndTransformer(cc, ct);
@@ -553,7 +544,8 @@ public final class Block implements CodeElement<Block, Op> {
          * Returns a block builder for the same block with the given code context and code transformer.
          * <p>
          * Both this block builder and the returned block builder may be operated on to build the same block. Both are
-         * equal to each other, and both become inoperable when the parent body is built.
+         * equal to each other, and both become inoperable when the parent body builder
+         * <a href="Body.Builder.html#body-building-finishing">finishes</a>.
          *
          * @param cc the code context
          * @param ct the code transformer
@@ -707,13 +699,20 @@ public final class Block implements CodeElement<Block, Op> {
          * <p>
          * The appended operation must be structurally valid for this block, requiring:
          * <ul>
-         * <li>the body builder for each child body is isolated, or has this block builder's parent body builder as its
-         * nearest ancestor body builder.
-         * <li>each operand is <a href="Body.Builder.html#reachable-value">reachable</a> from the operation;
-         * <li>each successor argument is <a href="Body.Builder.html#reachable-value">reachable</a> from the operation;
+         * <li>for each child body, the body builder for that child body is
+         * <a href="Body.Builder.html#connected-builder">connected</a> to this block builder's parent
+         * body builder, or is <a href="Body.Builder.html#isolated-builder">isolated</a>.
+         * <li>each operand is reachable from the operation;
+         * <li>each successor argument is reachable from the operation;
          * <li>each successor target is a sibling of this block; and
          * <li>this block does not already end with a terminating operation.
          * </ul>
+         * <a id="reachable-value"></a>A value is reachable if this block builder's {@link #parentBody() parent} body
+         * builder is the same as or is connected, directly or indirectly through its
+         * {@link Body.Builder#ancestorBody() nearest ancestor} body builder and so on, to the body builder for the
+         * value's declaring block's parent body. A value is not reachable if an isolated body builder is encountered
+         * (the isolated body builder's nearest ancestor body builder is {@code null} and therefore there is no
+         * connection, directly or indirectly).
          *
          * @apiNote
          * Copying is a special case of transform-on-append when this block builder's code transformer is, or

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -339,8 +339,9 @@ public final class Block implements CodeElement<Block, Op> {
      * @return the set of target blocks, as an unmodifiable set.
      */
     public SequencedSet<Block> successorTargets() {
-        return successors().stream().map(Block.Reference::targetBlock)
+        LinkedHashSet<Block> targets = successors().stream().map(Reference::targetBlock)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
+        return Collections.unmodifiableSequencedSet(targets);
     }
 
     /**
@@ -466,7 +467,13 @@ public final class Block implements CodeElement<Block, Op> {
     /**
      * A builder for a block.
      * <p>
-     * A block builder is operable while its {@link #parentBody() parent body builder} is building the parent body.
+     * A block builder defines the structure of the block that is being built. It is used to {@link #op(Op) append}
+     * operations to its block. It can also be used to {@link Block.Builder#block(List) create} block builders for
+     * sibling blocks.
+     * <p>
+     * A block builder has a {@link Block.Builder#parentBody() parent body builder}.
+     * <p>
+     * A block builder is operable while its parent body builder is building the parent body.
      * After the parent body is {@link Body.Builder#build(Op) built}, further attempts to operate on the block builder
      * throw an exception.
      * <p>
@@ -690,7 +697,7 @@ public final class Block implements CodeElement<Block, Op> {
          * <p>
          * If the operation is unattached, it is appended directly to this block.
          * <p>
-         * If the operation is attached to a block or a root operation, this method performs
+         * If the operation is attached to a block or is a root operation, this method performs
          * <a id="transform-on-append"><i>transform-on-append</i></a>: the operation is first
          * {@link Op#transform(CodeContext, CodeTransformer) transformed} using this block builder's code context and
          * code transformer; and then the resulting unattached operation is appended to this block.
@@ -700,16 +707,13 @@ public final class Block implements CodeElement<Block, Op> {
          * <p>
          * The appended operation must be structurally valid for this block, requiring:
          * <ul>
-         * <li>each body has the same ancestor body as this block's parent body;
-         * <li>each operand is reachable from this block;
-         * <li>each successor target is a sibling of this block;
-         * <li>each successor argument is reachable from this block; and
+         * <li>the body builder for each child body is isolated, or has this block builder's parent body builder as its
+         * nearest ancestor body builder.
+         * <li>each operand is <a href="Body.Builder.html#reachable-value">reachable</a> from the operation;
+         * <li>each successor argument is <a href="Body.Builder.html#reachable-value">reachable</a> from the operation;
+         * <li>each successor target is a sibling of this block; and
          * <li>this block does not already end with a terminating operation.
          * </ul>
-         * A value is reachable from this block if there is a path from this block's parent body,
-         * via its ancestor bodies, to the parent body of the value's declaring block. This check
-         * ensures the value belongs to the same code model being built, but it is weaker than a
-         * dominance check, which can only be performed when the parent body is built.
          *
          * @apiNote
          * Copying is a special case of transform-on-append when this block builder's code transformer is, or
@@ -784,7 +788,7 @@ public final class Block implements CodeElement<Block, Op> {
     private void bindOp(Op.Result opr, Op op) {
         // Structural checks
         if (!ops.isEmpty() && ops.getLast() instanceof Op.Terminating) {
-            throw new IllegalStateException("Operation cannot be appended, the block has a terminal operation");
+            throw new IllegalStateException("Operation cannot be appended, the block has a terminating operation");
         }
 
         for (Body b : op.bodies()) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -464,22 +464,25 @@ public final class Block implements CodeElement<Block, Op> {
     }
 
     /**
-     * A builder of a block.
+     * A builder for a block.
      * <p>
-     * A block builder is built when its {@link #parent() parent} body builder is {@link Body.Builder#build(Op) built}.
-     * If a built builder is operated on to append a block parameter, append an operation, build a sibling block,
-     * then an {@code IllegalStateException} is thrown.
+     * A block builder is operable while its {@link #parentBody() parent body builder} is building the parent body.
+     * After the parent body is {@link Body.Builder#build(Op) built}, further attempts to operate on the block builder
+     * throw an exception.
      * <p>
-     * A block is not observable while it is being built. Attempts to access a block being built through the block's
-     * parameters, appended operations, their operation results, or block references, result in an exception.
+     * The block being built is not observable while building is in progress. Attempts to observe it through its
+     * parameters, appended operations, their operation results, or block references, throw an exception.
      * <p>
-     * A block builder has a code {@link #context() context} and code {@link #transformer() transformer} which are used
-     * to transform an attached or root operation that is {@link #op appended}. Any sibling block builder
+     * A block builder always has a code {@link #context() context} and code {@link #transformer() transformer}. These
+     * are used when {@link #op appending} an attached or root operation. Any sibling block builder
      * {@link #block(List) created} from a block builder will have the same code context and code transformer.
      * <p>
-     * A block builder may be {@link #rebind rebound} to new block builder that builds the same block but with a
-     * different code context and code transformer. The rebound block builder can be used to apply alternative
-     * transformations to attached or root operations that are appended.
+     * A block builder may be obtained with a different code context and code transformer by calling
+     * {@link #withContextAndTransformer(CodeContext, CodeTransformer)}. Such a block builder can be used to apply
+     * alternative transformations to attached or root operations that are appended.
+     * <p>
+     * During {@link CodeTransformer code transformation}, a block builder may also serve as the current output block
+     * builder.
      */
     public final class Builder {
         final Body.Builder parentBody;
@@ -501,66 +504,67 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * {@return the block builder's code transformer}
+         * {@return this block builder's code transformer}
          */
         public CodeTransformer transformer() {
             return ct;
         }
 
         /**
-         * {@return the block builder's context}
+         * {@return this block builder's code context}
          */
         public CodeContext context() {
             return cc;
         }
 
         /**
-         * {@return the parent body builder}
+         * {@return this block builder's parent body builder}
          */
         public Body.Builder parentBody() {
             return parentBody;
         }
 
         /**
-         * Returns the entry block builder for parent body.
+         * Returns the entry block builder of this builder's parent body.
+         * <p>
+         * The returned block builder has this block builder's code context and code transformer.
          *
-         * <p>The returned block is rebound if necessary to this block builder's
-         * context and transformer.
-         *
-         * @return the entry block builder for parent body builder
+         * @return the entry block builder of this builder's parent body
          */
         public Block.Builder entryBlock() {
-            return parentBody.entryBlock.rebind(cc, ct);
+            return parentBody.entryBlock.withContextAndTransformer(cc, ct);
         }
 
         /**
-         * {@return true if this block builder is a builder of the entry block}
+         * {@return true if this block builder builds the entry block of its parent body}
          */
         public boolean isEntryBlock() {
             return Block.this == parentBody.target().entryBlock();
         }
 
         /**
-         * Rebinds this block builder to a new block builder with the given context and code transformer.
+         * Returns a block builder for the same block with the given code context and code transformer.
+         * <p>
+         * Both this block builder and the returned block builder may be operated on to build the same block. Both are
+         * equal to each other, and both become inoperable when the parent body is built.
          *
-         * <p>Either this block builder and the rebound block builder may be operated on to build
-         * the same block.
-         * Both are equal to each other, and both are closed when the parent body builder is closed.
-         *
-         * @param cc the context
+         * @param cc the code context
          * @param ct the code transformer
-         * @return the rebound block builder
+         * @return the block builder with the given code context and code transformer
          */
-        public Block.Builder rebind(CodeContext cc, CodeTransformer ct) {
+        public Block.Builder withContextAndTransformer(CodeContext cc, CodeTransformer ct) {
             return this.cc == cc && this.ct == ct
                     ? this
                     : this.target().new Builder(parentBody(), cc, ct);
         }
 
         /**
-         * Creates a new sibling block builder in the same parent body as this block builder.
+         * Creates a builder for a new sibling block in this builder's parent body.
+         * <p>
+         * The returned builder has the same code context and code transformer as this
+         * block builder.
          *
-         * @param params the block's parameter types
+         * @param params the parameter types of the new block
          * @return the new block builder
          */
         public Block.Builder block(CodeType... params) {
@@ -568,9 +572,12 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Creates a new sibling block builder in the same parent body as this block builder.
+         * Creates a builder for a new sibling block in this builder's parent body.
+         * <p>
+         * The returned builder has the same code context and code transformer as this
+         * block builder.
          *
-         * @param params the block's parameter types
+         * @param params the parameter types of the new block
          * @return the new block builder
          */
         public Block.Builder block(List<CodeType> params) {
@@ -578,16 +585,16 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Returns an unmodifiable list of the block's parameters.
+         * Returns an unmodifiable list of this block's parameters.
          *
-         * @return the unmodifiable list of the block's parameters
+         * @return the unmodifiable list of this block's parameters
          */
         public List<Parameter> parameters() {
             return Collections.unmodifiableList(parameters);
         }
 
         /**
-         * Appends a block parameter to the block's parameters.
+         * Appends a parameter of the given type to this block.
          *
          * @param p the parameter type
          * @return the appended block parameter
@@ -598,30 +605,28 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Creates a block reference to this block that can be used as a successor of a terminating operation.
+         * Creates a reference to this block that can be used as a successor of a terminating operation.
          * <p>
-         * A reference can only be constructed with block arguments whose declaring block is being built, otherwise
-         * construction fails with an exception.
+         * A reference can only be created with arguments whose declaring block is being built.
          *
          * @param args the block arguments
-         * @return the reference to this block
-         * @throws IllegalStateException if this block builder is associated with the entry block.
-         * @throws IllegalArgumentException if a block argument's declaring block is built.
+         * @return a reference to this block
+         * @throws IllegalStateException if this block builder builds the entry block.
+         * @throws IllegalArgumentException if any argument's declaring block is built.
          */
         public Reference reference(Value... args) {
             return reference(List.of(args));
         }
 
         /**
-         * Creates a block reference to this block that can be used as a successor of a terminating operation.
+         * Creates a reference to this block that can be used as a successor of a terminating operation.
          * <p>
-         * A reference can only be constructed with block arguments whose declaring block is being built, otherwise
-         * construction fails with an exception.
+         * A reference can only be created with arguments whose declaring block is being built.
          *
          * @param args the block arguments
-         * @return the reference to this block
-         * @throws IllegalStateException if this block builder is associated with the entry block.
-         * @throws IllegalArgumentException if a block argument's declaring block is built.
+         * @return a reference to this block
+         * @throws IllegalStateException if this block builder builds the entry block.
+         * @throws IllegalArgumentException if any argument's declaring block is built.
          */
         public Reference reference(List<? extends Value> args) {
             if (isEntryBlock()) {
@@ -637,8 +642,9 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Transforms a body starting from this block builder, using a {@link CodeContext#create(CodeContext) child}
-         * context of this builder's context and a given code transformer.
+         * Transforms a body using this block builder as the current output block builder, with a
+         * {@link CodeContext#create(CodeContext) child} of this block builder's code context and the given code
+         * transformer.
          *
          * @param body the body to transform
          * @param values the output values to map to the input parameters of the body's entry block
@@ -653,92 +659,96 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Transforms a body starting from this block builder, using a given context and code transformer.
+         * Transforms a body using this block builder as the current output block builder, with the given code context
+         * and code transformer.
          * <p>
-         * This method first {@link #rebind rebinds} this builder with the given context
-         * and code transformer, and then transforms the body using the code transformer by
-         * {@link CodeTransformer#acceptBody(Builder, Body, List) accepting}
-         * the rebound builder, the body, and the values.
+         * This method first obtains a block builder with the given code context and code transformer by calling
+         * {@link #withContextAndTransformer(CodeContext, CodeTransformer)}, and then transforms the body using the code
+         * transformer by {@link CodeTransformer#acceptBody(Builder, Body, List) accepting} the obtained block builder,
+         * the body, and the values.
          *
          * @apiNote
-         * The passing of a context can ensure block and value mappings produced by
-         * the transformation do not affect this builder's context.
+         * Supplying an explicit code context can ensure block and value mappings produced by the transformation do not
+         * affect this builder's code context.
          *
          * @param body the body to transform
          * @param values the output values to map to the input parameters of the body's entry block
          * @param cc the code context
          * @param ct the code transformer
-         * @see #rebind(CodeContext, CodeTransformer)
+         * @see #withContextAndTransformer(CodeContext, CodeTransformer)
          * @see CodeTransformer#acceptBody(Builder, Body, List)
          */
         public void body(Body body, List<? extends Value> values,
                          CodeContext cc, CodeTransformer ct) {
             check();
 
-            ct.acceptBody(rebind(cc, ct), body, values);
+            ct.acceptBody(withContextAndTransformer(cc, ct), body, values);
         }
 
         /**
-         * Appends an operation to the sequence of operations of this block builder, first transforming the operation
-         * if it is attached to a block, or a root operation.
+         * Appends an operation to this block.
          * <p>
-         * If the operation is unattached, then the operation is appended and attached to this block, and the operation
-         * is assigned an operation result.
-         * Otherwise, the operation (an attached or root operation) is first
-         * {@link Op#transform(CodeContext, CodeTransformer) transformed} with this builder's code context and
-         * code transformer, the resulting transformed and unattached operation is appended and attached, and the
-         * operation's result mapped to the transformed operation's result, using the builder's code context.
+         * If the operation is unattached, it is appended directly to this block.
          * <p>
-         * If the operation (transformed, or otherwise) is structurally invalid then an
-         * {@code IllegalStateException} is thrown. An operation is structurally invalid if:
+         * If the operation is attached to a block or a root operation, this method performs
+         * <a id="transform-on-append"><i>transform-on-append</i></a>: the operation is first
+         * {@link Op#transform(CodeContext, CodeTransformer) transformed} using this block builder's code context and
+         * code transformer; and then the resulting unattached operation is appended to this block.
+         * If the operation being appended has a result, it is {@link CodeContext#mapValueIfAbsent mapped},
+         * if no such mapping already exists, to the result of the appended operation in this block builder's code
+         * context.
+         * <p>
+         * The appended operation must be structurally valid for this block, requiring:
          * <ul>
-         * <li>any of its bodies does not have the same ancestor body as this block's parent body.
-         * <li>any of its operands (values) is not reachable from this block.
-         * <li>any of its successors is not a sibling of this block.
-         * <li>any of its successors arguments (values) is not reachable from this block.
-         * <li>a terminating operation is already appended as the last operation.
+         * <li>each body has the same ancestor body as this block's parent body;
+         * <li>each operand is reachable from this block;
+         * <li>each successor target is a sibling of this block;
+         * <li>each successor argument is reachable from this block; and
+         * <li>this block does not already end with a terminating operation.
          * </ul>
          * A value is reachable from this block if there is a path from this block's parent body,
-         * via its ancestor bodies, to the value's declaring block's parent body. (Note this structural check
-         * ensures values are only used from the same code model tree being built, but it is weaker than a
-         * dominance check that can only be performed when the parent body is built.)
+         * via its ancestor bodies, to the parent body of the value's declaring block. This check
+         * ensures the value belongs to the same code model being built, but it is weaker than a
+         * dominance check, which can only be performed when the parent body is built.
+         *
+         * @apiNote
+         * Copying is a special case of transform-on-append when this block builder's code transformer is, or
+         * behaves as a copying transformer, such as {@link CodeTransformer#COPYING_TRANSFORMER}.
          *
          * @param op the operation to append
-         * @return the operation result of the appended operation
+         * @return the result of the appended operation
          * @throws IllegalStateException if the operation is structurally invalid
          */
         public Op.Result op(Op op) {
             check();
 
-            final Op.Result oprToTransform = op.result();
+            // Perform transform-on-append for an attached or root operation
+            Op outputOp = op.isAttached() || op.isRoot()
+                    ? op.transform(cc, ct)
+                    : op;
+            assert outputOp.result == null;
 
-            Op transformedOp = op;
-            if (op.isRoot() || oprToTransform != null) {
-                // If operation is assigned to block, or it's sealed, then copy it and transform its contents
-                transformedOp = op.transform(cc, ct);
-                assert transformedOp.result == null;
-            }
+            Op.Result outputResult = insertOp(outputOp);
 
-            Op.Result transformedOpr = insertOp(transformedOp);
-
-            if (oprToTransform != null) {
+            Op.Result inputResult = op.result();
+            if (inputResult != null) {
                 // Map the result of the first transformation
                 // @@@ If the same operation is transformed more than once then subsequent
                 //  transformed ops will not get implicitly mapped
                 //  Should this be an error?
-                cc.mapValueIfAbsent(oprToTransform, transformedOpr);
+                cc.mapValueIfAbsent(inputResult, outputResult);
             }
 
-            return transformedOpr;
+            return outputResult;
         }
 
         /**
          * Returns true if this block builder is equal to the other object.
-         * <p>This block builder is equal if the other object is an instance of a block builder, and they are
-         * associated with the same block (but perhaps bound to different contexts and transformers).
+         * <p>This block builder is equal if the other object is an instance of a block builder, and they build
+         * the same block (but maybe bound to different code contexts and code transformers).
          *
          * @param o the other object
-         * @return true if this builder is equal to the other object.
+         * @return true if this block builder is equal to the other object.
          */
         @Override
         public boolean equals(Object o) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -713,6 +713,9 @@ public final class Block implements CodeElement<Block, Op> {
          * value's declaring block's parent body. A value is not reachable if an isolated body builder is encountered
          * (the isolated body builder's nearest ancestor body builder is {@code null} and therefore there is no
          * connection, directly or indirectly).
+         * This structural reachable check ensures values are only used from the same code model being built. It is
+         * weaker than the {@link Value#isDominatedBy(Value) dominance} check required for structurally valid use of a
+         * value, that can only be performed when the parent body is built.
          *
          * @apiNote
          * Copying is a special case of transform-on-append when this block builder's code transformer is, or

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -38,19 +38,14 @@ import java.util.*;
  * thus forming the graph. Otherwise, the last operation defines how the body passes control back to the parent
  * operation, and in doing so may optionally yield a value.
  * <p>
- * A body has a function type whose return type is the body's yield type and whose parameter types are the entry
- * block's parameters types, in order.
- * The function type describes the sequence of input parameters types for arguments that are passed to the
+ * A body has a signature, a function type, whose return type is the body's yield type and whose parameter types are the
+ * entry block's parameters types, in order.
+ * The signature describes the sequence of input parameters types for arguments that are passed to the
  * body when control is passed to it, and describes the return type of values that are yielded when the body passes
  * control back to its parent operation.
  * <p>
- * A body is built using a {@link Body.Builder body builder} that creates and {@link Builder#entryBlock() exposes} an
- * entry {@link Block.Builder block builder} from which further non-entry sibling blocks in the body may be created and
- * {@link Block.Builder#block(CodeType...) built}. A block builder can also be used to
- * {@link Block.Builder#reference(Value...) create} references to non-entry sibling blocks that can be used as
- * successors of terminating operations.
- * When a body completes {@link Body.Builder#build(Op) building} with a given operation all blocks in the body are also
- * built. The given operation becomes the body's {@link #parent()}.
+ * A body is built using a {@link Body.Builder}, which specifies the
+ * <a href="Body.Builder.html#body-building-process">building process</a>.
  */
 public final class Body implements CodeElement<Body, Block> {
     // @Stable?
@@ -426,23 +421,40 @@ public final class Body implements CodeElement<Body, Block> {
     /**
      * A builder for a body.
      * <p>
-     * A body builder defines the structure of the body that is being built. It creates and exposes the
-     * {@link Block.Builder block builder} of the body's entry block, from which block builders for sibling blocks may
-     * be {@link Block.Builder#block(List) created}. A block builder is used to append operations to its block.
+     * <a id="body-building-process"></a>
+     * The process of building a body starts with the {@link Builder#of(Builder, FunctionType, CodeContext, CodeTransformer) creation}
+     * of a body builder, which {@link Builder#entryBlock exposes} a {@link Block.Builder block builder} for the body's
+     * entry block.
      * <p>
-     * A body builder and its associated block builders are all operable during building. The body is built by invoking
-     * {@link Body.Builder#build(Op)}. After building, the body builder and its block builders all become inoperable,
-     * regardless of whether building succeeds or fails with an exception. Further attempts to operate on the body
-     * builder or any of its block builders throw an exception.
+     * Building then progresses with the building of the body's structure, where:
+     * <ul>
+     * <li>
+     * the entry block builder is used to {@link Block.Builder#block(List) create} block builders for sibling blocks,
+     * and likewise those block builders can also be used to create block builders for additional sibling blocks and so
+     * on;
+     * <li>
+     * a block builder is used to {@link Block.Builder#op(Op) append} operations to the block,
+     * {@link Block.Builder#parameter(CodeType) append} parameters to the block's parameters, and
+     * {@link Block.Builder#reference(List) create} references to the block, which can be used as successors of a
+     * terminating operation that is the last operation that is appended to the block or a sibling block; and
+     * <li>
+     * <a id="body-building-observability"></a>
+     * the body and its child blocks are not observable; attempts to observe them through appended operations, their
+     * operation results, block parameters, or block references, throw an exception.
+     * </ul>
      * <p>
-     * The body and its child blocks are not observable while building is in progress. Attempts to observe
-     * them through block parameters, appended operations, their operation results, or block references,
-     * throw an exception.
+     * Building finishes by invoking {@link #build(Op)}, with a given operation that becomes the body's
+     * parent.
+     * <p>
+     * <a id="body-building-finishing"></a>
+     * After building finishes, the body and its child blocks become observable, and the body builder and its block
+     * builders all become inoperable, regardless of whether building succeeds or fails with an exception.
+     * Further attempts to operate on the builders throw an exception.
      * <p>
      * A body builder may be connected to its {@link #ancestorBody() nearest ancestor} body builder. This connection
-     * constrains the order in which the connected builders can complete building, ancestors cannot complete before
-     * their descendants, and determines the <a href="#reachable-value">reachability</a> of values used by appended
-     * operations.
+     * constrains the order in which the connected builders can finish building, ancestors cannot finish before
+     * their descendants, and determines the <a href="Block.Builder.html#reachable-value">reachability</a> of values
+     * used by appended operations.
      */
     public final class Builder {
         /**
@@ -453,7 +465,7 @@ public final class Body implements CodeElement<Body, Block> {
          * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
          * @param bodySignature the initial body signature
          * @return the body builder
-         * @throws IllegalStateException if the ancestor body builder is built
+         * @throws IllegalStateException if the ancestor body builder is finished
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
          */
         public static Builder of(Builder ancestorBody, FunctionType bodySignature) {
@@ -469,7 +481,7 @@ public final class Body implements CodeElement<Body, Block> {
          * @param bodySignature the initial body signature
          * @param cc            the code context
          * @return the body builder
-         * @throws IllegalStateException if the ancestor body builder is built
+         * @throws IllegalStateException if the ancestor body builder is finished
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
          */
         public static Builder of(Builder ancestorBody, FunctionType bodySignature, CodeContext cc) {
@@ -480,34 +492,29 @@ public final class Body implements CodeElement<Body, Block> {
          * Creates a body builder whose entry block {@link #entryBlock builder} uses the given code context and code
          * transformer.
          * <p>
-         * If {@code ancestorBody} is non-{@code null}, the created body builder is <i>connected</i> to
-         * {@code ancestorBody} as the {@link #ancestorBody() nearest ancestor} body builder, and the following apply:
+         * If {@code ancestorBody} is non-{@code null}, the created body builder is
+         * <a id="connected-builder"><i>connected</i></a> to {@code ancestorBody} as the
+         * {@link #ancestorBody() nearest ancestor} body builder, and the following apply:
          * <ul>
          * <li>
-         * The created body builder must complete building before the nearest ancestor body builder completes building,
-         * which implies the ancestor body builder cannot complete building until all body builders connected to it
-         * complete building.
+         * the created body builder must finish before the nearest ancestor body builder finishes, which implies the
+         * ancestor body builder cannot finish until all body builders connected to it finish; and
          * <li>
-         * The body built by the created body builder must have, as its nearest {@link Body#ancestorBody ancestor body},
+         * the body built by the created body builder must have, as its nearest {@link Body#ancestorBody ancestor body},
          * the body built by the nearest ancestor body builder.
-         * <li>
-         * <a id="reachable-value"></a>A value used by an operation {@link Block.Builder#op(Op) appended} to a block builder, created from the
-         * created body builder, must be reachable.
-         * A value is reachable if the created body builder is the same as or is connected, directly or indirectly
-         * through its nearest ancestor body builder and so on, to the body builder that builds the value's declaring
-         * block's parent body.
          * </ul>
-         * If {@code ancestorBody} is {@code null}, the created body builder is <i>isolated</i>, it has no nearest
-         * ancestor body builder, and the following apply:
+         * If {@code ancestorBody} is {@code null}, the created body builder is
+         * <a id="isolated-builder"><i>isolated</i></a>, it has no nearest ancestor body builder, and the following
+         * applies:
          * <ul>
          * <li>
-         * By the prior definition of <a href="#reachable-value">reachable value</a>, a value is only reachable if the
-         * created body builder is the same as the body builder that builds the value's declaring block's parent body
-         * (since there is no connection to ancestor body builders).
+         * the scope of <a href="Block.Builder.html#reachable-value">reachable</a> values used by operations is
+         * reduced to that up to and including the created body builder.
          * </ul>
-         * One or more body builders can be connected to the created body builder, whether it be connected or isolated,
-         * which implies the created body builder cannot complete building until all of its connected body builders
-         * complete building.
+         * <p>
+         * One or more body builders can be connected to the created body builder, as their nearest ancestor body
+         * builder, whether the created body builder be connected or isolated, which implies the created body builder
+         * cannot finish until all of its connected body builders finish.
          * <p>
          * The initial body signature's return type defines the body's yield type, and its parameter types are used,
          * in order, to create the initial parameters of the entry block builder.
@@ -518,7 +525,7 @@ public final class Body implements CodeElement<Body, Block> {
          * @param cc            the code context for the entry block builder
          * @param ct            the code transformer for the entry block builder
          * @return the body builder
-         * @throws IllegalStateException if the ancestor body builder is already built
+         * @throws IllegalStateException if the ancestor body builder is finished
          */
         public static Builder of(Builder ancestorBody, FunctionType bodySignature,
                                  CodeContext cc, CodeTransformer ct) {
@@ -560,28 +567,26 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * Builds the body and its child blocks, associating the body with a parent operation.
-         * <p>
-         * After building, the body builder and its block builders all become inoperable, regardless of whether building
-         * succeeds or fails with an exception. Further attempts to operate on the body builder or any of its block
-         * builders throw an exception.
-         * <p>
-         * Body builders connected to this body builder must complete building before this body builder completes
-         * building.
+         * Finishes building the body and its child blocks, associating the body with a parent operation.
          * <p>
          * The parent operation must report the built body as one of its child bodies.
+         * <p>
+         * After building finishes, the body builder and its block builders all become inoperable, regardless of whether
+         * building succeeds or fails with an exception. Further attempts to operate on the builders throw an exception.
+         * <p>
+         * Body builders connected to this body builder must finish building before this body builder finishes.
          * <p>
          * Any unreferenced empty blocks are ignored and do not become children of the body. An unreferenced block is
          * a non-entry block with no predecessors.
          *
          * @apiNote
-         * This method is commonly called from the parent operation's constructor, which can hold a reference to the
-         * built body so it can report it as one of its child bodies.
+         * This method is commonly called from the parent operation's constructor, which holds a reference to the built
+         * body so it can report it as one of its child bodies.
          *
          * @param op the parent operation
          * @return the built body
-         * @throws IllegalStateException if this body builder is built
-         * @throws IllegalStateException if any connected body builder is not built
+         * @throws IllegalStateException if this body builder has finished
+         * @throws IllegalStateException if any connected body builder is not finished
          * @throws IllegalStateException if a block has no terminating operation, unless unreferenced and empty
          */
         // @@@ Check every operand dominates the operation result.
@@ -643,7 +648,7 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * Returns the body builder's signature, represented as a function type.
+         * Returns this body builder's signature, represented as a function type.
          * <p>
          * The signature's return type is the body builder's yield type and parameter types are
          * the currently built entry block's parameter types, in order.
@@ -657,15 +662,15 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * {@return the body builder's nearest ancestor body builder if this body is connected,
-         * otherwise {@code null} if this body builder is isolated}
+         * {@return this body builder's nearest ancestor body builder if this body builder is
+         * <a href="#connected-builder">connected</a>, otherwise {@code null} if this body builder is isolated}
          */
         public Builder ancestorBody() {
             return ancestorBody;
         }
 
         /**
-         * {@return the body's entry block builder}
+         * {@return this body builder's entry block builder}
          */
         public Block.Builder entryBlock() {
             return entryBlock;
@@ -714,22 +719,25 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * Transforms this body.
+     * Transforms this body, returning a body builder containing the transformed body.
      * <p>
-     * A new body builder is first {@link Body.Builder#of(Builder, FunctionType, CodeContext, CodeTransformer) created}
-     * with the following arguments:
+     * This method does the following:
      * <ul>
-     * <li>an ancestor body builder that is the {@link Block.Builder#parentBody parent} body builder of the entry block
-     * builder {@link CodeContext#getBlock(Block) associated} with this body's ancestor entry block in the parent code
-     * context, otherwise {@code null} if this body has no ancestor entry block or there is no associated entry block
-     * builder.
-     * <li>this body's signature.
-     * <li>a {@link CodeContext#create(CodeContext) child} code context of the given parent code context.
-     * <li>the given code transformer.
+     * <li>
+     * obtains an ancestor body builder, if one can be obtained, from the given parent code context by looking up the
+     * block builder {@link CodeContext#getBlock(Block) associated} with this body's nearest ancestor entry block, and
+     * then accessing that block builder's {@link Block.Builder#parentBody parent} body builder;
+     * <li>
+     * creates a body builder by invoking
+     * {@link Body.Builder#of(Builder, FunctionType, CodeContext, CodeTransformer)} with the obtained ancestor body
+     * builder if obtained otherwise {@code null}, this body's {@link #bodySignature() body signature}, a
+     * {@link CodeContext#create(CodeContext) child} of the given parent code context, and the given code transformer;
+     * and
+     * <li>
+     * transforms this body by invoking {@link CodeTransformer#acceptBody(Block.Builder, Body, List)} with the created
+     * body builder's {@link Body.Builder#entryBlock() entry block} builder, this body, and that entry block builder's
+     * parameters.
      * </ul>
-     * Then the given code transformer is used to transform this body by
-     * {@link CodeTransformer#acceptBody accepting} the new body builder's entry block builder, this body, and the entry
-     * block builder's parameters.
      *
      * @param cc the parent code context
      * @param ct the code transformer

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -44,8 +44,14 @@ import java.util.*;
  * body when control is passed to it, and describes the return type of values that are yielded when the body passes
  * control back to its parent operation.
  * <p>
+ * A body is either open or isolated. An open body may {@link #capturedValues() capture} values, depending on how the
+ * body's descendant operations use values. An {@link #isIsolated() isolated} body is guaranteed to never capture
+ * values.
+ * <p>
  * A body is built using a {@link Body.Builder}, which specifies the
- * <a href="Body.Builder.html#body-building-process">building process</a>.
+ * <a href="Body.Builder.html#body-building-process">building process</a>. An open body is built by a
+ * <a href="Body.Builder.html#connected-builder">connected</a> body builder. An isolated body is built by an
+ * <a href="Body.Builder.html#isolated-builder">isolated</a> body builder.
  */
 public final class Body implements CodeElement<Body, Block> {
     // @Stable?
@@ -53,9 +59,10 @@ public final class Body implements CodeElement<Body, Block> {
     // Non-null when body is built, and therefore child of an operation
     Op parentOp;
 
-    // The ancestor body, when null the body is isolated and cannot refer to values defined outside
-    // When non-null and body is built, ancestorBody == parentOp.result.block.parentBody
-    final Body ancestorBody;
+    // The connected ancestor body
+    // When non-null the body is open and when built/observable, connectedAncestorBody == this.ancestorBody()
+    // When null the body is isolated, and cannot refer to values defined outside
+    final Body connectedAncestorBody;
 
     final CodeType yieldType;
 
@@ -67,10 +74,10 @@ public final class Body implements CodeElement<Body, Block> {
     Map<Block, Block> idoms;
 
     /**
-     * Constructs a body, whose ancestor is the given ancestor body.
+     * Constructs a body, whose connected ancestor body is the given ancestor body.
      */
-    Body(Body ancestorBody, CodeType yieldType) {
-        this.ancestorBody = ancestorBody;
+    Body(Body connectedAncestorBody, CodeType yieldType) {
+        this.connectedAncestorBody = connectedAncestorBody;
         this.yieldType = yieldType;
         this.blocks = new ArrayList<>();
     }
@@ -375,6 +382,20 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
+     * {@return true if this body is isolated}
+     * <p>
+     * An isolated body, built by an <a href="Body.Builder.html#isolated-builder">isolated</a> body builder, is
+     * guaranteed to never {@link #capturedValues() capture} values. Conversely, an open body, built by a
+     * <a href="Body.Builder.html#connected-builder">connected</a> body builder, may or may not capture values,
+     * depending on how the body's descendant operations use values.
+     *
+     * @see #capturedValues()
+     */
+    public boolean isIsolated() {
+        return connectedAncestorBody == null;
+    }
+
+    /**
      * Computes values captured by this body. A captured value is a value that is used
      * but not declared by any descendant block or operation of this body.
      * <p>
@@ -451,7 +472,7 @@ public final class Body implements CodeElement<Body, Block> {
      * builders all become inoperable, regardless of whether building succeeds or fails with an exception.
      * Further attempts to operate on the builders throw an exception.
      * <p>
-     * A body builder may be connected to its {@link #ancestorBody() nearest ancestor} body builder. This connection
+     * A body builder may be connected to its {@link #connectedAncestorBody() nearest ancestor} body builder. This connection
      * constrains the order in which the connected builders can finish building, ancestors cannot finish before
      * their descendants, and determines the <a href="Block.Builder.html#reachable-value">reachability</a> of values
      * used by appended operations.
@@ -462,30 +483,32 @@ public final class Body implements CodeElement<Body, Block> {
          * {@link CodeContext#create() new} code context and a {@link CodeTransformer#COPYING_TRANSFORMER copying}
          * code transformer.
          *
-         * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
+         * @param connectedAncestorBody  the nearest ancestor body builder if the created body builder is connected, or
+         * {@code null} if the created body builder is isolated
          * @param bodySignature the initial body signature
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is finished
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
          */
-        public static Builder of(Builder ancestorBody, FunctionType bodySignature) {
+        public static Builder of(Builder connectedAncestorBody, FunctionType bodySignature) {
             // @@@ Creation of CodeContext
-            return of(ancestorBody, bodySignature, CodeContext.create(), CodeTransformer.COPYING_TRANSFORMER);
+            return of(connectedAncestorBody, bodySignature, CodeContext.create(), CodeTransformer.COPYING_TRANSFORMER);
         }
 
         /**
          * Creates a body builder, with an entry block {@link #entryBlock builder} that has the given code context
          * and a {@link CodeTransformer#COPYING_TRANSFORMER copying} code transformer.
          *
-         * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
+         * @param connectedAncestorBody  the nearest ancestor body builder if the created body builder is connected, or
+         * {@code null} if the created body builder is isolated
          * @param bodySignature the initial body signature
          * @param cc            the code context
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is finished
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
          */
-        public static Builder of(Builder ancestorBody, FunctionType bodySignature, CodeContext cc) {
-            return of(ancestorBody, bodySignature, cc, CodeTransformer.COPYING_TRANSFORMER);
+        public static Builder of(Builder connectedAncestorBody, FunctionType bodySignature, CodeContext cc) {
+            return of(connectedAncestorBody, bodySignature, cc, CodeTransformer.COPYING_TRANSFORMER);
         }
 
         /**
@@ -494,18 +517,19 @@ public final class Body implements CodeElement<Body, Block> {
          * <p>
          * If {@code ancestorBody} is non-{@code null}, the created body builder is
          * <a id="connected-builder"><i>connected</i></a> to {@code ancestorBody} as the
-         * {@link #ancestorBody() nearest ancestor} body builder, and the following apply:
+         * {@link #connectedAncestorBody() nearest ancestor} body builder, builds an <i>open</i> body, and the following
+         * apply:
          * <ul>
          * <li>
          * the created body builder must finish before the nearest ancestor body builder finishes, which implies the
          * ancestor body builder cannot finish until all body builders connected to it finish; and
          * <li>
-         * the body built by the created body builder must have, as its nearest {@link Body#ancestorBody ancestor body},
+         * the body built by the created body builder must have, as its nearest {@link Body#ancestorBody() ancestor body},
          * the body built by the nearest ancestor body builder.
          * </ul>
          * If {@code ancestorBody} is {@code null}, the created body builder is
-         * <a id="isolated-builder"><i>isolated</i></a>, it has no nearest ancestor body builder, and the following
-         * applies:
+         * <a id="isolated-builder"><i>isolated</i></a>, it has no nearest ancestor body builder, builds an
+         * <i>isolated</i> body, and the following applies:
          * <ul>
          * <li>
          * the scope of <a href="Block.Builder.html#reachable-value">reachable</a> values used by operations is
@@ -519,22 +543,23 @@ public final class Body implements CodeElement<Body, Block> {
          * The initial body signature's return type defines the body's yield type, and its parameter types are used,
          * in order, to create the initial parameters of the entry block builder.
          *
-         * @param ancestorBody  the nearest ancestor body builder, or {@code null} if the created body builder is
-         *                      isolated
+         * @param connectedAncestorBody  the nearest ancestor body builder if the created body builder is connected, or
+         * {@code null} if the created body builder is isolated
          * @param bodySignature the initial body signature
          * @param cc            the code context for the entry block builder
          * @param ct            the code transformer for the entry block builder
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is finished
          */
-        public static Builder of(Builder ancestorBody, FunctionType bodySignature,
+        public static Builder of(Builder connectedAncestorBody, FunctionType bodySignature,
                                  CodeContext cc, CodeTransformer ct) {
-            Body body = new Body(ancestorBody != null ? ancestorBody.target() : null, bodySignature.returnType());
-            return body.new Builder(ancestorBody, bodySignature, cc, ct);
+            Body body = new Body(connectedAncestorBody != null ? connectedAncestorBody.target() : null,
+                    bodySignature.returnType());
+            return body.new Builder(connectedAncestorBody, bodySignature, cc, ct);
         }
 
-        // The ancestor body, may be null
-        final Builder ancestorBody;
+        // The connected nearest ancestor body, may be null
+        final Builder connectedAncestorBody;
 
         // The entry block of this body, whose parameters are given by the body's function type
         final Block.Builder entryBlock;
@@ -554,7 +579,7 @@ public final class Body implements CodeElement<Body, Block> {
                 ancestorBody.addGreatgrandchild(this);
             }
 
-            this.ancestorBody = ancestorBody;
+            this.connectedAncestorBody = ancestorBody;
             // Create entry block from the body's function type
             Block eb = Body.this.createBlock(bodySignature.parameterTypes());
             this.entryBlock = eb.new Builder(this, cc, ct);
@@ -662,11 +687,11 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * {@return this body builder's nearest ancestor body builder if this body builder is
+         * {@return this body builder's connected ancestor body builder if this body builder is
          * <a href="#connected-builder">connected</a>, otherwise {@code null} if this body builder is isolated}
          */
-        public Builder ancestorBody() {
-            return ancestorBody;
+        public Builder connectedAncestorBody() {
+            return connectedAncestorBody;
         }
 
         /**
@@ -719,36 +744,40 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * Transforms this body, returning a body builder containing the transformed body.
+     * Transforms this body, returning an output body builder containing the transformed body.
      * <p>
-     * This method does the following:
-     * <ul>
-     * <li>
-     * obtains an ancestor body builder, if one can be obtained, from the given parent code context by looking up the
-     * block builder {@link CodeContext#getBlock(Block) associated} with this body's nearest ancestor entry block, and
-     * then accessing that block builder's {@link Block.Builder#parentBody parent} body builder;
-     * <li>
-     * creates a body builder by invoking
-     * {@link Body.Builder#of(Builder, FunctionType, CodeContext, CodeTransformer)} with the obtained ancestor body
-     * builder if obtained otherwise {@code null}, this body's {@link #bodySignature() body signature}, a
-     * {@link CodeContext#create(CodeContext) child} of the given parent code context, and the given code transformer;
-     * and
-     * <li>
-     * transforms this body by invoking {@link CodeTransformer#acceptBody(Block.Builder, Body, List)} with the created
-     * body builder's {@link Body.Builder#entryBlock() entry block} builder, this body, and that entry block builder's
+     * This method creates an output body builder for this input body's {@link #bodySignature() signature}, with a
+     * {@link CodeContext#create(CodeContext) child} of the given parent code context, and the given code transformer.
+     * <p>
+     * The output body builder is <a href="Body.Builder.html#connected-builder">connected</a> to a body builder, as its
+     * nearest ancestor body builder, if that builder can be determined from this input body and the given parent code
+     * context. Otherwise, the output body builder is <a href="Body.Builder.html#isolated-builder">isolated</a>.
+     * <p>
+     * This method then transforms this input body by invoking
+     * {@link CodeTransformer#acceptBody(Block.Builder, Body, List)} with the created output body builder's
+     * {@link Body.Builder#entryBlock() entry} block builder, this input body, and that entry block builder's
      * parameters.
-     * </ul>
+     *
+     * @apiNote
+     * The body builder connected to the output body builder can be explicitly determined when this
+     * input body's {@link Body#ancestorBody() nearest ancestor} body is present and observable, and the given parent
+     * code context {@link CodeContext#getBlock(Block) contains} the output block builder for that ancestor body's
+     * {@link Body#entryBlock() entry} block. For example, in such cases:
+     * {@snippet lang = "java":
+     * Body nearestAncestorBody = this.ancestorBody(); // @link substring="ancestorBody" target="jdk.incubator.code.CodeElement#ancestorBody"
+     * Block.Builder entryBlockBuilder = cc.getBlock(nearestAncestorBody.entryBlock());
+     * Body.Builder connectedBodyBuilder = entryBlockBuilder.parentBody();
+     * }
      *
      * @param cc the parent code context
      * @param ct the code transformer
      * @return a body builder containing the transformed body
      */
     public Builder transform(CodeContext cc, CodeTransformer ct) {
-        Block.Builder ancestorBlockBuilder = ancestorBody != null
-                ? cc.getBlock(ancestorBody.entryBlock()) : null;
-        Builder ancestorBodyBuilder = ancestorBlockBuilder != null
-                ? ancestorBlockBuilder.parentBody() : null;
-        Builder bodyBuilder = Builder.of(ancestorBodyBuilder,
+        Builder connectedAncestorBodyBuilder = connectedAncestorBody != null
+                ? cc.queryBody(connectedAncestorBody).orElse(null)
+                : null;
+        Builder bodyBuilder = Builder.of(connectedAncestorBodyBuilder,
                 bodySignature(),
                 // Create child context for mapped code items contained in this body
                 // thereby not polluting the given context

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -48,7 +48,7 @@ import java.util.*;
  * entry {@link Block.Builder block builder} from which further non-entry sibling blocks in the body may be created and
  * {@link Block.Builder#block(CodeType...) built}. A block builder can also be used to
  * {@link Block.Builder#reference(Value...) create} references to non-entry sibling blocks that can be used as
- * successors of terminal operations.
+ * successors of terminating operations.
  * When a body completes {@link Body.Builder#build(Op) building} with a given operation all blocks in the body are also
  * built. The given operation becomes the body's {@link #parent()}.
  */
@@ -426,11 +426,23 @@ public final class Body implements CodeElement<Body, Block> {
     /**
      * A builder for a body.
      * <p>
-     * When the body builder is {@link Body.Builder#build(Op) built} all associated {@link Block.Builder block builders}
-     * are also built and their blocks become children of the body.
+     * A body builder defines the structure of the body that is being built. It creates and exposes the
+     * {@link Block.Builder block builder} of the body's entry block, from which block builders for sibling blocks may
+     * be {@link Block.Builder#block(List) created}. A block builder is used to append operations to its block.
      * <p>
-     * A body builder has an entry block {@link #entryBlock builder} from which sibling block builders may be
-     * {@link Block.Builder#block(List) created}.
+     * A body builder and its associated block builders are all operable during building. The body is built by invoking
+     * {@link Body.Builder#build(Op)}. After building, the body builder and its block builders all become inoperable,
+     * regardless of whether building succeeds or fails with an exception. Further attempts to operate on the body
+     * builder or any of its block builders throw an exception.
+     * <p>
+     * The body and its child blocks are not observable while building is in progress. Attempts to observe
+     * them through block parameters, appended operations, their operation results, or block references,
+     * throw an exception.
+     * <p>
+     * A body builder may be connected to its {@link #ancestorBody() nearest ancestor} body builder. This connection
+     * constrains the order in which the connected builders can complete building, ancestors cannot complete before
+     * their descendants, and determines the <a href="#reachable-value">reachability</a> of values used by appended
+     * operations.
      */
     public final class Builder {
         /**
@@ -439,7 +451,7 @@ public final class Body implements CodeElement<Body, Block> {
          * code transformer.
          *
          * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
-         * @param bodySignature the body's signature
+         * @param bodySignature the initial body signature
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is built
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
@@ -454,7 +466,7 @@ public final class Body implements CodeElement<Body, Block> {
          * and a {@link CodeTransformer#COPYING_TRANSFORMER copying} code transformer.
          *
          * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
-         * @param bodySignature the body's signature
+         * @param bodySignature the initial body signature
          * @param cc            the code context
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is built
@@ -465,30 +477,48 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * Creates a body builder, with entry block {@link #entryBlock builder} that has the given code context
-         * and code transformer.
+         * Creates a body builder whose entry block {@link #entryBlock builder} uses the given code context and code
+         * transformer.
          * <p>
-         * Structurally, the created body builder must be built before its ancestor body builder (if non-null) is built,
-         * otherwise an {@code IllegalStateException} will occur.
+         * If {@code ancestorBody} is non-{@code null}, the created body builder is <i>connected</i> to
+         * {@code ancestorBody} as the {@link #ancestorBody() nearest ancestor} body builder, and the following apply:
+         * <ul>
+         * <li>
+         * The created body builder must complete building before the nearest ancestor body builder completes building,
+         * which implies the ancestor body builder cannot complete building until all body builders connected to it
+         * complete building.
+         * <li>
+         * The body built by the created body builder must have, as its nearest {@link Body#ancestorBody ancestor body},
+         * the body built by the nearest ancestor body builder.
+         * <li>
+         * <a id="reachable-value"></a>A value used by an operation {@link Block.Builder#op(Op) appended} to a block builder, created from the
+         * created body builder, must be reachable.
+         * A value is reachable if the created body builder is the same as or is connected, directly or indirectly
+         * through its nearest ancestor body builder and so on, to the body builder that builds the value's declaring
+         * block's parent body.
+         * </ul>
+         * If {@code ancestorBody} is {@code null}, the created body builder is <i>isolated</i>, it has no nearest
+         * ancestor body builder, and the following apply:
+         * <ul>
+         * <li>
+         * By the prior definition of <a href="#reachable-value">reachable value</a>, a value is only reachable if the
+         * created body builder is the same as the body builder that builds the value's declaring block's parent body
+         * (since there is no connection to ancestor body builders).
+         * </ul>
+         * One or more body builders can be connected to the created body builder, whether it be connected or isolated,
+         * which implies the created body builder cannot complete building until all of its connected body builders
+         * complete building.
          * <p>
-         * A function type, referred to as the body's signature, defines the body's yield type and the initial sequence
-         * of entry block parameters.
-         * The body's yield type is the function type's return type.
-         * An entry block builder is created with appended block parameters corresponding, in order, to
-         * the function type's parameter types.
-         * <p>
-         * If the ancestor body is {@code null} then the created body builder is isolated and descendant operations may
-         * only use values declared within the created body builder. Otherwise, operations may use reachable values
-         * declared in the ancestor body builders (outside the created body builder).
-         * <p>
-         * The entry block {@link #entryBlock builder}
+         * The initial body signature's return type defines the body's yield type, and its parameter types are used,
+         * in order, to create the initial parameters of the entry block builder.
          *
-         * @param ancestorBody  the nearest ancestor body builder, may be {@code null} if isolated
-         * @param bodySignature the body's signature
-         * @param cc            the code context
-         * @param ct            the code transformer
+         * @param ancestorBody  the nearest ancestor body builder, or {@code null} if the created body builder is
+         *                      isolated
+         * @param bodySignature the initial body signature
+         * @param cc            the code context for the entry block builder
+         * @param ct            the code transformer for the entry block builder
          * @return the body builder
-         * @throws IllegalStateException if the ancestor body builder is built
+         * @throws IllegalStateException if the ancestor body builder is already built
          */
         public static Builder of(Builder ancestorBody, FunctionType bodySignature,
                                  CodeContext cc, CodeTransformer ct) {
@@ -511,7 +541,7 @@ public final class Body implements CodeElement<Body, Block> {
         Builder(Builder ancestorBody, FunctionType bodySignature,
                 CodeContext cc, CodeTransformer ct) {
             // Structural check
-            // The ancestor body should not be built before this body is created
+            // The ancestor body should not be built before this body is built
             if (ancestorBody != null) {
                 ancestorBody.check();
                 ancestorBody.addGreatgrandchild(this);
@@ -532,17 +562,27 @@ public final class Body implements CodeElement<Body, Block> {
         /**
          * Builds the body and its child blocks, associating the body with a parent operation.
          * <p>
-         * Structurally, any descendant body builders must be built before this body is built,
-         * otherwise an {@code IllegalStateException} will occur.
+         * After building, the body builder and its block builders all become inoperable, regardless of whether building
+         * succeeds or fails with an exception. Further attempts to operate on the body builder or any of its block
+         * builders throw an exception.
+         * <p>
+         * Body builders connected to this body builder must complete building before this body builder completes
+         * building.
+         * <p>
+         * The parent operation must report the built body as one of its child bodies.
          * <p>
          * Any unreferenced empty blocks are ignored and do not become children of the body. An unreferenced block is
          * a non-entry block with no predecessors.
          *
+         * @apiNote
+         * This method is commonly called from the parent operation's constructor, which can hold a reference to the
+         * built body so it can report it as one of its child bodies.
+         *
          * @param op the parent operation
          * @return the built body
          * @throws IllegalStateException if this body builder is built
-         * @throws IllegalStateException if any descendant body builders are not built
-         * @throws IllegalStateException if a block has no terminal operation, unless unreferenced and empty
+         * @throws IllegalStateException if any connected body builder is not built
+         * @throws IllegalStateException if a block has no terminating operation, unless unreferenced and empty
          */
         // @@@ Check every operand dominates the operation result.
         //     An operation in block B that uses a value declared in block B requires no special checks, since an
@@ -617,7 +657,8 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         /**
-         * {@return the body builder's nearest ancestor body builder}
+         * {@return the body builder's nearest ancestor body builder if this body is connected,
+         * otherwise {@code null} if this body builder is isolated}
          */
         public Builder ancestorBody() {
             return ancestorBody;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -761,12 +761,11 @@ public final class Body implements CodeElement<Body, Block> {
      * @apiNote
      * The body builder connected to the output body builder can be explicitly determined when this
      * input body's {@link Body#ancestorBody() nearest ancestor} body is present and observable, and the given parent
-     * code context {@link CodeContext#getBlock(Block) contains} the output block builder for that ancestor body's
-     * {@link Body#entryBlock() entry} block. For example, in such cases:
+     * code context can be used to {@link CodeContext#queryBody(Body) query} the present body builder for that ancestor
+     * body. For example, in such cases:
      * {@snippet lang = "java":
      * Body nearestAncestorBody = this.ancestorBody(); // @link substring="ancestorBody" target="jdk.incubator.code.CodeElement#ancestorBody"
-     * Block.Builder entryBlockBuilder = cc.getBlock(nearestAncestorBody.entryBlock());
-     * Body.Builder connectedBodyBuilder = entryBlockBuilder.parentBody();
+     * Body.Builder connectedBodyBuilder = cc.queryBody(nearestAncestorBody).orElseThrow(); // @link substring="queryBody" target="jdk.incubator.code.CodeContext#queryBody"
      * }
      *
      * @param cc the parent code context

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -424,7 +424,7 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * A builder of a body.
+     * A builder for a body.
      * <p>
      * When the body builder is {@link Body.Builder#build(Op) built} all associated {@link Block.Builder block builders}
      * are also built and their blocks become children of the body.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -25,10 +25,7 @@
 
 package jdk.incubator.code;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 
 import static java.util.stream.Collectors.toList;
@@ -299,6 +296,23 @@ public final class CodeContext {
             referenceMap = new HashMap<>();
         }
         referenceMap.put(input, output);
+    }
+
+    /**
+     * Queries the output body builder for the given input body.
+     * <p>
+     * This method queries the output block builder for the given input body's {@link Body#entryBlock() entry} block. If
+     * such a block builder is present, this method returns an optional containing that block builder's
+     * {@link Block.Builder#parentBody() parent} body builder. Otherwise, this method returns an empty optional.
+     *
+     * @param body the input body
+     * @return an optional containing the output body builder for the given input body, otherwise an empty optional
+     */
+    public Optional<Body.Builder> queryBody(Body body) {
+        Block.Builder entryBlockBuilder = getBlock(body.entryBlock());
+        return entryBlockBuilder != null
+                ? Optional.of(entryBlockBuilder.parentBody())
+                : Optional.empty();
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -206,7 +206,7 @@ public sealed abstract class CoreOp extends Op {
         @Override
         public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
             // Isolate body with respect to ancestor transformations
-            b.rebind(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
             return b;
         }
 
@@ -385,7 +385,7 @@ public sealed abstract class CoreOp extends Op {
 
         @Override
         public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
-            b.rebind(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
             return b;
         }
 
@@ -564,7 +564,7 @@ public sealed abstract class CoreOp extends Op {
         public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
             // Isolate body with respect to ancestor transformations
             // and copy directly without lowering descendant operations
-            b.rebind(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);
             return b;
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -508,7 +508,7 @@ public sealed abstract class JavaOp extends Op {
         @Override
         public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
             // Isolate body with respect to ancestor transformations
-            b.rebind(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
             return b;
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -3430,7 +3430,7 @@ public sealed abstract class JavaOp extends Op {
             // @@@ Is this needed?
             if (bodyCs.size() % 2 == 0) {
                 bodyCs = new ArrayList<>(bodyCs);
-                Body.Builder end = Body.Builder.of(bodyCs.get(0).ancestorBody(),
+                Body.Builder end = Body.Builder.of(bodyCs.get(0).connectedAncestorBody(),
                         CoreType.FUNCTION_TYPE_VOID);
                 end.entryBlock().op(core_yield());
                 bodyCs.add(end);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1388,7 +1388,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             FunctionType matchFuncType = CoreType.functionType(JavaType.VOID, patternDescParams);
 
             // Create the match body, assigning pattern values to pattern variables
-            Body.Builder matchBody = Body.Builder.of(patternBody.ancestorBody(), matchFuncType);
+            Body.Builder matchBody = Body.Builder.of(patternBody.connectedAncestorBody(), matchFuncType);
             Block.Builder matchBuilder = matchBody.entryBlock();
             for (int i = 0; i < variables.size(); i++) {
                 Value v = matchBuilder.parameters().get(i);


### PR DESCRIPTION
The following API changes are made:
- rename `Block.Builder.rebind` to `Block.Builder.withContextAndTransformer`
- rename `Body.Builder.ancestorBody` to `Body.Builder.connectedAncestorBody`
- add method `Body.isIsolated`
- add method `Context.queryBody`

The specification was updated to:
- emphasize the life-cycle of building, specified on `Body.Builder`
- clarify the connected ancestor body builder when creating a body builder, and how this relates to connected and isolated body builders, which then relates to open and isolated bodies.
- clarify the observability of blocks and bodies.
- clarify the appending of an operation to a block.builder, using the term _transform-on-append_ if the operation is attached or a root.


Subsequent PRs will:
- design the look up methods around a common pattern, based in part on the specification of `Context.queryBody`. `getX` methods throw, `queryX` methods return `Optional`.
- Update the transformation API and specification, aligning with the specification of building (which was updated with this in mind).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1013/head:pull/1013` \
`$ git checkout pull/1013`

Update a local copy of the PR: \
`$ git checkout pull/1013` \
`$ git pull https://git.openjdk.org/babylon.git pull/1013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1013`

View PR using the GUI difftool: \
`$ git pr show -t 1013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1013.diff">https://git.openjdk.org/babylon/pull/1013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1013#issuecomment-4329296936)
</details>
