### PR TITLE
Remove Body.copy

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -736,18 +736,6 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * Copies the contents of this body.
-     *
-     * @param cc the code context
-     * @return the builder of a body containing the copied body
-     * @see #transform(CodeContext, CodeTransformer)
-     */
-    // @@@ Remove
-    public Builder copy(CodeContext cc) {
-        return transform(cc, CodeTransformer.COPYING_TRANSFORMER);
-    }
-
-    /**
      * Transforms this body, returning an output body builder containing the transformed body.
      * <p>
      * This method creates an output body builder for this input body's {@link #bodySignature() signature}, with a
@@ -763,6 +751,8 @@ public final class Body implements CodeElement<Body, Block> {
      * parameters.
      *
      * @apiNote
+     * To copy a body use the {@link CodeTransformer#COPYING_TRANSFORMER copying transformer}.
+     * <p>
      * The body builder connected to the output body builder can be explicitly determined when this
      * input body's {@link Body#ancestorBody() nearest ancestor} body is present and observable, and the given parent
      * code context can be used to {@link CodeContext#queryBody(Body) query} the present body builder for that ancestor

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -52,7 +52,7 @@ import java.util.function.Function;
  * code items and outputs. Some mappings are established implicitly: by the default traversal of an input body,
  * for mappings between input blocks and output block builders and for mappings between input block parameters and
  * output values; and by appending attached or root operations, for mappings between appended operation results and
- * emitted output operation results. Block reference mappings are never established implicitly.
+ * output operation results. By default, block reference mappings are never established implicitly.
  * <p>
  * Transformations that drop, replace, or expand input code elements are responsible for explicitly establishing any
  * mappings required by the transformation of subsequent code elements.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/ExternalizedOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/ExternalizedOp.java
@@ -102,7 +102,7 @@ public record ExternalizedOp(String name,
                 op.successors().stream().map(cc::getReferenceOrCreate).toList(),
                 op.resultType(),
                 op.externalize(),
-                op.bodies().stream().map(b -> b.copy(cc)).toList()
+                op.bodies().stream().map(b -> b.transform(cc, CodeTransformer.COPYING_TRANSFORMER)).toList()
         );
     }
 }


### PR DESCRIPTION
`Remove Body.copy`, and expand the api note on `Body.transform` on how to copy.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1027/head:pull/1027` \
`$ git checkout pull/1027`

Update a local copy of the PR: \
`$ git checkout pull/1027` \
`$ git pull https://git.openjdk.org/babylon.git pull/1027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1027`

View PR using the GUI difftool: \
`$ git pr show -t 1027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1027.diff">https://git.openjdk.org/babylon/pull/1027.diff</a>

</details>
