### PR TITLE
Specification of thread safety

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -486,6 +486,8 @@ public final class Block implements CodeElement<Block, Op> {
      * <p>
      * During {@link CodeTransformer code transformation}, a block builder may also serve as the current output block
      * builder.
+     * <p>
+     * Block builders are not thread-safe.
      */
     public final class Builder {
         final Body.Builder parentBody;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -472,10 +472,12 @@ public final class Body implements CodeElement<Body, Block> {
      * builders all become inoperable, regardless of whether building succeeds or fails with an exception.
      * Further attempts to operate on the builders throw an exception.
      * <p>
-     * A body builder may be connected to its {@link #connectedAncestorBody() nearest ancestor} body builder. This connection
-     * constrains the order in which the connected builders can finish building, ancestors cannot finish before
-     * their descendants, and determines the <a href="Block.Builder.html#reachable-value">reachability</a> of values
-     * used by appended operations.
+     * A body builder may be connected to its {@link #connectedAncestorBody() nearest ancestor} body builder. This
+     * connection constrains the order in which the connected builders can finish building, ancestors cannot finish
+     * before their descendants, and determines the <a href="Block.Builder.html#reachable-value">reachability</a> of
+     * values used by appended operations.
+     * <p>
+     * Body builders are not thread-safe. Block builders associated with a body builder are also not thread-safe.
      */
     public final class Builder {
         /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -77,6 +77,8 @@ import static java.util.stream.Collectors.toList;
  * and so on until a property is found or there is no parent context. Properties are always added to the current
  * context.
  * <p>
+ * Code contexts are not thread-safe.
+ * <p>
  * Unless otherwise specified the passing of a {@code null} argument to the methods of this class results in a
  * {@code NullPointerException}.
  */

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -31,6 +31,9 @@ import java.util.function.Function;
 
 /**
  * A code transformer.
+ * <p>
+ * Code transformer implementations are not required to be thread-safe. Code transformations operate on block builders
+ * and code contexts that are not thread-safe.
  */
 @FunctionalInterface
 public interface CodeTransformer {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -58,25 +58,33 @@ import java.util.function.BiFunction;
  * Alternatively an operation may model something more complex like method declarations, lambda expressions, or
  * try statements. In such cases an operation will contain one or more bodies modeling the nested structure.
  * <p>
- * An operation when initially constructed is unattached from any parent block.
- * An unattached operation's state and descendant elements are all immutable except for the operation's
- * {@link #result result}, {@link #parent parent} block, and {@link #location}, which are all initially {@code null}.
+ * The process of building an operation starts with construction of an <i>unattached</i> operation. The
+ * operation-specific state and any descendant elements of the unattached operation are fixed at construction.
  * <p>
- * An unattached operation can be attached to a block by {@link Block.Builder#op(Op) appending} it to a block that is
- * being built. Once attached the operation has a permanently non-{@code null} operation {@link #result} that can be
- * used as an operand of subsequent constructed operations.
- * After the block is built the operation has a permanently non-{@code null} {@link #parent}. Before then, the block
- * being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this operation and
- * any attempt to access the block throws {@link IllegalStateException}.
- * <p>
- * An unattached operation can be built as a {@link #isRoot() root} operation. Once built the operation's
+ * Building then progresses in one of two ways:
+ * <ol>
+ * <li>
+ * the unattached operation is <i>attached</i> to a block, as its parent block, by
+ * {@link Block.Builder#op(Op) appending} it to a block builder for that block. The attached operation has a permanently
+ * non-{@code null} {@link #result result} that can be used as an operand of subsequent constructed operations. The
+ * block being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this
+ * operation and any attempt to access the block throws {@link IllegalStateException}.
+ * <li>
+ * the unattached operation is built as a {@link #isRoot() <i>root</i>} operation. The root operation's
  * {@link #result result} and {@link #parent parent} are always {@code null}.
+ * </ol>
+ * <p>
+ * Building finishes when the parent body builder of the block to which the operation is attached
+ * <a href="Body.Builder.html#body-building-finishing">finishes</a>, or when the operation is built as a root operation.
  * <p>
  * The {@link #location} may be {@link #setLocation set} while the operation is unattached or attached to a block being
  * built.
  * <p>
  * An operation can only be constructed with operands whose declaring block is being built, otherwise construction fails
  * with an exception.
+ * <p>
+ * An unattached operation, or an operation attached to a block whose parent body builder has not
+ * <a href="Body.Builder.html#body-building-finishing">finished</a>, is not thread-safe.
  */
 public non-sealed abstract class Op implements CodeElement<Op, Body> {
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -260,7 +260,6 @@
 ///
 /// ## <a id="code-models-heading"/>Code models
 ///
-///
 /// A code model is an _immutable_ instance of data structures that can, in general, model many kinds of code, be it
 /// Java code or foreign code. It has some properties like an Abstract Syntax Tree ([AST][AST]) used by a source
 /// compiler, such as modeling code as a tree of arbitrary depth, and some properties like an
@@ -471,7 +470,7 @@
 /// run time uses it to produce models that are accessed. Instead, we anticipate many users will build parts of models
 /// when they transform them.
 ///
-/// ## <a id="transforming-heading"/> Transforming
+/// ## <a id="transforming-heading"/>Transforming
 ///
 /// Code reflection supports the transformation of code models by combining traversing and building. A code model
 /// transformation is represented by a function that takes an operation, encountered in the (input) model being
@@ -594,6 +593,12 @@
 /// model. However, in general, code transformers are not required to preserve program behavior and some will
 /// intentionally not do so as they may transform into a different output programming domain that partially maps from
 /// the input programming domain.
+///
+/// ## Thread safety
+///
+/// The processes of building and transforming code models are not thread-safe. Unless otherwise specified, objects used
+/// to build and transform code models are not thread-safe. Built code models are immutable and may be safely queried
+/// concurrently by multiple threads.
 ///
 /// ## Code model structure
 ///


### PR DESCRIPTION
Specify that building and transformation is not thread safe.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1018/head:pull/1018` \
`$ git checkout pull/1018`

Update a local copy of the PR: \
`$ git checkout pull/1018` \
`$ git pull https://git.openjdk.org/babylon.git pull/1018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1018`

View PR using the GUI difftool: \
`$ git pr show -t 1018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1018.diff">https://git.openjdk.org/babylon/pull/1018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1018#issuecomment-4348197762)
</details>
