### PR TITLE
Revise transformation composition and lowering

### DIFF
--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -34,6 +34,7 @@ import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
 
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 public class TritonOps {
@@ -246,7 +247,7 @@ public class TritonOps {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
             // and copy directly without lowering descendant operations
             b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);

--- a/hat/examples/experiments/src/main/java/experiments/TransformState.java
+++ b/hat/examples/experiments/src/main/java/experiments/TransformState.java
@@ -179,7 +179,7 @@ public class TransformState {
     static CodeTransformer trackingValueAndThenTransformer(
             CodeTransformer t,
             BiConsumer<Value, Value> mapAction) {
-        return CodeTransformer.andThen(t, (block, op) -> {
+        return CodeTransformer.applyOpAfter(t, (block, op) -> {
             Value in = op.result();
             Value out = block.context().queryValue(in).orElse(null);
             mapAction.accept(in, out);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -77,7 +77,7 @@ public final class Block implements CodeElement<Block, Op> {
          *     if (p.invokableOperation() instanceof CoreOp.FuncOp f) {
          *         assert f.parameters().indexOf(p) == p.index(); // @link substring="parameters()" target="Op.Invokable#parameters()"
          *     }
-         *}
+         * }
          *
          * @return the invokable operation, otherwise {@code null} if the operation
          * is not an instance of {@link Op.Invokable}.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -26,6 +26,7 @@
 package jdk.incubator.code;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -194,39 +195,52 @@ public interface CodeTransformer {
     Block.Builder acceptOp(Block.Builder builder, Op op);
 
     /**
-     * Returns a composed code transform that transforms an operation that first applies
-     * a block builder and operation to the function {@code f}, and then applies
-     * the resulting block builder and the same operation to {@link CodeTransformer#acceptOp acceptOp}
-     * of the code transformer {@code after}.
+     * Returns a code transformer that accepts an input operation by first applying the {@code before} operation
+     * transformer function to the block builder and input operation, then accepting the same input operation with the
+     * {@code after} code transformer.
      * <p>
-     * If the code transformer {@code after} is {@code null} then it is as if a code transformer
-     * is applied that does nothing except return the block builder it was given.
+     * If {@code after} is non-{@code null}, this method behaves as if it returns the result of the following
+     * lambda expression:
+     * {@snippet lang = "java":
+     * (builder, op) -> after.acceptOp(before.apply(builder, op), op);
+     * }
+     * If {@code after} is {@code null}, only {@code before} is applied.
      *
-     * @param after the code transformer to apply after
-     * @param f the operation transformer function to apply before
-     * @return the composed code transformer
+     * @param after the code transformer to accept after, or {@code null} if only {@code before} is applied
+     * @param before the operation transformer function to apply before
+     * @return the code transformer that applies an operation transformer function and then accepts the same operation
+     * @see #acceptOp(Block.Builder, Op)
+     * @see #applyOpAfter(CodeTransformer, BiFunction)
      */
-    static CodeTransformer compose(CodeTransformer after, BiFunction<Block.Builder, Op, Block.Builder> f) {
+    static CodeTransformer applyOpBefore(CodeTransformer after, BiFunction<Block.Builder, Op, Block.Builder> before) {
+        Objects.requireNonNull(before);
         return after == null
-                ? f::apply
-                : (builder, op) -> after.acceptOp(f.apply(builder, op), op);
+                ? before::apply
+                : (builder, op) -> after.acceptOp(before.apply(builder, op), op);
     }
 
     /**
-     * Returns a composed code transformer that first applies a block builder and operation to
-     * {@link CodeTransformer#acceptOp acceptOp} of the code transformer {@code before},
-     * and then applies resulting block builder and the same operation to the function {@code f}.
+     * Returns a code transformer that accepts an input operation by first accepting the input operation with the
+     * {@code before} code transformer, then applying the {@code after} operation transformer function to the
+     * resulting block builder and the same input operation.
      * <p>
-     * If the code transformer {@code before} is {@code null} then it is as if a code transformer
-     * is applied that does nothing except return the block builder it was given.
+     * if {@code before} is non-{@code null}, this method behaves as if it returns the result of the following
+     * lambda expression:
+     * {@snippet lang = "java":
+     * (builder, op) -> after.apply(before.acceptOp(builder, op), op);
+     * }
+     * If {@code before} is {@code null}, only {@code after} is applied.
      *
-     * @param before the code transformer to apply before
-     * @param f the operation transformer function to apply after
-     * @return the composed code transformer
+     * @param before the code transformer to accept before, or {@code null} if only {@code after} is applied
+     * @param after the operation transformer function to apply after
+     * @return the code transformer that accepts an operation and then applies an operation transformer function
+     * @see #acceptOp(Block.Builder, Op)
+     * @see #applyOpBefore(CodeTransformer, BiFunction)
      */
-    static CodeTransformer andThen(CodeTransformer before, BiFunction<Block.Builder, Op, Block.Builder> f) {
+    static CodeTransformer applyOpAfter(CodeTransformer before, BiFunction<Block.Builder, Op, Block.Builder> after) {
+        Objects.requireNonNull(after);
         return before == null
-                ? f::apply
-                : (builder, op) -> f.apply(before.acceptOp(builder, op), op);
+                ? after::apply
+                : (builder, op) -> after.apply(before.acceptOp(builder, op), op);
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -162,70 +162,77 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * An operation characteristic indicating the operation can replace itself with a lowered form.
+     * An operation characteristic indicating the operation can lower itself by replacing itself with blocks and
+     * operations that represent the same behavior.
      */
     // @@@ Hide this abstraction within JavaOp?
     public interface Lowerable {
 
         /**
-         * Lowers this operation into the block builder, commonly replacing nested structure
-         * with interconnected basic blocks. The previous lowering code transformation
-         * is used to compose with a lowering transformation that is applied to bodies
-         * of this operation, ensuring lowering is applied consistently to nested content.
-         *
-         * @param b the block builder
-         * @param opT the previous lowering code transformation, may be {@code null}
-         * @return the block builder to use for further building
-         */
-        Block.Builder lower(Block.Builder b, CodeTransformer opT);
-
-        /**
-         * Returns a composed code transformer that composes with an operation transformer function adapted to lower
+         * Lowers this operation into the given block builder.
+         * <p>
+         * A lowering implementation emits the replacement blocks and operations into the given builder, and returns
+         * the block builder to use for subsequent operations in an enclosing transformation.
+         * <p>
+         * If this operation lowers one of its bodies, it should transform that body with a lowering code transformer
+         * produced by {@link #loweringTransformer(BiFunction, BiFunction)}. This ensures that lowerable operations
+         * encountered in that body are lowered recursively.
+         * The {@code inherited} transformer is the operation transformer inherited from an enclosing lowering, if any.
+         * A lowering implementation may pass it directly to {@code loweringTransformer}, or compose it with another
+         * transformer and pass the composed transformer. The transformer passed to {@code loweringTransformer} is then
+         * supplied as the inherited transformer when that lowering code transformer recursively lowers lowerable
          * operations.
-         * <p>
-         * This method behaves as if it returns the result of the following expression:
-         * {@snippet lang = java:
-         * CodeTransformer.andThen(before, lowering(before, f));
-         *}
          *
-         * @param before the code transformer to apply before
-         * @param f the operation transformer function to apply after
-         * @return the composed code transformer
+         * @param b the block builder into which this operation is lowered
+         * @param inherited the inherited operation transformer, may be {@code null}
+         * @return the block builder to use for subsequent building
          */
-        static CodeTransformer andThenLowering(CodeTransformer before, BiFunction<Block.Builder, Op, Block.Builder> f) {
-            return CodeTransformer.andThen(before, lowering(before, f));
-        }
+        Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited);
 
         /**
-         * Returns an adapted operation transformer function that adapts an operation transformer function
-         * {@code f} to also transform lowerable operations.
+         * Returns a lowering code transformer that partially composes the given operation transformers and, if
+         * required, lowers lowerable operations and appends non-lowerable operations.
          * <p>
-         * The adapted operation transformer function first applies a block builder and operation
-         * to the operation transformer function {@code f}.
-         * If the result is not {@code null} then the result is returned.
-         * Otherwise, if the operation is a lowerable operation then the result of applying the
-         * block builder and code transformer {@code before} to {@link Lowerable#lower lower}
-         * of the lowerable operation is returned.
-         * Otherwise, the operation is copied by applying it to {@link Block.Builder#op op} of the block builder,
-         * and the block builder is returned.
+         * The returned code transformer accepts an operation by first applying the partial composition of
+         * {@code current} with {@code inherited} in the first argument of {@code current}, as if by the following:
+         * {@snippet lang = "java":
+         * Block.Builder composedBlock = inherited == null
+         *         ? block
+         *         : inherited.apply(block, op);
+         * Block.Builder currentBlock = current.apply(composedBlock, op);
+         * }
+         * The returned continuation builder is then selected as if by the following:
+         * {@snippet lang = "java":
+         * if (currentBlock != null) {
+         *     return currentBlock;
+         * } else if (op instanceof Op.Lowerable lop) {
+         *     return lop.lower(composedBlock, inherited);
+         * } else {
+         *     composedBlock.op(op);
+         *     return composedBlock;
+         * }
+         * }
          *
-         * @param before the code transformer to apply for lowering
-         * @param f the operation transformer function to apply after
-         * @return the adapted operation transformer function
+         * @param inherited the inherited operation transformer, may be {@code null}
+         * @param current the current operation transformer
+         * @return the lowering code transformer
          */
-        static BiFunction<Block.Builder, Op, Block.Builder> lowering(CodeTransformer before, BiFunction<Block.Builder, Op, Block.Builder> f) {
+        static CodeTransformer loweringTransformer(BiFunction<Block.Builder, Op, Block.Builder> inherited,
+                                                   BiFunction<Block.Builder, Op, Block.Builder> current) {
+            Objects.requireNonNull(current);
             return (block, op) -> {
-                Block.Builder b = f.apply(block, op);
-                if (b == null) {
-                    if (op instanceof Lowerable lop) {
-                        block = lop.lower(block, before);
-                    } else {
-                        block.op(op);
-                    }
-                } else {
-                    block = b;
+                if (inherited != null) {
+                    block = inherited.apply(block, op);
                 }
-                return block;
+                Block.Builder currentBlock = current.apply(block, op);
+                if (currentBlock != null) {
+                    return currentBlock;
+                } else if (op instanceof Op.Lowerable lop) {
+                    return lop.lower(block, inherited);
+                } else {
+                    block.op(op);
+                    return block;
+                }
             };
         }
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -36,6 +36,7 @@ import jdk.incubator.code.internal.OpDeclaration;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -204,7 +205,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
             b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
             return b;
@@ -384,7 +385,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
             return b;
         }
@@ -561,7 +562,7 @@ public sealed abstract class CoreOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
             // and copy directly without lowering descendant operations
             b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -48,7 +48,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static jdk.incubator.code.Op.Lowerable.*;
-import static jdk.incubator.code.CodeTransformer.*;
 import static jdk.incubator.code.dialect.core.CoreOp.*;
 import static jdk.incubator.code.dialect.java.JavaType.*;
 import static jdk.incubator.code.dialect.java.JavaType.VOID;
@@ -526,7 +525,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer _ignore) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
             b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
             return b;
@@ -2790,7 +2789,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             return lower(b, BranchTarget::breakBlock);
         }
     }
@@ -2824,7 +2823,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             return lower(b, BranchTarget::continueBlock);
         }
     }
@@ -2877,7 +2876,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             // for now, we will use breakBlock field to indicate java.yield target block
             return lower(b, BranchTarget::breakBlock);
         }
@@ -2973,11 +2972,11 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder exit = b.block();
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
-            b.body(body, List.of(), andThenLowering(opT, (block, op) -> {
+            b.body(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     block.op(branch(exit.reference()));
                     return block;
@@ -3073,9 +3072,9 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             // Lower the expression body, yielding a monitor target
-            b = lowerExpr(b, opT);
+            b = lowerExpr(b, inherited);
             Value monitorTarget = b.parameters().get(0);
 
             // Monitor enter
@@ -3090,7 +3089,7 @@ public sealed abstract class JavaOp extends Op {
             b.op(exceptionRegionEnter(
                     syncRegionEnter.reference(), catcherFinally.reference()));
 
-            CodeTransformer syncExitTransformer = compose(opT, (block, op) -> {
+            BiFunction<Block.Builder, Op, Block.Builder> syncExitTransformer = composeFirst(inherited, (block, op) -> {
                 if (op instanceof CoreOp.ReturnOp ||
                     (op instanceof StatementTargetOp lop && ifExitFromSynchronized(lop))) {
                     // Monitor exit
@@ -3104,7 +3103,7 @@ public sealed abstract class JavaOp extends Op {
                 }
             });
 
-            syncRegionEnter.body(blockBody, List.of(), andThenLowering(syncExitTransformer, (block, op) -> {
+            syncRegionEnter.body(blockBody, List.of(), loweringTransformer(syncExitTransformer, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     // Monitor exit
                     block.op(monitorExit(monitorTarget));
@@ -3134,9 +3133,9 @@ public sealed abstract class JavaOp extends Op {
             return exit;
         }
 
-        Block.Builder lowerExpr(Block.Builder b, CodeTransformer opT) {
+        Block.Builder lowerExpr(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder exprExit = b.block(exprBody.bodySignature().returnType());
-            b.body(exprBody, List.of(), andThenLowering(opT, (block, op) -> {
+            b.body(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value monitorTarget = block.context().getValue(yop.yieldValue());
                     block.op(branch(exprExit.reference(monitorTarget)));
@@ -3245,12 +3244,12 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder exit = b.block();
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
             AtomicBoolean first = new AtomicBoolean();
-            b.body(body, List.of(), andThenLowering(opT, (block, op) -> {
+            b.body(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                 // Drop first operation that corresponds to the label
                 if (!first.get()) {
                     first.set(true);
@@ -3484,7 +3483,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder exit = b.block();
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
@@ -3513,7 +3512,7 @@ public sealed abstract class JavaOp extends Op {
                     action = builders.get(i + 1);
                     Block.Builder next = builders.get(i + 2);
 
-                    pred.body(predBody, List.of(), andThenLowering(opT, (block, op) -> {
+                    pred.body(predBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp yo) {
                             block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                                     action.reference(), next.reference()));
@@ -3524,7 +3523,7 @@ public sealed abstract class JavaOp extends Op {
                     }));
                 }
 
-                action.body(actionBody, List.of(), andThenLowering(opT, (block, op) -> {
+                action.body(actionBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.reference()));
                         return block;
@@ -3586,7 +3585,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Value selectorExpression = b.context().getValue(operands().get(0));
 
             // @@@ we can add this during model generation
@@ -3667,7 +3666,7 @@ public sealed abstract class JavaOp extends Op {
                 boolean isLastLabel = i == blocks.size() - 2;
                 Block.Builder nextLabel = isLastLabel ? null : blocks.get(i + 2);
                 int finalDefLabelIndex = defLabelIndex;
-                blocks.get(i).body(bodies().get(i), List.of(selectorExpression), andThenLowering(opT,
+                blocks.get(i).body(bodies().get(i), List.of(selectorExpression), loweringTransformer(inherited,
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 Block.Reference falseTarget;
@@ -3685,7 +3684,7 @@ public sealed abstract class JavaOp extends Op {
                             default -> null;
                         }));
 
-                blocks.get(i + 1).body(bodies().get(i + 1), List.of(), andThenLowering(opT,
+                blocks.get(i + 1).body(bodies().get(i + 1), List.of(), loweringTransformer(inherited,
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 List<Value> args = yop.yieldValue() == null ? List.of() : List.of(block.context().getValue(yop.yieldValue()));
@@ -3697,7 +3696,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             if (defLabelIndex != -1) {
-                blocks.get(defLabelIndex + 1).body(bodies().get(defLabelIndex + 1), List.of(), andThenLowering(opT,
+                blocks.get(defLabelIndex + 1).body(bodies().get(defLabelIndex + 1), List.of(), loweringTransformer(inherited,
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 List<Value> args = yop.yieldValue() == null ? List.of() : List.of(block.context().getValue(yop.yieldValue()));
@@ -3852,7 +3851,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             return lower(b, BranchTarget::continueBlock);
         }
 
@@ -4098,7 +4097,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder header = b.block();
             Block.Builder body = b.block();
             Block.Builder update = b.block();
@@ -4107,7 +4106,7 @@ public sealed abstract class JavaOp extends Op {
             List<Value> initValues = new ArrayList<>();
             // @@@ Init body has one yield operation yielding
             //  void, a single variable, or a tuple of one or more variables
-            b.body(initBody, List.of(), andThenLowering(opT, (block, op) -> switch (op) {
+            b.body(initBody, List.of(), loweringTransformer(inherited, (block, op) -> switch (op) {
                 case TupleOp _ -> {
                     // Drop Tuple if a yielded
                     boolean isResult = op.result().uses().size() == 1 &&
@@ -4115,7 +4114,7 @@ public sealed abstract class JavaOp extends Op {
                     if (!isResult) {
                         block.op(op);
                     }
-                    yield  block;
+                    yield block;
                 }
                 case CoreOp.YieldOp yop -> {
                     if (yop.yieldValue() == null) {
@@ -4136,7 +4135,7 @@ public sealed abstract class JavaOp extends Op {
                 default -> null;
             }));
 
-            header.body(condBody, initValues, andThenLowering(opT, (block, op) -> {
+            header.body(condBody, initValues, loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
@@ -4148,9 +4147,9 @@ public sealed abstract class JavaOp extends Op {
 
             BranchTarget.setBranchTarget(b.context(), this, exit, update);
 
-            body.body(this.loopBody, initValues, andThenLowering(opT, (_, _) -> null));
+            body.body(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
 
-            update.body(this.updateBody, initValues, andThenLowering(opT, (block, op) -> {
+            update.body(this.updateBody, initValues, loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     block.op(branch(header.reference()));
                     return block;
@@ -4374,7 +4373,7 @@ public sealed abstract class JavaOp extends Op {
         static final MethodRef ITERATOR_NEXT = MethodRef.method(Iterator.class, "next", Object.class);
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             JavaType elementType = (JavaType) initBody.entryBlock().parameters().get(0).type();
             boolean isArray = exprBody.bodySignature().returnType() instanceof ArrayType;
 
@@ -4384,7 +4383,7 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder body = b.block();
             Block.Builder exit = b.block();
 
-            b.body(exprBody, List.of(), andThenLowering(opT, (block, op) -> {
+            b.body(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value loopSource = block.context().getValue(yop.yieldValue());
                     block.op(branch(preHeader.reference(loopSource)));
@@ -4406,7 +4405,7 @@ public sealed abstract class JavaOp extends Op {
 
                 Value e = init.op(arrayLoadOp(array, i));
                 List<Value> initValues = new ArrayList<>();
-                init.body(this.initBody, List.of(e), andThenLowering(opT, (block, op) -> {
+                init.body(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
                         block.op(branch(body.reference()));
@@ -4419,7 +4418,7 @@ public sealed abstract class JavaOp extends Op {
                 Block.Builder update = b.block();
                 BranchTarget.setBranchTarget(b.context(), this, exit, update);
 
-                body.body(this.loopBody, initValues, andThenLowering(opT, (_, _) -> null));
+                body.body(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
 
                 i = update.op(add(i, update.op(constant(INT, 1))));
                 update.op(branch(header.reference(i)));
@@ -4433,7 +4432,7 @@ public sealed abstract class JavaOp extends Op {
 
                 Value e = init.op(invoke(elementType, ITERATOR_NEXT, iterator));
                 List<Value> initValues = new ArrayList<>();
-                init.body(this.initBody, List.of(e), andThenLowering(opT, (block, op) -> {
+                init.body(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
                         block.op(branch(body.reference()));
@@ -4445,7 +4444,7 @@ public sealed abstract class JavaOp extends Op {
 
                 BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
-                body.body(this.loopBody, initValues, andThenLowering(opT, (_, _) -> null));
+                body.body(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
             }
 
             return exit;
@@ -4589,14 +4588,14 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder header = b.block();
             Block.Builder body = b.block();
             Block.Builder exit = b.block();
 
             b.op(branch(header.reference()));
 
-            header.body(predicateBody(), List.of(), andThenLowering(opT, (block, op) -> {
+            header.body(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
@@ -4608,7 +4607,7 @@ public sealed abstract class JavaOp extends Op {
 
             BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
-            body.body(loopBody(), List.of(), andThenLowering(opT, (_, _) -> null));
+            body.body(loopBody(), List.of(), loweringTransformer(inherited, (_, _) -> null));
 
             return exit;
         }
@@ -4751,7 +4750,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder body = b.block();
             Block.Builder header = b.block();
             Block.Builder exit = b.block();
@@ -4760,9 +4759,9 @@ public sealed abstract class JavaOp extends Op {
 
             BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
-            body.body(loopBody(), List.of(), andThenLowering(opT, (_, _) -> null));
+            body.body(loopBody(), List.of(), loweringTransformer(inherited, (_, _) -> null));
 
-            header.body(predicateBody(), List.of(), andThenLowering(opT, (block, op) -> {
+            header.body(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
@@ -4820,7 +4819,7 @@ public sealed abstract class JavaOp extends Op {
             return bodies;
         }
 
-        static Block.Builder lower(Block.Builder startBlock, CodeTransformer opT, JavaConditionalOp cop) {
+        static Block.Builder lower(Block.Builder startBlock, BiFunction<Block.Builder, Op, Block.Builder> before, JavaConditionalOp cop) {
             List<Body> bodies = cop.bodies();
 
             Block.Builder exit = startBlock.block();
@@ -4833,9 +4832,10 @@ public sealed abstract class JavaOp extends Op {
 
             Block.Builder pred = null;
             for (int i = bodies.size() - 1; i >= 0; i--) {
-                BiFunction<Block.Builder, Op, Block.Builder> opt;
+                CodeTransformer bodyTransformer;
+                BiFunction<Block.Builder, Op, Block.Builder> lowering;
                 if (i == bodies.size() - 1) {
-                    opt = lowering(opT, (block, op) -> {
+                    bodyTransformer = loweringTransformer(before, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp yop) {
                             Value p = block.context().getValue(yop.yieldValue());
                             block.op(branch(exit.reference(p)));
@@ -4846,7 +4846,7 @@ public sealed abstract class JavaOp extends Op {
                     });
                 } else {
                     Block.Builder nextPred = pred;
-                    opt = lowering(opT, (block, op) -> {
+                    bodyTransformer = loweringTransformer(before, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp yop) {
                             Value p = block.context().getValue(yop.yieldValue());
                             if (cop instanceof ConditionalAndOp) {
@@ -4863,10 +4863,10 @@ public sealed abstract class JavaOp extends Op {
 
                 Body fromPred = bodies.get(i);
                 if (i == 0) {
-                    startBlock.body(fromPred, List.of(), opt::apply);
+                    startBlock.body(fromPred, List.of(), bodyTransformer);
                 } else {
                     pred = startBlock.block(fromPred.bodySignature().parameterTypes());
-                    pred.body(fromPred, pred.parameters(), andThen(opT, opt));
+                    pred.body(fromPred, pred.parameters(), bodyTransformer);
                 }
             }
 
@@ -4943,8 +4943,8 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
-            return lower(b, opT, this);
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
+            return lower(b, inherited, this);
         }
     }
 
@@ -5012,8 +5012,8 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
-            return lower(b, opT, this);
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
+            return lower(b, inherited, this);
         }
     }
 
@@ -5103,14 +5103,14 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder exit = b.block(resultType());
             exit.context().mapValue(result(), exit.parameters().get(0));
 
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
             List<Block.Builder> builders = List.of(b.block(), b.block());
-            b.body(bodies.get(0), List.of(), andThenLowering(opT, (block, op) -> {
+            b.body(bodies.get(0), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             builders.get(0).reference(), builders.get(1).reference()));
@@ -5121,7 +5121,7 @@ public sealed abstract class JavaOp extends Op {
             }));
 
             for (int i = 0; i < 2; i++) {
-                builders.get(i).body(bodies.get(i + 1), List.of(), andThenLowering(opT, (block, op) -> {
+                builders.get(i).body(bodies.get(i + 1), List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         block.op(branch(exit.reference(block.context().getValue(yop.yieldValue()))));
                         return block;
@@ -5398,7 +5398,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
-        public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+        public Block.Builder lower(Block.Builder b, final BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             if (resourcesBody != null) {
                 throw new UnsupportedOperationException("Lowering of try-with-resources is unsupported");
             }
@@ -5408,7 +5408,7 @@ public sealed abstract class JavaOp extends Op {
 
             // Simple case with no catch and finally bodies
             if (catchBodies.isEmpty() && finallyBody == null) {
-                b.body(body, List.of(), andThenLowering(opT, (block, op) -> {
+                b.body(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.reference()));
                         return block;
@@ -5441,18 +5441,18 @@ public sealed abstract class JavaOp extends Op {
                     .toList();
             b.op(exceptionRegionEnter(tryRegionEnter.reference(), exitHandlers.reversed()));
 
-            CodeTransformer tryExitTransformer;
+            BiFunction<Block.Builder, Op, Block.Builder> tryExitTransformer;
             if (finallyBody != null) {
-                tryExitTransformer = compose(opT, (block, op) -> {
+                tryExitTransformer = composeFirst(inherited, (block, op) -> {
                     if (op instanceof CoreOp.ReturnOp ||
                             (op instanceof StatementTargetOp lop && ifExitFromTry(lop))) {
-                        return inlineFinalizer(block, exitHandlers, opT);
+                        return inlineFinalizer(block, exitHandlers, inherited);
                     } else {
                         return block;
                     }
                 });
             } else {
-                tryExitTransformer = compose(opT, (block, op) -> {
+                tryExitTransformer = composeFirst(inherited, (block, op) -> {
                     if (op instanceof CoreOp.ReturnOp ||
                             (op instanceof StatementTargetOp lop && ifExitFromTry(lop))) {
                         Block.Builder tryRegionReturnExit = block.block();
@@ -5465,7 +5465,7 @@ public sealed abstract class JavaOp extends Op {
             }
             // Inline the try body
             AtomicBoolean hasTryRegionExit = new AtomicBoolean();
-            tryRegionEnter.body(body, List.of(), andThenLowering(tryExitTransformer, (block, op) -> {
+            tryRegionEnter.body(body, List.of(), loweringTransformer(tryExitTransformer, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     hasTryRegionExit.set(true);
                     block.op(branch(tryRegionExit.reference()));
@@ -5502,18 +5502,18 @@ public sealed abstract class JavaOp extends Op {
                     Result catchExceptionRegion = catcher.op(
                             exceptionRegionEnter(catchRegionEnter.reference(), catcherFinally.reference()));
 
-                    CodeTransformer catchExitTransformer = compose(opT, (block, op) -> {
+                    BiFunction<Block.Builder, Op, Block.Builder> catchExitTransformer = composeFirst(inherited, (block, op) -> {
                         if (op instanceof CoreOp.ReturnOp) {
-                            return inlineFinalizer(block, List.of(catcherFinally.reference()), opT);
+                            return inlineFinalizer(block, List.of(catcherFinally.reference()), inherited);
                         } else if (op instanceof StatementTargetOp lop && ifExitFromTry(lop)) {
-                            return inlineFinalizer(block, List.of(catcherFinally.reference()), opT);
+                            return inlineFinalizer(block, List.of(catcherFinally.reference()), inherited);
                         } else {
                             return block;
                         }
                     });
                     // Inline the catch body
                     AtomicBoolean hasCatchRegionExit = new AtomicBoolean();
-                    catchRegionEnter.body(catcherBody, List.of(t), andThenLowering(catchExitTransformer, (block, op) -> {
+                    catchRegionEnter.body(catcherBody, List.of(t), loweringTransformer(catchExitTransformer, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
                             hasCatchRegionExit.set(true);
                             block.op(branch(catchRegionExit.reference()));
@@ -5530,7 +5530,7 @@ public sealed abstract class JavaOp extends Op {
                     }
                 } else {
                     // Inline the catch body
-                    catcher.body(catcherBody, List.of(t), andThenLowering(opT, (block, op) -> {
+                    catcher.body(catcherBody, List.of(t), loweringTransformer(inherited, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
                             block.op(branch(exit.reference()));
                             return block;
@@ -5543,7 +5543,7 @@ public sealed abstract class JavaOp extends Op {
 
             if (finallyBody != null && hasTryRegionExit.get()) {
                 // Inline the finally body
-                finallyEnter.body(finallyBody, List.of(), andThenLowering(opT, (block, op) -> {
+                finallyEnter.body(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.reference()));
                         return block;
@@ -5558,7 +5558,7 @@ public sealed abstract class JavaOp extends Op {
                 // Create the throwable argument
                 Block.Parameter t = catcherFinally.parameter(type(Throwable.class));
 
-                catcherFinally.body(finallyBody, List.of(), andThenLowering(opT, (block, op) -> {
+                catcherFinally.body(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(throw_(t));
                         return block;
@@ -5575,14 +5575,14 @@ public sealed abstract class JavaOp extends Op {
             return target == this || target.isAncestorOf(this);
         }
 
-        Block.Builder inlineFinalizer(Block.Builder block1, List<Block.Reference> tryHandlers, CodeTransformer opT) {
+        Block.Builder inlineFinalizer(Block.Builder block1, List<Block.Reference> tryHandlers, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder finallyEnter = block1.block();
             Block.Builder finallyExit = block1.block();
 
             block1.op(exceptionRegionExit(finallyEnter.reference(), tryHandlers));
 
             // Inline the finally body
-            finallyEnter.body(finallyBody, List.of(), andThenLowering(opT, (block2, op2) -> {
+            finallyEnter.body(finallyBody, List.of(), loweringTransformer(inherited, (block2, op2) -> {
                 if (op2 instanceof CoreOp.YieldOp) {
                     block2.op(branch(finallyExit.reference()));
                     return block2;
@@ -5978,7 +5978,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             @Override
-            public Block.Builder lower(Block.Builder b, CodeTransformer opT) {
+            public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
                 // No match block
                 Block.Builder endNoMatchBlock = b.block();
                 // Match block
@@ -6005,7 +6005,7 @@ public sealed abstract class JavaOp extends Op {
 
                 // Match block
                 // Lower match body and pass true
-                endMatchBlock.body(matchBody, patternValues, andThenLowering(opT, (block, op) -> {
+                endMatchBlock.body(matchBody, patternValues, loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(endBlock.reference(
                                 block.op(constant(BOOLEAN, true)))));
@@ -6180,6 +6180,24 @@ public sealed abstract class JavaOp extends Op {
                 return BOOLEAN;
             }
         }
+    }
+
+    /**
+     * Returns a composed function that composes {@code g} into the first argument of {@code f}.
+     * <p>
+     * if {@code f} is {@code null} then this method returns {@code g}.
+     *
+     * @param f the outer function
+     * @param g the inner function
+     * @return the composed
+     */
+    static <T, U> BiFunction<T, U, T> composeFirst(
+            BiFunction<T, U, T> f,
+            BiFunction<T, U, T> g) {
+        Objects.requireNonNull(g);
+        return f == null
+                ? g
+                : (builder, op) -> f.apply(g.apply(builder, op), op);
     }
 
     static Op createOp(ExternalizedOp def) {


### PR DESCRIPTION
Revise the specification and API for code transformation composition and lowering.

`CodeTransformer.compose` is renamed to `CodeTransformer.applyOpBefore` and specification revised.
`CodeTransformer.andThen` is renamed to `CodeTransformer.applyOpAfter` and specification revised.

`Op.Lowerable` specification was revised.

`Op.Lowerable.lowering` is removed.`.

`Op.Lowerable.andThenLowering` was replaced with `Op.Lowerable.loweringTransformer`, with a signature that accepts operation transformer functions, and a simplified implementation.

Overall the clarity of lowering is much improved.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1020/head:pull/1020` \
`$ git checkout pull/1020`

Update a local copy of the PR: \
`$ git checkout pull/1020` \
`$ git pull https://git.openjdk.org/babylon.git pull/1020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1020`

View PR using the GUI difftool: \
`$ git pr show -t 1020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1020.diff">https://git.openjdk.org/babylon/pull/1020.diff</a>

</details>
