### PR TITLE
Improve Op specification

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -749,7 +749,7 @@ public final class Block implements CodeElement<Block, Op> {
             check();
 
             // Perform transform-on-append for a placed operation
-            Op outputOp = op.isAttached() || op.isRoot()
+            Op outputOp = op.isPlacedInBlock() || op.isRoot()
                     ? op.transform(cc, ct)
                     : op;
             assert outputOp.result == null;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -477,12 +477,12 @@ public final class Block implements CodeElement<Block, Op> {
      * until the parent body builder <a href="Body.Builder.html#body-building-finishing">finishes</a>.
      * <p>
      * A block builder has a code {@link #context() context} and code {@link #transformer() transformer}. These are used
-     * when {@link #op appending} an attached or root operation, to <i>transform-on-append</i>. Any sibling block
-     * builder {@link #block(List) created} from a block builder will have the same code context and code transformer.
+     * to perform <i>transform-on-append</i> when {@link #op appending} a placed operation. Any sibling block builder
+     * {@link #block(List) created} from a block builder will have the same code context and code transformer.
      * <p>
      * A block builder may be obtained with a different code context and code transformer by calling
      * {@link #withContextAndTransformer(CodeContext, CodeTransformer)}. Such a block builder builds the same block, and
-     * can be used to apply alternative transformations to attached or root operations that are appended.
+     * can be used to apply alternative transformations to placed operations that are appended.
      * <p>
      * During {@link CodeTransformer code transformation}, a block builder may also serve as the current output block
      * builder.
@@ -707,13 +707,12 @@ public final class Block implements CodeElement<Block, Op> {
         /**
          * Appends an operation to this block.
          * <p>
-         * If the operation is unattached, it is appended directly to this block.
+         * If the operation is unplaced, it is appended directly to this block.
          * <p>
-         * If the operation is attached to a block or is a root operation, this method performs
-         * <a id="transform-on-append"><i>transform-on-append</i></a>: the operation is first
-         * {@link Op#transform(CodeContext, CodeTransformer) transformed} using this block builder's code context and
-         * code transformer; and then the resulting unattached operation is appended to this block.
-         * If the operation being appended has a result, it is implicitly
+         * If the operation is placed, this method performs <a id="transform-on-append"><i>transform-on-append</i></a>:
+         * the operation is first {@link Op#transform(CodeContext, CodeTransformer) transformed} using this block
+         * builder's code context and code transformer; and then the resulting unplaced operation is appended to this
+         * block. If the operation being appended has a result, it is implicitly
          * {@link CodeContext#mapValue(Value, Value) mapped}, if no such mapping already exists, to the result of the
          * appended operation in this block builder's code context.
          * <p>
@@ -749,7 +748,7 @@ public final class Block implements CodeElement<Block, Op> {
         public Op.Result op(Op op) {
             check();
 
-            // Perform transform-on-append for an attached or root operation
+            // Perform transform-on-append for a placed operation
             Op outputOp = op.isAttached() || op.isRoot()
                     ? op.transform(cc, ct)
                     : op;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -276,6 +276,7 @@ public final class CodeContext {
      * @param input the input block
      * @return an optional containing the output block builder mapped to the given input block, otherwise an empty
      * optional
+     * @see #getBlock(Block) 
      */
     public Optional<Block.Builder> queryBlock(Block input) {
         Objects.requireNonNull(input);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeContext.java
@@ -276,7 +276,7 @@ public final class CodeContext {
      * @param input the input block
      * @return an optional containing the output block builder mapped to the given input block, otherwise an empty
      * optional
-     * @see #getBlock(Block) 
+     * @see #getBlock(Block)
      */
     public Optional<Block.Builder> queryBlock(Block input) {
         Objects.requireNonNull(input);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -45,14 +45,14 @@ import java.util.function.Function;
  * By default, traversal transforms an input body by transforming each input block of the body, in order, and transforms
  * an input block by transforming each input operation of the block, in order. The single abstract method
  * {@link #acceptOp(Block.Builder, Op)} is the primitive transformation step. Implementations of that method may emit
- * output blocks and operations. Appending an attached or root operation using an output block builder may recursively
- * invoke the code transformer for descendant code elements.
+ * output blocks and operations. Appending a placed operation using an output block builder may recursively invoke the
+ * code transformer for descendant code elements.
  * <p>
  * A transformation uses the {@link CodeContext} of an output block builder to record correspondence between input
  * code items and outputs. Some mappings are established implicitly: by the default traversal of an input body,
  * for mappings between input blocks and output block builders and for mappings between input block parameters and
- * output values; and by appending attached or root operations, for mappings between appended operation results and
- * output operation results. By default, block reference mappings are never established implicitly.
+ * output values; and by appending placed operations, for mappings between appended operation results and output
+ * operation results. By default, block reference mappings are never established implicitly.
  * <p>
  * Transformations that drop, replace, or expand input code elements are responsible for explicitly establishing any
  * mappings required by the transformation of subsequent code elements.
@@ -94,7 +94,7 @@ public interface CodeTransformer {
          * The operation-building function encapsulates the current output block builder for this transformation step.
          * Applying the function {@link Block.Builder#op(Op) appends} an operation using the current output block
          * builder, which will perform <a href="Block.Builder.html#transform-on-append"><i>transform-on-append</i></a>
-         * when appending the input operation, or any other attached or root operation.
+         * when appending the input operation, or any other placed operation.
          *
          * @param builder  the operation-building function
          * @param op       the input operation to transform
@@ -129,7 +129,7 @@ public interface CodeTransformer {
         return (builder, inputOp) -> {
             // Allocate operation-building function capturing builder and inputOp
             // This is simpler and safer that using fields holding the builder and inputOp
-            // and protecting use against reentry of calls to builder.op for an attached
+            // and protecting use against reentry of calls to builder.op for a placed
             // operation that is transformed and contains bodies
             // @@@ If performance is an issue consider changing
             Function<Op, Op.Result> opBuilder = outputOp -> {
@@ -268,7 +268,7 @@ public interface CodeTransformer {
      * output operations and creating additional block builders.
      * <p>
      * A block builder will perform <a href="Block.Builder.html#transform-on-append"><i>transform-on-append</i></a> when
-     * appending the input operation, or any other attached or root operation. More specifically:
+     * appending the input operation, or any other placed operation. More specifically:
      * <ul>
      * <li>
      * if the block builder's code transformer is the same as this code transformer, as is the case for the current

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -74,12 +74,12 @@ import java.util.function.BiFunction;
  * <li>
  * the operation is <i>placed</i> in a block, which becomes its parent block, by using a block builder to
  * {@link Block.Builder#op(Op) append} the operation to the block. The placed operation has a permanently
- * non-{@code null} {@link #result result} that can be used as an operand of subsequently constructed operations. The
+ * non-{@code null} {@link #result() result} that can be used as an operand of subsequently constructed operations. The
  * block being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this
  * operation and any attempt to access the block throws {@link IllegalStateException}.
  * <li>
  * the operation is <i>placed</i> as the {@link #isRoot() <i>root operation</i>} of a code model by using
- * {@link #buildAsRoot()}. The root operation's {@link #result result} and {@link #parent parent} are always
+ * {@link #buildAsRoot()}. The root operation's {@link #result() result} and {@link #parent() parent} are always
  * {@code null}.
  * </ol>
  * <p>
@@ -608,7 +608,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     /**
      * {@return {@code true} if this operation is a root operation.}
      * @see #buildAsRoot()
-     * @see #isAttached()
+     * @see #isPlacedInBlock()
      * */
     public final boolean isRoot() {
         return result == Result.ROOT_RESULT;
@@ -619,7 +619,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @see #buildAsRoot()
      * @see #isRoot()
      * */
-    public final boolean isAttached() {
+    public final boolean isPlacedInBlock() {
         return !isRoot() && result != null;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -60,7 +60,7 @@ import java.util.function.BiFunction;
  *
  * <h2>Operation construction</h2>
  * <p>
- * Constructing an operation creates an <i>unattached</i> operation. An unattached operation is not yet part of a code
+ * Constructing an operation creates an <i>unplaced</i> operation. An unplaced operation is not yet part of a code
  * model. The operation's operands, successors, bodies, and operation-specific state are fixed when construction
  * completes.
  * <p>
@@ -69,26 +69,28 @@ import java.util.function.BiFunction;
  *
  * <h2>Operation building</h2>
  * <p>
- * Building an operation places an unattached operation in a code model in one of two ways:
+ * Building an operation places an unplaced operation in a code model in one of two ways:
  * <ol>
  * <li>
- * the unattached operation is <i>attached</i> to a block, as its parent block, by using a block builder to
- * {@link Block.Builder#op(Op) append} it to a block. The attached operation has a permanently non-{@code null}
- * {@link #result result} that can be used as an operand of subsequent constructed operations. The block being built is
- * not <a href="Body.Builder.html#body-building-observability">observable</a> through this operation and any attempt to
- * access the block throws {@link IllegalStateException}.
+ * the operation is <i>placed</i> in a block, which becomes its parent block, by using a block builder to
+ * {@link Block.Builder#op(Op) append} the operation to the block. The placed operation has a permanently
+ * non-{@code null} {@link #result result} that can be used as an operand of subsequently constructed operations. The
+ * block being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this
+ * operation and any attempt to access the block throws {@link IllegalStateException}.
  * <li>
- * the unattached operation is built as a {@link #isRoot() <i>root</i>} operation. The root operation's
- * {@link #result result} and {@link #parent parent} are always {@code null}.
+ * the operation is <i>placed</i> as the {@link #isRoot() <i>root operation</i>} of a code model by using
+ * {@link #buildAsRoot()}. The root operation's {@link #result result} and {@link #parent parent} are always
+ * {@code null}.
  * </ol>
  * <p>
- * Building finishes when the parent body builder of the block to which the operation is attached
- * <a href="Body.Builder.html#body-building-finishing">finishes</a>, or when the operation is built as a root operation.
+ * Building finishes when the parent body builder of the block in which the operation was placed
+ * <a href="Body.Builder.html#body-building-finishing">finishes</a>, after which the block becomes observable, or when
+ * the operation is placed as the root of a code model.
  * <p>
- * The {@link #location} may be {@link #setLocation set} while the operation is unattached or attached to a block being
- * built.
+ * The {@link #location} may be {@link #setLocation set} while the operation is unplaced or placed in a block whose
+ * parent body builder has not finished.
  * <p>
- * An unattached operation, or an operation attached to a block whose parent body builder has not
+ * An unplaced operation, or an operation placed in a block whose parent body builder has not
  * <a href="Body.Builder.html#body-building-finishing">finished</a>, is not thread-safe.
  *
  * <h2>Operation implementation requirements</h2>
@@ -98,7 +100,7 @@ import java.util.function.BiFunction;
  * <li>
  * implement {@link #resultType()} to return the result type of operation instances;
  * <li>
- * implement {@link #transform(CodeContext, CodeTransformer)} to return a newly constructed, unattached copy whose
+ * implement {@link #transform(CodeContext, CodeTransformer)} to return a newly constructed, unplaced copy whose
  * concrete class is the same as the operation's concrete class;
  * <li>
  * call an appropriate {@code Op} superclass constructor from each concrete operation constructor. Constructors
@@ -329,8 +331,8 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     public static final class Result extends Value {
 
         /**
-         * If assigned to an operation result, it indicates the operation is a root operation
-        */
+         * If assigned to an operation's result field, indicates the operation is a root operation.
+         */
         private static final Result ROOT_RESULT = new Result();
 
         final Op op;
@@ -395,7 +397,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
     }
 
-    // Set when op is attached to a block or root, otherwise null when unattached
+    // Set when op is placed in a block or as a root operation, otherwise null when unplaced
     // @@@ stable value?
     Result result;
 
@@ -426,7 +428,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     /**
      * Transforms this operation, copying the operation and transforming any of its bodies.
      * <p>
-     * This method returns a newly constructed, unattached copy of this operation. The returned operation's concrete
+     * This method returns a newly constructed, unplaced copy of this operation. The returned operation's concrete
      * class is the same as this operation's concrete class.
      * <p>
      * The returned operation copies this operation's operands, successors, and any operation-specific state. Operands
@@ -485,13 +487,13 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Returns this operation's parent block, otherwise {@code null} if this operation is unattached or a
+     * Returns this operation's parent block, otherwise {@code null} if this operation is unplaced or a
      * root operation.
      * <p>
      * The operation's parent block is the same as the operation result's {@link Value#declaringBlock declaring block}.
      *
-     * @return operation's parent block, or {@code null} if this operation is unattached or a root operation.
-     * @throws IllegalStateException if this operation is attached and its parent block is
+     * @return operation's parent block, or {@code null} if this operation is unplaced or a root operation.
+     * @throws IllegalStateException if this operation is placed in a block that is
      * <a href="Body.Builder.html#body-building-observability">unobservable</a>.
      * @see Value#declaringBlock()
      */
@@ -529,7 +531,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
 
     /**
-     * {@return the operation's result, or {@code null} if this operation is unattached or a
+     * {@return the operation's result, or {@code null} if this operation is unplaced or a
      * root operation.}
      */
     public final Result result() {
@@ -585,12 +587,12 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Builds this operation to become a built root operation. After this operation is built its
+     * Builds this operation, placing it as the root operation of a code model. After this operation is built its
      * {@link #result result} and {@link #parent parent} will always be {@code null}.
      * <p>
      * This method is idempotent.
      *
-     * @throws IllegalStateException if this operation is attached to a block.
+     * @throws IllegalStateException if this operation is placed in a block.
      * @see #isRoot()
      */
     public final void buildAsRoot() {
@@ -598,7 +600,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
             return;
         }
         if (result != null) {
-            throw new IllegalStateException("Operation is attached to a block");
+            throw new IllegalStateException("Operation is placed in a block");
         }
         result = Result.ROOT_RESULT;
     }
@@ -613,7 +615,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * {@return {@code true} if this operation is attached to a block.}
+     * {@return {@code true} if this operation is placed in a block.}
      * @see #buildAsRoot()
      * @see #isRoot()
      * */

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -54,17 +54,22 @@ import java.util.function.BiFunction;
 /**
  * An operation modeling a unit of program behavior.
  * <p>
- * An operation has direct state and zero or more bodies. An operation's direct state consists of zero or more operands,
- * zero or more successors (references to other blocks), and operation-specific state.
+ * An operation uses zero or more values, exposed as a sequence of {@link #operands()}. A
+ * {@link Op.Terminating terminating} operation may have block references, exposed as a sequence of
+ * {@link #successors()}. An operation has zero or more bodies, exposed as a sequence of {@link #bodies()}.
+ *
+ * <h2>Operation construction</h2>
  * <p>
- * An operation might model the addition of two integers, or a method invocation expression. Alternatively an operation
- * may model something more complex like method declarations, lambda expressions, or try statements. In such cases an
- * operation will contain one or more bodies modeling the nested structure.
+ * Constructing an operation creates an <i>unattached</i> operation. An unattached operation is not yet part of a code
+ * model. The operation's operands, successors, bodies, and operation-specific state are fixed when construction
+ * completes.
  * <p>
- * The process of building an operation starts with construction of an <i>unattached</i> operation. The direct state and
- * any bodies of the unattached operation are fixed at construction.
+ * An operation can only be constructed with operands whose declaring block is being built, otherwise construction fails
+ * with an exception.
+ *
+ * <h2>Operation building</h2>
  * <p>
- * Building then progresses in one of two ways:
+ * Building an operation places an unattached operation in a code model in one of two ways:
  * <ol>
  * <li>
  * the unattached operation is <i>attached</i> to a block, as its parent block, by using a block builder to
@@ -83,11 +88,52 @@ import java.util.function.BiFunction;
  * The {@link #location} may be {@link #setLocation set} while the operation is unattached or attached to a block being
  * built.
  * <p>
- * An operation can only be constructed with operands whose declaring block is being built, otherwise construction fails
- * with an exception.
- * <p>
  * An unattached operation, or an operation attached to a block whose parent body builder has not
  * <a href="Body.Builder.html#body-building-finishing">finished</a>, is not thread-safe.
+ *
+ * <h2>Operation implementation requirements</h2>
+ * <p>
+ * A concrete operation class must satisfy the following requirements:
+ * <ul>
+ * <li>
+ * implement {@link #resultType()} to return the result type of operation instances;
+ * <li>
+ * implement {@link #transform(CodeContext, CodeTransformer)} to return a newly constructed, unattached copy whose
+ * concrete class is the same as the operation's concrete class;
+ * <li>
+ * call an appropriate {@code Op} superclass constructor from each concrete operation constructor. Constructors
+ * for new operations pass the operation's operands to {@link #Op(List)}. Constructors for transformed copies can
+ * pass the input operation and code context to {@link #Op(Op, CodeContext)};
+ * <li>
+ * override {@link #bodies()} if instances may have bodies. If the operation class implements {@link Op.Nested}, then
+ * {@code bodies()} must return one or more bodies;
+ * <li>
+ * override {@link #successors()} if instances may have successors. If the operation class implements
+ * {@link Op.BlockTerminating}, then {@code successors()} must return one or more successors;
+ * <li>
+ * copy mutable constructor arguments that define successors, bodies, and operation-specific state, ensuring
+ * they are all fixed when construction completes; and
+ * <li>
+ * return unmodifiable views or immutable values from accessors that expose successors, bodies, and operation-specific
+ * state.
+ * </ul>
+ * <p>
+ * A concrete operation class may additionally:
+ * <ul>
+ * <li>
+ * override {@link #externalizeOpName()} and {@link #externalize()} to define an external form;
+ * <li>
+ * implement {@link Op.Lowerable} to define a lowering; and
+ * <li>
+ * provide operation-specific accessors for operation-specific state.
+ * </ul>
+ *
+ * @apiNote
+ * An operation might model the {@link JavaOp.AddOp addition} of two integers, or a method
+ * {@link JavaOp.InvokeOp invocation} expression. Alternatively an operation may model something more complex like
+ * {@link jdk.incubator.code.dialect.core.CoreOp.FuncOp method} declarations, {@link JavaOp.LambdaOp lambda}
+ * expressions, or {@link JavaOp.TryOp try} statements. In such cases an operation will contain one or more bodies
+ * modeling the nested structure.
  */
 public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
@@ -102,7 +148,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     public interface Nested {
         /**
-         * {@return the bodies of the nested operation.}
+         * {@return the non-empty list of bodies of this nested operation.}
          */
         List<Body> bodies();
     }
@@ -112,7 +158,9 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     public interface Loop extends Nested {
         /**
-         * {@return the body of the loop operation.}
+         * {@return the body of this loop operation.}
+         * <p>
+         * The returned body is one of this operation's {@link #bodies() bodies}.
          */
         Body loopBody();
     }
@@ -129,7 +177,9 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     public interface Invokable extends Nested {
         /**
-         * {@return the body of the invokable operation.}
+         * {@return the body of this invokable operation.}
+         * <p>
+         * The returned body is one of this operation's {@linkplain #bodies() bodies}.
          */
         Body body();
 
@@ -242,7 +292,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
     /**
      * An operation characteristic indicating the operation is a terminating operation
-     * occurring as the last operation in a block.
+     * that occurs as the last operation in a block.
      * <p>
      * A terminating operation passes control to either another block within the same parent body
      * or to that parent body.
@@ -268,7 +318,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      */
     public interface BlockTerminating extends Terminating {
         /**
-         * {@return the list of successor blocks associated with this block terminating operation}
+         * {@return the non-empty list of successors of this block terminating operation.}
          */
         List<Block.Reference> successors();
     }
@@ -374,17 +424,18 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Transforms this operation.
+     * Transforms this operation, copying the operation and transforming any of its bodies.
      * <p>
-     * Implementations of this method return an unattached transformed copy of this operation.
+     * This method returns a newly constructed, unattached copy of this operation. The returned operation's concrete
+     * class is the same as this operation's concrete class.
      * <p>
-     * An implementation copies this operation's direct state and transforms this operation's bodies, if any. Operands
+     * The returned operation copies this operation's operands, successors, and any operation-specific state. Operands
      * are copied by mapping this operation's operands, in order, with the given code context. Successors are copied as
      * specified by {@link CodeContext#getReferenceOrCreate(Block.Reference)}. Operation-specific state is copied as
-     * appropriate for the operation.
+     * appropriate for the operation, preserving operation-specific behavior.
      * <p>
      * Bodies are {@link Body#transform(CodeContext, CodeTransformer) transformed} with the given code context and code
-     * transformer.
+     * transformer, and built with the returned operation as their parent.
      *
      * @apiNote
      * To copy an operation use the {@link CodeTransformer#COPYING_TRANSFORMER copying transformer}.
@@ -434,7 +485,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Returns this operation's parent block, otherwise {@code null} if this operation is unattached to a block or a
+     * Returns this operation's parent block, otherwise {@code null} if this operation is unattached or a
      * root operation.
      * <p>
      * The operation's parent block is the same as the operation result's {@link Value#declaringBlock declaring block}.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
@@ -158,12 +158,12 @@ public final class Quoted<T extends Op> {
      *
      * @param op the operation
      * @return the quoting code model.
-     * @throws IllegalArgumentException if {@code op} is unattached or a root operation.
+     * @throws IllegalArgumentException if {@code op} is not placed in a block.
      * @throws IllegalStateException if an encountered block is being built and is not observable.
      */
     public static CoreOp.FuncOp embedOp(Op op) {
         if (op.result() == null) {
-            throw new IllegalArgumentException("Operation is unattached or a root operation");
+            throw new IllegalArgumentException("Operation is not placed in a block");
         }
 
         // if we don't remove duplicate operands we will have unused params in the new model

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -473,11 +473,13 @@
 /// ## <a id="transforming-heading"/>Transforming
 ///
 /// Code reflection supports the transformation of code models by combining traversing and building. A code model
-/// transformation is represented by a function that takes an operation, encountered in the (input) model being
-/// transformed, and a code model builder for the resulting transformed (output) model, and mediates how, if at all,
-/// that operation is transformed into other code elements that are built. We were inspired by the functional
-/// [transformation][cf-transformation] approach devised by the Class-File API and adapted that design to work on the
-/// nested structure of code models that are immutable trees of code elements.
+/// transformation is represented by a [CodeTransformer][jdk.incubator.code.CodeTransformer] that accepts input bodies,
+/// blocks, and operations while building an output code model with block builders. During transformation, a block
+/// builder may serve as the current output block builder. A transformer emits output operations by appending operations
+/// with output block builders, and emits output blocks by creating block builders for those blocks and appending
+/// operations using those builders. We were inspired by the functional [transformation][cf-transformation] approach
+/// devised by the Class-File API and adapted that design to work on the nested structure of code models that are
+/// immutable trees of code elements.
 ///
 /// [cf-transformation]: https://openjdk.org/jeps/484#Transforming-class-files
 ///
@@ -504,9 +506,10 @@
 /// The code transformation function, passed as lambda expression to
 /// [CodeTransformer.opTransformer][jdk.incubator.code.CodeTransformer#opTransformer], accepts as parameters a
 /// operation-building function, `builder`, an operation encountered when traversing the input code model, `inputOp`,
-/// and a list of values in the output model being built that are associated with input operation’s operands,
-/// `outputOperands`. We must have previously encountered and transformed the input operations whose results are
-/// associated with those values, since values can only be used after they have been declared.
+/// and `outputOperands`, a list with one entry for each input operation operand. Each entry is the output value
+/// currently mapped from the corresponding input operand, or `null` if no output value is mapped. In this example, the
+/// input operations that produce operands of the matched `add` operation have already been encountered and copied, so
+/// the corresponding output operands are mapped before the `add` operation is transformed.
 ///
 /// In the code transformer we switch over the input operation, and in this case we just match on `add` operation and
 /// by default any other operation. In the latter case we apply the input operation to the operation-building function,

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -58,7 +58,7 @@ public class TestBuild {
 
         var a = f.body().entryBlock().parameters().get(0);
         var b = f.body().entryBlock().parameters().get(1);
-        // Passing built values as operands to a new unattached operation
+        // Passing built values as operands to a new unplaced operation
         Assertions.assertThrows(IllegalArgumentException.class, () -> JavaOp.add(a, b));
     }
 

--- a/test/jdk/jdk/incubator/code/TestBuildOp.java
+++ b/test/jdk/jdk/incubator/code/TestBuildOp.java
@@ -56,11 +56,11 @@ public class TestBuildOp {
         });
 
         Assertions.assertFalse(funcOp.isRoot());
-        Assertions.assertFalse(funcOp.isAttached());
+        Assertions.assertFalse(funcOp.isPlacedInBlock());
         funcOp.buildAsRoot();
 
         Assertions.assertTrue(funcOp.isRoot());
-        Assertions.assertFalse(funcOp.isAttached());
+        Assertions.assertFalse(funcOp.isPlacedInBlock());
         funcOp.buildAsRoot();
     }
 
@@ -73,21 +73,21 @@ public class TestBuildOp {
         CoreOp.FuncOp funcOp = (CoreOp.FuncOp) quotedOp.ancestorOp();
 
         Assertions.assertTrue(funcOp.isRoot());
-        Assertions.assertFalse(funcOp.isAttached());
+        Assertions.assertFalse(funcOp.isPlacedInBlock());
     }
 
     @Test
-    void testOpBound() {
+    void testOpPlaced() {
         Body.Builder body = Body.Builder.of(null, FunctionType.FUNCTION_TYPE_VOID);
         Op.Result r = body.entryBlock().op(CoreOp.constant(JavaType.DOUBLE, 1d));
         body.entryBlock().op(CoreOp.return_());
 
         Assertions.assertThrows(IllegalStateException.class, () -> r.op().buildAsRoot());
-        Assertions.assertTrue(r.op().isAttached());
+        Assertions.assertTrue(r.op().isPlacedInBlock());
         Assertions.assertFalse(r.op().isRoot());
 
         CoreOp.func("f", body);
-        Assertions.assertTrue(r.op().isAttached());
+        Assertions.assertTrue(r.op().isPlacedInBlock());
     }
 
     @Test


### PR DESCRIPTION
Update `Op` specification to detail construction, building, and implementation requirements.

Change the specification of unattached/attached to unplaced/placed. An operation is either placed in a block, or placed as the root of a code model, in which case it is a root operation.

Rename `Op.isAttached` to `isPlacedInBlock`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1033/head:pull/1033` \
`$ git checkout pull/1033`

Update a local copy of the PR: \
`$ git checkout pull/1033` \
`$ git pull https://git.openjdk.org/babylon.git pull/1033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1033`

View PR using the GUI difftool: \
`$ git pr show -t 1033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1033.diff">https://git.openjdk.org/babylon/pull/1033.diff</a>

</details>
