### PR TITLE
Rename Block.Builder.body to transformBody

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
@@ -86,7 +86,7 @@ public final class OnnxTransformer {
                 b.context().mapValue(inputCapture, output);
             }
 
-            b.body(lambda.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+            b.transformBody(lambda.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
         });
 
         return OnnxTransformer.transform(l, f);
@@ -178,7 +178,7 @@ public final class OnnxTransformer {
             var ft = f.invokableSignature();
             int argsSize = ft.parameterTypes().size();
             return CoreOp.func(f.funcName(), CoreType.functionType(ft.returnType(), Stream.concat(ft.parameterTypes().stream(), initTypes.stream()).toList()))
-                    .body(bob -> bob.body(f.body(), bob.parameters().subList(0, argsSize), (bb, op) -> {
+                    .body(bob -> bob.transformBody(f.body(), bob.parameters().subList(0, argsSize), (bb, op) -> {
                         List<Block.Parameter> initArgs = bob.parameters().subList(argsSize, bob.parameters().size());
                         switch (op) {
                             // field loads mapped to initializers args
@@ -322,10 +322,11 @@ public final class OnnxTransformer {
     static CoreOp.FuncOp transformToOnnx(TypeConvertor tc, CoreOp.FuncOp func, OnnxPartialEvaluator pe) {
         FunctionType ft = tc.convertType(func);
         var func2 = CoreOp.func(func.funcName(), ft).body(b -> {
-            b.body(func.body(), b.parameters(), toOnnxCodeTransformer(tc, pe));
+            b.transformBody(func.body(), b.parameters(), toOnnxCodeTransformer(tc, pe));
         });
         // double transformation to fix return type by the returned tuple type
-        return CoreOp.func(func2.funcName(), tc.convertType(func2)).body(b -> b.body(func2.body(), b.parameters(), CodeTransformer.COPYING_TRANSFORMER));
+        return CoreOp.func(func2.funcName(), tc.convertType(func2))
+                .body(b -> b.transformBody(func2.body(), b.parameters(), CodeTransformer.COPYING_TRANSFORMER));
     }
 
     static CoreOp.FuncOp removeDropedFuncCallsArgs(CoreOp.FuncOp func, Map<String, BitSet> paramsToDropMap) {
@@ -363,7 +364,7 @@ public final class OnnxTransformer {
         var funcType = CoreType.functionType(func.invokableSignature().returnType(), usedParameters.stream().map(Value::type).toList());
         return CoreOp.func(func.funcName(), funcType).body(bob -> {
             bob.context().mapValues(usedParameters, bob.parameters());
-            bob.body(func.body(), List.of(), (b, op) -> {
+            bob.transformBody(func.body(), List.of(), (b, op) -> {
                 // Drop any non-terminating operation whose result is not used
                 if (op instanceof Op.Terminating || !op.result().uses().isEmpty() || op instanceof CoreOp.FuncOp || op instanceof CoreOp.VarAccessOp.VarStoreOp) {
                     b.op(op);
@@ -553,7 +554,7 @@ public final class OnnxTransformer {
         Body.Builder bb = Body.Builder.of(ancestor.parentBody(),
                 outputType, ancestor.context()); // translate types
 
-        bb.entryBlock().body(iop.body(), bb.entryBlock().parameters(), ot);
+        bb.entryBlock().transformBody(iop.body(), bb.entryBlock().parameters(), ot);
         return bb;
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
@@ -573,7 +573,7 @@ public final class TritonTransformer {
                     }
 
                     // Transform kernel body
-                    fblock.body(kernel.body(), args, (kblock, op) -> {
+                    fblock.transformBody(kernel.body(), args, (kblock, op) -> {
                         return transformToTritonOperation(kblock, op, valueTypeMap, opData, fsymTable);
                     });
                 });
@@ -744,7 +744,7 @@ public final class TritonTransformer {
                     }
 
                     // Transform the Java for body into the SCF for body
-                    builder.body(body, List.of(), (block, op) -> {
+                    builder.transformBody(body, List.of(), (block, op) -> {
                         // Yield iter values
                         if (op instanceof JavaOp.ContinueOp) {
                             // Replace with yield of loaded vars

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -648,58 +648,60 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Transforms a body using this block builder as the current output block builder, with a
-         * {@link CodeContext#create(CodeContext) child} of this block builder's code context and the given code
-         * transformer.
+         * Transforms the given body into this block builder's parent body, using this block builder as the current
+         * output block builder, a {@link CodeContext#create(CodeContext) child} of this block builder's code context,
+         * and the given code transformer.
          * <p>
-         * This method behaves as if invoking {@link #body(Body, List, CodeContext, CodeTransformer)} with the given
-         * body, the given values, a child of this block builder's code context, and the given code transformer.
+         * This method behaves as if invoking {@link #transformBody(Body, List, CodeContext, CodeTransformer)} with the given
+         * body, the given entry values, a child of this block builder's code context, and the given code transformer.
          *
          * @param body the body to transform
-         * @param values the output values to map, in order, from a prefix of the input body's entry block parameters
+         * @param entryValues the output entry values to map, in order, from a prefix of the input body's entry block
+         *                    parameters
          * @param ct the code transformer
-         * @throws IllegalArgumentException if there are more output values than entry block parameters
-         * @see #body(Body, List, CodeContext, CodeTransformer)
+         * @throws IllegalArgumentException if there are more output entry values than entry block parameters
+         * @see #transformBody(Body, List, CodeContext, CodeTransformer)
          */
-        public void body(Body body, List<? extends Value> values,
-                         CodeTransformer ct) {
+        public void transformBody(Body body, List<? extends Value> entryValues,
+                                  CodeTransformer ct) {
             check();
 
-            body(body, values, CodeContext.create(cc), ct);
+            transformBody(body, entryValues, CodeContext.create(cc), ct);
         }
 
         /**
-         * Transforms a body using this block builder as the current output block builder, with the given code context
-         * and code transformer.
+         * Transforms the given body into this block builder's parent body, using this block builder as the current
+         * output block builder, the given code context, and the given code transformer.
          * <p>
          * This method first obtains a block builder with the given code context and code transformer by calling
          * {@link #withContextAndTransformer(CodeContext, CodeTransformer)}, and then transforms the body using the code
          * transformer by {@link CodeTransformer#acceptBody(Builder, Body, List) accepting} the obtained block builder,
-         * the body, and the values.
+         * the body, and the entry values.
          * <p>
-         * A prefix of the input body's entry block parameters is mapped, in order, to the given output values. Any
-         * remaining entry block parameters are not mapped.
+         * A prefix of the input body's entry block parameters is mapped, in order, to the given output entry values.
+         * Any remaining entry block parameters are not mapped.
          *
          * @apiNote
          * Supplying an explicit code context can ensure block and value mappings produced by the transformation do not
          * affect this builder's code context. The explicit code context can also be used when some of the input body's
          * entry block parameters have already been mapped prior to transforming the body. This is useful when the
-         * transformation removes some entry block parameters. In such cases an empty list of output values can be
+         * transformation removes some entry block parameters. In such cases an empty list of output entry values can be
          * given.
          *
          * @param body the body to transform
-         * @param values the output values to map, in order, from a prefix of the input body's entry block parameters
+         * @param entryValues the output entry values to map, in order, from a prefix of the input body's entry block
+         *                    parameters
          * @param cc the code context
          * @param ct the code transformer
-         * @throws IllegalArgumentException if there are more output values than entry block parameters
+         * @throws IllegalArgumentException if there are more output entry values than entry block parameters
          * @see #withContextAndTransformer(CodeContext, CodeTransformer)
          * @see CodeTransformer#acceptBody(Builder, Body, List)
          */
-        public void body(Body body, List<? extends Value> values,
-                         CodeContext cc, CodeTransformer ct) {
+        public void transformBody(Body body, List<? extends Value> entryValues,
+                                  CodeContext cc, CodeTransformer ct) {
             check();
 
-            ct.acceptBody(withContextAndTransformer(cc, ct), body, values);
+            ct.acceptBody(withContextAndTransformer(cc, ct), body, entryValues);
         }
 
         /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -123,8 +123,8 @@ public interface CodeTransformer {
      * <ol>
      * <li>
      * the body's entry block is mapped to the block builder, and a prefix of the body's entry block parameters is
-     * mapped, in order, to the given values, using this builder's context. Any remaining entry block parameters are not
-     * mapped;
+     * mapped, in order, to the given entry values, using this builder's context. Any remaining entry block parameters
+     * are not mapped;
      * <li>
      * for each input block in the body, except the entry block, an output block builder is created from the builder
      * with the same parameter types as the input block, in order. The input block is mapped to the output builder, and
@@ -137,17 +137,18 @@ public interface CodeTransformer {
      *
      * @param builder the block builder
      * @param body the body to transform
-     * @param values the output values to map, in order, from a prefix of the input body's entry block parameters
-     * @throws IllegalArgumentException if there are more output values than entry block parameters
+     * @param entryValues the output entry values to map, in order, from a prefix of the input body's entry block
+     *                    parameters
+     * @throws IllegalArgumentException if there are more output entry values than entry block parameters
      */
-    default void acceptBody(Block.Builder builder, Body body, List<? extends Value> values) {
+    default void acceptBody(Block.Builder builder, Body body, List<? extends Value> entryValues) {
         CodeContext cc = builder.context();
 
         // Map blocks up front, for forward referencing successors
         for (Block block : body.blocks()) {
             if (block.isEntryBlock()) {
                 cc.mapBlock(block, builder);
-                cc.mapValuePrefix(block.parameters(), values);
+                cc.mapValuePrefix(block.parameters(), entryValues);
             } else {
                 Block.Builder blockBuilder = builder.block(block.parameterTypes());
                 cc.mapBlock(block, blockBuilder);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LoweringTransform.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LoweringTransform.java
@@ -106,7 +106,7 @@ public final class LoweringTransform {
 
         for (int i = 0; i < targets.size(); i++) {
             Block.Builder curr = blocks.get(i);
-            curr.body(targets.get(i).parent(), blocks.get(i).parameters(), (b, op) -> switch (op) {
+            curr.transformBody(targets.get(i).parent(), blocks.get(i).parameters(), (b, op) -> switch (op) {
                 case YieldOp _ when swOp instanceof JavaOp.SwitchStatementOp -> {
                     b.op(branch(exit.reference()));
                     yield b;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
@@ -28,7 +28,7 @@ public final class Inliner {
      * Inlines the invokable operation into the given block builder and returns the block builder from which to
      * continue building.
      * <p>
-     * This method {@link Block.Builder#body(Body, List, CodeContext, CodeTransformer) transforms} the
+     * This method {@link Block.Builder#transformBody(Body, List, CodeContext, CodeTransformer) transforms} the
      * body of the invokable operation with the given arguments, a new context, and an code transformer that
      * replaces return operations by applying the given consumer to a block builder and a return value.
      * <p>
@@ -72,7 +72,7 @@ public final class Inliner {
                          BiConsumer<Block.Builder, Value> inlineConsumer) {
         Map<Body, Block.Builder> returnBlocks = new HashMap<>();
         // Create new context, ensuring inlining is isolated
-        _this.body(invokableOp.body(), args, CodeContext.create(), (block, op) -> {
+        _this.transformBody(invokableOp.body(), args, CodeContext.create(), (block, op) -> {
             // If the return operation is associated with the invokable operation
             if (op instanceof CoreOp.ReturnOp rop && getNearestInvokeableAncestorOp(op) == invokableOp) {
                 // Compute the return block

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -662,7 +662,7 @@ public sealed abstract class JavaOp extends Op {
                     builder.context().mapValue(v, functionValue);
                 }
                 List<Block.Parameter> outputValues = builder.parameters().subList(0, this.invokableSignature().parameterTypes().size());
-                builder.body(this.body(), outputValues, CodeTransformer.COPYING_TRANSFORMER);
+                builder.transformBody(this.body(), outputValues, CodeTransformer.COPYING_TRANSFORMER);
             });
         }
 
@@ -2976,7 +2976,7 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder exit = b.block();
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
-            b.body(body, List.of(), loweringTransformer(inherited, (block, op) -> {
+            b.transformBody(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     block.op(branch(exit.reference()));
                     return block;
@@ -3103,7 +3103,7 @@ public sealed abstract class JavaOp extends Op {
                 }
             });
 
-            syncRegionEnter.body(blockBody, List.of(), loweringTransformer(syncExitTransformer, (block, op) -> {
+            syncRegionEnter.transformBody(blockBody, List.of(), loweringTransformer(syncExitTransformer, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     // Monitor exit
                     block.op(monitorExit(monitorTarget));
@@ -3135,7 +3135,7 @@ public sealed abstract class JavaOp extends Op {
 
         Block.Builder lowerExpr(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder exprExit = b.block(exprBody.bodySignature().returnType());
-            b.body(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
+            b.transformBody(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value monitorTarget = block.context().getValue(yop.yieldValue());
                     block.op(branch(exprExit.reference(monitorTarget)));
@@ -3249,7 +3249,7 @@ public sealed abstract class JavaOp extends Op {
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
             AtomicBoolean first = new AtomicBoolean();
-            b.body(body, List.of(), loweringTransformer(inherited, (block, op) -> {
+            b.transformBody(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                 // Drop first operation that corresponds to the label
                 if (!first.get()) {
                     first.set(true);
@@ -3512,7 +3512,7 @@ public sealed abstract class JavaOp extends Op {
                     action = builders.get(i + 1);
                     Block.Builder next = builders.get(i + 2);
 
-                    pred.body(predBody, List.of(), loweringTransformer(inherited, (block, op) -> {
+                    pred.transformBody(predBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp yo) {
                             block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                                     action.reference(), next.reference()));
@@ -3523,7 +3523,7 @@ public sealed abstract class JavaOp extends Op {
                     }));
                 }
 
-                action.body(actionBody, List.of(), loweringTransformer(inherited, (block, op) -> {
+                action.transformBody(actionBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.reference()));
                         return block;
@@ -3666,7 +3666,7 @@ public sealed abstract class JavaOp extends Op {
                 boolean isLastLabel = i == blocks.size() - 2;
                 Block.Builder nextLabel = isLastLabel ? null : blocks.get(i + 2);
                 int finalDefLabelIndex = defLabelIndex;
-                blocks.get(i).body(bodies().get(i), List.of(selectorExpression), loweringTransformer(inherited,
+                blocks.get(i).transformBody(bodies().get(i), List.of(selectorExpression), loweringTransformer(inherited,
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 Block.Reference falseTarget;
@@ -3684,7 +3684,7 @@ public sealed abstract class JavaOp extends Op {
                             default -> null;
                         }));
 
-                blocks.get(i + 1).body(bodies().get(i + 1), List.of(), loweringTransformer(inherited,
+                blocks.get(i + 1).transformBody(bodies().get(i + 1), List.of(), loweringTransformer(inherited,
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 List<Value> args = yop.yieldValue() == null ? List.of() : List.of(block.context().getValue(yop.yieldValue()));
@@ -3696,7 +3696,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             if (defLabelIndex != -1) {
-                blocks.get(defLabelIndex + 1).body(bodies().get(defLabelIndex + 1), List.of(), loweringTransformer(inherited,
+                blocks.get(defLabelIndex + 1).transformBody(bodies().get(defLabelIndex + 1), List.of(), loweringTransformer(inherited,
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 List<Value> args = yop.yieldValue() == null ? List.of() : List.of(block.context().getValue(yop.yieldValue()));
@@ -4106,7 +4106,7 @@ public sealed abstract class JavaOp extends Op {
             List<Value> initValues = new ArrayList<>();
             // @@@ Init body has one yield operation yielding
             //  void, a single variable, or a tuple of one or more variables
-            b.body(initBody, List.of(), loweringTransformer(inherited, (block, op) -> switch (op) {
+            b.transformBody(initBody, List.of(), loweringTransformer(inherited, (block, op) -> switch (op) {
                 case TupleOp _ -> {
                     // Drop Tuple if a yielded
                     boolean isResult = op.result().uses().size() == 1 &&
@@ -4135,7 +4135,7 @@ public sealed abstract class JavaOp extends Op {
                 default -> null;
             }));
 
-            header.body(condBody, initValues, loweringTransformer(inherited, (block, op) -> {
+            header.transformBody(condBody, initValues, loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
@@ -4147,9 +4147,9 @@ public sealed abstract class JavaOp extends Op {
 
             BranchTarget.setBranchTarget(b.context(), this, exit, update);
 
-            body.body(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
+            body.transformBody(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
 
-            update.body(this.updateBody, initValues, loweringTransformer(inherited, (block, op) -> {
+            update.transformBody(this.updateBody, initValues, loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     block.op(branch(header.reference()));
                     return block;
@@ -4383,7 +4383,7 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder body = b.block();
             Block.Builder exit = b.block();
 
-            b.body(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
+            b.transformBody(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value loopSource = block.context().getValue(yop.yieldValue());
                     block.op(branch(preHeader.reference(loopSource)));
@@ -4405,7 +4405,7 @@ public sealed abstract class JavaOp extends Op {
 
                 Value e = init.op(arrayLoadOp(array, i));
                 List<Value> initValues = new ArrayList<>();
-                init.body(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
+                init.transformBody(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
                         block.op(branch(body.reference()));
@@ -4418,7 +4418,7 @@ public sealed abstract class JavaOp extends Op {
                 Block.Builder update = b.block();
                 BranchTarget.setBranchTarget(b.context(), this, exit, update);
 
-                body.body(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
+                body.transformBody(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
 
                 i = update.op(add(i, update.op(constant(INT, 1))));
                 update.op(branch(header.reference(i)));
@@ -4432,7 +4432,7 @@ public sealed abstract class JavaOp extends Op {
 
                 Value e = init.op(invoke(elementType, ITERATOR_NEXT, iterator));
                 List<Value> initValues = new ArrayList<>();
-                init.body(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
+                init.transformBody(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
                         block.op(branch(body.reference()));
@@ -4444,7 +4444,7 @@ public sealed abstract class JavaOp extends Op {
 
                 BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
-                body.body(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
+                body.transformBody(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
             }
 
             return exit;
@@ -4595,7 +4595,7 @@ public sealed abstract class JavaOp extends Op {
 
             b.op(branch(header.reference()));
 
-            header.body(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
+            header.transformBody(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
@@ -4607,7 +4607,7 @@ public sealed abstract class JavaOp extends Op {
 
             BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
-            body.body(loopBody(), List.of(), loweringTransformer(inherited, (_, _) -> null));
+            body.transformBody(loopBody(), List.of(), loweringTransformer(inherited, (_, _) -> null));
 
             return exit;
         }
@@ -4759,9 +4759,9 @@ public sealed abstract class JavaOp extends Op {
 
             BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
-            body.body(loopBody(), List.of(), loweringTransformer(inherited, (_, _) -> null));
+            body.transformBody(loopBody(), List.of(), loweringTransformer(inherited, (_, _) -> null));
 
-            header.body(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
+            header.transformBody(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
@@ -4863,10 +4863,10 @@ public sealed abstract class JavaOp extends Op {
 
                 Body fromPred = bodies.get(i);
                 if (i == 0) {
-                    startBlock.body(fromPred, List.of(), bodyTransformer);
+                    startBlock.transformBody(fromPred, List.of(), bodyTransformer);
                 } else {
                     pred = startBlock.block(fromPred.bodySignature().parameterTypes());
-                    pred.body(fromPred, pred.parameters(), bodyTransformer);
+                    pred.transformBody(fromPred, pred.parameters(), bodyTransformer);
                 }
             }
 
@@ -5110,7 +5110,7 @@ public sealed abstract class JavaOp extends Op {
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
             List<Block.Builder> builders = List.of(b.block(), b.block());
-            b.body(bodies.get(0), List.of(), loweringTransformer(inherited, (block, op) -> {
+            b.transformBody(bodies.get(0), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
                     block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             builders.get(0).reference(), builders.get(1).reference()));
@@ -5121,7 +5121,7 @@ public sealed abstract class JavaOp extends Op {
             }));
 
             for (int i = 0; i < 2; i++) {
-                builders.get(i).body(bodies.get(i + 1), List.of(), loweringTransformer(inherited, (block, op) -> {
+                builders.get(i).transformBody(bodies.get(i + 1), List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         block.op(branch(exit.reference(block.context().getValue(yop.yieldValue()))));
                         return block;
@@ -5408,7 +5408,7 @@ public sealed abstract class JavaOp extends Op {
 
             // Simple case with no catch and finally bodies
             if (catchBodies.isEmpty() && finallyBody == null) {
-                b.body(body, List.of(), loweringTransformer(inherited, (block, op) -> {
+                b.transformBody(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.reference()));
                         return block;
@@ -5465,7 +5465,7 @@ public sealed abstract class JavaOp extends Op {
             }
             // Inline the try body
             AtomicBoolean hasTryRegionExit = new AtomicBoolean();
-            tryRegionEnter.body(body, List.of(), loweringTransformer(tryExitTransformer, (block, op) -> {
+            tryRegionEnter.transformBody(body, List.of(), loweringTransformer(tryExitTransformer, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     hasTryRegionExit.set(true);
                     block.op(branch(tryRegionExit.reference()));
@@ -5513,7 +5513,7 @@ public sealed abstract class JavaOp extends Op {
                     });
                     // Inline the catch body
                     AtomicBoolean hasCatchRegionExit = new AtomicBoolean();
-                    catchRegionEnter.body(catcherBody, List.of(t), loweringTransformer(catchExitTransformer, (block, op) -> {
+                    catchRegionEnter.transformBody(catcherBody, List.of(t), loweringTransformer(catchExitTransformer, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
                             hasCatchRegionExit.set(true);
                             block.op(branch(catchRegionExit.reference()));
@@ -5530,7 +5530,7 @@ public sealed abstract class JavaOp extends Op {
                     }
                 } else {
                     // Inline the catch body
-                    catcher.body(catcherBody, List.of(t), loweringTransformer(inherited, (block, op) -> {
+                    catcher.transformBody(catcherBody, List.of(t), loweringTransformer(inherited, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
                             block.op(branch(exit.reference()));
                             return block;
@@ -5543,7 +5543,7 @@ public sealed abstract class JavaOp extends Op {
 
             if (finallyBody != null && hasTryRegionExit.get()) {
                 // Inline the finally body
-                finallyEnter.body(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
+                finallyEnter.transformBody(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(exit.reference()));
                         return block;
@@ -5558,7 +5558,7 @@ public sealed abstract class JavaOp extends Op {
                 // Create the throwable argument
                 Block.Parameter t = catcherFinally.parameter(type(Throwable.class));
 
-                catcherFinally.body(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
+                catcherFinally.transformBody(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(throw_(t));
                         return block;
@@ -5582,7 +5582,7 @@ public sealed abstract class JavaOp extends Op {
             block1.op(exceptionRegionExit(finallyEnter.reference(), tryHandlers));
 
             // Inline the finally body
-            finallyEnter.body(finallyBody, List.of(), loweringTransformer(inherited, (block2, op2) -> {
+            finallyEnter.transformBody(finallyBody, List.of(), loweringTransformer(inherited, (block2, op2) -> {
                 if (op2 instanceof CoreOp.YieldOp) {
                     block2.op(branch(finallyExit.reference()));
                     return block2;
@@ -6005,7 +6005,7 @@ public sealed abstract class JavaOp extends Op {
 
                 // Match block
                 // Lower match body and pass true
-                endMatchBlock.body(matchBody, patternValues, loweringTransformer(inherited, (block, op) -> {
+                endMatchBlock.transformBody(matchBody, patternValues, loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.op(branch(endBlock.reference(
                                 block.op(constant(BOOLEAN, true)))));

--- a/test/jdk/jdk/incubator/code/CoreBinaryOpsTest.java
+++ b/test/jdk/jdk/incubator/code/CoreBinaryOpsTest.java
@@ -275,7 +275,7 @@ public class CoreBinaryOpsTest {
                     ? type
                     : functionType.returnType();
             return CoreOp.func(original.funcName(), CoreType.functionType(retType, type, type))
-                    .body(builder -> builder.body(original.body(), builder.parameters(), CodeTransformer.COPYING_TRANSFORMER)
+                    .body(builder -> builder.transformBody(original.body(), builder.parameters(), CodeTransformer.COPYING_TRANSFORMER)
                     );
         }
 

--- a/test/jdk/jdk/incubator/code/TestVarOp.java
+++ b/test/jdk/jdk/incubator/code/TestVarOp.java
@@ -57,7 +57,7 @@ public class TestVarOp {
         CoreOp.FuncOp f = getFuncOp("f");
         CoreOp.FuncOp ft = CoreOp.func("f", CoreType.functionType(JavaType.J_L_OBJECT, JavaType.type(CharSequence.class)))
                 .body(fb -> {
-                    fb.body(f.body(), fb.parameters(), CodeTransformer.COPYING_TRANSFORMER);
+                    fb.transformBody(f.body(), fb.parameters(), CodeTransformer.COPYING_TRANSFORMER);
                 });
 
         List<CoreOp.VarOp> vops = ft.elements()

--- a/test/jdk/jdk/incubator/code/Unreflect.java
+++ b/test/jdk/jdk/incubator/code/Unreflect.java
@@ -185,7 +185,7 @@ public final class Unreflect {
                 Op o = ops.get(i);
                 bb.context().mapValue(o.result(), bb.op(o));
             }
-            bb.body(lambda.body(),
+            bb.transformBody(lambda.body(),
                     bb.parameters().subList(capturedValues, bb.parameters().size()),
                     bb.context(),
                     CodeTransformer.COPYING_TRANSFORMER);


### PR DESCRIPTION
Rename `Block.Builder.body` to `transformBody`. This more clearly indicates the transformation of body starting from this block builder. Update the documentation to more clearer express this.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1022/head:pull/1022` \
`$ git checkout pull/1022`

Update a local copy of the PR: \
`$ git checkout pull/1022` \
`$ git pull https://git.openjdk.org/babylon.git pull/1022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1022`

View PR using the GUI difftool: \
`$ git pr show -t 1022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1022.diff">https://git.openjdk.org/babylon/pull/1022.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1022#issuecomment-4373465382)
</details>
