### PR TITLE
Op transform docs

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -36,16 +36,16 @@ import java.util.function.Function;
  * operations using block builders.
  * <p>
  * During transformation, a block builder may serve as the current output block builder when accepting bodies, blocks,
- * and operations. A transformation emits an output operation by appending it to an output block builder.
- * A transformation emits an output block by creating a block builder for that block and appending operations to it.
- * Emission is commonly performed by implementations of {@link #acceptOp(Block.Builder, Op)}, and less commonly so by
- * implementations that override {@link #acceptBlock(Block.Builder, Block)} and
+ * and operations. A transformation emits an output operation by appending it using an output block builder.
+ * A transformation emits an output block by creating a block builder for that block and appending operations using that
+ * block builder. Emission is commonly performed by implementations of {@link #acceptOp(Block.Builder, Op)}, and less
+ * commonly so by implementations that override {@link #acceptBlock(Block.Builder, Block)} and
  * {@link #acceptBody(Block.Builder, Body, List)}.
  * <p>
  * By default, traversal transforms an input body by transforming each input block of the body, in order, and transforms
  * an input block by transforming each input operation of the block, in order. The single abstract method
  * {@link #acceptOp(Block.Builder, Op)} is the primitive transformation step. Implementations of that method may emit
- * output blocks and operations. Appending an attached or root operation to an output block builder may recursively
+ * output blocks and operations. Appending an attached or root operation using an output block builder may recursively
  * invoke the code transformer for descendant code elements.
  * <p>
  * A transformation uses the {@link CodeContext} of an output block builder to record correspondence between input
@@ -68,34 +68,66 @@ import java.util.function.Function;
 public interface CodeTransformer {
 
     /**
-     * A simplified transformer for only transforming operations.
+     * A simplified transformer for transforming one input operation into an output code model.
      */
     @FunctionalInterface
     interface OpTransformer {
         /**
-         * Transforms an operation to zero or more operations.
+         * Transforms one input operation into the output code model.
+         * <p>
+         * Implementations of this method may emit zero or more output operations into the output model by applying the
+         * given operation-building function to operations.
+         * <p>
+         * Implementations can choose to drop the input operation by not applying the function, copy it by applying the
+         * function to the input operation, replace it by applying the function to a different output operation, or
+         * expand it by applying the function to multiple output operations.
+         * <p>
+         * Each application of the operation-building function implicitly maps the input operation's result to the
+         * result returned by the function, which is the result of the emitted output operation. A later application
+         * replaces the mapping established by any prior application. If the function is not applied, no mapping is
+         * established for the input operation's result.
+         * <p>
+         * The given operands list contains, in order, the output values currently mapped from the input operation's
+         * operands. It has the same number of values as the input operation's operands, but if an input operand
+         * has no mapped output value, the corresponding output value is {@code null}.
+         * <p>
+         * The operation-building function encapsulates the current output block builder for this transformation step.
+         * Applying the function {@link Block.Builder#op(Op) appends} an operation using the current output block
+         * builder, which will perform <a href="Block.Builder.html#transform-on-append"><i>transform-on-append</i></a>
+         * when appending the input operation, or any other attached or root operation.
          *
-         * @param op       the operation to transform
-         * @param operands the operands of the operation mapped to
-         *                 values in the transformed code model. If
-         *                 there is no mapping of an operand then it is
-         *                 mapped to {@code null}.
-         * @param builder  the function to apply zero or more operations
-         *                 into the transformed code model
+         * @param builder  the operation-building function
+         * @param op       the input operation to transform
+         * @param operands the mapped output values for the input operation's operands
          */
         void acceptOp(Function<Op, Op.Result> builder, Op op, List<Value> operands);
     }
 
     /**
-     * Creates a code transformer that transforms operations using the
-     * given operation transformer.
+     * Creates a code transformer that transforms operations using the given operation transformer.
+     * <p>
+     * This method is intended for simplified transformations that only emit output operations using the current output
+     * block builder. Transformations that need to emit output blocks, explicitly establish mappings, customize body or
+     * block traversal, or return a different continuation builder should directly implement {@code CodeTransformer}.
+     * <p>
+     * The created code transformer uses the default {@link #acceptBody(Block.Builder, Body, List)} and
+     * {@link #acceptBlock(Block.Builder, Block)} traversal. Its {@link #acceptOp(Block.Builder, Op)} implementation
+     * invokes the given operation transformer with an operation-building function for the current output block builder,
+     * the input operation, and output values currently mapped from the input operation's operands.
+     * <p>
+     * Applying the operation-building function appends the operation using the current output block builder and maps
+     * the input operation's result to the result of the appended operation, as specified by
+     * {@link OpTransformer#acceptOp(Function, Op, List)}.
+     * <p>
+     * After the operation transformer returns, the created code transformer returns the current output block builder as
+     * the continuation builder for the next input operation.
      *
      * @param opTransformer the operation transformer.
      * @return the code transformer that transforms operations.
      */
     static CodeTransformer opTransformer(OpTransformer opTransformer) {
         return (builder, inputOp) -> {
-            // Allocate op builder function capturing builder and inputOp
+            // Allocate operation-building function capturing builder and inputOp
             // This is simpler and safer that using fields holding the builder and inputOp
             // and protecting use against reentry of calls to builder.op for an attached
             // operation that is transformed and contains bodies
@@ -115,7 +147,7 @@ public interface CodeTransformer {
     }
 
     /**
-     * A copying transformer that applies the operation to the block builder, and returning the block builder.
+     * A copying transformer that appends the operation using the block builder, and returns the block builder.
      */
     CodeTransformer COPYING_TRANSFORMER = (builder, op) -> {
         builder.op(op);
@@ -228,7 +260,7 @@ public interface CodeTransformer {
      * emit an output operation, by using the block builder to {@link Block.Builder#op(Op) append} the operation; and
      * <li>
      * emit an output block, by using the builder to {@link Block.Builder#block(List) create} a block builder for that
-     * output block and appending operations to the created block builder.
+     * output block and appending operations using the created block builder.
      * </ul>
      * <p>
      * Implementations can choose to drop the input operation by not emitting any output operation, copy it by

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -54,21 +54,24 @@ import java.util.function.BiFunction;
 /**
  * An operation modeling a unit of program behavior.
  * <p>
- * An operation might model the addition of two integers, or a method invocation expression.
- * Alternatively an operation may model something more complex like method declarations, lambda expressions, or
- * try statements. In such cases an operation will contain one or more bodies modeling the nested structure.
+ * An operation has direct state and zero or more bodies. An operation's direct state consists of zero or more operands,
+ * zero or more successors (references to other blocks), and operation-specific state.
  * <p>
- * The process of building an operation starts with construction of an <i>unattached</i> operation. The
- * operation-specific state and any descendant elements of the unattached operation are fixed at construction.
+ * An operation might model the addition of two integers, or a method invocation expression. Alternatively an operation
+ * may model something more complex like method declarations, lambda expressions, or try statements. In such cases an
+ * operation will contain one or more bodies modeling the nested structure.
+ * <p>
+ * The process of building an operation starts with construction of an <i>unattached</i> operation. The direct state and
+ * any bodies of the unattached operation are fixed at construction.
  * <p>
  * Building then progresses in one of two ways:
  * <ol>
  * <li>
  * the unattached operation is <i>attached</i> to a block, as its parent block, by using a block builder to
- * {@link Block.Builder#op(Op) append} it to a block. The attached operation has a permanently
- * non-{@code null} {@link #result result} that can be used as an operand of subsequent constructed operations. The
- * block being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this
- * operation and any attempt to access the block throws {@link IllegalStateException}.
+ * {@link Block.Builder#op(Op) append} it to a block. The attached operation has a permanently non-{@code null}
+ * {@link #result result} that can be used as an operand of subsequent constructed operations. The block being built is
+ * not <a href="Body.Builder.html#body-building-observability">observable</a> through this operation and any attempt to
+ * access the block throws {@link IllegalStateException}.
  * <li>
  * the unattached operation is built as a {@link #isRoot() <i>root</i>} operation. The root operation's
  * {@link #result result} and {@link #parent parent} are always {@code null}.
@@ -353,14 +356,13 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     final List<Value> operands;
 
     /**
-     * Constructs an operation from a given operation.
+     * Constructs an operation with operands mapped from, and location copied from, the given operation.
      * <p>
-     * The constructor defers to the {@link Op#Op(List) operands} constructor passing a list of values computed, in
-     * order, by mapping the given operation's operands using the code context. The constructor also assigns the new
-     * operation's location to the given operation's location, if any.
+     * The constructed operation's operands are the values computed, in order, by mapping the given operation's operands
+     * using the given code context. The new operation's location is the given operation's location, if any.
      *
-     * @param that the given operation.
-     * @param cc   the code context.
+     * @param that the given operation
+     * @param cc   the code context
      */
     protected Op(Op that, CodeContext cc) {
         List<Value> outputOperands = cc.getValues(that.operands);
@@ -372,16 +374,24 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Copies this operation and transforms its bodies, if any.
+     * Transforms this operation.
      * <p>
-     * Bodies are {@link Body#transform(CodeContext, CodeTransformer) transformed} with the given code context and
-     * code transformer.
+     * Implementations of this method return an unattached transformed copy of this operation.
+     * <p>
+     * An implementation copies this operation's direct state and transforms this operation's bodies, if any. Operands
+     * are copied by mapping this operation's operands, in order, with the given code context. Successors are copied as
+     * specified by {@link CodeContext#getReferenceOrCreate(Block.Reference)}. Operation-specific state is copied as
+     * appropriate for the operation.
+     * <p>
+     * Bodies are {@link Body#transform(CodeContext, CodeTransformer) transformed} with the given code context and code
+     * transformer.
+     *
      * @apiNote
      * To copy an operation use the {@link CodeTransformer#COPYING_TRANSFORMER copying transformer}.
      *
-     * @param cc the code context.
-     * @param ct the code transformer.
-     * @return the transformed operation.
+     * @param cc the code context
+     * @param ct the code transformer
+     * @return the transformed operation
      * @see CodeTransformer#COPYING_TRANSFORMER
      */
     public abstract Op transform(CodeContext cc, CodeTransformer ct);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -502,16 +502,16 @@
 ///}
 ///
 /// The code transformation function, passed as lambda expression to
-/// [CodeTransformer.opTransformer][jdk.incubator.code.CodeTransformer#opTransformer], accepts as parameters a block
-/// builder function, `builder`, an operation encountered when traversing the input code model, `inputOp`, and a list of
-/// values in the output model being built that are associated with input operation’s operands, `outputOperands`. We
-/// must have previously encountered and transformed the input operations whose results are associated with those
-/// values, since values can only be used after they have been declared.
+/// [CodeTransformer.opTransformer][jdk.incubator.code.CodeTransformer#opTransformer], accepts as parameters a
+/// operation-building function, `builder`, an operation encountered when traversing the input code model, `inputOp`,
+/// and a list of values in the output model being built that are associated with input operation’s operands,
+/// `outputOperands`. We must have previously encountered and transformed the input operations whose results are
+/// associated with those values, since values can only be used after they have been declared.
 ///
 /// In the code transformer we switch over the input operation, and in this case we just match on `add` operation and
-/// by default any other operation. In the latter case we apply the input operation to the builder function, which
-/// creates a new output operation that is a copy of the input operation, appends the new operation to the block being
-/// built, and associates the new operation’s result with the input operation’s result. When we match on an `add`
+/// by default any other operation. In the latter case we apply the input operation to the operation-building function,
+/// which creates a new output operation that is a copy of the input operation, appends the new operation to the block
+/// being built, and associates the new operation’s result with the input operation’s result. When we match on an `add`
 /// operation we replace it by building part of a code model, a method `invoke` operation to the `Integer.sum` method
 /// constructed with the given output operands. The result of the output `invoke` operation is automatically associated
 /// with the result of the input `add` operation.


### PR DESCRIPTION
Update documentation for `CodeTransformer.OpTransformer`, `Op.transform`, and related areas where terminology intersects.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1029/head:pull/1029` \
`$ git checkout pull/1029`

Update a local copy of the PR: \
`$ git checkout pull/1029` \
`$ git pull https://git.openjdk.org/babylon.git pull/1029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1029`

View PR using the GUI difftool: \
`$ git pr show -t 1029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1029.diff">https://git.openjdk.org/babylon/pull/1029.diff</a>

</details>
