### PR TITLE
Remove CodeTransformer.applyOpBefore/After methods

### DIFF
--- a/hat/examples/experiments/src/main/java/experiments/TransformState.java
+++ b/hat/examples/experiments/src/main/java/experiments/TransformState.java
@@ -31,6 +31,7 @@ import jdk.incubator.code.dialect.java.JavaOp;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -179,14 +180,20 @@ public class TransformState {
     static CodeTransformer trackingValueAndThenTransformer(
             CodeTransformer t,
             BiConsumer<Value, Value> mapAction) {
-        return CodeTransformer.applyOpAfter(t, (block, op) -> {
+
+        // This only composes CodeTransformer.acceptOp.
+        // If the given code transformer overrides acceptBody or acceptBlock,
+        // that behavior is not preserved
+        return ((builder, op) -> {
+            builder = t.acceptOp(builder, op);
+
             Value in = op.result();
-            Value out = block.context().queryValue(in).orElse(null);
+            Value out = builder.context().queryValue(in).orElse(null);
             mapAction.accept(in, out);
-            return block;
+
+            return builder;
         });
     }
-
 
     static CoreOp.FuncOp getFuncOp(String name) {
         Optional<Method> om = Stream.of(TransformState.class.getDeclaredMethods())

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -636,7 +636,7 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public Reference reference(List<? extends Value> args) {
             if (isEntryBlock()) {
-                throw new IllegalStateException("Entry block cannot be referenced and used as a successor");
+                throw new IllegalStateException("Entry block cannot be referenced and targeted as a successor");
             }
             for (Value operand : args) {
                 if (operand.isBuilt()) {
@@ -742,6 +742,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @param op the operation to append
          * @return the result of the appended operation
          * @throws IllegalStateException if the operation is structurally invalid
+         * @see Op#transform(CodeContext, CodeTransformer)
          */
         public Op.Result op(Op op) {
             check();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -26,8 +26,6 @@
 package jdk.incubator.code;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -193,54 +191,4 @@ public interface CodeTransformer {
      * @return the block builder to append to for subsequent operations.
      */
     Block.Builder acceptOp(Block.Builder builder, Op op);
-
-    /**
-     * Returns a code transformer that accepts an input operation by first applying the {@code before} operation
-     * transformer function to the block builder and input operation, then accepting the same input operation with the
-     * {@code after} code transformer.
-     * <p>
-     * If {@code after} is non-{@code null}, this method behaves as if it returns the result of the following
-     * lambda expression:
-     * {@snippet lang = "java":
-     * (builder, op) -> after.acceptOp(before.apply(builder, op), op);
-     * }
-     * If {@code after} is {@code null}, only {@code before} is applied.
-     *
-     * @param after the code transformer to accept after, or {@code null} if only {@code before} is applied
-     * @param before the operation transformer function to apply before
-     * @return the code transformer that applies an operation transformer function and then accepts the same operation
-     * @see #acceptOp(Block.Builder, Op)
-     * @see #applyOpAfter(CodeTransformer, BiFunction)
-     */
-    static CodeTransformer applyOpBefore(CodeTransformer after, BiFunction<Block.Builder, Op, Block.Builder> before) {
-        Objects.requireNonNull(before);
-        return after == null
-                ? before::apply
-                : (builder, op) -> after.acceptOp(before.apply(builder, op), op);
-    }
-
-    /**
-     * Returns a code transformer that accepts an input operation by first accepting the input operation with the
-     * {@code before} code transformer, then applying the {@code after} operation transformer function to the
-     * resulting block builder and the same input operation.
-     * <p>
-     * if {@code before} is non-{@code null}, this method behaves as if it returns the result of the following
-     * lambda expression:
-     * {@snippet lang = "java":
-     * (builder, op) -> after.apply(before.acceptOp(builder, op), op);
-     * }
-     * If {@code before} is {@code null}, only {@code after} is applied.
-     *
-     * @param before the code transformer to accept before, or {@code null} if only {@code after} is applied
-     * @param after the operation transformer function to apply after
-     * @return the code transformer that accepts an operation and then applies an operation transformer function
-     * @see #acceptOp(Block.Builder, Op)
-     * @see #applyOpBefore(CodeTransformer, BiFunction)
-     */
-    static CodeTransformer applyOpAfter(CodeTransformer before, BiFunction<Block.Builder, Op, Block.Builder> after) {
-        Objects.requireNonNull(after);
-        return before == null
-                ? after::apply
-                : (builder, op) -> after.apply(before.acceptOp(builder, op), op);
-    }
 }


### PR DESCRIPTION
Remove `CodeTransformer.applyOpBefore/After` methods. These methods are misleading since they only compose the accepting of operations. If a code transformer overrides `acceptBody` and/or `acceptBlock` that behavior will not be preserved.

Lowering simplified the composition to accepting operations and we no longer need these methods.

`CodeTransformer` composition is a potentially complex area of design, beyond the simple and arguably elegant "code model in code model out" composition. We need to look carefully at the use cases e.g., composition may be useful because of the need to listen for side effects, but there may be other ways to solve that.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1021/head:pull/1021` \
`$ git checkout pull/1021`

Update a local copy of the PR: \
`$ git checkout pull/1021` \
`$ git pull https://git.openjdk.org/babylon.git pull/1021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1021`

View PR using the GUI difftool: \
`$ git pr show -t 1021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1021.diff">https://git.openjdk.org/babylon/pull/1021.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1021#issuecomment-4372866732)
</details>
