### PR TITLE
Update CodeType doc

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeType.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeType.java
@@ -29,16 +29,50 @@ import jdk.incubator.code.extern.ExternalizedCodeType;
 /**
  * A code type that classifies values.
  * <p>
- * A {@link Value value}, one of {@link Block.Parameter} or {@link Op.Result}, has a
- * {@code CodeType} classifying that value.
- * A {@link Body} has a {@code CodeType}, the {@link Body#yieldType yield type},
- * classifying values yielded from the body.
+ * A {@link Value value}, one of {@link Block.Parameter} or {@link Op.Result}, has a {@code CodeType} classifying that
+ * value. A {@link Body} has a {@code CodeType}, the {@link Body#yieldType yield type}, classifying values yielded from
+ * the body.
  * <p>
  * The {@code equals} method should be used to compare code types.
  *
+ * <h2>Code type implementation requirements</h2>
+ * <p>
+ * Instances of a concrete code type class must be immutable.
+ * <p>
+ * A concrete code type class must satisfy the following requirements:
+ * <ul>
+ * <li>
+ * implement {@link #equals(Object)}, {@link #hashCode()}, and {@link #toString()} so that their results are solely
+ * computed from code type state, and not from an instance's identity;
+ * <li>
+ * treat equal instances as freely substitutable, so that interchanging two instances that are equal according to
+ * {@code equals} produces no visible change in the behavior of the code type's methods;
+ * <li>
+ * ensure equal instances have equal {@link #externalize() externalized content};
+ * <li>
+ * provide no creation mechanism that promises unique identity for created instances;
+ * <li>
+ * copy mutable constructor arguments that define code type state, ensuring they are all fixed when construction
+ * completes; and
+ * <li>
+ * return unmodifiable views or immutable values from accessors that expose code type state.
+ * </ul>
+ * <p>
+ * A concrete code type class may additionally:
+ * <ul>
+ * <li>
+ * override {@link #externalize()} to define an external form; and
+ * <li>
+ * provide accessors for code type state.
+ * </ul>
+ *
  * @apiNote
- * Code types enable reasoning statically about a code model, approximating
- * run time behavior.
+ * Code types enable reasoning statically about a code model, approximating run time behavior.
+ * <p>
+ * A code type might model a Java primitive type such as {@link jdk.incubator.code.dialect.java.JavaType#INT int},
+ * a specific Java class such as {@link jdk.incubator.code.dialect.java.JavaType#J_L_STRING String}, or more generally a
+ * {@link jdk.incubator.code.dialect.core.FunctionType function type} or a
+ * {@link jdk.incubator.code.dialect.core.TupleType tuple type}.
  *
  * @see Value
  * @see Block.Parameter
@@ -52,12 +86,22 @@ public non-sealed interface CodeType extends CodeItem {
     /**
      * Externalizes this code type's content.
      *
+     * @implSpec
+     * This implementation returns an externalized code type whose identifier is the result of invoking
+     * {@link #toString()} and whose argument list is empty.
+     *
      * @return the code type's content.
      */
-    ExternalizedCodeType externalize();
+    default ExternalizedCodeType externalize() {
+        return ExternalizedCodeType.of(toString());
+    }
 
     /**
      * Return a string representation of this code type.
+     * <p>
+     * An implementing class should avoid implementing this method by returning the result of
+     * {@code externalize().toString()} unless that class overrides the {@code externalize} method with its own
+     * implementation.
      */
     @Override
     String toString();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -85,7 +85,8 @@ import java.util.function.BiFunction;
  * <p>
  * Building finishes when the parent body builder of the block in which the operation was placed
  * <a href="Body.Builder.html#body-building-finishing">finishes</a>, after which the block becomes observable, or when
- * the operation is placed as the root of a code model.
+ * the operation is placed as the root of a code model. After building finishes, the operation's placement and location
+ * are also fixed, and from then on the operation's observable state does not change.
  * <p>
  * The {@link #location} may be {@link #setLocation set} while the operation is unplaced or placed in a block whose
  * parent body builder has not finished.


### PR DESCRIPTION
Specification for code type implementations.

Provide a default implementation for `CodeType.externalize`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1036/head:pull/1036` \
`$ git checkout pull/1036`

Update a local copy of the PR: \
`$ git checkout pull/1036` \
`$ git pull https://git.openjdk.org/babylon.git pull/1036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1036`

View PR using the GUI difftool: \
`$ git pr show -t 1036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1036.diff">https://git.openjdk.org/babylon/pull/1036.diff</a>

</details>
