### PR TITLE
Clean up immediate dominators and post dominators

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -402,7 +402,7 @@ public final class Block implements CodeElement<Block, Op> {
         // Traverse the immediate dominators until dom is reached or the entry block
         Map<Block, Block> idoms = b.ancestorBody().immediateDominators();
         Block idom = idoms.get(b);
-        while (idom != entry) {
+        while (idom != null) {
             if (idom == dom) {
                 return true;
             }
@@ -419,37 +419,39 @@ public final class Block implements CodeElement<Block, Op> {
      * <p>
      * The immediate dominator is the unique block that strictly dominates this block, but does not strictly dominate
      * any other block that strictly dominates this block.
+     * <p>
+     * The entry block has no immediate dominator, since it is not strictly dominated by any other block.
      *
      * @return the immediate dominator of this block, otherwise {@code null} if this block is the entry block.
+     * @see Body#immediateDominators()
      */
     public Block immediateDominator() {
-        if (this == ancestorBody().entryBlock()) {
-            return null;
-        }
-
-        Map<Block, Block> idoms = ancestorBody().immediateDominators();
-        return idoms.get(this);
+        return ancestorBody().immediateDominators().get(this);
     }
 
     /**
      * Returns the immediate post dominator of this block.
      * <p>
-     * If this block has no successors then this method returns the synthetic block
-     * {@link Body#IPDOM_EXIT} representing the synthetic exit used to compute
-     * the immediate post dominators.
+     * If this block is one of many block's in the same body with no successors, then there are multiple exit blocks,
+     * and the immediate post dominator of those blocks is the synthetic block {@link Body#IPDOM_EXIT} representing the
+     * single exit block. Otherwise, if this block is the only block in the body with no successors, then that block is
+     * the single exit block, and this method returns {@code null}.
      * <p>
-     * Both this block and the immediate post dominator (if defined) have the same parent body,
-     * except for the synthetic block {@link Body#IPDOM_EXIT}.
+     * Both this block and the immediate post dominator (if defined) have the same parent body, except for the
+     * synthetic block {@link Body#IPDOM_EXIT}.
      * <p>
-     * The immediate post dominator is the unique block that strictly post dominates this block,
-     * but does not strictly post dominate any other block that strictly post dominates this block.
+     * The immediate post dominator is the unique block that strictly post dominates this block, but does not strictly
+     * post dominate any other block that strictly post dominates this block.
+     * <p>
+     * The exit block has no immediate post dominator, since it is not strictly post dominated by any other block.
      *
-     * @return the immediate post dominator of this block, otherwise {@code Body#IPDOM_EXIT}.
+     * @return the immediate post dominator of this block, {@code Body#IPDOM_EXIT} if the synthetic exit is this block's
+     * immediate post dominator, or {@code null} if this block is the single exit block.
+     * @throws IllegalStateException if there is no single exit block, synthesized or otherwise
+     * @see Body#immediatePostDominators()
      */
     public Block immediatePostDominator() {
-        Map<Block, Block> ipdoms = ancestorBody().immediatePostDominators();
-        Block ipdom = ipdoms.get(this);
-        return ipdom == this ? Body.IPDOM_EXIT : ipdom;
+        return ancestorBody().immediatePostDominators().get(this);
     }
 
     // @@@ isPostDominatedBy and immediatePostDominator

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -454,7 +454,7 @@ public final class Block implements CodeElement<Block, Op> {
         return ancestorBody().immediatePostDominators().get(this);
     }
 
-    // @@@ isPostDominatedBy and immediatePostDominator
+    // @@@ isPostDominatedBy
 
     private static Block findBlockForDomBody(Block b, final Body domr) {
         Body rb = b.ancestorBody();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -146,8 +146,8 @@ public final class Body implements CodeElement<Body, Block> {
     /**
      * Returns a map of block to its immediate dominator, for all blocks in this body.
      * <p>
-     * A block's immediate dominator is the unique block that strictly dominates that block, but does
-     * not strictly dominate any other block that strictly dominates that block.
+     * A block's immediate dominator is the unique block that strictly dominates that block, but does not strictly
+     * dominate any other block that strictly dominates that block.
      * <p>
      * The entry block has no immediate dominator, since it is not strictly dominated by any other block. Its
      * corresponding entry in the map has a {@code null} value.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -144,9 +144,16 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * Returns a map of block to its immediate dominator.
+     * Returns a map of block to its immediate dominator, for all blocks in this body.
+     * <p>
+     * A block's immediate dominator is the unique block that strictly dominates that block, but does
+     * not strictly dominate any other block that strictly dominates that block.
+     * <p>
+     * The entry block has no immediate dominator, since it is not strictly dominated by any other block. Its
+     * corresponding entry in the map has a {@code null} value.
      *
      * @return a map of block to its immediate dominator, as an unmodifiable map
+     * @see Block#immediateDominator()
      */
     public Map<Block, Block> immediateDominators() {
         return idoms.get();
@@ -166,7 +173,7 @@ public final class Body implements CodeElement<Body, Block> {
         // and wrap and a specific map implementation
 
         Map<Block, Block> doms = new HashMap<>();
-        doms.put(entryBlock(), entryBlock());
+        doms.put(entryBlock(), null);
 
         // Blocks are sorted in reverse postorder
         boolean changed;
@@ -184,7 +191,7 @@ public final class Body implements CodeElement<Body, Block> {
                         break;
                     }
                 }
-                assert b.predecessors().isEmpty() || newIdom != null : b;
+                assert newIdom != null : b;
 
                 // For all other predecessors, p, of b
                 for (Block p : b.predecessors()) {
@@ -269,13 +276,21 @@ public final class Body implements CodeElement<Body, Block> {
     }
 
     /**
-     * Returns a map of block to its immediate post dominator.
+     * Returns a map of block to its immediate post dominator, for all blocks in this body.
      * <p>
-     * If there are two or more blocks with no successors then
-     * a single exit point is synthesized using the {@link #IPDOM_EXIT}
-     * block, which represents the immediate post dominator of those blocks.
+     * If there are two or more blocks with no successors then a single exit block is synthesized using the
+     * {@link #IPDOM_EXIT} block, which represents the immediate post dominator of those blocks. The returned map
+     * will contain an entry mapping {@code IPDOM_EXIT} to {@code null}.
+     * <p>
+     * A block's immediate post dominator is the unique block that strictly post dominates that block, but does not
+     * strictly post dominate any other block that strictly post dominates that block.
+     * <p>
+     * The exit block has no immediate post dominator, since it is not strictly post dominated by any other block. Its
+     * corresponding entry in the map has a {@code null} value.
      *
      * @return a map of block to its immediate post dominator, as an unmodifiable map
+     * @throws IllegalStateException if there is no single exit block, synthesized or otherwise
+     * @see Block#immediatePostDominator()
      */
     public Map<Block, Block> immediatePostDominators() {
         Map<Block, Block> pdoms = new HashMap<>();
@@ -285,12 +300,11 @@ public final class Body implements CodeElement<Body, Block> {
         // the exit blocks
         boolean nSuccessors = blocks.stream().filter(b -> b.successors().isEmpty()).count() > 1;
 
-        if (nSuccessors) {
-            pdoms.put(IPDOM_EXIT, IPDOM_EXIT);
-        } else {
-            Block exit = blocks.getLast();
-            assert blocks.stream().filter(b -> b.successors().isEmpty()).findFirst().orElseThrow() == exit;
-            pdoms.put(exit, exit);
+        List<Block> exits = blocks.stream().filter(b -> b.successors().isEmpty()).toList();
+        switch (exits.size()) {
+            case 0 -> throw new IllegalStateException();
+            case 1 -> pdoms.put(exits.getFirst(), null);
+            default -> pdoms.put(IPDOM_EXIT, null);
         }
 
         // Blocks are sorted in reverse postorder
@@ -621,8 +635,9 @@ public final class Body implements CodeElement<Body, Block> {
          * @param op the parent operation
          * @return the built body
          * @throws IllegalStateException if this body builder has finished
-         * @throws IllegalStateException if any connected body builder is not successfully finished
-         * @throws IllegalStateException if any connected body builder built and its parent operation is unplaced
+         * @throws IllegalStateException if any connected body builder finishes unsuccessfully
+         * @throws IllegalStateException if any connected body builder finishes successfully and its body's parent
+         * operation is unplaced
          * @throws IllegalStateException if a reachable block has no terminating operation
          * @throws IllegalStateException if a reachable block has a successor whose number of arguments is greater than
          * the number of parameters of the successor's target block

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/SSA.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/SSA.java
@@ -679,19 +679,21 @@ public final class SSA {
 
         static Node buildDomTree(Block entryBlock, Map<Block, Block> idoms) {
             Map<Block, Node> tree = new HashMap<>();
+            Node root = new Node(entryBlock, new HashSet<>());
+            tree.put(entryBlock, root);
             for (Map.Entry<Block, Block> e : idoms.entrySet()) {
-                Block id = e.getValue();
                 Block b = e.getKey();
-
-                Node parent = tree.computeIfAbsent(id, _k -> new Node(_k, new HashSet<>()));
-                if (b == entryBlock) {
+                Block id = e.getValue();
+                if (id == null) {
+                    assert b == entryBlock;
                     continue;
                 }
 
+                Node parent = tree.computeIfAbsent(id, _k -> new Node(_k, new HashSet<>()));
                 Node child = tree.computeIfAbsent(b, _k -> new Node(_k, new HashSet<>()));
                 parent.children.add(child);
             }
-            return tree.get(entryBlock);
+            return root;
         }
     }
 }

--- a/test/jdk/jdk/incubator/code/TestDominate.java
+++ b/test/jdk/jdk/incubator/code/TestDominate.java
@@ -218,9 +218,12 @@ public class TestDominate {
         Block b6 = entry.successors().get(0).targetBlock();
 
         for (Block b : f.body().blocks()) {
-            if (b == entry || b == b6) {
+            if (b == entry) {
+                Assertions.assertNull(idoms.get(b));
+                Assertions.assertNull(b.immediateDominator());
+            } else if (b == b6) {
                 Assertions.assertEquals(entry, idoms.get(b));
-                Assertions.assertEquals(b == entry ? null : entry, b.immediateDominator());
+                Assertions.assertEquals(entry, b.immediateDominator());
             } else {
                 Assertions.assertEquals(b6, idoms.get(b));
                 Assertions.assertEquals(b6, b.immediateDominator());
@@ -366,8 +369,25 @@ public class TestDominate {
 
         for (Block b : f.body().blocks()) {
             Block ipb = ipdoms.get(b);
-            Assertions.assertEquals(ipb == b ? Body.IPDOM_EXIT : ipb, b.immediatePostDominator());
+            Assertions.assertEquals(ipb, b.immediatePostDominator());
         }
+    }
+
+    @Test
+    public void testPostDominanceNoExit() {
+        String m = """
+                func @"f" (%0 : java.type:"boolean")java.type:"void" -> {
+                    %5 : java.type:"void" = branch ^LOOP;
+
+                  ^LOOP:
+                    %8 : java.type:"void" = branch ^LOOP;
+                };
+                """;
+        CoreOp.FuncOp f = (CoreOp.FuncOp) OpParser.fromText(JavaOp.JAVA_DIALECT_FACTORY, m).get(0);
+
+        Assertions.assertThrows(IllegalStateException.class, () -> f.body().immediatePostDominators());
+        Assertions.assertThrows(IllegalStateException.class, () -> f.body().blocks().get(0).immediatePostDominator());
+        Assertions.assertThrows(IllegalStateException.class, () -> f.body().blocks().get(1).immediatePostDominator());
     }
 
     @Test
@@ -422,21 +442,23 @@ public class TestDominate {
         Assertions.assertEquals(dfExpected, df);
     }
 
-
     static Node<Block> buildDomTree(Block entryBlock, Map<Block, Block> idoms) {
-        Map<Block, Node<Block>> m = new HashMap<>();
+        Map<Block, Node<Block>> tree = new HashMap<>();
+        Node<Block> root = new Node<>(entryBlock, new HashSet<>());
+        tree.put(entryBlock, root);
         for (Map.Entry<Block, Block> e : idoms.entrySet()) {
-            Block id = e.getValue();
             Block b = e.getKey();
-            if (b == entryBlock) {
+            Block id = e.getValue();
+            if (id == null) {
+                assert b == entryBlock;
                 continue;
             }
 
-            Node<Block> parent = m.computeIfAbsent(id, _k -> new Node<>(_k, new HashSet<>()));
-            Node<Block> child = m.computeIfAbsent(b, _k -> new Node<>(_k, new HashSet<>()));
+            Node<Block> parent = tree.computeIfAbsent(id, _k -> new Node<>(_k, new HashSet<>()));
+            Node<Block> child = tree.computeIfAbsent(b, _k -> new Node<>(_k, new HashSet<>()));
             parent.children.add(child);
         }
-        return m.get(entryBlock);
+        return root;
     }
 
     @SafeVarargs

--- a/test/jdk/jdk/incubator/code/anf/AnfTransformer.java
+++ b/test/jdk/jdk/incubator/code/anf/AnfTransformer.java
@@ -301,7 +301,7 @@ public class AnfTransformer {
 
             //Reverse the idom relation
             b.immediateDominators().forEach((dominated, dominator) -> {
-                if (!dominated.equals(dominator)) {
+                if (dominator != null) {
                     dominatesMap.compute(dominator, (k, v) -> {
                         if (v == null) {
                             var newList = new ArrayList<Block>();


### PR DESCRIPTION
Change `Body.immediateDominators` to return a map where the entry block maps to null, rather than itself. This aligns with `Block.immediateDominator`.

Similarly change `Body.immediatePostDominators` to align with `Block.immediatePostDominator`. Further, throw an exception where there is no exit block.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1044/head:pull/1044` \
`$ git checkout pull/1044`

Update a local copy of the PR: \
`$ git checkout pull/1044` \
`$ git pull https://git.openjdk.org/babylon.git pull/1044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1044`

View PR using the GUI difftool: \
`$ git pr show -t 1044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1044.diff">https://git.openjdk.org/babylon/pull/1044.diff</a>

</details>
