### PR TITLE
JavaOp try-with-resources split

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -7613,8 +7613,9 @@ public sealed abstract class JavaOp extends Op {
         return new TryOp.BodyBuilder(connectedAncestorBody, resources);
     }
 
-    // resources ()Tuple<Var<R1>, Var<R2>, ..., Var<RN>>, or null
-    // try (Var<R1>, Var<R2>, ..., Var<RN>)void, or try ()void
+    // resources: ()T1, (T1)T2, ..., (T1, T2, ..., T{N-1})TN, or empty
+    // Ti is Ri for a resource expression, or Var<Ri> for a resource declaration
+    // try (T1, T2, ..., TN)void, or try ()void
     // catch (E )void, where E <: Throwable
     // finally ()void, or null
 
@@ -7622,9 +7623,9 @@ public sealed abstract class JavaOp extends Op {
      * Creates a try or try-with-resources operation.
      *
      * @param resourceBodies the resources body builders
-     * @param body            the try body builder
-     * @param catchBodies     the catch body builders
-     * @param finallyBody     the finalizer body builder, may be {@code null}
+     * @param body           the try body builder
+     * @param catchBodies    the catch body builders
+     * @param finallyBody    the finalizer body builder, may be {@code null}
      * @return the try or try-with-resources operation
      */
     public static TryOp try_(List<Body.Builder> resourceBodies,

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5147,7 +5147,9 @@ public sealed abstract class JavaOp extends Op {
      * <em>finally body</em>. Try operations may also feature zero or more <em>resources bodies</em>, modeling a
      * try-with-resources statement.
      * <p>
-     * Each resource body yields a value. The first resource body accepts no arguments. A second resource body accepts an argument whose type is the same as the yield type of the first resource body. A subsequent resource accepts, in order, arguments whose types are the same as all the prior resource body yield types.
+     * Each resource body yields a value. The first resource body accepts no arguments. A second resource body accepts
+     * an argument whose type is the same as the yield type of the first resource body. A subsequent resource accepts,
+     * in order, arguments whose types are the same as all the prior resource body yield types.
      * <p>
      * The try body yields {@linkplain JavaType#VOID no value}. If one or more resources bodies are present then
      * the try body accepts, in order, arguments whose types are the same as the resource bodies yield types.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5144,15 +5144,13 @@ public sealed abstract class JavaOp extends Op {
      * The try operation, that can model Java language try statements.
      * <p>
      * Try operations feature a <em>try body</em>, zero or more <em>catch bodies</em>, and an optional
-     * <em>finally body</em>. Try operations may also feature an optional <em>resources body</em>, modeling a
+     * <em>finally body</em>. Try operations may also feature zero or more <em>resources bodies</em>, modeling a
      * try-with-resources statement.
      * <p>
-     * The resources body, if present, accepts no arguments and yields a value of type {@code R}.
-     * For instance, a try-with-resources statement with two resources of type {@code X} and {@code Y},
-     * {@code R} is a {@linkplain TupleType tuple type}, such as {@code (X, Y)}.
+     * Each resources body, accepts all yield values from prepending resource bodies arguments and yields a value.
      * <p>
-     * The try body yields {@linkplain JavaType#VOID no value}. If a resources body is present then the try body should
-     * accept an argument of type {@code R}, otherwise it accepts no arguments.
+     * The try body yields {@linkplain JavaType#VOID no value}. If one or more resources bodies are present then
+     * the try body should accept arguments of all resource bodies yield types.
      * <p>
      * Each catch body should accept an exception value and yield {@linkplain JavaType#VOID no value}. The
      * finally body, if present, should accept no arguments and yield {@linkplain JavaType#VOID no value}.
@@ -5171,12 +5169,10 @@ public sealed abstract class JavaOp extends Op {
          */
         public static final class BodyBuilder {
             final Body.Builder connectedAncestorBody;
-            final List<? extends CodeType> resourceTypes;
-            final Body.Builder resources;
+            final List<Body.Builder> resources;
 
-            BodyBuilder(Body.Builder connectedAncestorBody, List<? extends CodeType> resourceTypes, Body.Builder resources) {
+            BodyBuilder(Body.Builder connectedAncestorBody, List<Body.Builder> resources) {
                 this.connectedAncestorBody = connectedAncestorBody;
-                this.resourceTypes = resourceTypes;
                 this.resources = resources;
             }
 
@@ -5188,7 +5184,7 @@ public sealed abstract class JavaOp extends Op {
              */
             public CatchBuilder body(Consumer<Block.Builder> c) {
                 Body.Builder body = Body.Builder.of(connectedAncestorBody,
-                        CoreType.functionType(VOID, resourceTypes));
+                        CoreType.functionType(VOID, resources.stream().map(bb -> bb.bodySignature().returnType()).toList()));
                 c.accept(body.entryBlock());
 
                 return new CatchBuilder(connectedAncestorBody, resources, body);
@@ -5200,11 +5196,11 @@ public sealed abstract class JavaOp extends Op {
          */
         public static final class CatchBuilder {
             final Body.Builder connectedAncestorBody;
-            final Body.Builder resources;
+            final List<Body.Builder> resources;
             final Body.Builder body;
             final List<Body.Builder> catchers;
 
-            CatchBuilder(Body.Builder connectedAncestorBody, Body.Builder resources, Body.Builder body) {
+            CatchBuilder(Body.Builder connectedAncestorBody, List<Body.Builder> resources, Body.Builder body) {
                 this.connectedAncestorBody = connectedAncestorBody;
                 this.resources = resources;
                 this.body = body;
@@ -5255,33 +5251,28 @@ public sealed abstract class JavaOp extends Op {
         static final MethodRef AUTO_CLOSEABLE_CLOSE_METHOD = MethodRef.method(AutoCloseable.class, "close", void.class);
         static final MethodRef THROWABLE_ADD_SUPPRESSED_METHOD = MethodRef.method(Throwable.class, "addSuppressed", void.class, Throwable.class);
 
-        final Body resourcesBody;
+        final List<Body> resourcesBodies;
         final Body body;
         final List<Body> catchBodies;
         final Body finallyBody;
 
         TryOp(ExternalizedOp def) {
             List<Body.Builder> bodies = def.bodyDefinitions();
-            Body.Builder first = bodies.getFirst();
-            Body.Builder resources;
-            Body.Builder body;
-            if (first.bodySignature().returnType().equals(VOID)) {
-                resources = null;
-                body = first;
-            } else {
-                resources = first;
-                body = bodies.get(1);
+            int bodyIndex = 0;
+            while (!bodies.get(bodyIndex).bodySignature().returnType().equals(VOID)) {
+                bodyIndex++;
             }
-
+            List<Body.Builder> resources = bodies.subList(0, bodyIndex);
+            Body.Builder body = bodies.get(bodyIndex);
             Body.Builder last = bodies.getLast();
             Body.Builder finalizer;
-            if (last.bodySignature().parameterTypes().isEmpty()) {
+            if (last != body && last.bodySignature().parameterTypes().isEmpty()) {
                 finalizer = last;
             } else {
                 finalizer = null;
             }
             List<Body.Builder> catchers = bodies.subList(
-                    resources == null ? 1 : 2,
+                    bodyIndex + 1,
                     bodies.size() - (finalizer == null ? 0 : 1));
 
             this(resources, body, catchers, finalizer);
@@ -5290,11 +5281,9 @@ public sealed abstract class JavaOp extends Op {
         TryOp(TryOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
-            if (that.resourcesBody != null) {
-                this.resourcesBody = that.resourcesBody.transform(cc, ct).build(this);
-            } else {
-                this.resourcesBody = null;
-            }
+            this.resourcesBodies = that.resourcesBodies.stream()
+                    .map(b -> b.transform(cc, ct).build(this))
+                    .toList();
             this.body = that.body.transform(cc, ct).build(this);
             this.catchBodies = that.catchBodies.stream()
                     .map(b -> b.transform(cc, ct).build(this))
@@ -5311,27 +5300,30 @@ public sealed abstract class JavaOp extends Op {
             return new TryOp(this, cc, ct);
         }
 
-        TryOp(Body.Builder resourcesC,
+        TryOp(List<Body.Builder> resourcesC,
               Body.Builder bodyC,
               List<Body.Builder> catchersC,
               Body.Builder finalizerC) {
             super(List.of());
 
-            if (resourcesC != null) {
-                this.resourcesBody = resourcesC.build(this);
-                if (resourcesBody.bodySignature().returnType().equals(VOID)) {
-                    throw new IllegalArgumentException("Resources should not return void: " + resourcesBody.bodySignature());
+            this.resourcesBodies = resourcesC.stream().map(r -> r.build(this)).toList();
+            List<CodeType> resourceTypes = new ArrayList<>();
+            for (Body _resource : resourcesBodies) {
+                if (_resource.bodySignature().returnType().equals(VOID)) {
+                    throw new IllegalArgumentException("Resource should not return void: " + _resource.bodySignature());
                 }
-                if (!resourcesBody.bodySignature().parameterTypes().isEmpty()) {
-                    throw new IllegalArgumentException("Resources should have zero parameters: " + resourcesBody.bodySignature());
+                if (!_resource.bodySignature().parameterTypes().equals(resourceTypes)) {
+                    throw new IllegalArgumentException("Resource should have parameters matching preceding resource yields: " + _resource.bodySignature());
                 }
-            } else {
-                this.resourcesBody = null;
+                resourceTypes.add(_resource.bodySignature().returnType());
             }
 
             this.body = bodyC.build(this);
             if (!body.bodySignature().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Try should return void: " + body.bodySignature());
+            }
+            if (!body.bodySignature().parameterTypes().equals(resourceTypes)) {
+                throw new IllegalArgumentException("Try should have parameters matching resource yields: " + body.bodySignature());
             }
 
             this.catchBodies = catchersC.stream().map(c -> c.build(this)).toList();
@@ -5360,9 +5352,7 @@ public sealed abstract class JavaOp extends Op {
         @Override
         public List<Body> bodies() {
             ArrayList<Body> bodies = new ArrayList<>();
-            if (resourcesBody != null) {
-                bodies.add(resourcesBody);
-            }
+            bodies.addAll(resourcesBodies);
             bodies.add(body);
             bodies.addAll(catchBodies);
             if (finallyBody != null) {
@@ -5372,10 +5362,10 @@ public sealed abstract class JavaOp extends Op {
         }
 
         /**
-         * {@return the resources body, or {@code null} if this try operation has no resources}
+         * {@return the resources bodies}
          */
-        public Body resourcesBody() {
-            return resourcesBody;
+        public List<Body> resourcesBody() {
+            return resourcesBodies;
         }
 
         /**
@@ -5408,8 +5398,8 @@ public sealed abstract class JavaOp extends Op {
             // the lower method: extended try-with-resources -> basic try-with-resources ->
             // try-catch-finally -> lower-level try form.
             // There is no recursion here, each time it is structurally different TryOp.
-            if (resourcesBody != null) {
-                b.transformBody(!(resourcesBody.bodySignature().returnType() instanceof TupleType)
+            if (!resourcesBodies.isEmpty()) {
+                b.transformBody(resourcesBodies.size() == 1
                         && catchBodies.isEmpty()
                         && finallyBody == null
                                 ? lowerBasicTryWithResources()
@@ -5679,10 +5669,7 @@ public sealed abstract class JavaOp extends Op {
             return syntheticBody(entryBlock -> {
                 Function<Block.Builder, TryOp> normalizedTry = block -> {
                     block.context().mapValues(capturedValues(), entryBlock.parameters());
-                    return !(resourcesBody.bodySignature().returnType() instanceof TupleType)
-                            ? try_(resourcesBody.transform(block.context(), CodeTransformer.COPYING_TRANSFORMER),
-                                   body.transform(block.context(), CodeTransformer.COPYING_TRANSFORMER), List.of(), null)
-                            : normalizeExtendedTryWithResources(block.parentBody(), block.context(), 0);
+                    return normalizeExtendedTryWithResources(block.parentBody(), block.context(), new ArrayList<>());
                 };
                 if (catchBodies.isEmpty() && finallyBody == null) {
                     entryBlock.op(normalizedTry.apply(entryBlock));
@@ -5732,11 +5719,11 @@ public sealed abstract class JavaOp extends Op {
         ///
         /// @jls 14.20.3.1 Basic try-with-resources
         Body lowerBasicTryWithResources() {
-            CodeType resourceType = resourcesBody.bodySignature().returnType();
-            assert !(resourceType instanceof TupleType);
+            assert resourcesBodies.size() == 1;
+            CodeType resourceType = resourcesBodies.getFirst().bodySignature().returnType();
             return syntheticBody(entryBlock -> {
                 Block.Builder afterAcquire = entryBlock.block(resourceType);
-                entryBlock.transformBody(resourcesBody, List.of(), (block, op) -> {
+                entryBlock.transformBody(resourcesBodies.getFirst(), List.of(), (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         block.op(branch(afterAcquire.reference(block.context().getValue(yop.yieldValue()))));
                     } else {
@@ -5787,30 +5774,21 @@ public sealed abstract class JavaOp extends Op {
         ///
         /// Resource `index` becomes the current outer basic try-with-resources.
         ///
-        /// Asumes the resources (uni)body can be split into slices per resource.
-        ///
         /// @jls 14.20.3.2 Extended try-with-resources
-        TryOp normalizeExtendedTryWithResources(Body.Builder ancestorBody, CodeContext cc, int index) {
-            List<Op> resourceOps = resourcesBody.entryBlock().ops();
-            CodeType resourceType = ((TupleType)resourcesBody.bodySignature().returnType()).componentTypes().get(index);
-            List<Value> resourceValues = ((CoreOp.TupleOp)((CoreOp.YieldOp)(resourceOps.getLast())).yieldValue().asResult().op()).operands();
-            int fromIndex = index == 0 ? 0 : resourceOps.indexOf(resourceValues.get(index - 1).asResult().op()) + 1;
-            int toIndex = resourceOps.indexOf(resourceValues.get(index).asResult().op()) + 1;
-            Body.Builder resourceBody = Body.Builder.of(ancestorBody, CoreType.functionType(resourceType), cc);
-            Block.Builder bb = resourceBody.entryBlock();
-            // @@@ assumption: resource initialization operations can be split into subsequent lists
-            resourceOps.subList(fromIndex, toIndex).forEach(bb::op);
-            bb.op(core_yield(cc.getValue(resourceValues.get(index))));
-            Body.Builder basicBody = Body.Builder.of(ancestorBody, CoreType.functionType(VOID, List.of(resourceType)), cc);
+        TryOp normalizeExtendedTryWithResources(Body.Builder ancestorBody, CodeContext cc, List<Value> resourceValues) {
+            Body resource = resourcesBodies.get(resourceValues.size());
+            Body.Builder resourceBody = Body.Builder.of(ancestorBody, CoreType.functionType(resource.yieldType()), cc);
+            resourceBody.entryBlock().transformBody(resource, resourceValues, cc, CodeTransformer.COPYING_TRANSFORMER);
+            Body.Builder basicBody = Body.Builder.of(ancestorBody, CoreType.functionType(VOID, List.of(resource.yieldType())), cc);
             Block.Builder bodyB = basicBody.entryBlock();
-            cc.mapValue(resourceValues.get(index), bodyB.parameters().getFirst());
-            if (index + 1 < resourceValues.size()) {
-                bodyB.op(normalizeExtendedTryWithResources(basicBody, cc, index + 1));
+            resourceValues.add(bodyB.parameters().getFirst());
+            if (resourceValues.size() < resourcesBodies.size()) {
+                bodyB.op(normalizeExtendedTryWithResources(basicBody, cc, resourceValues));
                 bodyB.op(core_yield());
             } else {
-                bodyB.transformBody(body, cc.getValues(resourceValues), CodeTransformer.COPYING_TRANSFORMER);
+                bodyB.transformBody(body, resourceValues, cc, CodeTransformer.COPYING_TRANSFORMER);
             }
-            return try_(resourceBody, basicBody, List.of(), null);
+            return try_(List.of(resourceBody), basicBody, List.of(), null);
         }
 
         Body syntheticBody(Consumer<Block.Builder> c) {
@@ -7603,7 +7581,7 @@ public sealed abstract class JavaOp extends Op {
     public static TryOp.CatchBuilder try_(Body.Builder connectedAncestorBody, Consumer<Block.Builder> c) {
         Body.Builder _try = Body.Builder.of(connectedAncestorBody, CoreType.FUNCTION_TYPE_VOID);
         c.accept(_try.entryBlock());
-        return new TryOp.CatchBuilder(connectedAncestorBody, null, _try);
+        return new TryOp.CatchBuilder(connectedAncestorBody, List.of(), _try);
     }
 
     /**
@@ -7612,17 +7590,24 @@ public sealed abstract class JavaOp extends Op {
      * @param connectedAncestorBody the nearest ancestor body builder to which body builders for this operation are
      *                              connected, or {@code null} if they are isolated
      * @param resourceTypes         the resource types used in the try-with-resources construct
-     * @param c                     a consumer that populates the resources body
+     * @param c                     a consumers that populate the resources bodies
      * @return the try-with-resources operation builder
      */
     public static TryOp.BodyBuilder tryWithResources(Body.Builder connectedAncestorBody,
                                                      List<? extends CodeType> resourceTypes,
-                                                     Consumer<Block.Builder> c) {
+                                                     List<Consumer<Block.Builder>> c) {
+        assert resourceTypes.size() == c.size();
         resourceTypes = resourceTypes.stream().map(CoreType::varType).toList();
-        Body.Builder resources = Body.Builder.of(connectedAncestorBody,
-                CoreType.functionType(CoreType.tupleType(resourceTypes)));
-        c.accept(resources.entryBlock());
-        return new TryOp.BodyBuilder(connectedAncestorBody, resourceTypes, resources);
+        List<Body.Builder> resources = new ArrayList<>();
+        List<CodeType> prefixTypes = new ArrayList<>();
+        for (int i = 0; i < resourceTypes.size(); i++) {
+            Body.Builder resource = Body.Builder.of(connectedAncestorBody,
+                    CoreType.functionType(resourceTypes.get(i), List.copyOf(prefixTypes)));
+            c.get(i).accept(resource.entryBlock());
+            resources.add(resource);
+            prefixTypes.add(resourceTypes.get(i));
+        }
+        return new TryOp.BodyBuilder(connectedAncestorBody, resources);
     }
 
     // resources ()Tuple<Var<R1>, Var<R2>, ..., Var<RN>>, or null
@@ -7633,17 +7618,17 @@ public sealed abstract class JavaOp extends Op {
     /**
      * Creates a try or try-with-resources operation.
      *
-     * @param resourcesBody the resources body builder, may be {@code null}
-     * @param body          the try body builder
-     * @param catchBodies   the catch body builders
-     * @param finallyBody   the finalizer body builder, may be {@code null}
+     * @param resourcesBodies the resources body builders
+     * @param body            the try body builder
+     * @param catchBodies     the catch body builders
+     * @param finallyBody     the finalizer body builder, may be {@code null}
      * @return the try or try-with-resources operation
      */
-    public static TryOp try_(Body.Builder resourcesBody,
+    public static TryOp try_(List<Body.Builder> resourcesBodies,
                              Body.Builder body,
                              List<Body.Builder> catchBodies,
                              Body.Builder finallyBody) {
-        return new TryOp(resourcesBody, body, catchBodies, finallyBody);
+        return new TryOp(resourcesBodies, body, catchBodies, finallyBody);
     }
 
     //

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5151,7 +5151,6 @@ public sealed abstract class JavaOp extends Op {
      * <p>
      * The try body yields {@linkplain JavaType#VOID no value}. If one or more resources bodies are present then
      * the try body accepts, in order, arguments whose types are the same as the resource bodies yield types.
-     *,     
      * <p>
      * Each catch body should accept an exception value and yield {@linkplain JavaType#VOID no value}. The
      * finally body, if present, should accept no arguments and yield {@linkplain JavaType#VOID no value}.
@@ -7632,7 +7631,7 @@ public sealed abstract class JavaOp extends Op {
                              Body.Builder body,
                              List<Body.Builder> catchBodies,
                              Body.Builder finallyBody) {
-        return new TryOp(resourcesBodies, body, catchBodies, finallyBody);
+        return new TryOp(resourceBodies, body, catchBodies, finallyBody);
     }
 
     //

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5165,15 +5165,31 @@ public sealed abstract class JavaOp extends Op {
             implements Op.Nested, Op.Lowerable, JavaStatement {
 
         /**
-         * Builder for the try body of a try operation.
+         * Builder for the resource bodies and the try body of a try operation.
          */
         public static final class BodyBuilder {
             final Body.Builder connectedAncestorBody;
             final List<Body.Builder> resources;
 
-            BodyBuilder(Body.Builder connectedAncestorBody, List<Body.Builder> resources) {
+            BodyBuilder(Body.Builder connectedAncestorBody) {
                 this.connectedAncestorBody = connectedAncestorBody;
-                this.resources = resources;
+                this.resources = new ArrayList<>();
+            }
+
+            /**
+             * Adds a resource body to a try-with-resources operation.
+             *
+             * @param yieldType the resource type for a resource expression, or the Var type for a resource declaration
+             * @param c a consumer that populates the resource body
+             * @return this builder
+             */
+            public BodyBuilder resource(CodeType yieldType, Consumer<Block.Builder> c) {
+                List<CodeType> paramTypes = resources.stream().map(r -> r.bodySignature().returnType()).toList();
+                Body.Builder resource = Body.Builder.of(connectedAncestorBody,
+                        CoreType.functionType(yieldType, paramTypes));
+                c.accept(resource.entryBlock());
+                resources.add(resource);
+                return this;
             }
 
             /**
@@ -7592,25 +7608,10 @@ public sealed abstract class JavaOp extends Op {
      *
      * @param connectedAncestorBody the nearest ancestor body builder to which body builders for this operation are
      *                              connected, or {@code null} if they are isolated
-     * @param resourceTypes         the resource types used in the try-with-resources construct
-     * @param c                     a consumers that populate the resources bodies
      * @return the try-with-resources operation builder
      */
-    public static TryOp.BodyBuilder tryWithResources(Body.Builder connectedAncestorBody,
-                                                     List<? extends CodeType> resourceTypes,
-                                                     List<Consumer<Block.Builder>> c) {
-        assert resourceTypes.size() == c.size();
-        resourceTypes = resourceTypes.stream().map(CoreType::varType).toList();
-        List<Body.Builder> resources = new ArrayList<>();
-        List<CodeType> prefixTypes = new ArrayList<>();
-        for (int i = 0; i < resourceTypes.size(); i++) {
-            Body.Builder resource = Body.Builder.of(connectedAncestorBody,
-                    CoreType.functionType(resourceTypes.get(i), List.copyOf(prefixTypes)));
-            c.get(i).accept(resource.entryBlock());
-            resources.add(resource);
-            prefixTypes.add(resourceTypes.get(i));
-        }
-        return new TryOp.BodyBuilder(connectedAncestorBody, resources);
+    public static TryOp.BodyBuilder tryWithResources(Body.Builder connectedAncestorBody) {
+        return new TryOp.BodyBuilder(connectedAncestorBody);
     }
 
     // resources: ()T1, (T1)T2, ..., (T1, T2, ..., T{N-1})TN, or empty

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5147,10 +5147,11 @@ public sealed abstract class JavaOp extends Op {
      * <em>finally body</em>. Try operations may also feature zero or more <em>resources bodies</em>, modeling a
      * try-with-resources statement.
      * <p>
-     * Each resources body, accepts all yield values from prepending resource bodies arguments and yields a value.
+     * Each resource body yields a value. The first resource body accepts no arguments. A second resource body accepts an argument whose type is the same as the yield type of the first resource body. A subsequent resource accepts, in order, arguments whose types are the same as all the prior resource body yield types.
      * <p>
      * The try body yields {@linkplain JavaType#VOID no value}. If one or more resources bodies are present then
-     * the try body should accept arguments of all resource bodies yield types.
+     * the try body accepts, in order, arguments whose types are the same as the resource bodies yield types.
+     *,     
      * <p>
      * Each catch body should accept an exception value and yield {@linkplain JavaType#VOID no value}. The
      * finally body, if present, should accept no arguments and yield {@linkplain JavaType#VOID no value}.
@@ -5364,7 +5365,7 @@ public sealed abstract class JavaOp extends Op {
         /**
          * {@return the resources bodies}
          */
-        public List<Body> resourcesBody() {
+        public List<Body> resourceBodies() {
             return resourcesBodies;
         }
 
@@ -7618,13 +7619,13 @@ public sealed abstract class JavaOp extends Op {
     /**
      * Creates a try or try-with-resources operation.
      *
-     * @param resourcesBodies the resources body builders
+     * @param resourceBodies the resources body builders
      * @param body            the try body builder
      * @param catchBodies     the catch body builders
      * @param finallyBody     the finalizer body builder, may be {@code null}
      * @return the try or try-with-resources operation
      */
-    public static TryOp try_(List<Body.Builder> resourcesBodies,
+    public static TryOp try_(List<Body.Builder> resourceBodies,
                              Body.Builder body,
                              List<Body.Builder> catchBodies,
                              Body.Builder finallyBody) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5314,7 +5314,9 @@ public sealed abstract class JavaOp extends Op {
                     throw new IllegalArgumentException("Resource should not return void: " + _resource.bodySignature());
                 }
                 if (!_resource.bodySignature().parameterTypes().equals(resourceTypes)) {
-                    throw new IllegalArgumentException("Resource should have parameters matching preceding resource yields: " + _resource.bodySignature());
+                    throw new IllegalArgumentException(
+                            "Resource should have parameters matching preceding resource yields: "
+                                    + _resource.bodySignature());
                 }
                 resourceTypes.add(_resource.bodySignature().returnType());
             }
@@ -5324,7 +5326,8 @@ public sealed abstract class JavaOp extends Op {
                 throw new IllegalArgumentException("Try should return void: " + body.bodySignature());
             }
             if (!body.bodySignature().parameterTypes().equals(resourceTypes)) {
-                throw new IllegalArgumentException("Try should have parameters matching resource yields: " + body.bodySignature());
+                throw new IllegalArgumentException("Try should have parameters matching resource yields: "
+                        + body.bodySignature());
             }
 
             this.catchBodies = catchersC.stream().map(c -> c.build(this)).toList();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2215,52 +2215,46 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitTry(JCTree.JCTry tree) {
-            List<JCVariableDecl> rVariableDecls = new ArrayList<>();
+            List<Symbol> rVariableDecls = new ArrayList<>();
             List<CodeType> rTypes = new ArrayList<>();
-            Body.Builder resources;
+            List<Body.Builder> resources = new ArrayList<>();
             if (!tree.resources.isEmpty()) {
-                // Resources body returns a tuple that contains the resource variables/values
-                // in order of declaration
+                // Resources bodies return the resource variables/values in order of declaration
                 for (JCTree resource : tree.resources) {
+                    CodeType rType;
                     if (resource instanceof JCVariableDecl vdecl) {
-                        rVariableDecls.add(vdecl);
-                        rTypes.add(CoreType.varType(typeToCodeType(vdecl.type)));
+                        rType = CoreType.varType(typeToCodeType(vdecl.type));
                     } else {
-                        rTypes.add(typeToCodeType(resource.type));
+                        rType = typeToCodeType(resource.type);
                     }
-                }
 
-                // Push resources body
-                pushBody(null, CoreType.functionType(CoreType.tupleType(rTypes)));
+                    // Push resources body
+                    pushBody(null, CoreType.functionType(rType, rTypes));
+                    for (int i = 0; i < rVariableDecls.size(); i++) {
+                        stack.localToOp.put(rVariableDecls.get(i), stack.block.parameters().get(i));
+                    }
 
-                List<Value> rValues = new ArrayList<>();
-                for (JCTree resource : tree.resources) {
                     if (resource instanceof JCTree.JCExpression e) {
-                        rValues.add(toValue(e));
+                        append(CoreOp.core_yield(toValue(e)));
                     } else if (resource instanceof JCTree.JCStatement s) {
-                        rValues.add(toValue(s));
+                        append(CoreOp.core_yield(toValue(s)));
                     }
+
+                    resources.add(stack.body);
+
+                    // Pop resources body
+                    popBody();
+
+                    rVariableDecls.add(resource instanceof JCVariableDecl vdecl ? vdecl.sym : null);
+                    rTypes.add(rType);
                 }
-
-                append(CoreOp.core_yield(append(CoreOp.tuple(rValues))));
-                resources = stack.body;
-
-                // Pop resources body
-                popBody();
-            } else {
-                resources = null;
             }
 
             // Push body
             // Try body accepts the resource variables (in order of declaration).
-            List<VarType> rVarTypes = rTypes.stream().<VarType>mapMulti((t, c) -> {
-                if (t instanceof VarType vt) {
-                    c.accept(vt);
-                }
-            }).toList();
-            pushBody(tree.body, CoreType.functionType(JavaType.VOID, rVarTypes));
+            pushBody(tree.body, CoreType.functionType(JavaType.VOID, rTypes));
             for (int i = 0; i < rVariableDecls.size(); i++) {
-                stack.localToOp.put(rVariableDecls.get(i).sym, stack.block.parameters().get(i));
+                stack.localToOp.put(rVariableDecls.get(i), stack.block.parameters().get(i));
             }
             scan(tree.body);
             appendTerminating(CoreOp::core_yield);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2231,7 +2231,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     // Push resources body
                     pushBody(null, CoreType.functionType(rType, rTypes));
                     for (int i = 0; i < rVariableDecls.size(); i++) {
-                        stack.localToOp.put(rVariableDecls.get(i), stack.block.parameters().get(i));
+                        Symbol rVariableDecl = rVariableDecls.get(i);
+                        if (rVariableDecl != null) {
+                            stack.localToOp.put(rVariableDecl, stack.block.parameters().get(i));
+                        }
                     }
 
                     if (resource instanceof JCTree.JCExpression e) {
@@ -2245,6 +2248,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     // Pop resources body
                     popBody();
 
+                    // Null entries preserve positions for resource expressions, which have no variable declaration.
                     rVariableDecls.add(resource instanceof JCVariableDecl vdecl ? vdecl.sym : null);
                     rTypes.add(rType);
                 }

--- a/test/langtools/tools/javac/reflect/TryTest.java
+++ b/test/langtools/tools/javac/reflect/TryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,35 +165,40 @@ public class TryTest {
     @IR("""
             func @"test4" (%0 : java.type:"TryTest")java.type:"void" -> {
                 java.try
-                    ()Tuple<Var<java.type:"TryTest$A">, java.type:"TryTest$B", Var<java.type:"TryTest$C">> -> {
+                    ()Var<java.type:"TryTest$A"> -> {
                         %1 : java.type:"TryTest$A" = invoke %0 @java.ref:"TryTest::a():TryTest$A";
                         %2 : Var<java.type:"TryTest$A"> = var %1 @"a";
-                        %3 : java.type:"TryTest$A" = var.load %2;
-                        %4 : java.type:"TryTest$B" = field.load %3 @java.ref:"TryTest$A::b:TryTest$B";
-                        %5 : java.type:"TryTest$A" = var.load %2;
-                        %6 : java.type:"TryTest$B" = field.load %5 @java.ref:"TryTest$A::b:TryTest$B";
-                        %7 : java.type:"TryTest$C" = field.load %6 @java.ref:"TryTest$B::c:TryTest$C";
-                        %8 : Var<java.type:"TryTest$C"> = var %7 @"c";
-                        %9 : Tuple<Var<java.type:"TryTest$A">, java.type:"TryTest$B", Var<java.type:"TryTest$C">> = tuple %2 %4 %8;
-                        yield %9;
+                        yield %2;
                     }
-                    (%10 : Var<java.type:"TryTest$A">, %11 : Var<java.type:"TryTest$C">)java.type:"void" -> {
-                        %12 : java.type:"TryTest$A" = var.load %10;
-                        %13 : Var<java.type:"TryTest$A"> = var %12 @"_a";
-                        %14 : java.type:"TryTest$C" = var.load %11;
-                        %15 : Var<java.type:"TryTest$C"> = var %14 @"_c";
+                    (%3 : Var<java.type:"TryTest$A">)java.type:"TryTest$B" -> {
+                        %4 : java.type:"TryTest$A" = var.load %3;
+                        %5 : java.type:"TryTest$B" = field.load %4 @java.ref:"TryTest$A::b:TryTest$B";
+                        yield %5;
+                    }
+                    (%6 : Var<java.type:"TryTest$A">, %7 : java.type:"TryTest$B")Var<java.type:"TryTest$C"> -> {
+                        %8 : java.type:"TryTest$A" = var.load %6;
+                        %9 : java.type:"TryTest$B" = field.load %8 @java.ref:"TryTest$A::b:TryTest$B";
+                        %10 : java.type:"TryTest$C" = field.load %9 @java.ref:"TryTest$B::c:TryTest$C";
+                        %11 : Var<java.type:"TryTest$C"> = var %10 @"c";
+                        yield %11;
+                    }
+                    (%12 : Var<java.type:"TryTest$A">, %13 : java.type:"TryTest$B", %14 : Var<java.type:"TryTest$C">)java.type:"void" -> {
+                        %15 : java.type:"TryTest$A" = var.load %12;
+                        %16 : Var<java.type:"TryTest$A"> = var %15 @"_a";
+                        %17 : java.type:"TryTest$C" = var.load %14;
+                        %18 : Var<java.type:"TryTest$C"> = var %17 @"_c";
                         yield;
                     }
-                    (%16 : java.type:"java.lang.Throwable")java.type:"void" -> {
-                        %17 : Var<java.type:"java.lang.Throwable"> = var %16 @"t";
-                        %18 : java.type:"java.lang.Throwable" = var.load %17;
-                        invoke %18 @java.ref:"java.lang.Throwable::printStackTrace():void";
+                    (%19 : java.type:"java.lang.Throwable")java.type:"void" -> {
+                        %20 : Var<java.type:"java.lang.Throwable"> = var %19 @"t";
+                        %21 : java.type:"java.lang.Throwable" = var.load %20;
+                        invoke %21 @java.ref:"java.lang.Throwable::printStackTrace():void";
                         yield;
                     }
                     ()java.type:"void" -> {
-                        %19 : java.type:"java.io.PrintStream" = field.load @java.ref:"java.lang.System::out:java.io.PrintStream";
-                        %20 : java.type:"java.lang.String" = constant @"F";
-                        invoke %19 %20 @java.ref:"java.io.PrintStream::println(java.lang.String):void";
+                        %22 : java.type:"java.io.PrintStream" = field.load @java.ref:"java.lang.System::out:java.io.PrintStream";
+                        %23 : java.type:"java.lang.String" = constant @"F";
+                        invoke %22 %23 @java.ref:"java.io.PrintStream::println(java.lang.String):void";
                         yield;
                     };
                 return;


### PR DESCRIPTION
Split TryOp try-with-resources modeling from a single tuple-valued resources body into one body per resource.

This PR reshapes the try-with-resources model from a single resource body that yields a tuple of all resources into an ordered sequence of one body per resource. Each body yields exactly one resource and takes previously yielded resources as parameters so that evaluation order and resource dependencies are explicit.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [fd3efbd2](https://git.openjdk.org/babylon/pull/1032/files/fd3efbd21bf6fbf9208318afbf73e839906fc9c7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1032/head:pull/1032` \
`$ git checkout pull/1032`

Update a local copy of the PR: \
`$ git checkout pull/1032` \
`$ git pull https://git.openjdk.org/babylon.git pull/1032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1032`

View PR using the GUI difftool: \
`$ git pr show -t 1032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1032.diff">https://git.openjdk.org/babylon/pull/1032.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1032#issuecomment-4437701621)
</details>
