### PR TITLE
Improve areas of exception reporting

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -81,11 +81,13 @@ public final class Block implements CodeElement<Block, Op> {
          *
          * @return the invokable operation, otherwise {@code null} if the operation
          * is not an instance of {@link Op.Invokable}.
+         * @throws IllegalStateException if an <a href="Body.Builder.html#body-building-observability">unobservable</a>
+         * block is encountered
          * @see Op.Invokable#parameters()
          */
         public Op.Invokable invokableOperation() {
-            if (declaringBlock().isEntryBlock() &&
-                    declaringBlock().ancestorOp() instanceof Op.Invokable o) {
+            Block b = declaringBlock();
+            if (b.isEntryBlock() && b.ancestorOp() instanceof Op.Invokable o) {
                 return o;
             } else {
                 return null;
@@ -94,6 +96,8 @@ public final class Block implements CodeElement<Block, Op> {
 
         /**
          * {@return the index of this block parameter in the parameters of its declaring block.}
+         * @throws IllegalStateException if this parameter's declaring block is
+         * <a href="Body.Builder.html#body-building-observability">unobservable</a>
          * @see Value#declaringBlock()
          * @see Block#parameters()
          */
@@ -126,11 +130,12 @@ public final class Block implements CodeElement<Block, Op> {
 
         /**
          * {@return the target block.}
-         * @throws IllegalStateException if the target block is being built and is not observable.
+         * @throws IllegalStateException if the target block is
+         * <a href="Body.Builder.html#body-building-observability">unobservable</a>
          */
         public Block targetBlock() {
             if (!isBuilt()) {
-                throw new IllegalStateException("Target block is being built and is not observable");
+                throw new IllegalStateException("Target block is unobservable");
             }
 
             return target;
@@ -651,6 +656,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @param body the body to transform
          * @param values the output values to map, in order, from a prefix of the input body's entry block parameters
          * @param ct the code transformer
+         * @throws IllegalArgumentException if there are more output values than entry block parameters
          * @see #body(Body, List, CodeContext, CodeTransformer)
          */
         public void body(Body body, List<? extends Value> values,
@@ -683,6 +689,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @param values the output values to map, in order, from a prefix of the input body's entry block parameters
          * @param cc the code context
          * @param ct the code transformer
+         * @throws IllegalArgumentException if there are more output values than entry block parameters
          * @see #withContextAndTransformer(CodeContext, CodeTransformer)
          * @see CodeTransformer#acceptBody(Builder, Body, List)
          */
@@ -833,7 +840,7 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         // State updates after structural checks
-        // @@@ The alternative is to close the body builder on failure, rendering it inoperable,
+        // @@@ The alternative is to finish the body builder on failure, rendering it inoperable,
         // so checks and updates can be merged
         for (Value v : op.operands()) {
             v.uses.add(opr);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -461,7 +461,7 @@ public final class Body implements CodeElement<Body, Block> {
      * <li>
      * <a id="body-building-observability"></a>
      * the body and its child blocks are not observable; attempts to observe them through appended operations, their
-     * operation results, block parameters, or block references, throw an exception.
+     * operation results, block parameters, or block references, throw an {@link IllegalStateException}.
      * </ul>
      * <p>
      * Building finishes by invoking {@link #build(Op)}, with a given operation that becomes the body's
@@ -567,8 +567,8 @@ public final class Body implements CodeElement<Body, Block> {
         // When non-null contains one or more great-grandchildren
         List<Builder> greatgrandchildren;
 
-        // True when built
-        boolean closed;
+        // True when finished
+        boolean finished;
 
         Builder(Builder ancestorBody, FunctionType bodySignature,
                 CodeContext cc, CodeTransformer ct) {
@@ -629,15 +629,15 @@ public final class Body implements CodeElement<Body, Block> {
             Objects.requireNonNull(op);
 
             // Structural check
-            // This body should not be closed
+            // This body builder should not be finished
             check();
-            closed = true;
+            finished = true;
 
             // Structural check
             // All great-grandchildren bodies should be built
             if (greatgrandchildren != null) {
                 for (Builder greatgrandchild : greatgrandchildren) {
-                    if (!greatgrandchild.closed) {
+                    if (!greatgrandchild.finished) {
                         throw new IllegalStateException("Descendant body builder is not built");
                     }
                 }
@@ -713,8 +713,8 @@ public final class Body implements CodeElement<Body, Block> {
         }
 
         void check() {
-            if (closed) {
-                throw new IllegalStateException("Builder is closed");
+            if (finished) {
+                throw new IllegalStateException("Builder is finished");
             }
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeElement.java
@@ -78,7 +78,8 @@ public sealed interface CodeElement<
      * Returns the parent element, otherwise {@code null} if this element is an operation that has no parent block.
      *
      * @return the parent code element.
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
+     * @throws IllegalStateException if an <a href="Body.Builder.html#body-building-observability">unobservable</a> block
+     * is encountered
      */
     CodeElement<?, E> parent();
 
@@ -88,7 +89,8 @@ public sealed interface CodeElement<
      * Finds the nearest ancestor operation, otherwise {@code null} if there is no nearest ancestor.
      *
      * @return the nearest ancestor operation.
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
+     * @throws IllegalStateException if an <a href="Body.Builder.html#body-building-observability">unobservable</a> block
+     * is encountered
      */
     default Op ancestorOp() {
         return switch (this) {
@@ -98,7 +100,7 @@ public sealed interface CodeElement<
             case Body body -> body.parent();
             // op -> block? -> body -> op~
             case Op op -> {
-                // Throws ISE if encountering block being built
+                // Throws ISE if an unobservable block is encountered
                 Block parent = op.parent();
                 yield parent == null ? null : parent.parent().parent();
             }
@@ -109,7 +111,8 @@ public sealed interface CodeElement<
      * Finds the nearest ancestor body, otherwise {@code null} if there is no nearest ancestor.
      *
      * @return the nearest ancestor body.
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
+     * @throws IllegalStateException if an <a href="Body.Builder.html#body-building-observability">unobservable</a> block
+     * is encountered
      */
     default Body ancestorBody() {
         return switch (this) {
@@ -117,13 +120,13 @@ public sealed interface CodeElement<
             case Block block -> block.parent();
             // body -> op~ -> block? -> body
             case Body body -> {
-                // Throws ISE if block is not built
+                // Throws ISE if an unobservable block is encountered
                 Block ancestor = body.parent().parent();
                 yield ancestor == null ? null : ancestor.parent();
             }
             // op~ -> block? -> body
             case Op op -> {
-                // Throws ISE if encountering block being built
+                // Throws ISE if an unobservable block is encountered
                 Block parent = op.parent();
                 yield parent == null ? null : parent.parent();
             }
@@ -134,18 +137,19 @@ public sealed interface CodeElement<
      * Finds the nearest ancestor block, otherwise {@code null} if there is no nearest ancestor.
      *
      * @return the nearest ancestor block.
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
+     * @throws IllegalStateException if an <a href="Body.Builder.html#body-building-observability">unobservable</a> block
+     * is encountered
      */
     default Block ancestorBlock() {
         return switch (this) {
             // block -> body -> op~ -> block?
-            // Throws ISE if encountering block being built
+            // Throws ISE if an unobservable block is encountered
             case Block block -> block.parent().parent().parent();
             // body -> op~ -> block?
-            // Throws ISE if encountering block being built
+            // Throws ISE if an unobservable block is encountered
             case Body body -> body.parent().parent();
             // op~ -> block?
-            // Throws ISE if encountering block being built
+            // Throws ISE if an unobservable block is encountered
             case Op op -> op.parent();
         };
     }
@@ -155,7 +159,6 @@ public sealed interface CodeElement<
      *
      * @param descendant the descendant element.
      * @return true if this element is an ancestor of the descendant element.
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see #isDescendantOf
      */
     default boolean isAncestorOf(CodeElement<?, ?> descendant) {
@@ -173,7 +176,6 @@ public sealed interface CodeElement<
      *
      * @param ancestor the ancestor element.
      * @return true if this element is a descendant of the ancestor element.
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see #isAncestorOf
      */
     default boolean isDescendantOf(CodeElement<?, ?> ancestor) {
@@ -201,7 +203,6 @@ public sealed interface CodeElement<
      * is less than {@code b}'s position; and {@code 1} if {@code a}'s pre-order traversal position
      * is greater than {@code b}'s position
      * @throws IllegalArgumentException if {@code a} and {@code b} are not present in the same code model
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     static int compare(CodeElement<?, ?> a, CodeElement<?, ?> b) {
         if (a == b) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -136,6 +136,7 @@ public interface CodeTransformer {
      * @param builder the block builder
      * @param body the body to transform
      * @param values the output values to map, in order, from a prefix of the input body's entry block parameters
+     * @throws IllegalArgumentException if there are more output values than entry block parameters
      */
     default void acceptBody(Block.Builder builder, Body body, List<? extends Value> values) {
         CodeContext cc = builder.context();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -66,7 +66,8 @@ import java.util.function.BiFunction;
  * being built. Once attached the operation has a permanently non-{@code null} operation {@link #result} that can be
  * used as an operand of subsequent constructed operations.
  * After the block is built the operation has a permanently non-{@code null} {@link #parent}. Before then, the block
- * being built is not observable through this operation and any attempt to access the block results in an exception.
+ * being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this operation and
+ * any attempt to access the block throws {@link IllegalStateException}.
  * <p>
  * An unattached operation can be built as a {@link #isRoot() root} operation. Once built the operation's
  * {@link #result result} and {@link #parent parent} are always {@code null}.
@@ -414,8 +415,8 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * The operation's parent block is the same as the operation result's {@link Value#declaringBlock declaring block}.
      *
      * @return operation's parent block, or {@code null} if this operation is unattached or a root operation.
-     * @throws IllegalStateException if this operation is attached and the parent block is being built and is not
-     * observable.
+     * @throws IllegalStateException if this operation is attached and its parent block is
+     * <a href="Body.Builder.html#body-building-observability">unobservable</a>.
      * @see Value#declaringBlock()
      */
     @Override
@@ -425,7 +426,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
 
         if (!result.block.isBuilt()) {
-            throw new IllegalStateException("Parent block is being built and is not observable");
+            throw new IllegalStateException("Parent block is unobservable");
         }
 
         return result.block;
@@ -495,7 +496,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * first search of this operation's descendant operations.
      *
      * @return the list of captured values, modifiable
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see Body#capturedValues()
      */
     public final List<Value> capturedValues() {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
@@ -52,11 +52,12 @@ public sealed abstract class Value implements CodeItem
      * If the value is a block parameter then the declaring block is the block declaring the parameter.
      *
      * @return the value's declaring block.
-     * @throws IllegalStateException if the declaring block is being built and is not observable.
+     * @throws IllegalStateException if the declaring block is
+     * <a href="Body.Builder.html#body-building-observability">unobservable</a>
      */
     public Block declaringBlock() {
         if (!isBuilt()) {
-            throw new IllegalStateException("Declaring block is being built and is not observable");
+            throw new IllegalStateException("Declaring block is unobservable");
         }
         return block;
     }
@@ -67,12 +68,12 @@ public sealed abstract class Value implements CodeItem
      * If the value is a block parameter then the declaring code element is this value's declaring block.
      *
      * @return the value's declaring code element.
-     * @throws IllegalStateException if this value is a block parameter and its declaring block is being built and is
-     * not observable.
+     * @throws IllegalStateException if the declaring code element is a block and that block is
+     * <a href="Body.Builder.html#body-building-observability">unobservable</a>
      */
     public CodeElement<?, ?> declaringElement() {
         return switch (this) {
-            case Block.Parameter _ -> block;
+            case Block.Parameter _ -> declaringBlock();
             case Op.Result r -> r.op();
         };
     }
@@ -130,11 +131,12 @@ public sealed abstract class Value implements CodeItem
      *
      * @return the uses of this value, as an unmodifiable sequenced set. The encouncter order is unspecified
      * and determined by the order in which operations are built into blocks.
-     * @throws IllegalStateException if this value's declaring block is being built and is not observable.
+     * @throws IllegalStateException if this value's declaring block is
+     * <a href="Body.Builder.html#body-building-observability">unobservable</a>
      */
     public SequencedSet<Op.Result> uses() {
         if (!isBuilt()) {
-            throw new IllegalStateException("Declaring block is being built and is not observable");
+            throw new IllegalStateException("Declaring block is unobservable");
         }
 
         return Collections.unmodifiableSequencedSet(uses);
@@ -158,7 +160,6 @@ public sealed abstract class Value implements CodeItem
      *
      * @param dom the dominating value
      * @return {@code true} if this value is dominated by the given value {@code dom}.
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see Block#isDominatedBy
      */
     public boolean isDominatedBy(Value dom) {
@@ -197,7 +198,6 @@ public sealed abstract class Value implements CodeItem
      * @return the value {@code 0} if {@code a == b}; {@code -1} if {@code a} is less than {@code b}; and {@code -1}
      * if {@code a} is greater than {@code b}.
      * @throws IllegalArgumentException if {@code a} and {@code b} are not present in the same code model
-     * @throws IllegalStateException if an encountered block is being built and is not observable.
      * @see CodeElement#compare
      */
     public static int compare(Value a, Value b) {


### PR DESCRIPTION
Improve the documentation for reporting `IllegalStateException` when encountering an unobservable block (limit the `@throws` declarations to more direct methods, rather than those that perform analysis).

Improve the documentation for reporting `IllegalStateArgument` for output values whose number is greater than the input values, in `Block.Builder.body` and `CodeTransformer.acceptBody`.

Update implementation to be consistent with specified terminology.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1017/head:pull/1017` \
`$ git checkout pull/1017`

Update a local copy of the PR: \
`$ git checkout pull/1017` \
`$ git pull https://git.openjdk.org/babylon.git pull/1017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1017`

View PR using the GUI difftool: \
`$ git pr show -t 1017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1017.diff">https://git.openjdk.org/babylon/pull/1017.diff</a>

</details>
