### PR TITLE
Revert change to unmodifiable list

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -162,6 +162,7 @@ public final class CodeContext {
      */
     public List<Value> getValues(List<? extends Value> inputs) {
         // @@@ Consider making this an unmodifiable list
+        // There are usages that currently rely on a modifiable list
         return inputs.stream().map(this::getValue).collect(Collectors.toCollection(ArrayList::new));
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -27,6 +27,7 @@ package jdk.incubator.code;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -155,12 +156,13 @@ public final class CodeContext {
      * The output value for each input value is obtained using {@link #getValue(Value)}.
      *
      * @param inputs the list of input values
-     * @return an unmodifiable list of output values mapped to the given input values, in order
+     * @return a modifiable list of output values mapped to the given input values, in order
      * @throws IllegalArgumentException if an input value has no mapping
      * @see #getValue(Value)
      */
     public List<Value> getValues(List<? extends Value> inputs) {
-        return inputs.stream().map(this::getValue).toList();
+        // @@@ Consider making this an unmodifiable list
+        return inputs.stream().map(this::getValue).collect(Collectors.toCollection(ArrayList::new));
     }
 
     private Value getValueOrNull(Value input) {


### PR DESCRIPTION
`CodeContext.getValues` was changes in a prior commit to return an unmodifiable list. This was a mistake. There is existing code that relies on the list being modifiable. Revert the changes, also making the implementation clearer it returns a modifiable list.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1016/head:pull/1016` \
`$ git checkout pull/1016`

Update a local copy of the PR: \
`$ git checkout pull/1016` \
`$ git pull https://git.openjdk.org/babylon.git pull/1016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1016`

View PR using the GUI difftool: \
`$ git pr show -t 1016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1016.diff">https://git.openjdk.org/babylon/pull/1016.diff</a>

</details>
