### PR TITLE
Use LazyConstant for computing immediate dominators

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -69,9 +69,10 @@ public final class Body implements CodeElement<Body, Block> {
     // Sorted in reverse postorder
     final List<Block> blocks;
 
-    // Map of a block to its immediate dominator
-    // Computed lazily, null if not computed
-    Map<Block, Block> idoms;
+    // Lazily computed map of a block to its immediate dominator
+    // Computed after body is built
+    // @@@ when dominance checks are implemented, may be computed and used in build method
+    LazyConstant<Map<Block, Block>> idoms = LazyConstant.of(this::computeImmediateDominators);
 
     /**
      * Constructs a body, whose connected ancestor body is the given ancestor body.
@@ -146,6 +147,11 @@ public final class Body implements CodeElement<Body, Block> {
      * @return a map of block to its immediate dominator, as an unmodifiable map
      */
     public Map<Block, Block> immediateDominators() {
+        return idoms.get();
+    }
+
+    // Called by LazyConstant field
+    private Map<Block, Block> computeImmediateDominators() {
         /*
          * Compute dominators of blocks in a body.
          * <p>
@@ -153,10 +159,6 @@ public final class Body implements CodeElement<Body, Block> {
          * A Simple, Fast Dominance Algorithm
          * Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy
          */
-
-        if (idoms != null) {
-            return idoms;
-        }
 
         // @@@ Compute the idoms as a block index mapping using int[]
         // and wrap and a specific map implementation
@@ -201,7 +203,7 @@ public final class Body implements CodeElement<Body, Block> {
             }
         } while (changed);
 
-        return idoms = Collections.unmodifiableMap(doms);
+        return Collections.unmodifiableMap(doms);
     }
 
     static Block intersect(Map<Block, Block> doms, Block b1, Block b2) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -65,7 +65,7 @@ import java.util.function.BiFunction;
  * <ol>
  * <li>
  * the unattached operation is <i>attached</i> to a block, as its parent block, by using a block builder to
- * {@link Block.Builder#op(Op) appending} it to a block. The attached operation has a permanently
+ * {@link Block.Builder#op(Op) append} it to a block. The attached operation has a permanently
  * non-{@code null} {@link #result result} that can be used as an operand of subsequent constructed operations. The
  * block being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this
  * operation and any attempt to access the block throws {@link IllegalStateException}.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -64,8 +64,8 @@ import java.util.function.BiFunction;
  * Building then progresses in one of two ways:
  * <ol>
  * <li>
- * the unattached operation is <i>attached</i> to a block, as its parent block, by
- * {@link Block.Builder#op(Op) appending} it to a block builder for that block. The attached operation has a permanently
+ * the unattached operation is <i>attached</i> to a block, as its parent block, by using a block builder to
+ * {@link Block.Builder#op(Op) appending} it to a block. The attached operation has a permanently
  * non-{@code null} {@link #result result} that can be used as an operand of subsequent constructed operations. The
  * block being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this
  * operation and any attempt to access the block throws {@link IllegalStateException}.


### PR DESCRIPTION
Use `LazyConstant` for computing immediate dominators, ensuring computation is thread safe.

Also, minor update to op building process.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1019/head:pull/1019` \
`$ git checkout pull/1019`

Update a local copy of the PR: \
`$ git checkout pull/1019` \
`$ git pull https://git.openjdk.org/babylon.git pull/1019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1019`

View PR using the GUI difftool: \
`$ git pr show -t 1019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1019.diff">https://git.openjdk.org/babylon/pull/1019.diff</a>

</details>
