### PR TITLE
Remove unreferenced blocks and validate value use

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -165,7 +165,7 @@ public final class Block implements CodeElement<Block, Op> {
 
     // Reverse postorder index
     // Set when block's body has sorted its blocks and therefore set when built
-    // Block is inoperable when < 0 i.e., when not built
+    // Block is unobservable when < 0 i.e., when not built
     int index = -1;
 
     Block(Body parentBody) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -854,14 +854,12 @@ public final class Block implements CodeElement<Block, Op> {
             for (Value v : s.arguments()) {
                 v.uses.add(opr);
             }
-
-            s.target.predecessors.add(Block.this);
         }
 
         op.result = opr;
     }
 
-    // Determine if the parent body of value's block is an ancestor of this block
+    // Determine if the parent body of value's block is the same as or an ancestor of this block
     private boolean isReachable(Value v) {
         Body b = parentBody;
         while (b != null && b != v.block.parentBody) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -159,9 +159,8 @@ public final class Block implements CodeElement<Block, Op> {
 
     final List<Op> ops;
 
-    // @@@ In topological order
-    // @@@ Create lazily
-    //     Can the representation be more efficient e.g. an array?
+    // In topological order of reverse postorder traversal
+    // @@@ Use bitset of block indexes?
     final SequencedSet<Block> predecessors;
 
     // Reverse postorder index

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -166,7 +166,8 @@ public final class Block implements CodeElement<Block, Op> {
     // Reverse postorder index
     // Set when block's body has sorted its blocks and therefore set when built
     // Block is unobservable when < 0 i.e., when not built
-    int index = -1;
+    static final int UNBUILT_BLOCK_INDEX = -1;
+    int index = UNBUILT_BLOCK_INDEX;
 
     Block(Body parentBody) {
         this(parentBody, List.of());

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -619,7 +619,7 @@ public final class Body implements CodeElement<Body, Block> {
          * @param op the parent operation
          * @return the built body
          * @throws IllegalStateException if this body builder has finished
-         * @throws IllegalStateException if any connected body builder is not finished
+         * @throws IllegalStateException if any connected body builder is not successfully finished
          * @throws IllegalStateException if any connected body builder built and its parent operation is unplaced
          * @throws IllegalStateException if a reachable block has no terminating operation
          * @throws IllegalStateException if a reachable block has a successor whose number of arguments is greater than
@@ -639,7 +639,8 @@ public final class Body implements CodeElement<Body, Block> {
             // All great-grandchildren bodies should be built
             if (greatgrandchildren != null) {
                 for (Builder greatgrandchild : greatgrandchildren) {
-                    if (!greatgrandchild.finished) {
+                    if (!greatgrandchild.finished || greatgrandchild.target().parentOp == null) {
+                        // Building did not finish, or finished with an exception
                         throw new IllegalStateException("Descendant body builder is not built");
                     }
 
@@ -648,21 +649,6 @@ public final class Body implements CodeElement<Body, Block> {
                         throw new IllegalStateException("Parent operation of descendant body is unplaced");
                     }
                     assert Body.this == grandchild.block.parentBody;
-                }
-            }
-
-            for (Block b : blocks) {
-                for (Block.Reference s : b.successors()) {
-                    // @@@ model implicit params ?
-                    // block may have optional/implicit params at the end
-                    // so num of arg is same or less than num of params
-                    // as the case for ExceptionRegionEnter, that reference catch blocks without the exception arg
-                    Block target = s.target;
-                    if (s.arguments().size() > target.parameters().size()) {
-                        String m = String.format("Reference to block %s with %d arguments but the block has %d parameters",
-                                target, s.arguments().size(), target.parameters().size());
-                        throw new IllegalStateException(m);
-                    }
                 }
             }
 
@@ -715,6 +701,14 @@ public final class Body implements CodeElement<Body, Block> {
                     n.index = UNASSIGNED_INDEX;
                     for (Block.Reference s : n.successors()) {
                         Block target = s.target;
+
+                        // Check successor arity
+                        if (s.arguments().size() > target.parameters().size()) {
+                            String m = String.format("Reference to block %s with %d arguments but the block has %d parameters",
+                                    target, s.arguments().size(), target.parameters().size());
+                            throw new IllegalStateException(m);
+                        }
+
                         // Update target's predecessors with n
                         target.predecessors.add(n);
                         if (target.index != UNSORTED_INDEX) {
@@ -754,6 +748,11 @@ public final class Body implements CodeElement<Body, Block> {
             // Remove uses of values in unreachable blocks
             for (Block b : unreachableBlocks) {
                 assert b.index == UNSORTED_INDEX;
+                // Set back to unobservable state
+                // @@@ change UNSORTED_INDEX to be -1 and adjust the
+                // sort function so that -ve indexes occur last
+                b.index = -1;
+
                 // If an operation in an unreachable block uses a value not declared in an unreachable
                 // block, then the use needs to be removed.
                 // It is simpler to remove all uses, rather than check for specific uses.
@@ -786,13 +785,13 @@ public final class Body implements CodeElement<Body, Block> {
                     switch (ce) {
                         case Op op -> {
                             Op.Result use = op.result;
-                            if (!use.uses().isEmpty()) {
+                            if (!use.uses.isEmpty()) {
                                 throw new IllegalStateException("Use of an operation result is not dominated by the result");
                             }
                         }
                         case Block bb -> {
                             for (Block.Parameter p : bb.parameters()) {
-                                if (!p.uses().isEmpty()) {
+                                if (!p.uses.isEmpty()) {
                                     throw new IllegalStateException("Use of block parameter is not dominated by the parameter");
                                 }
                             }
@@ -801,7 +800,6 @@ public final class Body implements CodeElement<Body, Block> {
                         }
                     }
                 });
-
             }
             // Remove unreachable blocks
             unreachableBlocks.clear();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -626,6 +626,8 @@ public final class Body implements CodeElement<Body, Block> {
          * the number of parameters of the successor's target block
          * @throws IllegalStateException if an operation result or block parameter declared in an unreachable block is
          * used by an operation in a reachable block or a descendant block of a reachable block.
+         * @throws IllegalStateException if an operation result or block parameter declared in a reachable block does
+         * not dominate a use of that value
          */
         public Body build(Op op) {
             Objects.requireNonNull(op);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -34,7 +34,7 @@ import java.util.stream.IntStream;
 /**
  * A body containing a sequence of blocks.
  * <p>
- * The sequence of blocks form a graph topologically sorted in reverse postorder.
+ * The sequence of blocks form a control-flow graph topologically sorted in reverse postorder.
  * The first block in the sequence is the entry block, and no other blocks refer to it as a successor.
  * The last operation in a block, a terminating operation, may refer to other blocks in the sequence as successors,
  * thus forming the graph. Otherwise, the last operation defines how the body passes control back to the parent
@@ -608,8 +608,11 @@ public final class Body implements CodeElement<Body, Block> {
          * Body builders connected to this body builder must finish building before this body builder finishes.
          * <p>
          * The entry block and all blocks reachable from it, by following successors, become children of the body. The
-         * reachable blocks are sorted in reverse postorder. Any unreachable blocks, those not reachable from the entry
-         * block by following successors, do not become children of the body.
+         * reachable blocks are sorted in reverse postorder and form a control-flow graph. In that graph, the entry
+         * block dominates every other block. Any block not reached from the entry block is unreachable, does not become
+         * a child of the body, and remains unobservable after building finishes. An unreachable block may have a
+         * successor whose target is a reachable block, and may use a value declared in a reachable block or an ancestor
+         * block being built.
          *
          * @apiNote
          * This method is commonly called from the parent operation's constructor, which holds a reference to the built
@@ -626,7 +629,7 @@ public final class Body implements CodeElement<Body, Block> {
          * @throws IllegalStateException if an operation result or block parameter declared in an unreachable block is
          * used by an operation in a reachable block or a descendant block of a reachable block.
          * @throws IllegalStateException if an operation result or block parameter declared in a reachable block does
-         * not dominate a use of that value
+         * not {@link Value#isDominatedBy(Value) dominate} a use of that value
          */
         public Body build(Op op) {
             Objects.requireNonNull(op);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -27,7 +27,6 @@ package jdk.incubator.code;
 
 import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.FunctionType;
-import jdk.incubator.code.dialect.java.JavaOp;
 
 import java.util.*;
 import java.util.stream.IntStream;
@@ -661,8 +660,8 @@ public final class Body implements CodeElement<Body, Block> {
             return Body.this;
         }
 
-        private static final int UNASSIGNED_INDEX = Integer.MIN_VALUE;
-        private static final int UNSORTED_INDEX = Integer.MAX_VALUE;
+        private static final int UNSORTED_INDEX = Block.UNBUILT_BLOCK_INDEX;
+        private static final int UNASSIGNED_INDEX = -2;
 
         // Sort blocks in reverse post order, removing any unreachable blocks
         // After sorting the following holds for a block
@@ -674,12 +673,6 @@ public final class Body implements CodeElement<Body, Block> {
 
                 e.index = 0;
                 return;
-            }
-
-            // Reset block indexes
-            // Also ensuring unreachable blocks occur last after sorting by block index
-            for (Block b : blocks) {
-                b.index = UNSORTED_INDEX;
             }
 
             Deque<Block> stack = new ArrayDeque<>();
@@ -723,9 +716,9 @@ public final class Body implements CodeElement<Body, Block> {
             }
 
             // Sort blocks by their reverse postorder indexes
-            blocks.sort(Comparator.comparingInt(b -> b.index));
+            blocks.sort(Comparator.comparingInt(b -> b.index < 0 ? Integer.MAX_VALUE : b.index));
             // Remove unreachable blocks, those that are not dominated by the entry block
-            // They will be sorted at the end, sharing the same sort key UNSORTED_INDEX
+            // They will be sorted at the end
             int nUnreachableBlocks = blocks.get(0).index;
             if (nUnreachableBlocks > 0) {
                 removeUnreachableBlocksAndValueUses(nUnreachableBlocks);
@@ -750,10 +743,9 @@ public final class Body implements CodeElement<Body, Block> {
             // Remove uses of values in unreachable blocks
             for (Block b : unreachableBlocks) {
                 assert b.index == UNSORTED_INDEX;
-                // Set back to unobservable state
-                // @@@ change UNSORTED_INDEX to be -1 and adjust the
-                // sort function so that -ve indexes occur last
-                b.index = -1;
+
+                // It is ok to traverse the unobservable blocks via elements() prior to removal
+                // Direct access of the uses field is required since public access requires an observable block
 
                 // If an operation in an unreachable block uses a value not declared in an unreachable
                 // block, then the use needs to be removed.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -28,13 +28,10 @@ package jdk.incubator.code;
 import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.FunctionType;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Gatherers;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
- * A body containing a sequence of (basic) blocks.
+ * A body containing a sequence of blocks.
  * <p>
  * The sequence of blocks form a graph topologically sorted in reverse postorder.
  * The first block in the sequence is the entry block, and no other blocks refer to it as a successor.
@@ -609,8 +606,9 @@ public final class Body implements CodeElement<Body, Block> {
          * <p>
          * Body builders connected to this body builder must finish building before this body builder finishes.
          * <p>
-         * Any unreferenced empty blocks are ignored and do not become children of the body. An unreferenced block is
-         * a non-entry block with no predecessors.
+         * The entry block and all blocks reachable from it, by following successors, become children of the body. The
+         * reachable blocks are sorted in reverse postorder. Any unreachable blocks, those not reachable from the entry
+         * block by following successors, do not become children of the body.
          *
          * @apiNote
          * This method is commonly called from the parent operation's constructor, which holds a reference to the built
@@ -620,19 +618,11 @@ public final class Body implements CodeElement<Body, Block> {
          * @return the built body
          * @throws IllegalStateException if this body builder has finished
          * @throws IllegalStateException if any connected body builder is not finished
-         * @throws IllegalStateException if a block has no terminating operation, unless unreferenced and empty
+         * @throws IllegalStateException if any connected body builder built and its parent operation is unplaced
+         * @throws IllegalStateException if a reachable block has no terminating operation
+         * @throws IllegalStateException if an operation result or block parameter declared in an unreachable block is
+         * used by an operation in a reachable block or a descendant block of a reachable block.
          */
-        // @@@ Check every operand dominates the operation result.
-        //     An operation in block B that uses a value declared in block B requires no special checks, since an
-        //     operation result does not exist until an operation is appended to a block, and B's parameters always
-        //     occur before any of its operations.
-        //     Similarly, when an operation uses a value declared in an ancestor no special checks are required due to
-        //     structural checks and reachability checks when building.
-        //     Therefore, a body with only one entry block requires no special checks when building.
-        //     A body with two or more blocks requires dominance checks. An operation in block C that uses a value
-        //     declared in block B, where C and B are siblings, requires that B dominates C.
-        //     Since blocks are already sorted in reverse postorder the work to compute the immediate dominator map
-        //     is incremental and can it be represented efficiently as an integer array of block indexes.
         public Body build(Op op) {
             Objects.requireNonNull(op);
 
@@ -648,17 +638,170 @@ public final class Body implements CodeElement<Body, Block> {
                     if (!greatgrandchild.finished) {
                         throw new IllegalStateException("Descendant body builder is not built");
                     }
+
+                    Op.Result grandchild = greatgrandchild.target().parentOp.result;
+                    if (grandchild == null) {
+                        throw new IllegalStateException("Parent operation of descendant body is unplaced");
+                    }
+                    assert Body.this == grandchild.block.parentBody;
                 }
             }
 
             sortReversePostorder();
+            checkValueUse();
 
-            // Validate each use of a value declared in the body.
-            // The use's declaring block must be dominated by the value's declaring block
+            Body.this.parentOp = op;
+            return Body.this;
+        }
+
+        private static final int UNASSIGNED_INDEX = Integer.MIN_VALUE;
+        private static final int UNSORTED_INDEX = Integer.MAX_VALUE;
+
+        // Sort blocks in reverse post order, removing any unreachable blocks
+        // After sorting the following holds for a block
+        //   block.parentBody().blocks().indexOf(block) == block.index()
+        private void sortReversePostorder() {
+            if (blocks.size() == 1) {
+                Block e = blocks.getFirst();
+                checkBlock(e);
+
+                e.index = 0;
+                return;
+            }
+
+            // Reset block indexes
+            // Also ensuring unreachable blocks occur last after sorting by block index
+            for (Block b : blocks) {
+                b.index = UNSORTED_INDEX;
+            }
+
+            Deque<Block> stack = new ArrayDeque<>();
+            stack.push(blocks.get(0));
+
+            // Postorder iteration, starting from the entry block
+            int index = blocks.size();
+            while (!stack.isEmpty()) {
+                Block n = stack.peek();
+                if (n.index == UNASSIGNED_INDEX) {
+                    // If n's successor has been processed then add n
+                    stack.pop();
+                    n.index = --index;
+                } else if (n.index != UNSORTED_INDEX) {
+                    // If n has already been processed then ignore
+                    stack.pop();
+                } else {
+                    checkBlock(n);
+
+                    // Mark before processing successors, a successor may refer back to n
+                    n.index = UNASSIGNED_INDEX;
+                    for (Block.Reference s : n.successors()) {
+                        Block target = s.target;
+                        // Update target's predecessors with n
+                        target.predecessors.add(n);
+                        if (target.index != UNSORTED_INDEX) {
+                            continue;
+                        }
+
+                        stack.push(target);
+                    }
+                }
+            }
+
+            // Sort blocks by their reverse postorder indexes
+            blocks.sort(Comparator.comparingInt(b -> b.index));
+            // Remove unreachable blocks, those that are not dominated by the entry block
+            // They will be sorted at the end, sharing the same sort key UNSORTED_INDEX
+            int nUnreachableBlocks = blocks.get(0).index;
+            if (nUnreachableBlocks > 0) {
+                removeUnreachableBlocksAndValueUses(nUnreachableBlocks);
+            }
+
+            assert IntStream.range(0, blocks().size()).allMatch(i -> i == blocks.get(i).index);
+            assert blocks.stream().<List<Block>>mapMulti((b, consumer) -> {
+                for (Block.Reference s : b.successors()) {
+                    consumer.accept(List.of(s.target, b));
+                }
+            }).allMatch(l -> l.get(0).predecessors.contains(l.get(1)));
+        }
+
+        private static void checkBlock(Block b) {
+            if (b.ops.isEmpty() || !(b.ops.getLast() instanceof Op.Terminating)) {
+                throw new IllegalStateException("Block has no terminating operation as the last operation");
+            }
+        }
+
+        private void removeUnreachableBlocksAndValueUses(int nUnreachableBlocks) {
+            List<Block> unreachableBlocks = blocks.subList(blocks.size() - nUnreachableBlocks, blocks.size());
+            // Remove uses of values in unreachable blocks
+            for (Block b : unreachableBlocks) {
+                assert b.index == UNSORTED_INDEX;
+                // If an operation in an unreachable block uses a value not declared in an unreachable
+                // block, then the use needs to be removed.
+                // It is simpler to remove all uses, rather than check for specific uses.
+                b.elements().forEach(ce -> {
+                    switch (ce) {
+                        case Op op -> {
+                            Op.Result use = op.result;
+                            for (Value v : op.operands()) {
+                                v.uses.remove(use);
+                            }
+
+                            for (Block.Reference s : op.successors()) {
+                                for (Value v : s.arguments()) {
+                                    v.uses.remove(use);
+                                }
+                            }
+                        }
+                        default -> {
+                        }
+                    }
+                });
+            }
+            // Check uses of values declared in unreachable blocks
+            for (Block b : unreachableBlocks) {
+                // If an operation result or block parameter declared in an unreachable block is used by an operation
+                // in block that is not an unreachable block, then such use is invalid.
+                // Given the prior removal of all uses we only need to check if a declared value has uses or not.
+                // If so they must be from a block that is not unreachable and therefore the is invalid
+                b.elements().forEach(ce -> {
+                    switch (ce) {
+                        case Op op -> {
+                            Op.Result use = op.result;
+                            if (!use.uses().isEmpty()) {
+                                throw new IllegalStateException("Use of an operation result is not dominated by the result");
+                            }
+                        }
+                        case Block bb -> {
+                            for (Block.Parameter p : bb.parameters()) {
+                                if (!p.uses().isEmpty()) {
+                                    throw new IllegalStateException("Use of block parameter is not dominated by the parameter");
+                                }
+                            }
+                        }
+                        default -> {
+                        }
+                    }
+                });
+
+            }
+            // Remove unreachable blocks
+            unreachableBlocks.clear();
+
+            // Reassign indexes to their natural indexes, sort order is preserved
+            for (int i = 0; i < blocks.size(); i++) {
+                blocks.get(i).index = i;
+            }
+        }
+
+        // Validate each use of a value declared in the body.
+        // The use's declaring block must be dominated by the value's declaring block
+        private void checkValueUse() {
             if (blocks.size() > 1) {
                 // Only need to check when there is more than one block, since for one block
                 // the use's declaring block will be the same as or a descendant of the
-                // value's declaring block
+                // value's declaring block.
+                // No need to check use within the same block, since operation results
+                // cannot be used until an operation is appended.
                 for (Block block : blocks) {
                     for (Block.Parameter p : block.parameters()) {
                         for (Op.Result use : p.uses()) {
@@ -678,130 +821,6 @@ public final class Body implements CodeElement<Body, Block> {
                     }
                 }
             }
-
-            Body.this.parentOp = op;
-            return Body.this;
-        }
-
-        private static final int UNASSIGNED_INDEX = Integer.MIN_VALUE;
-        private static final int UNSORTED_INDEX = Integer.MAX_VALUE;
-
-        // Sort blocks in reverse post order
-        // After sorting the following holds for a block
-        //   block.parentBody().blocks().indexOf(block) == block.index()
-        private void sortReversePostorder() {
-            if (blocks.size() == 1) {
-                Block e = blocks.getFirst();
-                checkBlock(e);
-
-                e.index = 0;
-                return;
-            }
-
-            // Reset block indexes
-            // Also ensuring blocks with no predecessors occur last
-            for (Block b : blocks) {
-                b.index = UNSORTED_INDEX;
-            }
-
-            Deque<Block> stack = new ArrayDeque<>();
-            stack.push(blocks.get(0));
-
-            // Postorder iteration
-            int index = blocks.size();
-            while (!stack.isEmpty()) {
-                Block n = stack.peek();
-                if (n.index == UNASSIGNED_INDEX) {
-                    // If n's successor has been processed then add n
-                    stack.pop();
-                    n.index = --index;
-                } else if (n.index != UNSORTED_INDEX) {
-                    // If n has already been processed then ignore
-                    stack.pop();
-                } else {
-                    checkBlock(n);
-
-                    // Mark before processing successors, a successor may refer back to n
-                    n.index = UNASSIGNED_INDEX;
-                    for (Block.Reference s : n.successors()) {
-                        Block target = s.target;
-                        target.predecessors.add(n);
-                        if (target.index != UNSORTED_INDEX) {
-                            continue;
-                        }
-
-                        stack.push(target);
-                    }
-                }
-            }
-
-            int nUnreferencedBlocks = blocks.get(0).index;
-            if (nUnreferencedBlocks == 0) {
-                blocks.sort(Comparator.comparingInt(b -> b.index));
-            } else {
-                // There are blocks that are unreferenced from the entry block
-                assert nUnreferencedBlocks == blocks.stream().filter(b -> b.index == UNSORTED_INDEX).count();
-                blocks.sort(Comparator.comparingInt(b -> b.index));
-
-                List<Block> unreferencedBlocks = blocks.subList(blocks.size() - nUnreferencedBlocks, blocks.size());
-                for (Block b : unreferencedBlocks) {
-                    assert b.index == UNSORTED_INDEX : blocks().size();
-
-                    // If an operation in a referenced block uses a value declared in an unreferenced block
-                    // then dominance checks will fail, since the unreferenced block will not be present in
-                    // the map of immediate dominators.
-
-                    // If an operation in an unreferenced block uses a value declared in a referenced block
-                    // then we need to check if the declaration is out of scope, and if so the use should
-                    // be removed or an exception is thrown
-                    // Outside the scope means:
-                    // 1. the value is not declared in this body, is declared in a block whose parent body is an
-                    // ancestor of this body; or
-                    // 2. the value is declared in a block of this body, and that block is referenced
-
-                    b.elements()
-                            .<Op>mapMulti((ce, consumer) -> {
-                                if (ce instanceof Op op) {
-                                    consumer.accept(op);
-                                }
-                            })
-                            .forEach(use -> {
-                                for (Value v : use.operands()) {
-                                    v.uses.remove(use);
-                                }
-
-                                for (Block.Reference s : use.successors()) {
-                                    for (Value v : s.arguments()) {
-                                        v.uses.remove(use);
-                                    }
-                                }
-                            });
-                }
-
-                blocks.removeIf(b -> b.index == UNSORTED_INDEX);
-
-                // Reassign indexes to their natural indexes, sort order is preserved
-                for (int i = 0; i < blocks.size(); i++) {
-                    blocks.get(i).index = i;
-                }
-            }
-            assert IntStream.range(0, blocks().size()).allMatch(i -> i == blocks.get(i).index);
-
-            assert blocks.stream().<List<Block>>mapMulti((b, consumer) -> {
-                for (Block.Reference s : b.successors()) {
-                    consumer.accept(List.of(s.target, b));
-                }
-            }).allMatch(l -> l.get(0).predecessors.contains(l.get(1)));
-        }
-
-        private static void checkBlock(Block b) {
-            if (b.ops.isEmpty() || !(b.ops.getLast() instanceof Op.Terminating)) {
-                throw noTerminatingOperation();
-            }
-        }
-
-        private static IllegalStateException noTerminatingOperation() {
-            return new IllegalStateException("Block has no terminating operation as the last operation");
         }
 
         /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -622,6 +622,8 @@ public final class Body implements CodeElement<Body, Block> {
          * @throws IllegalStateException if any connected body builder is not finished
          * @throws IllegalStateException if any connected body builder built and its parent operation is unplaced
          * @throws IllegalStateException if a reachable block has no terminating operation
+         * @throws IllegalStateException if a reachable block has a successor whose number of arguments is greater than
+         * the number of parameters of the successor's target block
          * @throws IllegalStateException if an operation result or block parameter declared in an unreachable block is
          * used by an operation in a reachable block or a descendant block of a reachable block.
          */

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -28,6 +28,10 @@ package jdk.incubator.code;
 import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.FunctionType;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Gatherers;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * A body containing a sequence of (basic) blocks.
@@ -647,32 +651,156 @@ public final class Body implements CodeElement<Body, Block> {
                 }
             }
 
-            Iterator<Block> i = blocks.iterator();
-            while (i.hasNext()) {
-                Block block = i.next();
+            sortReversePostorder();
 
-                // Structural check
-                // All referenced blocks should have a terminating operation as the last operation
-                if (block.ops.isEmpty()) {
-                    if (block.isEntryBlock() || !block.predecessors.isEmpty()) {
-                        throw noTerminatingOperation();
+            // Validate each use of a value declared in the body.
+            // The use's declaring block must be dominated by the value's declaring block
+            if (blocks.size() > 1) {
+                // Only need to check when there is more than one block, since for one block
+                // the use's declaring block will be the same as or a descendant of the
+                // value's declaring block
+                for (Block block : blocks) {
+                    for (Block.Parameter p : block.parameters()) {
+                        for (Op.Result use : p.uses()) {
+                            if (!use.declaringBlock().isDominatedBy(block)) {
+                                throw new IllegalStateException("Use of value is not dominated by value");
+                            }
+                        }
                     }
 
-                    // Remove unreferenced empty block
-                    assert !block.isEntryBlock() && block.predecessors.isEmpty();
-                    i.remove();
-                } else if (!(block.ops.getLast() instanceof Op.Terminating)) {
-                    throw noTerminatingOperation();
+                    for (Op o : block.ops()) {
+                        Op.Result r = o.result();
+                        for (Op.Result use : r.uses()) {
+                            if (!use.declaringBlock().isDominatedBy(block)) {
+                                throw new IllegalStateException("Use of value is not dominated by value");
+                            }
+                        }
+                    }
                 }
             }
-
-            sortReversePostorder();
 
             Body.this.parentOp = op;
             return Body.this;
         }
 
-        static IllegalStateException noTerminatingOperation() {
+        private static final int UNASSIGNED_INDEX = Integer.MIN_VALUE;
+        private static final int UNSORTED_INDEX = Integer.MAX_VALUE;
+
+        // Sort blocks in reverse post order
+        // After sorting the following holds for a block
+        //   block.parentBody().blocks().indexOf(block) == block.index()
+        private void sortReversePostorder() {
+            if (blocks.size() == 1) {
+                Block e = blocks.getFirst();
+                checkBlock(e);
+
+                e.index = 0;
+                return;
+            }
+
+            // Reset block indexes
+            // Also ensuring blocks with no predecessors occur last
+            for (Block b : blocks) {
+                b.index = UNSORTED_INDEX;
+            }
+
+            Deque<Block> stack = new ArrayDeque<>();
+            stack.push(blocks.get(0));
+
+            // Postorder iteration
+            int index = blocks.size();
+            while (!stack.isEmpty()) {
+                Block n = stack.peek();
+                if (n.index == UNASSIGNED_INDEX) {
+                    // If n's successor has been processed then add n
+                    stack.pop();
+                    n.index = --index;
+                } else if (n.index != UNSORTED_INDEX) {
+                    // If n has already been processed then ignore
+                    stack.pop();
+                } else {
+                    checkBlock(n);
+
+                    // Mark before processing successors, a successor may refer back to n
+                    n.index = UNASSIGNED_INDEX;
+                    for (Block.Reference s : n.successors()) {
+                        Block target = s.target;
+                        target.predecessors.add(n);
+                        if (target.index != UNSORTED_INDEX) {
+                            continue;
+                        }
+
+                        stack.push(target);
+                    }
+                }
+            }
+
+            int nUnreferencedBlocks = blocks.get(0).index;
+            if (nUnreferencedBlocks == 0) {
+                blocks.sort(Comparator.comparingInt(b -> b.index));
+            } else {
+                // There are blocks that are unreferenced from the entry block
+                assert nUnreferencedBlocks == blocks.stream().filter(b -> b.index == UNSORTED_INDEX).count();
+                blocks.sort(Comparator.comparingInt(b -> b.index));
+
+                List<Block> unreferencedBlocks = blocks.subList(blocks.size() - nUnreferencedBlocks, blocks.size());
+                for (Block b : unreferencedBlocks) {
+                    assert b.index == UNSORTED_INDEX : blocks().size();
+
+                    // If an operation in a referenced block uses a value declared in an unreferenced block
+                    // then dominance checks will fail, since the unreferenced block will not be present in
+                    // the map of immediate dominators.
+
+                    // If an operation in an unreferenced block uses a value declared in a referenced block
+                    // then we need to check if the declaration is out of scope, and if so the use should
+                    // be removed or an exception is thrown
+                    // Outside the scope means:
+                    // 1. the value is not declared in this body, is declared in a block whose parent body is an
+                    // ancestor of this body; or
+                    // 2. the value is declared in a block of this body, and that block is referenced
+
+                    b.elements()
+                            .<Op>mapMulti((ce, consumer) -> {
+                                if (ce instanceof Op op) {
+                                    consumer.accept(op);
+                                }
+                            })
+                            .forEach(use -> {
+                                for (Value v : use.operands()) {
+                                    v.uses.remove(use);
+                                }
+
+                                for (Block.Reference s : use.successors()) {
+                                    for (Value v : s.arguments()) {
+                                        v.uses.remove(use);
+                                    }
+                                }
+                            });
+                }
+
+                blocks.removeIf(b -> b.index == UNSORTED_INDEX);
+
+                // Reassign indexes to their natural indexes, sort order is preserved
+                for (int i = 0; i < blocks.size(); i++) {
+                    blocks.get(i).index = i;
+                }
+            }
+            assert IntStream.range(0, blocks().size()).allMatch(i -> i == blocks.get(i).index);
+
+            assert blocks.stream().<List<Block>>mapMulti((b, consumer) -> {
+                for (Block.Reference s : b.successors()) {
+                    consumer.accept(List.of(s.target, b));
+                }
+            }).allMatch(l -> l.get(0).predecessors.contains(l.get(1)));
+        }
+
+        private static void checkBlock(Block b) {
+            if (b.ops.isEmpty() || !(b.ops.getLast() instanceof Op.Terminating)) {
+                throw noTerminatingOperation();
+            }
+        }
+
+        private static IllegalStateException noTerminatingOperation() {
             return new IllegalStateException("Block has no terminating operation as the last operation");
         }
 
@@ -779,60 +907,6 @@ public final class Body implements CodeElement<Body, Block> {
         // Transform body starting from the entry block builder
         ct.acceptBody(bodyBuilder.entryBlock, this, bodyBuilder.entryBlock.parameters());
         return bodyBuilder;
-    }
-
-    // Sort blocks in reverse post order
-    // After sorting the following holds for a block
-    //   block.parentBody().blocks().indexOf(block) == block.index()
-    private void sortReversePostorder() {
-        if (blocks.size() < 2) {
-            for (int i = 0; i < blocks.size(); i++) {
-                blocks.get(i).index = i;
-            }
-            return;
-        }
-
-        // Reset block indexes
-        // Also ensuring blocks with no predecessors occur last
-        for (Block b : blocks) {
-            b.index = Integer.MAX_VALUE;
-        }
-
-        Deque<Block> stack = new ArrayDeque<>();
-        stack.push(blocks.get(0));
-
-        // Postorder iteration
-        int index = blocks.size();
-        while (!stack.isEmpty()) {
-            Block n = stack.peek();
-            if (n.index == Integer.MIN_VALUE) {
-                // If n's successor has been processed then add n
-                stack.pop();
-                n.index = --index;
-            } else if (n.index < Integer.MAX_VALUE) {
-                // If n has already been processed then ignore
-                stack.pop();
-            } else {
-                // Mark before processing successors, a successor may refer back to n
-                n.index = Integer.MIN_VALUE;
-                for (Block.Reference s : n.successors()) {
-                    if (s.target.index < Integer.MAX_VALUE) {
-                        continue;
-                    }
-
-                    stack.push(s.target);
-                }
-            }
-        }
-
-        blocks.sort(Comparator.comparingInt(b -> b.index));
-        if (blocks.get(0).index > 0) {
-            // There are blocks with no predecessors
-            // Reassign indexes to their natural indexes, sort order is preserved
-            for (int i = 0; i < blocks.size(); i++) {
-                blocks.get(i).index = i;
-            }
-        }
     }
 
     // Modifying methods

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -25,6 +25,7 @@ import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;
 import jdk.incubator.code.Reflect;
 import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.SSA;
 import jdk.incubator.code.dialect.java.JavaOp;
 import org.junit.jupiter.api.Assertions;
@@ -35,8 +36,7 @@ import java.util.function.IntBinaryOperator;
 import static jdk.incubator.code.dialect.core.CoreOp.*;
 import static jdk.incubator.code.dialect.core.CoreType.FUNCTION_TYPE_VOID;
 import static jdk.incubator.code.dialect.core.CoreType.functionType;
-import static jdk.incubator.code.dialect.java.JavaType.INT;
-import static jdk.incubator.code.dialect.java.JavaType.type;
+import static jdk.incubator.code.dialect.java.JavaType.*;
 
 /*
  * @test
@@ -241,6 +241,21 @@ public class TestBuild {
     }
 
     @Test
+    public void testBodyBuilderWithUnplacedOperation() {
+        var body1 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+        var block1 = body1.entryBlock();
+        block1.op(return_());
+
+        var body2 = Body.Builder.of(body1, FUNCTION_TYPE_VOID);
+        var block2 = body2.entryBlock();
+        block2.op(return_());
+        CoreOp.func("f", body2);
+
+        // Great-grandchild body is child of unplaced operation
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body1));
+    }
+
+    @Test
     public void testMistmatchedBody() {
         var body1 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block1 = body1.entryBlock();
@@ -254,6 +269,34 @@ public class TestBuild {
 
         // lambdaOp's grandparent body is not parent body of block1
         Assertions.assertThrows(IllegalStateException.class, () -> block1.op(lambdaOp));
+    }
+
+    @Test
+    public void testIsolatedBody() {
+        var body1 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+        var block1 = body1.entryBlock();
+
+        var body2 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+        var block2 = body2.entryBlock();
+        block2.op(return_());
+        var lambdaOp = JavaOp.lambda(type(Runnable.class), body2);
+
+        Assertions.assertDoesNotThrow(() -> block1.op(lambdaOp));
+        block1.op(return_());
+        Assertions.assertDoesNotThrow(() -> func("f", body1));
+    }
+
+    @Test
+    public void testValueUseInIsolatedBody() {
+        var body1 = Body.Builder.of(null, functionType(VOID, INT));
+        var block1 = body1.entryBlock();
+        var p = block1.parameters().get(0);
+        block1.op(return_());
+
+        var body2 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+        var block2 = body2.entryBlock();
+        // Value p is not reachable from block2
+        Assertions.assertThrows(IllegalStateException.class, () -> block2.op(JavaOp.neg(p)));
     }
 
     @Test

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -256,6 +256,21 @@ public class TestBuild {
     }
 
     @Test
+    public void testFailedBodyBuilder() {
+        var body1 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+        var block1 = body1.entryBlock();
+        block1.op(return_());
+
+        var body2 = Body.Builder.of(body1, FUNCTION_TYPE_VOID);
+        var block2 = body2.entryBlock();
+        // body2 finishes in failure
+        Assertions.assertThrows(IllegalStateException.class, () -> CoreOp.func("f", body2));
+
+        // Great-grandchild body finishes in failure
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body1));
+    }
+
+    @Test
     public void testMistmatchedBody() {
         var body1 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block1 = body1.entryBlock();

--- a/test/jdk/jdk/incubator/code/TestBuildDominatingUse.java
+++ b/test/jdk/jdk/incubator/code/TestBuildDominatingUse.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.code
+ * @run junit TestBuildDominatingUse
+ */
+
+import jdk.incubator.code.*;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static jdk.incubator.code.dialect.core.CoreOp.*;
+import static jdk.incubator.code.dialect.core.CoreType.FUNCTION_TYPE_VOID;
+
+public class TestBuildDominatingUse {
+
+    @Test
+    public void testUndominatedOperandUse() {
+        Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+
+        Block.Builder entryBlock = body.entryBlock();
+        Block.Builder block1 = entryBlock.block();
+
+        Op.Result zeroValue = block1.op(CoreOp.constant(JavaType.INT, 0));
+        block1.op(return_());
+
+        // Use of operation result as operand is not dominated by its declaration
+        entryBlock.op(JavaOp.neg(zeroValue));
+        entryBlock.op(branch(block1.reference()));
+
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+
+    @Test
+    public void testUndominatedParameterUse() {
+        Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+
+        Block.Builder entryBlock = body.entryBlock();
+        Block.Builder block1 = entryBlock.block(JavaType.INT);
+        Block.Parameter p = block1.parameters().getFirst();
+
+        block1.op(return_());
+
+        // Use of block parameter as block argument is not dominated by its declaration
+        entryBlock.op(branch(block1.reference(p)));
+
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+
+    @Test
+    public void testUndominatedOperandNestedUse() {
+        Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+
+        Block.Builder entryBlock = body.entryBlock();
+        Block.Builder block1 = entryBlock.block();
+
+        Op.Result zeroValue = block1.op(CoreOp.constant(JavaType.INT, 0));
+        block1.op(return_());
+
+        entryBlock.op(JavaOp.lambda(body, FUNCTION_TYPE_VOID, JavaType.type(Runnable.class))
+                .body(block2 -> {
+                    // Use of operation result as operand is not dominated by its declaration
+                    block2.op(JavaOp.neg(zeroValue));
+                    block2.op(return_());
+                }));
+        entryBlock.op(branch(block1.reference()));
+
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+
+    @Test
+    public void testUndominatedParameterNestedUse() {
+        Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+
+        Block.Builder entryBlock = body.entryBlock();
+        Block.Builder block1 = entryBlock.block(JavaType.INT);
+        Block.Parameter p = block1.parameters().getFirst();
+
+        block1.op(return_());
+
+        entryBlock.op(JavaOp.lambda(body, FUNCTION_TYPE_VOID, JavaType.type(Runnable.class))
+                .body(block2 -> {
+                    Block.Builder block3 = block2.block(JavaType.INT);
+                    block3.op(return_());
+
+                    // Use of block parameter as block argument is not dominated by its declaration
+                    block2.op(branch(block3.reference(p)));
+                }));
+        Op.Result zero = entryBlock.op(constant(JavaType.INT, 0));
+        entryBlock.op(branch(block1.reference(zero)));
+
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+}

--- a/test/jdk/jdk/incubator/code/TestBuildUnreachableBlocks.java
+++ b/test/jdk/jdk/incubator/code/TestBuildUnreachableBlocks.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 
 import static jdk.incubator.code.dialect.core.CoreOp.*;
@@ -37,10 +38,10 @@ import static jdk.incubator.code.dialect.core.CoreType.FUNCTION_TYPE_VOID;
 /*
  * @test
  * @modules jdk.incubator.code
- * @run junit TestBuildUnreferencedBlocks
+ * @run junit TestBuildUnreachableBlocks
  */
 
-public class TestBuildUnreferencedBlocks {
+public class TestBuildUnreachableBlocks {
 
     @Reflect
     public static int f() {
@@ -53,17 +54,17 @@ public class TestBuildUnreferencedBlocks {
 
     @Test
     public void testRemoveNestedBlocks() throws Throwable {
-        Method m = TestBuildUnreferencedBlocks.class.getDeclaredMethod("f");
+        Method m = TestBuildUnreachableBlocks.class.getDeclaredMethod("f");
         CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
 
         CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
             b.op(CoreOp.return_());
 
-            Block.Builder unreferencedBlock1 = b.block();
-            unreferencedBlock1.transformBody(f.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+            Block.Builder unreachableBlock1 = b.block();
+            unreachableBlock1.transformBody(f.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
 
-            Block.Builder unreferencedBlock2 = b.block();
-            unreferencedBlock2.transformBody(f.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+            Block.Builder unreachableBlock2 = b.block();
+            unreachableBlock2.transformBody(f.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
         });
 
         Assertions.assertEquals(1, g.body().blocks().size());
@@ -73,7 +74,7 @@ public class TestBuildUnreferencedBlocks {
 
     @Test
     public void testRemoveBlocks() throws Throwable {
-        Method m = TestBuildUnreferencedBlocks.class.getDeclaredMethod("f");
+        Method m = TestBuildUnreachableBlocks.class.getDeclaredMethod("f");
         CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
 
         CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
@@ -81,20 +82,44 @@ public class TestBuildUnreferencedBlocks {
 
             CoreOp.FuncOp fLowered = f.transform(CodeTransformer.LOWERING_TRANSFORMER);
 
-            Block.Builder unreferencedBlock1 = b.block();
-            unreferencedBlock1.transformBody(fLowered.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+            Block.Builder unreachableBlock1 = b.block();
+            unreachableBlock1.transformBody(fLowered.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
 
-            Block.Builder unreferencedBlock2 = b.block();
-            unreferencedBlock2.transformBody(fLowered.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+            Block.Builder unreachableBlock2 = b.block();
+            unreachableBlock2.transformBody(fLowered.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
         });
 
         Assertions.assertEquals(1, g.body().blocks().size());
         Assertions.assertEquals(1, g.body().entryBlock().ops().size());
     }
 
+    @Test
+    public void testUnobservableUnreachableBlocks() throws Throwable {
+        Method m = TestBuildUnreachableBlocks.class.getDeclaredMethod("f");
+        CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
+
+        List<Op.Result> results = new ArrayList<>();
+        CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
+            b.op(CoreOp.return_());
+
+            Block.Builder unreachableBlock1 = b.block();
+            results.add(unreachableBlock1.op(return_()));
+
+            Block.Builder unreachableBlock2 = b.block();
+            results.add(unreachableBlock2.op(return_()));
+        });
+
+        Assertions.assertEquals(1, g.body().blocks().size());
+        Assertions.assertEquals(1, g.body().entryBlock().ops().size());
+
+        for (Op.Result r : results) {
+            // Declaring block, an unreachable block, is not observable
+            Assertions.assertThrows(IllegalStateException.class, r::declaringBlock);
+        }
+    }
 
     @Test
-    public void testNestedUsesInUnreferencedBlock() {
+    public void testNestedUsesInUnreachableBlock() {
         CoreOp.FuncOp g = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
             Op.Result zeroValue = b.op(CoreOp.constant(JavaType.INT, 0));
             Op.Result oneValue = b.op(CoreOp.constant(JavaType.INT, 1));
@@ -102,14 +127,14 @@ public class TestBuildUnreferencedBlocks {
 
             JavaType.type(Runnable.class);
 
-            Block.Builder unreferencedBlock1 = b.block();
+            Block.Builder unreachableBlock1 = b.block();
             JavaOp.LambdaOp lop = JavaOp.lambda(b.parentBody(), FunctionType.FUNCTION_TYPE_VOID, JavaType.type(Runnable.class)).body(lb -> {
                 lb.op(JavaOp.neg(zeroValue));
                 lb.op(JavaOp.neg(oneValue));
                 lb.op(CoreOp.return_());
             });
-            unreferencedBlock1.op(lop);
-            unreferencedBlock1.op(CoreOp.return_());
+            unreachableBlock1.op(lop);
+            unreachableBlock1.op(CoreOp.return_());
         });
 
         Assertions.assertEquals(1, g.body().blocks().size());
@@ -123,21 +148,21 @@ public class TestBuildUnreferencedBlocks {
     }
 
     @Test
-    public void testUsesInUnreferencedBlocks() {
+    public void testUsesInUnreachableBlocks() {
         CoreOp.FuncOp g = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
             Op.Result zeroValue = b.op(CoreOp.constant(JavaType.INT, 0));
             Op.Result oneValue = b.op(CoreOp.constant(JavaType.INT, 1));
             b.op(CoreOp.return_());
 
-            Block.Builder unreferencedBlock1 = b.block();
-            unreferencedBlock1.op(JavaOp.neg(zeroValue));
-            unreferencedBlock1.op(JavaOp.neg(oneValue));
-            unreferencedBlock1.op(CoreOp.return_());
+            Block.Builder unreachableBlock1 = b.block();
+            unreachableBlock1.op(JavaOp.neg(zeroValue));
+            unreachableBlock1.op(JavaOp.neg(oneValue));
+            unreachableBlock1.op(CoreOp.return_());
 
-            Block.Builder unreferencedBlock2 = b.block();
-            unreferencedBlock2.op(JavaOp.neg(zeroValue));
-            unreferencedBlock2.op(JavaOp.neg(oneValue));
-            unreferencedBlock2.op(CoreOp.return_());
+            Block.Builder unreachableBlock2 = b.block();
+            unreachableBlock2.op(JavaOp.neg(zeroValue));
+            unreachableBlock2.op(JavaOp.neg(oneValue));
+            unreachableBlock2.op(CoreOp.return_());
         });
 
         Assertions.assertEquals(1, g.body().blocks().size());
@@ -151,16 +176,16 @@ public class TestBuildUnreferencedBlocks {
     }
 
     @Test
-    public void testResultUseFromUnreferencedBlock() {
+    public void testResultUseFromUnreachableBlock() {
         Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
 
         Block.Builder entryBlock = body.entryBlock();
 
-        Block.Builder unreferencedBlock = entryBlock.block();
-        Op.Result zeroValue = unreferencedBlock.op(CoreOp.constant(JavaType.INT, 0));
-        unreferencedBlock.op(return_());
+        Block.Builder unreachableBlock = entryBlock.block();
+        Op.Result zeroValue = unreachableBlock.op(CoreOp.constant(JavaType.INT, 0));
+        unreachableBlock.op(return_());
 
-        // Uses operation result declared in unreferenced block
+        // Uses operation result declared in unreachable block
         entryBlock.op(JavaOp.neg(zeroValue));
         entryBlock.op(return_());
 
@@ -168,16 +193,16 @@ public class TestBuildUnreferencedBlocks {
     }
 
     @Test
-    public void testParameterUseFromUnreferencedBlock() {
+    public void testParameterUseFromUnreachableBlock() {
         Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
 
         Block.Builder entryBlock = body.entryBlock();
 
-        Block.Builder unreferencedBlock = entryBlock.block(JavaType.INT);
-        unreferencedBlock.op(return_());
+        Block.Builder unreachableBlock = entryBlock.block(JavaType.INT);
+        unreachableBlock.op(return_());
 
-        // Uses block parameter declared in unreferenced block
-        entryBlock.op(JavaOp.neg(unreferencedBlock.parameters().getFirst()));
+        // Uses block parameter declared in unreachable block
+        entryBlock.op(JavaOp.neg(unreachableBlock.parameters().getFirst()));
         entryBlock.op(return_());
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));

--- a/test/jdk/jdk/incubator/code/TestBuildUnreachableBlocks.java
+++ b/test/jdk/jdk/incubator/code/TestBuildUnreachableBlocks.java
@@ -94,12 +94,31 @@ public class TestBuildUnreachableBlocks {
     }
 
     @Test
-    public void testUnobservableUnreachableBlocks() throws Throwable {
-        Method m = TestBuildUnreachableBlocks.class.getDeclaredMethod("f");
-        CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
+    public void testNoUnreachablePredecessors() {
+        CoreOp.FuncOp f = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
+            Block.Builder reachableBlock1 = b.block();
 
+            b.op(branch(reachableBlock1.reference()));
+
+            reachableBlock1.op(CoreOp.return_());
+
+            Block.Builder unreachableBlock1 = b.block();
+            unreachableBlock1.op(branch(reachableBlock1.reference()));
+
+            Block.Builder unreachableBlock2 = b.block();
+            unreachableBlock2.op(branch(reachableBlock1.reference()));
+        });
+
+        Assertions.assertEquals(2, f.body().blocks().size());
+
+        Block reachableBlock = f.body().blocks().get(1);
+        Assertions.assertEquals(1, reachableBlock.predecessors().size());
+    }
+
+    @Test
+    public void testUnobservableUnreachableBlocks() {
         List<Op.Result> results = new ArrayList<>();
-        CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
+        CoreOp.FuncOp f = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
             b.op(CoreOp.return_());
 
             Block.Builder unreachableBlock1 = b.block();
@@ -109,8 +128,8 @@ public class TestBuildUnreachableBlocks {
             results.add(unreachableBlock2.op(return_()));
         });
 
-        Assertions.assertEquals(1, g.body().blocks().size());
-        Assertions.assertEquals(1, g.body().entryBlock().ops().size());
+        Assertions.assertEquals(1, f.body().blocks().size());
+        Assertions.assertEquals(1, f.body().entryBlock().ops().size());
 
         for (Op.Result r : results) {
             // Declaring block, an unreachable block, is not observable

--- a/test/jdk/jdk/incubator/code/TestBuildUnreferencedBlocks.java
+++ b/test/jdk/jdk/incubator/code/TestBuildUnreferencedBlocks.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.code.*;
+import jdk.incubator.code.dialect.core.*;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static jdk.incubator.code.dialect.core.CoreOp.*;
+import static jdk.incubator.code.dialect.core.CoreType.FUNCTION_TYPE_VOID;
+
+/*
+ * @test
+ * @modules jdk.incubator.code
+ * @run junit TestBuildUnreferencedBlocks
+ */
+
+public class TestBuildUnreferencedBlocks {
+
+    @Reflect
+    public static int f() {
+        int sum = 0;
+        for (int i = 0; i < 1; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    @Test
+    public void testRemoveNestedBlocks() throws Throwable {
+        Method m = TestBuildUnreferencedBlocks.class.getDeclaredMethod("f");
+        CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
+
+        CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
+            b.op(CoreOp.return_());
+
+            Block.Builder unreferencedBlock1 = b.block();
+            unreferencedBlock1.transformBody(f.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+
+            Block.Builder unreferencedBlock2 = b.block();
+            unreferencedBlock2.transformBody(f.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+        });
+
+        Assertions.assertEquals(1, g.body().blocks().size());
+        Assertions.assertEquals(1, g.body().entryBlock().ops().size());
+    }
+
+
+    @Test
+    public void testRemoveBlocks() throws Throwable {
+        Method m = TestBuildUnreferencedBlocks.class.getDeclaredMethod("f");
+        CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
+
+        CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
+            b.op(CoreOp.return_());
+
+            CoreOp.FuncOp fLowered = f.transform(CodeTransformer.LOWERING_TRANSFORMER);
+
+            Block.Builder unreferencedBlock1 = b.block();
+            unreferencedBlock1.transformBody(fLowered.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+
+            Block.Builder unreferencedBlock2 = b.block();
+            unreferencedBlock2.transformBody(fLowered.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
+        });
+
+        Assertions.assertEquals(1, g.body().blocks().size());
+        Assertions.assertEquals(1, g.body().entryBlock().ops().size());
+    }
+
+
+    @Test
+    public void testNestedUsesInUnreferencedBlock() {
+        CoreOp.FuncOp g = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
+            Op.Result zeroValue = b.op(CoreOp.constant(JavaType.INT, 0));
+            Op.Result oneValue = b.op(CoreOp.constant(JavaType.INT, 1));
+            b.op(CoreOp.return_());
+
+            JavaType.type(Runnable.class);
+
+            Block.Builder unreferencedBlock1 = b.block();
+            JavaOp.LambdaOp lop = JavaOp.lambda(b.parentBody(), FunctionType.FUNCTION_TYPE_VOID, JavaType.type(Runnable.class)).body(lb -> {
+                lb.op(JavaOp.neg(zeroValue));
+                lb.op(JavaOp.neg(oneValue));
+                lb.op(CoreOp.return_());
+            });
+            unreferencedBlock1.op(lop);
+            unreferencedBlock1.op(CoreOp.return_());
+        });
+
+        Assertions.assertEquals(1, g.body().blocks().size());
+        Assertions.assertEquals(3, g.body().entryBlock().ops().size());
+
+        Op.Result zeroValue = g.body().entryBlock().ops().get(0).result();
+        Assertions.assertTrue(zeroValue.uses().isEmpty());
+
+        Op.Result oneValue = g.body().entryBlock().ops().get(1).result();
+        Assertions.assertTrue(oneValue.uses().isEmpty());
+    }
+
+    @Test
+    public void testUsesInUnreferencedBlocks() {
+        CoreOp.FuncOp g = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
+            Op.Result zeroValue = b.op(CoreOp.constant(JavaType.INT, 0));
+            Op.Result oneValue = b.op(CoreOp.constant(JavaType.INT, 1));
+            b.op(CoreOp.return_());
+
+            Block.Builder unreferencedBlock1 = b.block();
+            unreferencedBlock1.op(JavaOp.neg(zeroValue));
+            unreferencedBlock1.op(JavaOp.neg(oneValue));
+            unreferencedBlock1.op(CoreOp.return_());
+
+            Block.Builder unreferencedBlock2 = b.block();
+            unreferencedBlock2.op(JavaOp.neg(zeroValue));
+            unreferencedBlock2.op(JavaOp.neg(oneValue));
+            unreferencedBlock2.op(CoreOp.return_());
+        });
+
+        Assertions.assertEquals(1, g.body().blocks().size());
+        Assertions.assertEquals(3, g.body().entryBlock().ops().size());
+
+        Op.Result zeroValue = g.body().entryBlock().ops().get(0).result();
+        Assertions.assertTrue(zeroValue.uses().isEmpty());
+
+        Op.Result oneValue = g.body().entryBlock().ops().get(1).result();
+        Assertions.assertTrue(oneValue.uses().isEmpty());
+    }
+
+    @Test
+    public void testResultUseFromUnreferencedBlock() {
+        Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+
+        Block.Builder entryBlock = body.entryBlock();
+
+        Block.Builder unreferencedBlock = entryBlock.block();
+        Op.Result zeroValue = unreferencedBlock.op(CoreOp.constant(JavaType.INT, 0));
+        unreferencedBlock.op(return_());
+
+        // Uses operation result declared in unreferenced block
+        entryBlock.op(JavaOp.neg(zeroValue));
+        entryBlock.op(return_());
+
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+
+    @Test
+    public void testParameterUseFromUnreferencedBlock() {
+        Body.Builder body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+
+        Block.Builder entryBlock = body.entryBlock();
+
+        Block.Builder unreferencedBlock = entryBlock.block(JavaType.INT);
+        unreferencedBlock.op(return_());
+
+        // Uses block parameter declared in unreferenced block
+        entryBlock.op(JavaOp.neg(unreferencedBlock.parameters().getFirst()));
+        entryBlock.op(return_());
+
+        Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+}


### PR DESCRIPTION
When building a body remove any unreachable blocks. An unreachable block is a block that is not dominated by the entry block.

If there are one or more unreachable blocks it indicates there are two or more entry points into the body and there can only be one, the entry block. Generally, it indicates that unreachable blocks can be removed, such as those produced by a transformation e.g. the lowering transformation generates exit blocks upfront that may end up never being connected because they model dead code paths.

We assume that any unreachable block, by default, can be removed. Unreachable blocks may have reachable blocks as successors, and may refer to values declared in reachable blocks or in blocks of connected ancestor body builders. These do not impact those reachable blocks and so the unreachable blocks can be safely detached.

It is an error if a reachable block refers to a value declared in an unreachable block. The unreachable block cannot be safely detached.

Implementation wise, we can update a block's predecessor state when sorting blocks, from the entry block, in reverse postorder. For uses, however, it is easier and more efficient to retain the existing approach of updating use state as operations are appended to blocks, rather than computing it when a body is built. Therefore, we remove uses from all operations under an unreachable block, and it is simpler to do it for all uses rather than identify particular uses declared in reachable blocks or blocks of connected ancestor body builders.

After unreachable blocks have been successfully removed we can create the map of immediate dominators and then validate value use.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1041/head:pull/1041` \
`$ git checkout pull/1041`

Update a local copy of the PR: \
`$ git checkout pull/1041` \
`$ git pull https://git.openjdk.org/babylon.git pull/1041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1041`

View PR using the GUI difftool: \
`$ git pr show -t 1041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1041.diff">https://git.openjdk.org/babylon/pull/1041.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1041#issuecomment-4503304477)
</details>
