### PR TITLE
Rename Value.result to asResult

### DIFF
--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
@@ -101,7 +101,7 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
     public OpenCLHATKernelBuilder hatVectorStoreOp( HATVectorOp.HATVectorStoreView hatVectorStoreView) {
         vstore(hatVectorStoreView.vectorShape().lanes()).paren(_-> {
             // if the value to be stored is an operation, recurse on the operation
-            if (hatVectorStoreView.operands().get(1).result().op() instanceof HATVectorOp.HATVectorBinaryOp binOp) {
+            if (hatVectorStoreView.operands().get(1).asResult().op() instanceof HATVectorOp.HATVectorBinaryOp binOp) {
                 recurse(binOp);
             } else {
                 varName(hatVectorStoreView);
@@ -135,7 +135,7 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
 
     @Override
     public OpenCLHATKernelBuilder hatSelectLoadOp( HATVectorOp.HATVectorSelectLoadOp hatVSelectLoadOp) {
-        if (hatVSelectLoadOp.operands().getFirst().result().op() instanceof HATVectorOp.HATVectorLoadOp vLoadOp) {
+        if (hatVSelectLoadOp.operands().getFirst().asResult().op() instanceof HATVectorOp.HATVectorLoadOp vLoadOp) {
             recurse( vLoadOp);
         } else {
             id(hatVSelectLoadOp.varName());
@@ -146,7 +146,7 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
 
     @Override
     public OpenCLHATKernelBuilder hatSelectStoreOp( HATVectorOp.HATVectorSelectStoreOp hatVSelectStoreOp) {
-        if (hatVSelectStoreOp.operands().getFirst().result().op() instanceof HATVectorOp.HATVectorLoadOp vLoadOp) {
+        if (hatVSelectStoreOp.operands().getFirst().asResult().op() instanceof HATVectorOp.HATVectorLoadOp vLoadOp) {
             recurse( vLoadOp);
         } else {
             id(hatVSelectStoreOp.varName());

--- a/hat/core/src/main/java/hat/BufferTagger.java
+++ b/hat/core/src/main/java/hat/BufferTagger.java
@@ -165,7 +165,7 @@ public class BufferTagger {
         Op invokeOp = HATPhaseUtils.findOpInResultFromFirstOperandsOrNull(op, JavaOp.InvokeOp.class);
         while (invokeOp != null && !invokeOp.operands().isEmpty()) {
             if (invokeOp.operands().getFirst() instanceof Block.Parameter p) return p; // return the parameter that is the global buffer
-            invokeOp = HATPhaseUtils.findOpInResultFromFirstOperandsOrNull(invokeOp.operands().getFirst().result().op(), JavaOp.InvokeOp.class);
+            invokeOp = HATPhaseUtils.findOpInResultFromFirstOperandsOrNull(invokeOp.operands().getFirst().asResult().op(), JavaOp.InvokeOp.class);
         }
         return (invokeOp == null) ? null : invokeOp.result(); // return the shared/private buffer invokeop that creates the buffer
     }

--- a/hat/core/src/main/java/hat/codebuilders/C99VecAndMatHandler.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99VecAndMatHandler.java
@@ -192,7 +192,7 @@ public class C99VecAndMatHandler {
             }).recurse(invoke.opFromOperandNOrNull(1)));
         } else if (invoke.named("abs") && invoke.refIs(IfaceValue.vec.class)) {
             bldr.funcName("f" + invoke.name()).paren(_ ->
-                    bldr.sep(invoke.op().operands(), _ -> bldr.csp(), v -> bldr.recurse(v.result().op()))
+                    bldr.sep(invoke.op().operands(), _ -> bldr.csp(), v -> bldr.recurse(v.asResult().op()))
             );
         } else if (invoke.named("fract") && invoke.operandCount() == 1) {
             // return x - floor(x);
@@ -200,11 +200,11 @@ public class C99VecAndMatHandler {
                     .paren(_ -> bldr.recurse(invoke.opFromFirstOperandOrNull())));
         } else if (invoke.nameMatchesRegex("(dot|length|max|mix|min|smoothstep|step|normalize|clamp|pow|cross|distance|floor|fract|round|sin|cos|abs)")) {
             bldr.funcName(invoke.op()).paren(_ ->
-                    bldr.sep(invoke.op().operands(), _ -> bldr.csp(), v -> bldr.recurse(v.result().op()))
+                    bldr.sep(invoke.op().operands(), _ -> bldr.csp(), v -> bldr.recurse(v.asResult().op()))
             );
         } else {
             StringBuilder stringBuilder = new StringBuilder("For vec types we need to IMPLEMENT " + invoke.refType() + ":" + invoke.name() + "(");
-            invoke.op().operands().forEach(o -> stringBuilder.append(" " + o.result().type()));
+            invoke.op().operands().forEach(o -> stringBuilder.append(" " + o.asResult().type()));
             stringBuilder.append(")");
             throw new RuntimeException(stringBuilder.toString());
         }
@@ -219,7 +219,7 @@ public class C99VecAndMatHandler {
             mangledNameAndArgs(invoke, bldr);
         } else {
             StringBuilder stringBuilder = new StringBuilder("For mat types we need to IMPLEMENT " + invoke.refType() + ":" + invoke.name() + "(");
-            invoke.op().operands().forEach(o -> stringBuilder.append(" " + o.result().type()));
+            invoke.op().operands().forEach(o -> stringBuilder.append(" " + o.asResult().type()));
             stringBuilder.append(")");
             throw new RuntimeException(stringBuilder.toString());
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Value.java
@@ -89,28 +89,66 @@ public sealed abstract class Value implements CodeItem
 
     /**
      * Returns this value as an operation result.
+     * <p>
+     * This method is a narrowing conversion from {@code Value} to {@link Op.Result}.
+     * If this value is not an operation result, this method throws an exception.
      *
-     * @return the value as an operation result.
-     * @throws IllegalStateException if the value is not an instance of an operation result.
+     * @return this value, as an operation result.
+     * @throws IllegalStateException if this value is not an operation result.
+     * @see #queryResult()
+     * @see Op.Result
      */
-    public Op.Result result() {
+    public Op.Result asResult() {
         if (this instanceof Op.Result r) {
             return r;
         }
-        throw new IllegalStateException("Value is not an instance of operation result");
+        throw new IllegalStateException("Value is not an operation result");
+    }
+
+    /**
+     * Queries this value as an operation result.
+     *
+     * @return an optional containing this value as an operation result, otherwise
+     * an empty optional if this value is not an operation result
+     * @see #asResult()
+     * @see Op.Result
+     */
+    public Optional<Op.Result> queryResult() {
+        return this instanceof Op.Result r
+                ? Optional.of(r)
+                : Optional.empty();
     }
 
     /**
      * Returns this value as a block parameter.
+     * <p>
+     * This method is a narrowing conversion from {@code Value} to {@link Block.Parameter}.
+     * If this value is not a block parameter, this method throws an exception.
      *
-     * @return the value as a block parameter.
-     * @throws IllegalStateException if the value is not an instance of a block parameter.
+     * @return this value, as a block parameter.
+     * @throws IllegalStateException if this value is not a block parameter.
+     * @see #queryParameter()
+     * @see Block.Parameter
      */
-    public Block.Parameter parameter() {
+    public Block.Parameter asParameter() {
         if (this instanceof Block.Parameter p) {
             return p;
         }
-        throw new IllegalStateException("Value is not an instance of block parameter");
+        throw new IllegalStateException("Value is not a block parameter");
+    }
+
+    /**
+     * Queries this value as a block parameter.
+     *
+     * @return an optional containing this value as a block parameter, otherwise
+     * an empty optional if this value is not a block parameter
+     * @see #asParameter()
+     * @see Block.Parameter
+     */
+    public Optional<Block.Parameter> queryParameter() {
+        return this instanceof Block.Parameter p
+                ? Optional.of(p)
+                : Optional.empty();
     }
 
     /**

--- a/test/jdk/jdk/incubator/code/TestValueCast.java
+++ b/test/jdk/jdk/incubator/code/TestValueCast.java
@@ -65,8 +65,8 @@ public class TestValueCast {
         Stream<Value> stream = values(f);
         stream.forEach(v -> {
             switch (v) {
-                case Op.Result r -> Assertions.assertEquals(r, v.result());
-                case Block.Parameter p -> Assertions.assertEquals(p, v.parameter());
+                case Op.Result r -> Assertions.assertEquals(r, v.asResult());
+                case Block.Parameter p -> Assertions.assertEquals(p, v.asParameter());
             }
         });
     }
@@ -77,8 +77,32 @@ public class TestValueCast {
         Stream<Value> stream = values(f);
         stream.forEach(v -> {
             switch (v) {
-                case Op.Result r -> Assertions.assertThrows(IllegalStateException.class, () -> v.parameter());
-                case Block.Parameter p -> Assertions.assertThrows(IllegalStateException.class, () -> v.result());
+                case Op.Result r -> Assertions.assertThrows(IllegalStateException.class, v::asParameter);
+                case Block.Parameter p -> Assertions.assertThrows(IllegalStateException.class, v::asResult);
+            }
+        });
+    }
+
+    @Test
+    public void testQueryPresent() {
+        JavaOp.LambdaOp f = f();
+        Stream<Value> stream = values(f);
+        stream.forEach(v -> {
+            switch (v) {
+                case Op.Result r -> Assertions.assertEquals(r, v.queryResult().orElse(null));
+                case Block.Parameter p -> Assertions.assertEquals(p, v.queryParameter().orElse(null));
+            }
+        });
+    }
+
+    @Test
+    public void testQueryEmpty() {
+        JavaOp.LambdaOp f = f();
+        Stream<Value> stream = values(f);
+        stream.forEach(v -> {
+            switch (v) {
+                case Op.Result r -> Assertions.assertEquals(null, v.queryParameter().orElse(null));
+                case Block.Parameter p -> Assertions.assertEquals(null, v.queryResult().orElse(null));
             }
         });
     }


### PR DESCRIPTION
Rename `Value.result` to `asResult`, and `Value.parameter` to `asParameter`.

Use of just the noun is misleading. The prefix "as"  uses a more expected convention signifying conversion or viewing, which can be partial and could throw an exception.

Also added `queryResult` and `queryParameter` as companion methods. Unsure if they are needed but its useful to compare with the method pairs in `CodeContext`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1023/head:pull/1023` \
`$ git checkout pull/1023`

Update a local copy of the PR: \
`$ git checkout pull/1023` \
`$ git pull https://git.openjdk.org/babylon.git pull/1023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1023`

View PR using the GUI difftool: \
`$ git pr show -t 1023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1023.diff">https://git.openjdk.org/babylon/pull/1023.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1023#issuecomment-4374639947)
</details>
