### PR TITLE
Check field value is constant in the evaluator

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -255,15 +255,22 @@ public sealed abstract class JavaOp extends Op {
                                 !isConstantType(fieldLoadOp.fieldReference().type())) {
                             throw new NonConstantExpression();
                         }
-                        Object v;
                         if ((field.getModifiers() & Modifier.STATIC) != 0) {
-                            v = vh.get();
+                            Object v;
+                            try {
+                                v = vh.get();
+                            } catch (Throwable t) {
+                                throw new NonConstantExpression();
+                            }
+                            if (!isConstantValue(v)) {
+                                throw new NonConstantExpression();
+                            }
+                            yield v instanceof String s ? s.intern() : v;
                         } else {
                             // we can't get the value of an instance field from the model
                             // we need the value of the receiver
                             throw new NonConstantExpression();
                         }
-                        yield v instanceof String s ? s.intern() : v;
                     }
                     case ArithmeticOperation _ -> {
                         List<Object> values = op.operands().stream().map(this::eval).toList();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2390,8 +2390,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 Type lhsType = tree.lhs.type;
                 Type rhsType = tree.rhs.type;
 
-                Value lhs = toValue(tree.lhs, lhsType);
-                Value rhs = toValue(tree.rhs, rhsType);
+                Value lhs = toValue(tree.lhs, lhsType.hasTag(BOT) ? syms.stringType : lhsType);
+                Value rhs = toValue(tree.rhs, rhsType.hasTag(BOT) ? syms.stringType : rhsType);
 
                 result = append(JavaOp.concat(lhs, rhs));
             }

--- a/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
+++ b/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
@@ -297,6 +297,12 @@ public class TestConstantExpressionEvaluation {
         String s = null;
         return s;
     }
+
+    @Reflect
+    static String fcNullConcat() {
+        return "a" + null;
+    }
+
     @ParameterizedTest
     @MethodSource("cases")
     void test(Method m) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {

--- a/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
+++ b/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
@@ -300,7 +300,7 @@ public class TestConstantExpressionEvaluation {
 
     @Reflect
     static String fcNullConcat() {
-        return "a" + null;
+        return (String) null + null;
     }
 
     @ParameterizedTest

--- a/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
+++ b/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
@@ -286,6 +286,17 @@ public class TestConstantExpressionEvaluation {
         return S;
     }
 
+    static final String T = null;
+    @Reflect
+    static String fcFieldNull() {
+        return T;
+    }
+
+    @Reflect
+    static String fcNullVar() {
+        String s = null;
+        return s;
+    }
     @ParameterizedTest
     @MethodSource("cases")
     void test(Method m) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {


### PR DESCRIPTION
In the evaluator, we were missing the check on the field value. This allowed `null` to be considered a constant expression.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [50be763c](https://git.openjdk.org/babylon/pull/1042/files/50be763cd00f0873ebd710a6fff67187759fb8b7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1042/head:pull/1042` \
`$ git checkout pull/1042`

Update a local copy of the PR: \
`$ git checkout pull/1042` \
`$ git pull https://git.openjdk.org/babylon.git pull/1042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1042`

View PR using the GUI difftool: \
`$ git pr show -t 1042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1042.diff">https://git.openjdk.org/babylon/pull/1042.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1042#issuecomment-4502037985)
</details>
