### PR TITLE
Rename Block.Builder.op to add

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
@@ -79,7 +79,7 @@ public final class OnnxTransformer {
                 if (inputCapture instanceof Op.Result r &&
                         r.op() instanceof CoreOp.VarOp vop &&
                         vop.initOperand() instanceof Block.Parameter) {
-                    output = b.op(CoreOp.var(b.parameters().get(i)));
+                    output = b.add(CoreOp.var(b.parameters().get(i)));
                 } else {
                     output = b.parameters().get(i);
                 }
@@ -136,13 +136,13 @@ public final class OnnxTransformer {
         return f.transform(fname, (bb, op) -> {
             if (op instanceof JavaOp.InvokeOp io && funcs.get(io.invokeReference()) instanceof CoreOp.FuncOp fo) {
                 if (doNotInline.contains(fo)) {
-                    bb.context().mapValue(op.result(), bb.op(CoreOp.funcCall(fo, bb.context().getValues(op.operands()))));
+                    bb.context().mapValue(op.result(), bb.add(CoreOp.funcCall(fo, bb.context().getValues(op.operands()))));
                 } else {
                     LOG.log(System.Logger.Level.DEBUG, "Inlining " + fo.funcName() + " into " + fname);
                     Inliner.inline(bb, mapOrInline(fo, funcs, doNotInline), bb.context().getValues(io.operands()), (_, v) -> bb.context().mapValue(io.result(), v));
                 }
             } else {
-                bb.op(op);
+                bb.add(op);
             }
             return bb;
         });
@@ -190,11 +190,11 @@ public final class OnnxTransformer {
                                 FunctionType newType = CoreType.functionType(fco.opSignature().returnType(),
                                         Stream.concat(fco.opSignature().parameterTypes().stream(), initTypes.stream()).toList());
                                 List<Value> newOperands = Stream.concat(bb.context().getValues(fco.operands()).stream(), initArgs.stream()).toList();
-                                Op.Result newCall = bb.op(CoreOp.funcCall(fco.funcName(), newType, newOperands));
+                                Op.Result newCall = bb.add(CoreOp.funcCall(fco.funcName(), newType, newOperands));
                                 bb.context().mapValue(op.result(), newCall);
                             }
                             default -> {
-                                bb.op(op);
+                                bb.add(op);
                             }
                         }
                         return bb;
@@ -249,7 +249,7 @@ public final class OnnxTransformer {
         while (f.elements().skip(1).anyMatch(ce -> ce instanceof Op op && unused.test(op))) {
             f = f.transform((block, op) -> {
                 if (!unused.test(op)) {
-                    block.op(op);
+                    block.add(op);
                 }
                 return block;
             });
@@ -339,9 +339,9 @@ public final class OnnxTransformer {
                                                             CoreType.functionType(fco.opSignature().returnType(),
                                                                                       newOperands.stream().map(Value::type).toList()),
                                                             newOperands);
-                cc.mapValue(op.result(), bb.op(newCall));
+                cc.mapValue(op.result(), bb.add(newCall));
             } else {
-                bb.op(op);
+                bb.add(op);
             }
             return bb;
         });
@@ -367,7 +367,7 @@ public final class OnnxTransformer {
             bob.transformBody(func.body(), List.of(), (b, op) -> {
                 // Drop any non-terminating operation whose result is not used
                 if (op instanceof Op.Terminating || !op.result().uses().isEmpty() || op instanceof CoreOp.FuncOp || op instanceof CoreOp.VarAccessOp.VarStoreOp) {
-                    b.op(op);
+                    b.add(op);
                 }
                 return b;
             });
@@ -465,28 +465,28 @@ public final class OnnxTransformer {
                     } catch (ReflectiveOperationException | RuntimeException e) {
                         throw new RuntimeException(e);
                     }
-                    Op.Result result = bb.op(onnxOp);
+                    Op.Result result = bb.add(onnxOp);
                     bb.context().mapValue(io.result(), result);
                 }
                 // Transform access to the result of an operator that is a record access
                 case JavaOp.InvokeOp io when
                         tc.recordComponentAccessToTupleIndex(io.invokeReference()) instanceof Integer index -> {
-                    Op.Result result = bb.op(CoreOp.tupleLoad(bb.context().getValue(io.operands().getFirst()), index));
+                    Op.Result result = bb.add(CoreOp.tupleLoad(bb.context().getValue(io.operands().getFirst()), index));
                     bb.context().mapValue(io.result(), result);
                 }
                 // Transform constant array load access
                 case JavaOp.ArrayAccessOp.ArrayLoadOp alo -> {
                     var tuple = bb.context().getValue(alo.operands().getFirst());
                     int index = (Integer)((CoreOp.ConstantOp)((Op.Result)alo.operands().get(1)).op()).value();
-                    Op.Result result = bb.op(CoreOp.tupleLoad(tuple, index));
+                    Op.Result result = bb.add(CoreOp.tupleLoad(tuple, index));
                     bb.context().mapValue(alo.result(), result);
                 }
                 // Transform record construction
                 case JavaOp.NewOp no when tc.isRecord(no.resultType()) -> {
-                    Op.Result result = bb.op(CoreOp.tuple(no.operands().stream().map(v -> {
+                    Op.Result result = bb.add(CoreOp.tuple(no.operands().stream().map(v -> {
                         Value mv = bb.context().queryValue(v).orElse(null);
                         if (mv == null && bb.context().getProperty(skipVars(v)) instanceof List list) {
-                            mv = bb.op(CoreOp.tuple(bb.context().getValues((List<Value>) list)));
+                            mv = bb.add(CoreOp.tuple(bb.context().getValues((List<Value>) list)));
                         }
                         return mv;
                     }).toList()));
@@ -495,25 +495,25 @@ public final class OnnxTransformer {
                 // Transform access to the result of an operator that is a list access
                 // @@@ raw use of List::get with constant argument
                 case JavaOp.InvokeOp io when io.invokeReference().refType().equals(LIST_CLASS) && io.invokeReference().name().equals("get") -> {
-                    Op.Result result = bb.op(JavaOp.invoke(
+                    Op.Result result = bb.add(JavaOp.invoke(
                             io.invokeReference(),
                             bb.context().getValue(io.operands().getFirst()),
-                            bb.op(CoreOp.constant(JavaType.INT, pe.evaluatedAttributes.get(io).getLast()))));
+                            bb.add(CoreOp.constant(JavaType.INT, pe.evaluatedAttributes.get(io).getLast()))));
                     bb.context().mapValue(io.result(), result);
                 }
                 // Skip nested lambdas
                 case JavaOp.LambdaOp _ -> {
                 }
                 case CoreOp.FuncCallOp fco -> {
-                    Op.Result result = bb.op(CoreOp.funcCall(fco.funcName(), tc.convertType(fco.opSignature()), bb.context().getValues(fco.operands())));
+                    Op.Result result = bb.add(CoreOp.funcCall(fco.funcName(), tc.convertType(fco.opSignature()), bb.context().getValues(fco.operands())));
                     bb.context().mapValue(fco.result(), result);
                 }
                 case JavaOp.FieldAccessOp.FieldLoadOp flo when flo.operands().isEmpty() -> {
-                    Op.Result result = bb.op(JavaOp.fieldLoad(tc.convertType(flo.result()), flo.fieldReference()));
+                    Op.Result result = bb.add(JavaOp.fieldLoad(tc.convertType(flo.result()), flo.fieldReference()));
                     bb.context().mapValue(flo.result(), result);
                 }
                 case JavaOp.FieldAccessOp.FieldLoadOp flo -> {
-                    Op.Result result = bb.op(JavaOp.fieldLoad(tc.convertType(flo.result()), flo.fieldReference(), bb.context().getValue(flo.operands().getFirst())));
+                    Op.Result result = bb.add(JavaOp.fieldLoad(tc.convertType(flo.result()), flo.fieldReference(), bb.context().getValue(flo.operands().getFirst())));
                     bb.context().mapValue(flo.result(), result);
                 }
                 case JavaOp.ArrayAccessOp.ArrayStoreOp aso when aso.operands().get(1) instanceof Op.Result or && or.op() instanceof CoreOp.ConstantOp cop -> {
@@ -523,11 +523,11 @@ public final class OnnxTransformer {
                     list.set(index, aso.operands().get(2));
                 }
                 case CoreOp.ReturnOp ro when bb.context().getProperty(skipVars(ro.operands().getFirst())) instanceof List list -> {
-                    bb.op(CoreOp.return_(bb.op(CoreOp.tuple(bb.context().getValues(list)))));
+                    bb.add(CoreOp.return_(bb.add(CoreOp.tuple(bb.context().getValues(list)))));
                 }
                 // Copy remaining operations, which may be removed later transformations
                 default -> {
-                    bb.op(op);
+                    bb.add(op);
                 }
             }
             return bb;

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/PartialEvaluator.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/PartialEvaluator.java
@@ -234,15 +234,15 @@ public final class PartialEvaluator {
                     if (op instanceof CoreOp.VarOp) {
                         // @@@ Do not turn into constant to avoid conflicts with the interpreter
                         // and its runtime representation of vars
-                        outBlock.op(op);
+                        outBlock.add(op);
                     } else {
                         // Result was evaluated, replace with constant operation
-                        Op.Result constantResult = outBlock.op(CoreOp.constant(op.resultType(), result));
+                        Op.Result constantResult = outBlock.add(CoreOp.constant(op.resultType(), result));
                         outBlock.context().mapValue(op.result(), constantResult);
                     }
                 } else {
                     // Copy unevaluated operation
-                    Op.Result r = outBlock.op(op);
+                    Op.Result r = outBlock.add(op);
                     // Explicitly remap result, since the op can be copied more than once in pealed loops
                     // @@@ See comment Block.op code which implicitly limits this
                     outBlock.context().mapValue(op.result(), r);
@@ -273,13 +273,13 @@ public final class PartialEvaluator {
 
                         processBlock(bc, inBlock, nextInBlock, outBlock);
 
-                        outBlock.op(CoreOp.branch(outBlock.context().getReferenceOrCreate(nextInBlockRef)));
+                        outBlock.add(CoreOp.branch(outBlock.context().getReferenceOrCreate(nextInBlockRef)));
                     } else {
                         // @@@ might be non-constant latch to loop
                         processBlock(bc, inBlock, cb.falseBranch().targetBlock(), outBlock);
                         processBlock(bc, inBlock, cb.trueBranch().targetBlock(), outBlock);
 
-                        outBlock.op(to);
+                        outBlock.add(to);
                     }
                 }
                 case CoreOp.BranchOp b -> {
@@ -298,9 +298,9 @@ public final class PartialEvaluator {
 
                     processBlock(bc, inBlock, nextInBlock, outBlock);
 
-                    outBlock.op(b);
+                    outBlock.add(b);
                 }
-                case CoreOp.ReturnOp _ -> outBlock.op(to);
+                case CoreOp.ReturnOp _ -> outBlock.add(to);
                 default -> throw evaluationException(
                         new UnsupportedOperationException("Unsupported terminating operation: " + to));
             }

--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/lift/OnnxLift.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/lift/OnnxLift.java
@@ -398,7 +398,7 @@ public final class OnnxLift {
                         returnType,
                         extOp.attributes(),
                         extOp.bodyDefinitions());
-                Op.Result res = fb.op((OnnxOp)ONNX_OP_FACTORY.constructOpOrFail(extOp));
+                Op.Result res = fb.add((OnnxOp)ONNX_OP_FACTORY.constructOpOrFail(extOp));
 
                 // map outputs
                 if (schema.outputs().size() == 1) {
@@ -406,17 +406,17 @@ public final class OnnxLift {
                 } else {
                     valueMap.put(n.name(), res);
                     for (int i = 0; i < outputNames.size(); i++) {
-                        valueMap.put(outputNames.get(i), fb.op(CoreOp.tupleLoad(res, i)));
+                        valueMap.put(outputNames.get(i), fb.add(CoreOp.tupleLoad(res, i)));
                     }
                 }
             }
 
             if (g.output().size() == 1) {
-                fb.op(CoreOp.return_(valueMap.get(g.output().getFirst().name())));
+                fb.add(CoreOp.return_(valueMap.get(g.output().getFirst().name())));
             } else {
-                Op.Result ret = fb.op(CoreOp.tuple(g.output().stream().map(OnnxModel.ValueInfoProto::name).map(valueMap::get).toList()));
+                Op.Result ret = fb.add(CoreOp.tuple(g.output().stream().map(OnnxModel.ValueInfoProto::name).map(valueMap::get).toList()));
                 valueMap.put(g.name() + "_return", ret);
-                fb.op(CoreOp.return_(ret));
+                fb.add(CoreOp.return_(ret));
             }
         });
         return new LiftedModelWrapper(func, List.of(valueMap.sequencedKeySet().toArray(String[]::new)),

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/CNNTest.java
@@ -184,7 +184,7 @@ public class CNNTest {
             Block.Parameter fc3Biases = b.parameters().get(9);
             Block.Parameter ubyteImage = b.parameters().get(10);
 
-            var inputImage = b.op(OnnxOps.Cast(OnnxType.TENSOR_FLOAT32,
+            var inputImage = b.add(OnnxOps.Cast(OnnxType.TENSOR_FLOAT32,
                     ubyteImage,
                     empty(),
                     OnnxType.TENSOR_FLOAT32.eType().id(),
@@ -192,7 +192,7 @@ public class CNNTest {
             ));
 
             // Scaling the features
-            var scalingFactor = b.op(OnnxOps.Constant(OnnxType.TENSOR_FLOAT32,
+            var scalingFactor = b.add(OnnxOps.Constant(OnnxType.TENSOR_FLOAT32,
                     empty(),
                     empty(),
                     empty(),
@@ -201,10 +201,10 @@ public class CNNTest {
                     empty(),
                     empty(),
                     empty()));
-            var scaledInput = b.op(OnnxOps.Div(inputImage.type(), inputImage, scalingFactor));
+            var scaledInput = b.add(OnnxOps.Div(inputImage.type(), inputImage, scalingFactor));
 
             // First conv layer
-            var conv1 = b.op(OnnxOps.Conv(scaledInput.type(),
+            var conv1 = b.add(OnnxOps.Conv(scaledInput.type(),
                     scaledInput,
                     conv1Weights,
                     of(conv1Biases),
@@ -214,12 +214,12 @@ public class CNNTest {
                     of(new long[]{1, 1, 1, 1}),
                     of(1L),
                     of(new long[]{5,5})));
-            var relu1 = b.op(OnnxOps.Relu(conv1.type(),
+            var relu1 = b.add(OnnxOps.Relu(conv1.type(),
                     conv1));
 
             // First pooling layer
             // @@@ multiple results?
-            var pool1Result = b.op(OnnxOps.MaxPool(CoreType.tupleType(relu1.type(), OnnxType.TENSOR_INT64),
+            var pool1Result = b.add(OnnxOps.MaxPool(CoreType.tupleType(relu1.type(), OnnxType.TENSOR_INT64),
                     Set.of(OnnxOps.MaxPool.OutputParameter.Indices),
                     relu1,
                     of(new long[4]),
@@ -231,8 +231,8 @@ public class CNNTest {
                     new long[]{2, 2}));
 
             // Second conv layer
-            var pool1 = b.op(CoreOp.tupleLoad(pool1Result, 0));
-            var conv2 = b.op(OnnxOps.Conv(pool1.type(),
+            var pool1 = b.add(CoreOp.tupleLoad(pool1Result, 0));
+            var conv2 = b.add(OnnxOps.Conv(pool1.type(),
                     pool1,
                     conv2Weights,
                     of(conv2Biases),
@@ -242,12 +242,12 @@ public class CNNTest {
                     of(new long[]{1, 1, 1, 1}),
                     of(1L),
                     of(new long[]{5,5})));
-            var relu2 = b.op(OnnxOps.Relu(conv2.type(),
+            var relu2 = b.add(OnnxOps.Relu(conv2.type(),
                     conv2));
 
             // Second pooling layer
             // @@@ multiple results?
-            var pool2Result = b.op(OnnxOps.MaxPool(CoreType.tupleType(relu2.type(), OnnxType.TENSOR_INT64),
+            var pool2Result = b.add(OnnxOps.MaxPool(CoreType.tupleType(relu2.type(), OnnxType.TENSOR_INT64),
                     Set.of(OnnxOps.MaxPool.OutputParameter.Indices),
                     relu2,
                     of(new long[4]),
@@ -259,13 +259,13 @@ public class CNNTest {
                     new long[]{2, 2}));
 
             // Flatten inputs
-            var pool2 = b.op(CoreOp.tupleLoad(pool2Result, 0));
-            var flatten = b.op(OnnxOps.Flatten(pool2.type(),
+            var pool2 = b.add(CoreOp.tupleLoad(pool2Result, 0));
+            var flatten = b.add(OnnxOps.Flatten(pool2.type(),
                     pool2,
                     of(1L)));
 
             // First fully connected layer
-            var fc1 = b.op(OnnxOps.Gemm(flatten.type(),
+            var fc1 = b.add(OnnxOps.Gemm(flatten.type(),
                     flatten,
                     fc1Weights,
                     of(fc1Biases),
@@ -273,11 +273,11 @@ public class CNNTest {
                     of(1L),
                     of(1f),
                     empty()));
-            var relu3 = b.op(OnnxOps.Relu(fc1.type(),
+            var relu3 = b.add(OnnxOps.Relu(fc1.type(),
                     fc1));
 
             // Second fully connected layer
-            var fc2 = b.op(OnnxOps.Gemm(relu3.type(),
+            var fc2 = b.add(OnnxOps.Gemm(relu3.type(),
                     relu3,
                     fc2Weights,
                     of(fc2Biases),
@@ -285,11 +285,11 @@ public class CNNTest {
                     of(1L),
                     of(1f),
                     empty()));
-            var relu4 = b.op(OnnxOps.Relu(fc2.type(),
+            var relu4 = b.add(OnnxOps.Relu(fc2.type(),
                     fc2));
 
             // Softmax layer
-            var fc3 = b.op(OnnxOps.Gemm(relu4.type(),
+            var fc3 = b.add(OnnxOps.Gemm(relu4.type(),
                     relu4,
                     fc3Weights,
                     of(fc3Biases),
@@ -297,11 +297,11 @@ public class CNNTest {
                     of(1L),
                     of(1f),
                     empty()));
-            var prediction = b.op(OnnxOps.Softmax(fc3.type(),
+            var prediction = b.add(OnnxOps.Softmax(fc3.type(),
                     fc3,
                     of(1L)));
 
-            b.op(CoreOp.return_(prediction));
+            b.add(CoreOp.return_(prediction));
         }));
     }
 

--- a/cr-examples/onnx/src/test/java/oracle/code/onnx/proto/OnnxModelTest.java
+++ b/cr-examples/onnx/src/test/java/oracle/code/onnx/proto/OnnxModelTest.java
@@ -289,7 +289,7 @@ public class OnnxModelTest {
                         returnType,
                         extOp.attributes(),
                         extOp.bodyDefinitions());
-                Op.Result res = fb.op((OnnxOp)ONNX_OP_FACTORY.constructOpOrFail(extOp));
+                Op.Result res = fb.add((OnnxOp)ONNX_OP_FACTORY.constructOpOrFail(extOp));
 
                 // map outputs
                 if (outputNames.size() == 1) {
@@ -297,17 +297,17 @@ public class OnnxModelTest {
                 } else {
                     valueMap.put(n.name(), res);
                     for (int i = 0; i < outputNames.size(); i++) {
-                        valueMap.put(outputNames.get(i), fb.op(CoreOp.tupleLoad(res, i)));
+                        valueMap.put(outputNames.get(i), fb.add(CoreOp.tupleLoad(res, i)));
                     }
                 }
             }
 
             if (g.output().size() == 1) {
-                fb.op(CoreOp.return_(valueMap.get(g.output().getFirst().name())));
+                fb.add(CoreOp.return_(valueMap.get(g.output().getFirst().name())));
             } else {
-                Op.Result ret = fb.op(CoreOp.tuple(g.output().stream().map(OnnxModel.ValueInfoProto::name).map(valueMap::get).toList()));
+                Op.Result ret = fb.add(CoreOp.tuple(g.output().stream().map(OnnxModel.ValueInfoProto::name).map(valueMap::get).toList()));
                 valueMap.put(g.name() + "_return", ret);
-                fb.op(CoreOp.return_(ret));
+                fb.add(CoreOp.return_(ret));
             }
         });
 
@@ -409,7 +409,7 @@ public class OnnxModelTest {
             OpWithNames<CoreOp.FuncOp> cnnFuncOp = toFuncOp(protoModel.graph());
 
             System.out.println(cnnFuncOp.toText());
-//            System.out.println(cnnFuncOp.op().toText());
+//            System.out.println(cnnFuncOp.add().toText());
 
             // test the lifted model
             try (Arena a = Arena.ofConfined()) {

--- a/cr-examples/samples/src/main/java/oracle/code/samples/DialectFMAOp.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/DialectFMAOp.java
@@ -149,7 +149,7 @@ public class DialectFMAOp {
         CoreOp.FuncOp dialectModel = functionModel.transform((builder, op) -> {
             CodeContext context = builder.context();
             if (!nodesInvolved.contains(op)) {
-                builder.op(op);
+                builder.add(op);
             } else if (op instanceof JavaOp.MulOp  mulOp) {
                 // In this case, we can eliminate the node (we don't insert it into the builder)
                 context.mapValue(mulOp.result(), context.getValue(mulOp.operands().getFirst()));
@@ -176,7 +176,7 @@ public class DialectFMAOp {
                     FMA myFMAOp = new FMA(outFMA, addOp.resultType());
 
                     // 8. Attach the new Op to the builder
-                    Op.Result resultFMA = builder.op(myFMAOp);
+                    Op.Result resultFMA = builder.add(myFMAOp);
 
                     // 9. Propagate the location of the new op
                     myFMAOp.setLocation(addOp.location());

--- a/cr-examples/samples/src/main/java/oracle/code/samples/DialectWithInvoke.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/DialectWithInvoke.java
@@ -122,7 +122,7 @@ public class DialectWithInvoke {
                 FMAIntrinsicOp myCustomFunction = new FMAIntrinsicOp(invokeOp.resultType(), outputOperands);
 
                 // Add the new node to the code builder
-                Op.Result outputResult = blockBuilder.op(myCustomFunction);
+                Op.Result outputResult = blockBuilder.add(myCustomFunction);
 
                 // Preserve the location from the original invoke
                 myCustomFunction.setLocation(invokeOp.location());
@@ -130,7 +130,7 @@ public class DialectWithInvoke {
                 // Map input-> new output
                 context.mapValue(invokeOp.result(), outputResult);
             } else {
-                blockBuilder.op(op);
+                blockBuilder.add(op);
             }
             return blockBuilder;
         });

--- a/cr-examples/samples/src/main/java/oracle/code/samples/DynamicFunctionBuild.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/DynamicFunctionBuild.java
@@ -92,7 +92,7 @@ public class DynamicFunctionBuild {
                     // Create an op to represent the constant 1
                     CoreOp.ConstantOp constant1 = CoreOp.constant(JavaType.DOUBLE, 1.0);
                     // Add the Op into the builder
-                    Op.Result constantResult = builder.op(constant1);
+                    Op.Result constantResult = builder.add(constant1);
 
                     // Create a MethodRef to point to Math.sqrt
                     MethodRef sqrtMethodRef = MethodRef.method(Math.class, "sqrt", double.class, double.class);
@@ -105,15 +105,15 @@ public class DynamicFunctionBuild {
                     JavaOp.InvokeOp invokeMathOp = JavaOp.invoke(InvokeKind.STATIC, false, JavaType.DOUBLE, sqrtMethodRef, arguments);
 
                     // Add the invoke op into the builder
-                    Op.Result invokeResult = builder.op(invokeMathOp);
+                    Op.Result invokeResult = builder.add(invokeMathOp);
 
                     // Create a division node and add it to the code builder
                     JavaOp.BinaryOp divOp = JavaOp.div(constantResult, invokeResult);
-                    Op.Result divResult = builder.op(divOp);
+                    Op.Result divResult = builder.add(divOp);
 
                     // Finally, add a return and add it to the code builder
                     CoreOp.ReturnOp retOp = CoreOp.return_(divResult);
-                    builder.op(retOp);
+                    builder.add(retOp);
                 });
 
         // Print the code model for the function we have just created

--- a/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/InlineExample.java
@@ -91,7 +91,7 @@ public class InlineExample {
 
                     // Build a new op with a pre-defined constant. We will place this constant
                     // as one of the parameters of the function and then inline with the new values.
-                    Op.Result myConstantValue = blockBuilder.op(CoreOp.ConstantOp.constant(JavaType.FLOAT, 50.f));
+                    Op.Result myConstantValue = blockBuilder.add(CoreOp.ConstantOp.constant(JavaType.FLOAT, 50.f));
 
                     // Inline the function with the new values
                     Inliner.inline(blockBuilder,

--- a/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizer.java
@@ -154,7 +154,7 @@ public class MathOptimizer {
 
                     if (canApplyBitShift) {
                         // Narrow type from DOUBLE to INT for the input parameter of the new function.
-                        Op.Result op2 = blockBuilder.op(JavaOp.conv(JavaType.INT, operands.get(1)));
+                        Op.Result op2 = blockBuilder.add(JavaOp.conv(JavaType.INT, operands.get(1)));
                         List<Value> newOperandList = new ArrayList<>();
                         newOperandList.add(op2);
 
@@ -164,9 +164,9 @@ public class MathOptimizer {
                         newInvoke.setLocation(invokeOp.location());
 
                         // Replace the invoke node with the new optimized invoke
-                        Op.Result newResult = blockBuilder.op(newInvoke);
+                        Op.Result newResult = blockBuilder.add(newInvoke);
                         // Apply type conversion to double
-                        newResult = blockBuilder.op(JavaOp.conv(JavaType.DOUBLE, newResult));
+                        newResult = blockBuilder.add(JavaOp.conv(JavaType.DOUBLE, newResult));
                         // Propagate the new result
                         blockBuilder.context().mapValue(invokeOp.result(), newResult);
 
@@ -179,15 +179,15 @@ public class MathOptimizer {
                         newInvoke.setLocation(invokeOp.location());
 
                         // Replace the invoke node with the new optimized invoke
-                        Op.Result newResult = blockBuilder.op(newInvoke);
+                        Op.Result newResult = blockBuilder.add(newInvoke);
                         blockBuilder.context().mapValue(invokeOp.result(), newResult);
 
                     } else {
                         // ignore the transformation
-                        blockBuilder.op(op);
+                        blockBuilder.add(op);
                     }
                 }
-                default -> blockBuilder.op(op);
+                default -> blockBuilder.add(op);
             }
             return blockBuilder;
         });

--- a/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizerWithInlining.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/MathOptimizerWithInlining.java
@@ -157,7 +157,7 @@ public class MathOptimizerWithInlining {
 
                 if (canApplyBitShift) {
                     // Narrow type from DOUBLE to INT for the input parameter of the new function.
-                    Op.Result op2 = blockBuilder.op(JavaOp.conv(JavaType.INT, operands.get(1)));
+                    Op.Result op2 = blockBuilder.add(JavaOp.conv(JavaType.INT, operands.get(1)));
                     List<Value> newOperandList = new ArrayList<>();
                     newOperandList.add(op2);
 
@@ -167,9 +167,9 @@ public class MathOptimizerWithInlining {
                     newInvoke.setLocation(invokeOp.location());
 
                     // Replace the invoke node with the new optimized invoke
-                    Op.Result newResult = blockBuilder.op(newInvoke);
+                    Op.Result newResult = blockBuilder.add(newInvoke);
                     // Type conversion to double
-                    newResult = blockBuilder.op(JavaOp.conv(JavaType.DOUBLE, newResult));
+                    newResult = blockBuilder.add(JavaOp.conv(JavaType.DOUBLE, newResult));
                     blockBuilder.context().mapValue(invokeOp.result(), newResult);
 
                     replace.set(FunctionToUse.SHIFT);
@@ -183,16 +183,16 @@ public class MathOptimizerWithInlining {
                     newInvoke.setLocation(invokeOp.location());
 
                     // Replace the invoke node with the new optimized invoke
-                    Op.Result newResult = blockBuilder.op(newInvoke);
+                    Op.Result newResult = blockBuilder.add(newInvoke);
                     blockBuilder.context().mapValue(invokeOp.result(), newResult);
                     replace.set(FunctionToUse.MULT);
 
                 } else {
                     // ignore the transformation
-                    blockBuilder.op(op);
+                    blockBuilder.add(op);
                 }
             } else {
-                blockBuilder.op(op);
+                blockBuilder.add(op);
             }
             return blockBuilder;
         });
@@ -233,7 +233,7 @@ public class MathOptimizerWithInlining {
                             (builder, val) -> blockBuilder.context().mapValue(invokeOp.result(), val)); // Propagate the new result
                 } else {
                     // copy the op into the builder if it is not the invoke node we are looking for
-                    blockBuilder.op(op);
+                    blockBuilder.add(op);
                 }
 
                 // return new transformed block builder

--- a/cr-examples/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
+++ b/cr-examples/spirv/src/main/java/intel/code/spirv/TranslateToSpirvModel.java
@@ -76,7 +76,7 @@ public class TranslateToSpirvModel  {
             Block.Parameter bp = entryBlock.parameters().get(i);
             assert entryBlock.ops().get(i) instanceof CoreOp.VarOp;
             SpirvOp funcParam = new SpirvOps.FunctionParameterOp(bp.type(), List.of());
-            spirvBlock.op(funcParam);
+            spirvBlock.add(funcParam);
             valueMap.put(bp, funcParam.result());
             paramOps.add(funcParam);
         }
@@ -86,7 +86,7 @@ public class TranslateToSpirvModel  {
             CoreOp.VarOp jvop = (CoreOp.VarOp)entryBlock.ops().get(i);
             CodeType resultType = new PointerType(jvop.varValueType(), StorageType.CROSSWORKGROUP);
             SpirvOps.VariableOp svop = new SpirvOps.VariableOp((String)jvop.externalize().get(""), resultType, jvop.varValueType());
-            spirvBlock.op(svop);
+            spirvBlock.add(svop);
             valueMap.put(jvop.result(), svop.result());
             varOps.add(svop);
         }
@@ -101,7 +101,7 @@ public class TranslateToSpirvModel  {
                 if (op instanceof CoreOp.VarOp jvop) {
                     CodeType resultType = new PointerType(jvop.varValueType(), StorageType.CROSSWORKGROUP);
                     SpirvOps.VariableOp svop = new SpirvOps.VariableOp((String)jvop.externalize().get(""), resultType, jvop.varValueType());
-                    bodyBuilder.entryBlock().op(svop);
+                    bodyBuilder.entryBlock().add(svop);
                     valueMap.put(jvop.result(), svop.result());
                     varOps.add(svop);
                 }
@@ -113,36 +113,36 @@ public class TranslateToSpirvModel  {
             for (Op op : block.ops()) {
                 switch (op) {
                     case CoreOp.ReturnOp rop -> {
-                        spirvBlock.op(new SpirvOps.ReturnOp(rop.resultType(), mapOperands(rop)));
+                        spirvBlock.add(new SpirvOps.ReturnOp(rop.resultType(), mapOperands(rop)));
                     }
                     case CoreOp.VarOp vop -> {
                         Value dest = valueMap.get(vop.result());
                         Value value = valueMap.get(vop.operands().get(0));
                         // init variable here; declaration has been moved to top of function
-                        spirvBlock.op(new SpirvOps.StoreOp(dest, value));
+                        spirvBlock.add(new SpirvOps.StoreOp(dest, value));
                     }
                     case CoreOp.VarAccessOp.VarLoadOp vlo -> {
                         List<Value> operands = mapOperands(vlo);
                         SpirvOps.LoadOp load = new SpirvOps.LoadOp(vlo.resultType(), operands);
-                        spirvBlock.op(load);
+                        spirvBlock.add(load);
                         valueMap.put(vlo.result(), load.result());
                     }
                     case CoreOp.VarAccessOp.VarStoreOp vso -> {
                         Value dest = valueMap.get(vso.varOp().result());
                         Value value = valueMap.get(vso.operands().get(1));
-                        spirvBlock.op(new SpirvOps.StoreOp(dest, value));
+                        spirvBlock.add(new SpirvOps.StoreOp(dest, value));
                     }
                     case JavaOp.ArrayAccessOp.ArrayLoadOp alo -> {
                         Value array = valueMap.get(alo.operands().get(0));
                         Value index = valueMap.get(alo.operands().get(1));
                         CodeType arrayType = array.type();
                         SpirvOps.ConvertOp convert = new SpirvOps.ConvertOp(JavaType.type(long.class), List.of(index));
-                        spirvBlock.op(new SpirvOps.LoadOp(arrayType, List.of(array)));
-                        spirvBlock.op(convert);
+                        spirvBlock.add(new SpirvOps.LoadOp(arrayType, List.of(array)));
+                        spirvBlock.add(convert);
                         SpirvOp ibac = new SpirvOps.InBoundAccessChainOp(arrayType, List.of(array, convert.result()));
-                        spirvBlock.op(ibac);
+                        spirvBlock.add(ibac);
                         SpirvOp load = new SpirvOps.LoadOp(alo.resultType(), List.of(ibac.result()));
-                        spirvBlock.op(load);
+                        spirvBlock.add(load);
                         valueMap.put(alo.result(), load.result());
                     }
                     case JavaOp.ArrayAccessOp.ArrayStoreOp aso -> {
@@ -150,12 +150,12 @@ public class TranslateToSpirvModel  {
                         Value index = valueMap.get(aso.operands().get(1));
                         CodeType arrayType = array.type();
                         SpirvOp ibac = new SpirvOps.InBoundAccessChainOp(arrayType, List.of(array, index));
-                        spirvBlock.op(ibac);
-                        spirvBlock.op(new SpirvOps.StoreOp(ibac.result(), valueMap.get(aso.operands().get(2))));
+                        spirvBlock.add(ibac);
+                        spirvBlock.add(new SpirvOps.StoreOp(ibac.result(), valueMap.get(aso.operands().get(2))));
                     }
                     case JavaOp.ArrayLengthOp alo -> {
                         Op len = new SpirvOps.ArrayLengthOp(JavaType.INT, List.of(valueMap.get(alo.operands().get(0))));
-                        spirvBlock.op(len);
+                        spirvBlock.add(len);
                         valueMap.put(alo.result(), len.result());
                     }
                     case JavaOp.AddOp aop -> {
@@ -165,7 +165,7 @@ public class TranslateToSpirvModel  {
                         if (isIntegerType(type)) addOp = new SpirvOps.IAddOp(type, operands);
                         else if (isFloatType(type)) addOp = new SpirvOps.FAddOp(type, operands);
                         else throw unsupported("type", type);
-                        spirvBlock.op(addOp);
+                        spirvBlock.add(addOp);
                         valueMap.put(aop.result(), addOp.result());
                      }
                     case JavaOp.SubOp sop -> {
@@ -175,7 +175,7 @@ public class TranslateToSpirvModel  {
                         if (isIntegerType(type)) subOp = new SpirvOps.ISubOp(type, operands);
                         else if (isFloatType(type)) subOp = new SpirvOps.FSubOp(type, operands);
                         else throw unsupported("type", type);
-                        spirvBlock.op(subOp);
+                        spirvBlock.add(subOp);
                         valueMap.put(sop.result(), subOp.result());
                      }
                     case JavaOp.MulOp mop -> {
@@ -185,7 +185,7 @@ public class TranslateToSpirvModel  {
                         if (isIntegerType(type)) mulOp = new SpirvOps.IMulOp(type, operands);
                         else if (isFloatType(type)) mulOp = new SpirvOps.FMulOp(type, operands);
                         else throw unsupported("type", type);
-                        spirvBlock.op(mulOp);
+                        spirvBlock.add(mulOp);
                         valueMap.put(mop.result(), mulOp.result());
                     }
                     case JavaOp.DivOp dop -> {
@@ -195,14 +195,14 @@ public class TranslateToSpirvModel  {
                         if (isIntegerType(type)) divOp = new SpirvOps.IDivOp(type, operands);
                         else if (isFloatType(type)) divOp = new SpirvOps.FDivOp(type, operands);
                         else throw unsupported("type", type);
-                        spirvBlock.op(divOp);
+                        spirvBlock.add(divOp);
                         valueMap.put(dop.result(), divOp.result());
                     }
                     case JavaOp.ModOp mop -> {
                         CodeType type = mop.operands().get(0).type();
                         List<Value> operands = mapOperands(mop);
                         SpirvOp modOp = new SpirvOps.ModOp(type, operands);
-                        spirvBlock.op(modOp);
+                        spirvBlock.add(modOp);
                         valueMap.put(mop.result(), modOp.result());
                     }
                     case JavaOp.EqOp eqop -> {
@@ -212,7 +212,7 @@ public class TranslateToSpirvModel  {
                         if (isIntegerType(type)) seqop = new SpirvOps.IEqualOp(type, operands);
                         else if (isFloatType(type)) seqop = new SpirvOps.FEqualOp(type, operands);
                         else throw unsupported("type", type);
-                        spirvBlock.op(seqop);
+                        spirvBlock.add(seqop);
                         valueMap.put(eqop.result(), seqop.result());
                     }
                     case JavaOp.NeqOp neqop -> {
@@ -222,48 +222,48 @@ public class TranslateToSpirvModel  {
                         if (isIntegerType(type)) sneqop = new SpirvOps.INotEqualOp(type, operands);
                         else if (isFloatType(type)) sneqop = new SpirvOps.FNotEqualOp(type, operands);
                         else throw unsupported("type", type);
-                        spirvBlock.op(sneqop);
+                        spirvBlock.add(sneqop);
                         valueMap.put(neqop.result(), sneqop.result());
                     }
                     case JavaOp.LtOp ltop -> {
                         CodeType type = ltop.operands().get(0).type();
                         List<Value> operands = mapOperands(ltop);
                         SpirvOp sltop = new SpirvOps.LtOp(type, operands);
-                        spirvBlock.op(sltop);
+                        spirvBlock.add(sltop);
                         valueMap.put(ltop.result(), sltop.result());
                     }
                     case JavaOp.InvokeOp inv -> {
                         List<Value> operands = mapOperands(inv);
                         SpirvOp spirvCall = new SpirvOps.CallOp(inv.invokeReference(), operands);
-                        spirvBlock.op(spirvCall);
+                        spirvBlock.add(spirvCall);
                         valueMap.put(inv.result(), spirvCall.result());
                     }
                     case CoreOp.ConstantOp cop -> {
                         SpirvOp scop = new SpirvOps.ConstantOp(cop.resultType(), cop.value());
-                        spirvBlock.op(scop);
+                        spirvBlock.add(scop);
                         valueMap.put(cop.result(), scop.result());
                     }
                     case JavaOp.ConvOp cop -> {
                         List<Value> operands = mapOperands(cop);
                         SpirvOp scop = new SpirvOps.ConvertOp(cop.resultType(), operands);
-                        spirvBlock.op(scop);
+                        spirvBlock.add(scop);
                         valueMap.put(cop.result(), scop.result());
                     }
                     case JavaOp.FieldAccessOp.FieldLoadOp flo -> {
                         SpirvOp load = new SpirvOps.FieldLoadOp(flo.resultType(), flo.fieldReference(), mapOperands(flo));
-                        spirvBlock.op(load);
+                        spirvBlock.add(load);
                         valueMap.put(flo.result(), load.result());
                     }
                     case CoreOp.BranchOp bop -> {
                         Block.Reference successor = blockMap.get(bop.branch().targetBlock()).reference();
-                        spirvBlock.op(new SpirvOps.BranchOp(successor));
+                        spirvBlock.add(new SpirvOps.BranchOp(successor));
                     }
                     case CoreOp.ConditionalBranchOp cbop -> {
                         Block trueBlock = cbop.trueBranch().targetBlock();
                         Block falseBlock = cbop.falseBranch().targetBlock();
                         Block.Reference spvTrueBlock = blockMap.get(trueBlock).reference();
                         Block.Reference spvFalseBlock = blockMap.get(falseBlock).reference();
-                        spirvBlock.op(new SpirvOps.ConditionalBranchOp(spvTrueBlock, spvFalseBlock, mapOperands(cbop)));
+                        spirvBlock.add(new SpirvOps.ConditionalBranchOp(spvTrueBlock, spvFalseBlock, mapOperands(cbop)));
                     }
                     default -> unsupported("op", op.getClass());
                 }

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -125,10 +125,10 @@ public class TritonOps {
             Block.Builder entryBlock = bodyC.entryBlock();
             Map<String, FuncOp> table = new HashMap<>();
             for (FuncOp f : functions) {
-                entryBlock.op(f);
+                entryBlock.add(f);
                 table.put(f.funcName(), f);
             }
-            entryBlock.op(CoreOp.unreachable());
+            entryBlock.add(CoreOp.unreachable());
             this.table = Collections.unmodifiableMap(table);
             this.body = bodyC.build(this);
         }
@@ -250,7 +250,7 @@ public class TritonOps {
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
             // and copy directly without lowering descendant operations
-            b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).add(this);
             return b;
         }
     }

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
@@ -564,7 +564,7 @@ public final class TritonTransformer {
                         CodeType type = valueTypeMap.get(kp);
                         if (type instanceof ConstantType ct) {
                             // Constant
-                            Op.Result cr = fblock.op(ArithMathOps.constant(
+                            Op.Result cr = fblock.add(ArithMathOps.constant(
                                     ct.cType(), ct.value()));
                             args.add(cr);
                         } else {
@@ -594,17 +594,17 @@ public final class TritonTransformer {
                 // @@@ Cannot copy op because the result type
                 //     is derived from init type
                 Value init = cc.getValue(op.operands().get(0));
-                Op.Result r = kblock.op(var(varOp.varName(), init));
+                Op.Result r = kblock.add(var(varOp.varName(), init));
                 cc.mapValue(op.result(), r);
             }
             case ConstantOp cop -> {
                 CodeType t = valueTypeMap.get(cop.result());
                 if (t instanceof ConstantType ct) {
-                    Op.Result r = kblock.op(ArithMathOps.constant(
+                    Op.Result r = kblock.add(ArithMathOps.constant(
                             ct.cType(), ct.value()));
                     cc.mapValue(op.result(), r);
                 } else {
-                    kblock.op(op);
+                    kblock.add(op);
                 }
             }
             case ArithmeticOperation _ -> {
@@ -624,13 +624,13 @@ public final class TritonTransformer {
                     Value a = cc.getValue(op.operands().get(0));
                     Value b = cc.getValue(op.operands().get(1));
 
-                    Op.Result result = kblock.op(ArithMathOps.maximum(a, b));
+                    Op.Result result = kblock.add(ArithMathOps.maximum(a, b));
                     cc.mapValue(op.result(), result);
                 } else if (name.equals("min")) {
                     Value a = cc.getValue(op.operands().get(0));
                     Value b = cc.getValue(op.operands().get(1));
 
-                    Op.Result result = kblock.op(ArithMathOps.minimum(a, b));
+                    Op.Result result = kblock.add(ArithMathOps.minimum(a, b));
                     cc.mapValue(op.result(), result);
                 }
             }
@@ -641,7 +641,7 @@ public final class TritonTransformer {
                     // contributing to the computation
                     Value a = op.operands().get(0);
                     TensorType aType = (TensorType) valueTypeMap.get(a);
-                    Op.Result result = kblock.op(CoreOp.constant(iop.resultType(), aType));
+                    Op.Result result = kblock.add(CoreOp.constant(iop.resultType(), aType));
                     cc.mapValue(op.result(), result);
                     valueTypeMap.put(result, aType);
                 }
@@ -664,13 +664,13 @@ public final class TritonTransformer {
             }
             case ReturnOp rop -> {
                 if (rop.operands().isEmpty()) {
-                    kblock.op(TritonOps.return_());
+                    kblock.add(TritonOps.return_());
                 } else {
-                    kblock.op(TritonOps.return_(
+                    kblock.add(TritonOps.return_(
                             cc.getValue(rop.returnValue())));
                 }
             }
-            default -> kblock.op(op);
+            default -> kblock.add(op);
         }
         return kblock;
     }
@@ -708,7 +708,7 @@ public final class TritonTransformer {
         // Loaded values are hoisted out of the loop body
         Map<Value, Value> loadValues = new HashMap<>();
         for (Value v : capturedVars.get(false)) {
-            Value load = kblock.op(varLoad(cc.getValue(v)));
+            Value load = kblock.add(varLoad(cc.getValue(v)));
             valueTypeMap.put(load, valueTypeMap.get(v));
             loadValues.put(v, load);
         }
@@ -718,7 +718,7 @@ public final class TritonTransformer {
         // are then to be stored to the iteration variables
         List<Value> iterValues = new ArrayList<>();
         for (Value v : capturedAndStoredVars) {
-            iterValues.add(kblock.op(varLoad(cc.getValue(v))));
+            iterValues.add(kblock.add(varLoad(cc.getValue(v))));
         }
 
         // @@@ Build in java code model, then transform?
@@ -728,7 +728,7 @@ public final class TritonTransformer {
                     // Create index var initialized from entry block parameter
                     Value index = builder.parameters().get(0);
                     valueTypeMap.put(index, JavaType.INT);
-                    Value varIndex = builder.op(var("index", index));
+                    Value varIndex = builder.add(var("index", index));
                     valueTypeMap.put(varIndex, JavaType.INT);
                     builder.context().mapValue(body.entryBlock().parameters().get(0), varIndex);
 
@@ -738,7 +738,7 @@ public final class TritonTransformer {
                         CodeType type = valueTypeMap.get(v);
                         Value iter = builder.parameters().get(pi++);
                         valueTypeMap.put(iter, type);
-                        Value varIter = builder.op(var(Integer.toString(pi), iter));
+                        Value varIter = builder.add(var(Integer.toString(pi), iter));
                         valueTypeMap.put(varIter, type);
                         builder.context().mapValue(v, varIter);
                     }
@@ -751,17 +751,17 @@ public final class TritonTransformer {
                             List<Value> yieldValues = new ArrayList<>();
                             for (Value value : capturedAndStoredVars) {
                                 Value varIter = block.context().getValue(value);
-                                Value v = block.op(varLoad(varIter));
+                                Value v = block.add(varLoad(varIter));
                                 yieldValues.add(v);
                             }
-                            block.op(SCFOps.yield_(yieldValues));
+                            block.add(SCFOps.yield_(yieldValues));
                         } else if (op instanceof VarAccessOp.VarLoadOp) {
                             // Replace with value loaded immediately before loop
                             Value v = op.operands().get(0);
                             if (capturedVars.get(false).contains(v)) {
                                 block.context().mapValue(op.result(), loadValues.get(v));
                             } else {
-                                block.op(op);
+                                block.add(op);
                             }
                         } else {
                             block = transformToTritonOperation(block, op, valueTypeMap, opData, fsymTable);
@@ -769,18 +769,18 @@ public final class TritonTransformer {
                         return block;
                     });
                 });
-        Op.Result forResult = kblock.op(scffor);
+        Op.Result forResult = kblock.add(scffor);
 
         // Assign back result to iter vars
         if (capturedAndStoredVars.size() == 1) {
             for (Value v : capturedAndStoredVars) {
-                kblock.op(varStore(cc.getValue(v), forResult));
+                kblock.add(varStore(cc.getValue(v), forResult));
             }
         } else {
             int i = 0;
             for (Value v : capturedAndStoredVars) {
-                kblock.op(varStore(cc.getValue(v),
-                        kblock.op(tupleLoad(forResult, i++))));
+                kblock.add(varStore(cc.getValue(v),
+                        kblock.add(tupleLoad(forResult, i++))));
             }
         }
     }
@@ -840,7 +840,7 @@ public final class TritonTransformer {
                 return fblock;
             }
 
-            fblock.op(op);
+            fblock.add(op);
             return fblock;
         });
         return f;
@@ -889,14 +889,14 @@ public final class TritonTransformer {
 
         public Value programId(CodeType rType, Op.Result r,
                                ConstantType axisType, Value axis) {
-            return block.op(TritonOps.getProgramId(
+            return block.add(TritonOps.getProgramId(
                     (int) axisType.value()));
         }
 
         public Value arange(TensorType rType, Op.Result r,
                             ConstantType startType, Value start,
                             ConstantType endType, Value end) {
-            return block.op(TritonOps.makeRange(
+            return block.add(TritonOps.makeRange(
                     (int) startType.value(),
                     (int) endType.value()));
         }
@@ -904,7 +904,7 @@ public final class TritonTransformer {
         public Value expand(TensorType rType, Op.Result r,
                             TensorType aType, Value a,
                             ConstantType axisType, Value axis) {
-            return block.op(TritonOps.expand(
+            return block.add(TritonOps.expand(
                     (int) axisType.value(),
                     rType,
                     block.context().getValue(a)));
@@ -920,14 +920,14 @@ public final class TritonTransformer {
             } catch (Throwable e) {
                 throw new RuntimeException(e);
             }
-            return block.op(ArithMathOps.constant(rType, zero));
+            return block.add(ArithMathOps.constant(rType, zero));
         }
 
         public Value load(TensorType rType, Op.Result r,
                           TensorType ptrType, Value ptr,
                           TensorType maskType, Value mask) {
             broadcastConversionRight(ptrType, maskType, mask);
-            return block.op(TritonOps.load(
+            return block.add(TritonOps.load(
                     rType,
                     block.context().getValue(ptr),
                     block.context().getValue(mask)));
@@ -938,9 +938,9 @@ public final class TritonTransformer {
                           TensorType maskType, Value mask,
                           ConstantType otherType, Value other) {
             broadcastConversionRight(ptrType, maskType, mask);
-            Value mb = block.op(ArithMathOps.constant(rType, (float)otherType.value()));
+            Value mb = block.add(ArithMathOps.constant(rType, (float)otherType.value()));
             block.context().mapValue(other, mb);
-            return block.op(TritonOps.load(
+            return block.add(TritonOps.load(
                     rType,
                     block.context().getValue(ptr),
                     block.context().getValue(mask),
@@ -953,7 +953,7 @@ public final class TritonTransformer {
                            TensorType maskType, Value mask) {
             broadcastConversionRight(ptrType, valueType, value);
             broadcastConversionRight(ptrType, maskType, mask);
-            return block.op(TritonOps.store(
+            return block.add(TritonOps.store(
                     block.context().getValue(ptr),
                     block.context().getValue(value),
                     block.context().getValue(mask)));
@@ -964,11 +964,11 @@ public final class TritonTransformer {
                                TensorType tensorTypeType, Value tensorType) {
             // @@@ tt.splat with scalar operand, tt.broadcast with tensor operand
             if (oType instanceof TensorType) {
-                return block.op(TritonOps.broadcast(
+                return block.add(TritonOps.broadcast(
                         rType,
                         block.context().getValue(o)));
             } else {
-                return block.op(TritonOps.splat(
+                return block.add(TritonOps.splat(
                         rType,
                         block.context().getValue(o)));
             }
@@ -980,11 +980,11 @@ public final class TritonTransformer {
             // Replace with constant operation to produce tensor type.
             // Result may be used, but transitively it will be removed due to no uses
             // contributing to the computation
-            return block.op(CoreOp.constant(JavaType.type(TensorType.class), r.type()));
+            return block.add(CoreOp.constant(JavaType.type(TensorType.class), r.type()));
         }
 
 
-        public Value add(CodeType rType, Op.Result r,
+        public Value add(CodeType rType, Result r,
                          CodeType aType, Value a,
                          CodeType bType, Value b) {
             broadcastConversion(rType, aType, a, bType, b);
@@ -993,9 +993,9 @@ public final class TritonTransformer {
 
             if (rType instanceof PtrType ||
                     rType instanceof TensorType t && t.eType() instanceof PtrType) {
-                return block.op(TritonOps.addptr(a, b));
+                return block.add(TritonOps.addptr(a, b));
             } else {
-                return block.op(ArithMathOps.add(a, b));
+                return block.add(ArithMathOps.add(a, b));
             }
         }
 
@@ -1006,7 +1006,7 @@ public final class TritonTransformer {
             a = block.context().getValue(a);
             b = block.context().getValue(b);
 
-            return block.op(ArithMathOps.sub(a, b));
+            return block.add(ArithMathOps.sub(a, b));
         }
 
         public Value mul(CodeType rType, Op.Result r,
@@ -1016,7 +1016,7 @@ public final class TritonTransformer {
             a = block.context().getValue(a);
             b = block.context().getValue(b);
 
-            return block.op(ArithMathOps.mul(a, b));
+            return block.add(ArithMathOps.mul(a, b));
         }
 
         public Value div(CodeType rType, Op.Result r,
@@ -1026,7 +1026,7 @@ public final class TritonTransformer {
             a = block.context().getValue(a);
             b = block.context().getValue(b);
 
-            return block.op(ArithMathOps.div(a, b));
+            return block.add(ArithMathOps.div(a, b));
         }
 
         public Value mod(CodeType rType, Op.Result r,
@@ -1036,7 +1036,7 @@ public final class TritonTransformer {
             a = block.context().getValue(a);
             b = block.context().getValue(b);
 
-            return block.op(ArithMathOps.rem(a, b));
+            return block.add(ArithMathOps.rem(a, b));
         }
 
         public Value and(CodeType rType, Op.Result r,
@@ -1046,7 +1046,7 @@ public final class TritonTransformer {
             a = block.context().getValue(a);
             b = block.context().getValue(b);
 
-            return block.op(ArithMathOps.and(a, b));
+            return block.add(ArithMathOps.and(a, b));
         }
 
         public Value dot(TensorType rType, Op.Result r,
@@ -1056,8 +1056,8 @@ public final class TritonTransformer {
             b = block.context().getValue(b);
             // Computed result is tensor of floats, regardless of inputs
             Object zero = 0.0f;
-            var c = block.op(ArithMathOps.constant(rType, zero));
-            return block.op(TritonOps.dot(rType, a, b, c));
+            var c = block.add(ArithMathOps.constant(rType, zero));
+            return block.add(TritonOps.dot(rType, a, b, c));
         }
 
         public Value cdiv(CodeType rType, Op.Result r,
@@ -1077,7 +1077,7 @@ public final class TritonTransformer {
             if (!(bType instanceof ConstantType)) {
                 args.add(b);
             }
-            return block.op(TritonOps.call(cdiv, args));
+            return block.add(TritonOps.call(cdiv, args));
         }
 
         public Value conv(CodeType rType, Op.Result r,
@@ -1096,7 +1096,7 @@ public final class TritonTransformer {
             }
 
             if (rScalarType.equals(Float16.FLOAT_16_TYPE) && aScalarType.equals(JavaType.FLOAT)) {
-                return block.op(ArithMathOps.trunc(rType, a));
+                return block.add(ArithMathOps.trunc(rType, a));
             } else if (rType.equals(aType)) {
                 return a;
             } else {
@@ -1106,7 +1106,7 @@ public final class TritonTransformer {
 
         public Value exp(TritonType rType, Op.Result r,
                          TritonType aType, Value a) {
-            return block.op(ArithMathOps.exp(
+            return block.add(ArithMathOps.exp(
                     block.context().getValue(a)));
         }
 
@@ -1125,7 +1125,7 @@ public final class TritonTransformer {
             a = block.context().getValue(a);
             b = block.context().getValue(b);
 
-            return block.op(ArithMathOps.cmp(ack, a, b));
+            return block.add(ArithMathOps.cmp(ack, a, b));
         }
 
 
@@ -1155,7 +1155,7 @@ public final class TritonTransformer {
             TritonOps.FuncOp rf = fsymTable.computeIfAbsent(signature,
                     s -> reduce(rType, xType, axisConstant, s, f));
 
-            return block.op(TritonOps.call(rf, block.context().getValue(x)));
+            return block.add(TritonOps.call(rf, block.context().getValue(x)));
         }
 
         static TritonOps.FuncOp reduce(CodeType elementType,
@@ -1171,19 +1171,19 @@ public final class TritonTransformer {
                                 .body(rblock -> {
                                     Block.Parameter a = rblock.parameters().get(0);
                                     Block.Parameter b = rblock.parameters().get(1);
-                                    Op.Result _r = rblock.op(TritonOps.call(scalarFunc, a, b));
-                                    rblock.op(TritonOps.reduceReturn(_r));
+                                    Op.Result _r = rblock.add(TritonOps.call(scalarFunc, a, b));
+                                    rblock.add(TritonOps.reduceReturn(_r));
                                 });
 
-                        Op.Result opr = fblock.op(reduceOp);
-                        fblock.op(TritonOps.return_(opr));
+                        Op.Result opr = fblock.add(reduceOp);
+                        fblock.add(TritonOps.return_(opr));
                     });
         }
 
         // @@@ Test
         public Value consume(CodeType rType, Op.Result r,
                              CodeType aType, Value a) {
-            return block.op(TritonTestOps.consume(block.context().getValue(a)));
+            return block.add(TritonTestOps.consume(block.context().getValue(a)));
         }
 
         void broadcastConversion(CodeType rType,
@@ -1194,27 +1194,27 @@ public final class TritonTransformer {
             if (aType instanceof TensorType at && bType instanceof TensorType bTensorType) {
                 TensorType rTensorType = (TensorType) rType;
                 if (!at.shape().equals(rTensorType.shape())) {
-                    ma = block.op(TritonOps.broadcast(rTensorType, ma));
+                    ma = block.add(TritonOps.broadcast(rTensorType, ma));
                 }
                 if (!bTensorType.shape().equals(rTensorType.shape())) {
                     if (rTensorType.eType() instanceof PtrType) {
                         bTensorType = new TensorType(bType, rTensorType.shape());
-                        mb = block.op(TritonOps.broadcast(bTensorType, mb));
+                        mb = block.add(TritonOps.broadcast(bTensorType, mb));
                     } else {
-                        mb = block.op(TritonOps.broadcast(rTensorType, mb));
+                        mb = block.add(TritonOps.broadcast(rTensorType, mb));
                     }
                 }
             } else if (aType instanceof TensorType) {
                 TensorType rTensorType = (TensorType) rType;
                 if (rTensorType.eType() instanceof PtrType) {
                     TensorType bTensorType = new TensorType(bType, rTensorType.shape());
-                    mb = block.op(TritonOps.splat(bTensorType, mb));
+                    mb = block.add(TritonOps.splat(bTensorType, mb));
                 } else {
-                    mb = block.op(TritonOps.splat(rTensorType, mb));
+                    mb = block.add(TritonOps.splat(rTensorType, mb));
                 }
             } else if (bType instanceof TensorType) {
                 TensorType rTensorType = (TensorType) rType;
-                ma = block.op(TritonOps.splat(rTensorType, ma));
+                ma = block.add(TritonOps.splat(rTensorType, ma));
             }
             block.context().mapValue(a, ma);
             block.context().mapValue(b, mb);
@@ -1227,17 +1227,17 @@ public final class TritonTransformer {
                 if (!bTensorType.shape().equals(aTensorType.shape())) {
                     if (aTensorType.eType() instanceof PtrType) {
                         bTensorType = new TensorType(bTensorType.eType(), aTensorType.shape());
-                        mb = block.op(TritonOps.broadcast(bTensorType, mb));
+                        mb = block.add(TritonOps.broadcast(bTensorType, mb));
                     } else {
-                        mb = block.op(TritonOps.broadcast(aTensorType, mb));
+                        mb = block.add(TritonOps.broadcast(aTensorType, mb));
                     }
                 }
             } else if (aType instanceof TensorType rTensorType) {
                 if (rTensorType.eType() instanceof PtrType) {
                     TensorType bTensorType = new TensorType(bType, rTensorType.shape());
-                    mb = block.op(TritonOps.splat(bTensorType, mb));
+                    mb = block.add(TritonOps.splat(bTensorType, mb));
                 } else {
-                    mb = block.op(TritonOps.splat(rTensorType, mb));
+                    mb = block.add(TritonOps.splat(rTensorType, mb));
                 }
             }
             block.context().mapValue(b, mb);

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaBackend.java
@@ -453,16 +453,16 @@ public class CudaBackend extends C99FFIBackend {
                    // Op.Result inputResult = invokeOp.result();
                     BoundSchema<?> boundSchema = MappableIface.getBoundSchema(buffer);
                     PTXPtrOp ptxOp = new PTXPtrOp(invoke.returnType(), invoke.name(), outputOperands, boundSchema);
-                    Op.Result outputResult = block.op(ptxOp);
+                    Op.Result outputResult = block.add(ptxOp);
                     cc.mapValue(invoke.op().result(), outputResult);
                 } else if (invoke.refIs(Math.class) && mathFns.containsKey(invoke.name() + "_" + invoke.returnType().toString())){
                     usedMathFns.add(invoke.name() + "_" + invoke.returnType().toString());
-                    block.op(op);
+                    block.add(op);
                 } else {
-                    block.op(op);
+                    block.add(op);
                 }
             } else {
-                block.op(op);
+                block.add(op);
             }
             return block;
         }).funcOp();

--- a/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -105,7 +105,7 @@ public class KernelCallGraph implements LookupCarrier {
                     changed.set(true);
                     return exitBlockBuilder.withContextAndTransformer(blockbuilder.context(), blockbuilder.transformer());
                 }
-                blockbuilder.op(op);
+                blockbuilder.add(op);
                 return blockbuilder;
             });
         }

--- a/hat/core/src/main/java/hat/phases/HATArrayViewPhase.java
+++ b/hat/core/src/main/java/hat/phases/HATArrayViewPhase.java
@@ -175,7 +175,7 @@ public record HATArrayViewPhase() implements HATPhase {
                                 getVectorShape(lookup,invoke.returnType()),
                                 blockBuilder.context().getValues(invoke.op().operands())
                         );
-                        context.mapValue(invoke.returnResult(), blockBuilder.op(copyLocation(invoke.op(),hatVectorBinaryOp)));
+                        context.mapValue(invoke.returnResult(), blockBuilder.add(copyLocation(invoke.op(),hatVectorBinaryOp)));
                         return blockBuilder;
                     }
                 }
@@ -187,7 +187,7 @@ public record HATArrayViewPhase() implements HATPhase {
                                 getVectorShape(lookup,varOp.resultType().valueType()),
                                 context.getValues(OpHelper.firstOperandAsListOrEmpty(varOp))
                         );
-                        context.mapValue(varOp.result(), blockBuilder.op(copyLocation(varOp,hatVectorVarOp)));
+                        context.mapValue(varOp.result(), blockBuilder.add(copyLocation(varOp,hatVectorVarOp)));
                         return blockBuilder;
                     }
                 }
@@ -199,7 +199,7 @@ public record HATArrayViewPhase() implements HATPhase {
                         var vectorShape = getVectorShape(lookup,arrayLoadOp.resultType());
                         List<Value> operands = context.getValues(List.of(buffer, arrayLoadOp.operands().getLast()));
                         HATVectorOp vLoadOp = buildArrayViewVector(arrayLoadOp, name, resultType, vectorShape, operands);
-                        context.mapValue(arrayLoadOp.result(), blockBuilder.op(copyLocation(arrayLoadOp,vLoadOp)));
+                        context.mapValue(arrayLoadOp.result(), blockBuilder.add(copyLocation(arrayLoadOp,vLoadOp)));
                     }
                     return blockBuilder;
                 }
@@ -212,14 +212,14 @@ public record HATArrayViewPhase() implements HATPhase {
                         var vectorShape = getVectorShape(lookup,arrayStoreOp.operands().getLast().type());
                         List<Value> operands = context.getValues(List.of(buffer, arrayStoreOp.operands().getLast(), arrayStoreOp.operands().get(1)));
                         HATVectorOp vStoreOp = buildArrayViewVector(arrayStoreOp, name, resultType, vectorShape, operands);
-                        context.mapValue(arrayStoreOp.result(), blockBuilder.op(copyLocation(arrayStoreOp,vStoreOp)));
+                        context.mapValue(arrayStoreOp.result(), blockBuilder.add(copyLocation(arrayStoreOp,vStoreOp)));
                     }
                     return blockBuilder;
                 }
                 default -> {
                 }
             }
-            blockBuilder.op(op);
+            blockBuilder.add(op);
             return blockBuilder;
         }).funcOp();
     }
@@ -258,7 +258,7 @@ public record HATArrayViewPhase() implements HATPhase {
                                     bufferVarLoads.get(replaced.get(r).op()).result();
                         } else { // if this is a VarLoadOp loading the buffer
                             CoreOp.VarAccessOp.VarLoadOp newVarLoad = CoreOp.VarAccessOp.varLoad(blockBuilder.context().getValue(replaced.get(r)));
-                            replacement = blockBuilder.op(copyLocation(varLoadOp,newVarLoad));
+                            replacement = blockBuilder.add(copyLocation(varLoadOp,newVarLoad));
                             context.mapValue(varLoadOp.result(), replacement);
                         }
                         replaced.put(varLoadOp.result(), replacement);
@@ -286,7 +286,7 @@ public record HATArrayViewPhase() implements HATPhase {
                         } else { // we only use the last array load
                             return blockBuilder;
                         }
-                        context.mapValue(arrayLoadOp.result(), blockBuilder.op(copyLocation(arrayLoadOp,replacementOp)));
+                        context.mapValue(arrayLoadOp.result(), blockBuilder.add(copyLocation(arrayLoadOp,replacementOp)));
                         return blockBuilder;
                     }
                 }
@@ -312,7 +312,7 @@ public record HATArrayViewPhase() implements HATPhase {
                         } else {
                             return blockBuilder;
                         }
-                        context.mapValue(arrayStoreOp.result(), blockBuilder.op(copyLocation(arrayStoreOp, replacementOp)));
+                        context.mapValue(arrayStoreOp.result(), blockBuilder.add(copyLocation(arrayStoreOp, replacementOp)));
                         return blockBuilder;
                     }
                 }
@@ -325,13 +325,13 @@ public record HATArrayViewPhase() implements HATPhase {
                             (Class<?>) OpHelper.classTypeToTypeOrThrow(lookup, (ClassType) arrayAccessInfo.buffer().type()),
                             context.getValues(List.of(arrayAccessInfo.buffer()))
                     );
-                    context.mapValue(arrayLengthOp.result(), blockBuilder.op(copyLocation(arrayLengthOp,hatPtrLengthOp)));
+                    context.mapValue(arrayLengthOp.result(), blockBuilder.add(copyLocation(arrayLengthOp,hatPtrLengthOp)));
                     return blockBuilder;
                 }
                 default -> {
                 }
             }
-            blockBuilder.op(op);
+            blockBuilder.add(op);
             return blockBuilder;
         }).funcOp();
     }

--- a/hat/core/src/main/java/hat/phases/HATFP16Phase.java
+++ b/hat/core/src/main/java/hat/phases/HATFP16Phase.java
@@ -89,7 +89,7 @@ public record HATFP16Phase() implements HATPhase {
 
     public static void createF16VarOp(CoreOp.VarOp varOp, Block.Builder blockBuilder, Class<?> reducedFloatType) {
         blockBuilder.context().mapValue(varOp.result(),
-                blockBuilder.op(copyLocation(varOp,
+                blockBuilder.add(copyLocation(varOp,
                                 new HATF16Op.HATF16VarOp(
                                         varOp.varName(),
                                         reducedFloatType, varOp.resultType(),
@@ -101,7 +101,7 @@ public record HATFP16Phase() implements HATPhase {
 
     private void createF16ConvOP(Invoke invoke, Block.Builder blockBuilder, Class<?> reducedFloatType) {
         blockBuilder.context().mapValue(invoke.op().result(),
-                blockBuilder.op(copyLocation(invoke.op(), new HATF16Op.HATF16ConvOp(
+                blockBuilder.add(copyLocation(invoke.op(), new HATF16Op.HATF16ConvOp(
                                 JavaType.VOID,
                                 reducedFloatType,
                                 blockBuilder.context().getValues(invoke.op().operands()))
@@ -112,7 +112,7 @@ public record HATFP16Phase() implements HATPhase {
 
     private void createF16VarLoadOp(CoreOp.VarAccessOp.VarLoadOp varLoadOp, Block.Builder blockBuilder) {
         blockBuilder.context().mapValue(varLoadOp.result(),
-                blockBuilder.op(copyLocation(varLoadOp,
+                blockBuilder.add(copyLocation(varLoadOp,
                                 new HATF16Op.HATF16VarLoadOp(
                                         findVarNameOrNull(varLoadOp),
                                         varLoadOp.varType(),
@@ -124,7 +124,7 @@ public record HATFP16Phase() implements HATPhase {
 
     private void createFloatFromF16(Invoke invoke, Block.Builder blockBuilder, Class<?> reducedFloatType) {
         blockBuilder.context().mapValue(invoke.op().result(),
-                blockBuilder.op(copyLocation(invoke.op(), new HATF16Op.HATF16ToFloatConvOp(
+                blockBuilder.add(copyLocation(invoke.op(), new HATF16Op.HATF16ToFloatConvOp(
                                 JavaType.FLOAT,
                                 reducedFloatType,
                                 isF16Local(invoke.op().operands().getFirst()),
@@ -146,7 +146,7 @@ public record HATFP16Phase() implements HATPhase {
             case MUL -> new HATF16Op.HATF16BinaryOp.HATF16MulOp(codeType, reducedFloatType, outputOperands);
             case DIV -> new HATF16Op.HATF16BinaryOp.HATF16DivOp(codeType, reducedFloatType, outputOperands);
         };
-        blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.op(copyLocation(invokeOp, binaryOp)));
+        blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.add(copyLocation(invokeOp, binaryOp)));
     }
 
     private CoreOp.FuncOp dialectifyF16Ops(MethodHandles.Lookup lookup,CoreOp.FuncOp funcOp, BinaryOpEnum binaryOpEnum) {

--- a/hat/core/src/main/java/hat/phases/HATMathLibPhase.java
+++ b/hat/core/src/main/java/hat/phases/HATMathLibPhase.java
@@ -63,7 +63,7 @@ public record HATMathLibPhase() implements HATPhase {
             if (Objects.requireNonNull(op) instanceof CoreOp.VarOp varOp) {
                 if (setTypeMap.get(varOp) == null) {
                     // this varOp is not a special type we insert the varOp into the new tree
-                    blockBuilder.op(varOp);
+                    blockBuilder.add(varOp);
                 } else {
                     // Add the special type as a VarOp
                     HATFP16Phase.createF16VarOp(varOp, blockBuilder, setTypeMap.get(varOp));
@@ -71,7 +71,7 @@ public record HATMathLibPhase() implements HATPhase {
                     // we may need to also add the new <X>HATVarOps here as well.
                 }
             } else {
-                blockBuilder.op(op);
+                blockBuilder.add(op);
             }
             return blockBuilder;
         }).funcOp();

--- a/hat/core/src/main/java/hat/phases/HATMemoryPhase.java
+++ b/hat/core/src/main/java/hat/phases/HATMemoryPhase.java
@@ -76,12 +76,12 @@ public abstract sealed class HATMemoryPhase implements HATPhase {
                         .filter(result->result.op() instanceof CoreOp.VarOp)
                         .map(r->(CoreOp.VarOp)r.op())
                         .forEach(varOp->
-                            blockBuilder.context().mapValue(invoke.op().result(), blockBuilder.op(create(blockBuilder, varOp, invoke.op())))
+                            blockBuilder.context().mapValue(invoke.op().result(), blockBuilder.add(create(blockBuilder, varOp, invoke.op())))
                         );
             } else if (OpHelper.Named.Variable.var(lookup,op) instanceof OpHelper.Named.Variable variable && nodesInvolved.contains(variable.op())) {
                 blockBuilder.context().mapValue(variable.op().result(), blockBuilder.context().getValue(variable.op().operands().getFirst()));
             } else {
-                blockBuilder.op(op);
+                blockBuilder.add(op);
             }
             return blockBuilder;
         }).funcOp();
@@ -158,7 +158,7 @@ public abstract sealed class HATMemoryPhase implements HATPhase {
             return Trxfmr.of(lookup,funcOp).transform(nodesInvolved::contains, (blockBuilder, op) -> {
                if (invoke(lookup,op) instanceof Invoke invoke) {
                    blockBuilder.context().mapValue(invoke.op().result(),
-                           blockBuilder.op(copyLocation(invoke.op(),
+                           blockBuilder.add(copyLocation(invoke.op(),
                                    new HATMemoryDefOp.HATMemoryLoadOp(invoke.returnType(),
                                            invoke.refType(),
                                            invoke.name(),
@@ -178,7 +178,7 @@ public abstract sealed class HATMemoryPhase implements HATPhase {
                     varOp.resultType(),
                     invokeOp.invokeReference().refType(),
                     blockBuilder.context().getValues(varOp.operands())));
-            blockBuilder.context().mapValue(varOp.result(), blockBuilder.op(privateVarOp));
+            blockBuilder.context().mapValue(varOp.result(), blockBuilder.add(privateVarOp));
             return privateVarOp;
         }
     }

--- a/hat/core/src/main/java/hat/phases/HATVectorPhase.java
+++ b/hat/core/src/main/java/hat/phases/HATVectorPhase.java
@@ -130,7 +130,7 @@ public abstract sealed class HATVectorPhase implements HATPhase
                 vectorShape,
                 blockBuilder.context().getValues(varOp.operands())
         );
-        blockBuilder.context().mapValue(varOp.result(), blockBuilder.op(copyLocation(varOp, memoryViewOp)));
+        blockBuilder.context().mapValue(varOp.result(), blockBuilder.add(copyLocation(varOp, memoryViewOp)));
     }
 
     private CoreOp.FuncOp dialectifyVectorLoad(MethodHandles.Lookup lookup,CoreOp.FuncOp funcOp) {
@@ -163,7 +163,7 @@ public abstract sealed class HATVectorPhase implements HATPhase
                         shape,
                         blockBuilder.context().getValues(invoke.op().operands())
                 );
-                blockBuilder.context().mapValue(invoke.op().result(), blockBuilder.op(copyLocation(varOp, memoryViewOp)));
+                blockBuilder.context().mapValue(invoke.op().result(), blockBuilder.add(copyLocation(varOp, memoryViewOp)));
             } else if (op instanceof CoreOp.VarOp varOp) {
                 addVectorVarOp(blockBuilder, varOp, vectorShapeMap.get(varOp));
             }
@@ -205,7 +205,7 @@ public abstract sealed class HATVectorPhase implements HATPhase
                         vectorShapeMap.get(invokeOp),
                         blockBuilder.context().getValues(invokeOp.operands())
                 );
-                blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.op(copyLocation(invokeToVar.get(invokeOp), memoryViewOp)));
+                blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.add(copyLocation(invokeToVar.get(invokeOp), memoryViewOp)));
             } else if (op instanceof CoreOp.VarOp varOp) {
                 addVectorVarOp(blockBuilder, varOp, vectorShapeMap.get(varOp));
             }
@@ -239,7 +239,7 @@ public abstract sealed class HATVectorPhase implements HATPhase
                         vectorShape,
                         blockBuilder.context().getValues(invokeOp.operands())
                 );
-                blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.op(copyLocation(invokeOp, memoryViewOp)));
+                blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.add(copyLocation(invokeOp, memoryViewOp)));
             } else if (op instanceof CoreOp.VarOp varOp) {
                 addVectorVarOp(blockBuilder, varOp, vectorShapeMap.get(varOp));
             }
@@ -258,7 +258,7 @@ public abstract sealed class HATVectorPhase implements HATPhase
                         vectorShape.lanes(),
                         blockBuilder.context().getValues(invokeOp.operands())
                 );
-                blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.op(copyLocation(invokeOp, makeOf)));
+                blockBuilder.context().mapValue(invokeOp.result(), blockBuilder.add(copyLocation(invokeOp, makeOf)));
             } else if (op instanceof CoreOp.VarOp varOp) {
                 addVectorVarOp(blockBuilder, varOp, vectorShapeMap.get(varOp));
             }
@@ -296,7 +296,7 @@ public abstract sealed class HATVectorPhase implements HATPhase
                         getVectorShape(invoke.lookup(), invoke.returnType()),
                         blockBuilder.context().getValues(invoke.op().operands())
                 );
-                blockBuilder.context().mapValue(invoke.op().result(), blockBuilder.op(copyLocation(invoke.op(), memoryViewOp)));
+                blockBuilder.context().mapValue(invoke.op().result(), blockBuilder.add(copyLocation(invoke.op(), memoryViewOp)));
             } else if (op instanceof CoreOp.VarAccessOp.VarLoadOp varLoadOp) {
                 HATVectorOp memoryViewOp = new HATVectorOp.HATVectorVarLoadOp(
                         findVectorVarNameOrNull(varLoadOp),
@@ -304,7 +304,7 @@ public abstract sealed class HATVectorPhase implements HATPhase
                         getVectorShapeOrNullFromVarLoad(varLoadOp),
                         blockBuilder.context().getValues(varLoadOp.operands())
                 );
-                blockBuilder.context().mapValue(varLoadOp.result(), blockBuilder.op(copyLocation(varLoadOp, memoryViewOp)));
+                blockBuilder.context().mapValue(varLoadOp.result(), blockBuilder.add(copyLocation(varLoadOp, memoryViewOp)));
             }
             return blockBuilder;
         }).funcOp();

--- a/hat/core/src/main/java/hat/phases/HATVectorSelectPhase.java
+++ b/hat/core/src/main/java/hat/phases/HATVectorSelectPhase.java
@@ -121,7 +121,7 @@ public record HATVectorSelectPhase() implements HATPhase {
                                 context.getValues(invokeVar.invokeOp.operands())
                         );
 
-                context.mapValue(invokeVar.invokeOp.result(), blockBuilder.op(
+                context.mapValue(invokeVar.invokeOp.result(), blockBuilder.add(
                         copyLocation(invokeVar.invokeOp, newOp)));
             } else if (op instanceof CoreOp.VarAccessOp.VarLoadOp varLoadOp) {
                 context.mapValue(varLoadOp.result(), context.getValue(varLoadOp.operands().getFirst()));

--- a/hat/core/src/main/java/hat/phases/HATVectorStorePhase.java
+++ b/hat/core/src/main/java/hat/phases/HATVectorStorePhase.java
@@ -104,7 +104,7 @@ public abstract sealed class HATVectorStorePhase implements HATPhase {
                                 vectorShape,//.lanes(),
                                // vectorShape.codeType(),
                                 context.getValues(invoke.op().operands()));
-                context.mapValue(invoke.op().result(), blockBuilder.op(copyLocation(invoke.op(),storeView)));
+                context.mapValue(invoke.op().result(), blockBuilder.add(copyLocation(invoke.op(),storeView)));
             } else if (op instanceof CoreOp.VarAccessOp.VarLoadOp varLoadOp) {
                 // pass value
                 context.mapValue(varLoadOp.result(), context.getValue(varLoadOp.operands().getFirst()));

--- a/hat/examples/experiments/src/main/java/experiments/AddArbitraryBlock.java
+++ b/hat/examples/experiments/src/main/java/experiments/AddArbitraryBlock.java
@@ -59,24 +59,24 @@ public class AddArbitraryBlock {
         Trxfmr.of(lookup,hackMeFuncOp)
                 .toJava("Before injecting")
                 .transform("withNewBlock", ce -> invoke(lookup,ce) instanceof Invoke $ && $.named("printf"), c -> {
-                    var beforeString = c.builder().op(CoreOp.constant(JavaType.J_L_STRING, "Before ...."));
-                    var afterString = c.builder().op(CoreOp.constant(JavaType.J_L_STRING, "After ...."));
+                    var beforeString = c.builder().add(CoreOp.constant(JavaType.J_L_STRING, "Before ...."));
+                    var afterString = c.builder().add(CoreOp.constant(JavaType.J_L_STRING, "After ...."));
                     c.add(JavaOp.if_(c.builder().parentBody()).if_(b -> {
-                        b.op(CoreOp.core_yield(b.op(CoreOp.constant(JavaType.BOOLEAN, true))));
+                        b.add(CoreOp.core_yield(b.add(CoreOp.constant(JavaType.BOOLEAN, true))));
                     }).then(b -> {
-                        b.op(JavaOp.invoke( JavaType.VOID, Println, beforeString));
-                        b.op(CoreOp.core_yield());
+                        b.add(JavaOp.invoke( JavaType.VOID, Println, beforeString));
+                        b.add(CoreOp.core_yield());
                     }).else_(e->
-                            e.op(CoreOp.core_yield()))
+                            e.add(CoreOp.core_yield()))
                     );
                     c.retain();
                     c.add(JavaOp.if_(c.builder().parentBody()).if_(b -> {
-                        b.op(CoreOp.core_yield(b.op(CoreOp.constant(JavaType.BOOLEAN, true))));
+                        b.add(CoreOp.core_yield(b.add(CoreOp.constant(JavaType.BOOLEAN, true))));
                     }).then(b -> {
-                        b.op(JavaOp.invoke( JavaType.VOID, Println, afterString));
-                        b.op(CoreOp.core_yield());
+                        b.add(JavaOp.invoke( JavaType.VOID, Println, afterString));
+                        b.add(CoreOp.core_yield());
                     }).else_(e->
-                            e.op(CoreOp.core_yield()))
+                            e.add(CoreOp.core_yield()))
                     );
                 })
                 .toJava( "After injecting")

--- a/hat/examples/experiments/src/main/java/experiments/BlockGroup.java
+++ b/hat/examples/experiments/src/main/java/experiments/BlockGroup.java
@@ -86,8 +86,8 @@ public class BlockGroup {
 
                 // Add ops to the entry block
                 Block.Builder groupBlockBuilder = groupBodyBuilder.entryBlock();
-                opsToGroup.forEach(groupBlockBuilder::op); // transfers all to this builder?
-                groupBlockBuilder.op(CoreOp.core_yield());
+                opsToGroup.forEach(groupBlockBuilder::add); // transfers all to this builder?
+                groupBlockBuilder.add(CoreOp.core_yield());
 
                 c.replace(JavaOp.block(groupBodyBuilder)); // Replace all those added ops with the block op
             }else{

--- a/hat/examples/experiments/src/main/java/experiments/CreateFuncOp.java
+++ b/hat/examples/experiments/src/main/java/experiments/CreateFuncOp.java
@@ -152,16 +152,16 @@ public class CreateFuncOp {
                 .body(builder -> {// double rsqrt(double arg){return 1 / Math.sqrt(qrg)}
                     // var arg = builder.parameters().getFirst();
                     var argOp = CoreOp.var("arg", builder.parameters().getFirst());
-                    var arg = builder.op(argOp);
+                    var arg = builder.add(argOp);
                     // var arg = builder.parameters().getFirst();
                     var sqrtInvoke = JavaOp.invoke(InvokeKind.STATIC, false, JavaType.DOUBLE, MathSqrt, arg);
-                    var _1f = builder.op(CoreOp.constant(JavaType.DOUBLE, 1.0));
+                    var _1f = builder.add(CoreOp.constant(JavaType.DOUBLE, 1.0));
 
-                    Op.Result invokeResult = builder.op(sqrtInvoke);
-                    Op.Result divResult = builder.op(
+                    Op.Result invokeResult = builder.add(sqrtInvoke);
+                    Op.Result divResult = builder.add(
                             JavaOp.div(_1f, invokeResult)
                     );
-                    builder.op(CoreOp.return_(divResult));
+                    builder.add(CoreOp.return_(divResult));
                 });
 
         System.out.println(OpCodeBuilder.toText(rsqrtFuncOp));
@@ -172,21 +172,21 @@ public class CreateFuncOp {
                         && $.returns(double.class)
                         && $.receives(double.class), c -> {
                     c.add(JavaOp.if_(c.builder().parentBody()).if_(b -> {
-                        var lhs = b.op(CoreOp.constant(JavaType.BOOLEAN, false));
-                        var rhs = b.op(CoreOp.constant(JavaType.BOOLEAN, true));
-                        b.op(CoreOp.core_yield(b.op(JavaOp.or(lhs, rhs))));
+                        var lhs = b.add(CoreOp.constant(JavaType.BOOLEAN, false));
+                        var rhs = b.add(CoreOp.constant(JavaType.BOOLEAN, true));
+                        b.add(CoreOp.core_yield(b.add(JavaOp.or(lhs, rhs))));
                     }).then(b -> {
-                        var msg = b.op(CoreOp.constant(JavaType.J_L_STRING, "Then \"With this text\""));
-                        b.op(new Pre(List.of()));
-                        b.op(JavaOp.invoke(InvokeKind.STATIC, false, JavaType.VOID, Println, msg));
-                        b.op(new Post(List.of()));
-                        b.op(CoreOp.core_yield());
+                        var msg = b.add(CoreOp.constant(JavaType.J_L_STRING, "Then \"With this text\""));
+                        b.add(new Pre(List.of()));
+                        b.add(JavaOp.invoke(InvokeKind.STATIC, false, JavaType.VOID, Println, msg));
+                        b.add(new Post(List.of()));
+                        b.add(CoreOp.core_yield());
                     }).else_(b -> {
-                        var msg = b.op(CoreOp.constant(JavaType.J_L_STRING, "Else"));
-                        b.op(new Pre(List.of()));
-                        b.op(JavaOp.invoke(InvokeKind.STATIC, false, JavaType.VOID, Println, msg));
-                        b.op(new Post(List.of()));
-                        b.op(CoreOp.core_yield());
+                        var msg = b.add(CoreOp.constant(JavaType.J_L_STRING, "Else"));
+                        b.add(new Pre(List.of()));
+                        b.add(JavaOp.invoke(InvokeKind.STATIC, false, JavaType.VOID, Println, msg));
+                        b.add(new Post(List.of()));
+                        b.add(CoreOp.core_yield());
                     }));
                     c.add(new Pre(List.of()));
                     c.replace(JavaOp.invoke(InvokeKind.STATIC, false, JavaType.DOUBLE, MathAbs, c.mappedOperand(0)));

--- a/hat/examples/experiments/src/main/java/experiments/SwapMath.java
+++ b/hat/examples/experiments/src/main/java/experiments/SwapMath.java
@@ -52,17 +52,17 @@ public class SwapMath {
                 .body(builder -> {// double rsqrt(double arg){return 1 / Math.sqrt(qrg)}
                    // var arg = builder.parameters().getFirst();
                     var argOp = CoreOp.var("arg", builder.parameters().getFirst());
-                    var arg = builder.op(argOp);
+                    var arg = builder.add(argOp);
 
                     // We can pass builder.parameters().getFirst() directly as arg below.  But then we don't know the name
                     var sqrtInvoke = JavaOp.invoke(InvokeKind.STATIC, false, JavaType.DOUBLE, MathSqrt, arg);
-                    var _1f = builder.op(CoreOp.constant(JavaType.DOUBLE, 1.0));
+                    var _1f = builder.add(CoreOp.constant(JavaType.DOUBLE, 1.0));
 
-                    Op.Result invokeResult = builder.op(sqrtInvoke);
-                    Op.Result divResult = builder.op(
+                    Op.Result invokeResult = builder.add(sqrtInvoke);
+                    Op.Result divResult = builder.add(
                             JavaOp.div(_1f, invokeResult)
                     );
-                    builder.op(CoreOp.return_(divResult));
+                    builder.add(CoreOp.return_(divResult));
                 });
         var javaCodeBuilder = new JavaCodeBuilder<>(lookup,rsqrt);
         System.out.println(rsqrt.toText());
@@ -78,10 +78,10 @@ public class SwapMath {
                 var absStaticMethod = MethodRef.method(Math.class, "abs", double.class, double.class);
                 var absInvoke =  JavaOp.invoke(InvokeKind.STATIC, false, absStaticMethod.signature().returnType(), absStaticMethod,
                         builder.context().getValue(op.operands().get(0)));
-                var absResult= builder.op(absInvoke);
+                var absResult= builder.add(absInvoke);
                 builder.context().mapValue(op.result(), absResult);
             }else{
-                builder.op(op);
+                builder.add(op);
             }
             return builder;
         });

--- a/hat/examples/experiments/src/main/java/experiments/TransformState.java
+++ b/hat/examples/experiments/src/main/java/experiments/TransformState.java
@@ -52,11 +52,11 @@ public class TransformState {
             if (op instanceof JavaOp.AddOp) {
                 CodeContext cc = block.context();
                 var newSubOp = JavaOp.sub(cc.getValue(op.operands().get(0)), cc.getValue(op.operands().get(1)));
-                Op.Result result = block.op(newSubOp);
+                Op.Result result = block.add(newSubOp);
                 cc.mapValue(op.result(), result);
                 oldOpToNewOpMap.put(op,newSubOp);// <-- this maps op -> new subOp
             } else {
-                var result = block.op(op);
+                var result = block.add(op);
                 oldOpToNewOpMap.put(op,result.op()); //<-- this maps op ->  op'
             }
             return block;
@@ -83,11 +83,11 @@ public class TransformState {
             if (op instanceof JavaOp.AddOp) {
                 CodeContext cc = block.context();
                 var newSubOp = JavaOp.sub(cc.getValue(op.operands().get(0)), cc.getValue(op.operands().get(1)));
-                Op.Result result = block.op(newSubOp);
+                Op.Result result = block.add(newSubOp);
                 cc.mapValue(op.result(), result);
                 transformedOpMapState.put(op,newSubOp);// <-- this maps op -> new subOp
             } else {
-                var result = block.op(op);
+                var result = block.add(op);
                 transformedOpMapState.put(op,result.op()); //<-- this maps op ->  op'
             }
             return block;
@@ -97,11 +97,11 @@ public class TransformState {
                     if (op instanceof JavaOp.AddOp) {
                         CodeContext cc = block.context();
                         var newSubOp = JavaOp.sub(cc.getValue(op.operands().get(0)), cc.getValue(op.operands().get(1)));
-                        Op.Result r = block.op(newSubOp);
+                        Op.Result r = block.add(newSubOp);
                         cc.mapValue(op.result(), r);
                         transformedOpMapState.put(op,newSubOp);
                     } else {
-                        var r = block.op(op);
+                        var r = block.add(op);
                         transformedOpMapState.put(op,r.op());
                     }
                     return block;
@@ -155,12 +155,12 @@ public class TransformState {
                 (block, op) -> {
                     if (op instanceof JavaOp.AddOp) {
                         CodeContext cc = block.context();
-                        Op.Result r = block.op(JavaOp.sub(
+                        Op.Result r = block.add(JavaOp.sub(
                                 cc.getValue(op.operands().get(0)),
                                 cc.getValue(op.operands().get(1))));
                         cc.mapValue(op.result(), r);
                     } else {
-                        block.op(op);
+                        block.add(op);
                     }
                     return block;
                 },

--- a/hat/optkl/src/main/java/optkl/Trxfmr.java
+++ b/hat/optkl/src/main/java/optkl/Trxfmr.java
@@ -245,7 +245,7 @@ public class Trxfmr implements LookupCarrier{
                 public Op.Result replace(Op replacement, Consumer<Mapper<?>> mapperConsumer) {
                     handled(true);
                     action(Action.REPLACE);
-                    var result = trxfmr.opToResultOp(op(),builder().op(OpHelper.copyLocation(op(), replacement)));
+                    var result = trxfmr.opToResultOp(op(),builder().add(OpHelper.copyLocation(op(), replacement)));
                     if (result.type() instanceof PrimitiveType primitiveType && primitiveType.isVoid()) {
                     }else {
                         mapperConsumer.accept(Mapper.of(this).map(op().result(), result));
@@ -255,7 +255,7 @@ public class Trxfmr implements LookupCarrier{
                 public Op.Result add(Op newOne, Consumer<Mapper<?>> mapperConsumer) {
                     handled(true); // is this appropriate here?
                     action(Action.ADDED);
-                    var result = trxfmr.opToResultOp(op(),builder().op(OpHelper.copyLocation(op(), newOne)));
+                    var result = trxfmr.opToResultOp(op(),builder().add(OpHelper.copyLocation(op(), newOne)));
                     if (result.type() instanceof PrimitiveType primitiveType && primitiveType.isVoid()) {
 
                     }else{
@@ -268,7 +268,7 @@ public class Trxfmr implements LookupCarrier{
                 public Op.Result retain( Consumer<Mapper<?>> mapperConsumer) {
                     handled(true);
                     action(Action.RETAIN);
-                    return trxfmr.opToResultOp(op(),builder().op(op()));
+                    return trxfmr.opToResultOp(op(),builder().add(op()));
                 }
                 @Override
                 public void remove( Consumer<Mapper<?>> mapperConsumer) {
@@ -384,13 +384,13 @@ public class Trxfmr implements LookupCarrier{
                 Cursor cursor = Cursor.of(this, funcOp, blockBuilder,cursorOp);
                 cursorConsumer.accept(cursor);
                 if (!cursor.handled()){
-                    var result = blockBuilder.op(cursorOp);
+                    var result = blockBuilder.add(cursorOp);
                     var opFromResult= result.op();
                     biMap.add(cursorOp,opFromResult);
                 }
             } else {
                 try {
-                    var result = blockBuilder.op(cursorOp);
+                    var result = blockBuilder.add(cursorOp);
                     var opFromResult = result.op();
                     biMap.add(cursorOp, opFromResult);
                 }catch (Throwable t){
@@ -416,7 +416,7 @@ public class Trxfmr implements LookupCarrier{
             if (predicate.test(op)){
                 codeTransformer.acceptOp(blockBuilder,op);
             } else {
-                biMap.add(op,blockBuilder.op(op).op());
+                biMap.add(op,blockBuilder.add(op).op());
             }
             return blockBuilder;
         });

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -29,12 +29,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * A (basic) block containing an ordered sequence of operations, where the last operation is
- * a {@link Op.Terminating terminating} operation.
+ * A block containing an ordered sequence of operations, where the last operation is a
+ * {@link Op.Terminating terminating} operation.
  * <p>
- * The terminating operation, according to its specification, may branch to other blocks contained in the
- * same parent body, by way of its {@link Op#successors() successors}, or exit the parent body and optionally
- * yield a result.
+ * The terminating operation, according to its specification, may branch to other blocks contained in the same parent
+ * body, by way of its {@link Op#successors() successors}, or exit the parent body and optionally yield a result.
  * <p>
  * Blocks declare zero or more block parameters.
  * <p>
@@ -479,7 +478,7 @@ public final class Block implements CodeElement<Block, Op> {
      * until the parent body builder <a href="Body.Builder.html#body-building-finishing">finishes</a>.
      * <p>
      * A block builder has a code {@link #context() context} and code {@link #transformer() transformer}. These are used
-     * to perform <i>transform-on-append</i> when {@link #op appending} a placed operation. Any sibling block builder
+     * to perform <i>transform-on-append</i> when {@link #add appending} a placed operation. Any sibling block builder
      * {@link #block(List) created} from a block builder will have the same code context and code transformer.
      * <p>
      * A block builder may be obtained with a different code context and code transformer by calling
@@ -707,7 +706,7 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         /**
-         * Appends an operation to this block.
+         * Appends an operation to the end of this block.
          * <p>
          * If the operation is unplaced, it is appended directly to this block.
          * <p>
@@ -747,7 +746,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @throws IllegalStateException if the operation is structurally invalid
          * @see Op#transform(CodeContext, CodeTransformer)
          */
-        public Op.Result op(Op op) {
+        public Op.Result add(Op op) {
             check();
 
             // Perform transform-on-append for a placed operation

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -472,7 +472,7 @@ public final class Body implements CodeElement<Body, Block> {
      * and likewise those block builders can also be used to create block builders for additional sibling blocks and so
      * on;
      * <li>
-     * a block builder is used to {@link Block.Builder#op(Op) append} operations to the block,
+     * a block builder is used to {@link Block.Builder#add(Op) append} operations to the block,
      * {@link Block.Builder#parameter(CodeType) append} parameters to the block's parameters, and
      * {@link Block.Builder#reference(List) create} references to the block, which can be used as successors of a
      * terminating operation that is the last operation that is appended to the block or a sibling block; and

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/CodeTransformer.java
@@ -61,7 +61,7 @@ import java.util.function.Function;
  * and code contexts that are not thread-safe.
  *
  * @see Block.Builder#block(List)
- * @see Block.Builder#op(Op)
+ * @see Block.Builder#add(Op)
  * @see CodeContext
  */
 @FunctionalInterface
@@ -92,7 +92,7 @@ public interface CodeTransformer {
          * has no mapped output value, the corresponding output value is {@code null}.
          * <p>
          * The operation-building function encapsulates the current output block builder for this transformation step.
-         * Applying the function {@link Block.Builder#op(Op) appends} an operation using the current output block
+         * Applying the function {@link Block.Builder#add(Op) appends} an operation using the current output block
          * builder, which will perform <a href="Block.Builder.html#transform-on-append"><i>transform-on-append</i></a>
          * when appending the input operation, or any other placed operation.
          *
@@ -133,7 +133,7 @@ public interface CodeTransformer {
             // operation that is transformed and contains bodies
             // @@@ If performance is an issue consider changing
             Function<Op, Op.Result> opBuilder = outputOp -> {
-                Op.Result result = builder.op(outputOp);
+                Op.Result result = builder.add(outputOp);
                 builder.context().mapValue(inputOp.result(), result);
                 return result;
             };
@@ -150,7 +150,7 @@ public interface CodeTransformer {
      * A copying transformer that appends the operation using the block builder, and returns the block builder.
      */
     CodeTransformer COPYING_TRANSFORMER = (builder, op) -> {
-        builder.op(op);
+        builder.add(op);
         return builder;
     };
 
@@ -158,7 +158,7 @@ public interface CodeTransformer {
      * A transformer that drops location information from operations.
      */
     CodeTransformer DROP_LOCATION_TRANSFORMER = (builder, op) -> {
-        Op.Result r = builder.op(op);
+        Op.Result r = builder.add(op);
         r.op().setLocation(Op.Location.NO_LOCATION);
         return builder;
     };
@@ -171,7 +171,7 @@ public interface CodeTransformer {
         if (op instanceof Op.Lowerable lop) {
             return lop.lower(builder, null);
         } else {
-            builder.op(op);
+            builder.add(op);
             return builder;
         }
     };
@@ -257,7 +257,7 @@ public interface CodeTransformer {
      * block builder created for this transformation. Such a block builder can be used to:
      * <ul>
      * <li>
-     * emit an output operation, by using the block builder to {@link Block.Builder#op(Op) append} the operation; and
+     * emit an output operation, by using the block builder to {@link Block.Builder#add(Op) append} the operation; and
      * <li>
      * emit an output block, by using the builder to {@link Block.Builder#block(List) create} a block builder for that
      * output block and appending operations using the created block builder.
@@ -295,10 +295,10 @@ public interface CodeTransformer {
      * implemented as follows:
      * {@snippet lang = "java":
      * CodeTransformer copyingTransformer = (builder, inputOp) -> {
-     *     builder.op(inputOp);
+     *     builder.add(inputOp);
      *     return builder;
      * };
-     * }
+     *}
      * The call to {@code builder.op(inputOp)} performs transform-on-append. If the input operation has descendant code
      * elements, this code transformer is recursively invoked to transform those elements. The result is that all input
      * code elements are copied into the output model.
@@ -309,7 +309,7 @@ public interface CodeTransformer {
      * @param builder the current output block builder.
      * @param op      the input operation to transform.
      * @return the continuation builder to use to transform subsequent input operations from the same input block
-     * @see Block.Builder#op(Op)
+     * @see Block.Builder#add(Op)
      * @see CodeTransformer#COPYING_TRANSFORMER
      */
     Block.Builder acceptOp(Block.Builder builder, Op op);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -73,7 +73,7 @@ import java.util.function.BiFunction;
  * <ol>
  * <li>
  * the operation is <i>placed</i> in a block, which becomes its parent block, by using a block builder to
- * {@link Block.Builder#op(Op) append} the operation to the block. The placed operation has a permanently
+ * {@link Block.Builder#add(Op) append} the operation to the block. The placed operation has a permanently
  * non-{@code null} {@link #result() result} that can be used as an operand of subsequently constructed operations. The
  * block being built is not <a href="Body.Builder.html#body-building-observability">observable</a> through this
  * operation and any attempt to access the block throws {@link IllegalStateException}.
@@ -286,7 +286,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
                 } else if (op instanceof Op.Lowerable lop) {
                     return lop.lower(block, inherited);
                 } else {
-                    block.op(op);
+                    block.add(op);
                     return block;
                 }
             };

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Quoted.java
@@ -186,13 +186,13 @@ public final class Quoted<T extends Op> {
                 Value inputValue = inputOperandsAndCaptures.get(i);
                 Value outputValue = b.parameters().get(i);
                 if (inputValue.type() instanceof VarType) {
-                    outputValue = b.op(CoreOp.var(String.valueOf(i), outputValue));
+                    outputValue = b.add(CoreOp.var(String.valueOf(i), outputValue));
                 }
                 outputOperandsAndCaptures.add(outputValue);
             }
 
             // Quoted the lambda expression
-            Value q = b.op(CoreOp.quoted(b.parentBody(), qb -> {
+            Value q = b.add(CoreOp.quoted(b.parentBody(), qb -> {
                 // Map the entry block of the op's ancestor body to the quoted block
                 // We are copying op in the context of the quoted block, the block mapping
                 // ensures the use of operands and captured values are reachable when building
@@ -202,7 +202,7 @@ public final class Quoted<T extends Op> {
                 // Return the op to be copied in the quoted operation
                 return op;
             }));
-            b.op(CoreOp.return_(q));
+            b.add(CoreOp.return_(q));
         });
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -192,7 +192,7 @@ public final class BytecodeGenerator {
             if (!modelsToBuild.isEmpty()) {
                 var module = OpBuilder.createBuilderFunctions(
                         modelsToBuild,
-                        b -> b.op(JavaOp.fieldLoad(
+                        b -> b.add(JavaOp.fieldLoad(
                                 FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))));
 
                 for (var e : module.functionTable().sequencedEntrySet()) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LoweringTransform.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LoweringTransform.java
@@ -68,7 +68,7 @@ public final class LoweringTransform {
             }
             case Op.Lowerable lop -> lop.lower(block, null);
             default -> {
-                block.op(op);
+                block.add(op);
                 yield block;
             }
         };
@@ -108,11 +108,11 @@ public final class LoweringTransform {
             Block.Builder curr = blocks.get(i);
             curr.transformBody(targets.get(i).parent(), blocks.get(i).parameters(), (b, op) -> switch (op) {
                 case YieldOp _ when swOp instanceof JavaOp.SwitchStatementOp -> {
-                    b.op(branch(exit.reference()));
+                    b.add(branch(exit.reference()));
                     yield b;
                 }
                 case YieldOp yop when swOp instanceof JavaOp.SwitchExpressionOp -> {
-                    b.op(branch(exit.reference(b.context().getValue(yop.yieldValue()))));
+                    b.add(branch(exit.reference(b.context().getValue(yop.yieldValue()))));
                     yield b;
                 }
                 default -> transformer.acceptOp(b, op);
@@ -123,9 +123,9 @@ public final class LoweringTransform {
         if (integralReferenceTypes.contains(selector.type())) {
             // unbox selector
             if (selector.type().equals(J_L_CHARACTER)) {
-                selector = block.op(JavaOp.invoke(MethodRef.method(selector.type(), "charValue", JavaType.CHAR), selector));
+                selector = block.add(JavaOp.invoke(MethodRef.method(selector.type(), "charValue", JavaType.CHAR), selector));
             } else {
-                selector = block.op(JavaOp.invoke(MethodRef.method(selector.type(), "intValue", JavaType.INT), selector));
+                selector = block.add(JavaOp.invoke(MethodRef.method(selector.type(), "intValue", JavaType.INT), selector));
             }
         }
         var labels = labelsAndTargets.labels();
@@ -134,7 +134,7 @@ public final class LoweringTransform {
             labels.add(null);
             blocks.add(exit);
         }
-        block.op(new ConstantLabelSwitchOp(selector, labels, blocks.stream().map(Block.Builder::reference).toList()));
+        block.add(new ConstantLabelSwitchOp(selector, labels, blocks.stream().map(Block.Builder::reference).toList()));
         return exit;
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -207,7 +207,7 @@ public sealed abstract class CoreOp extends Op {
         @Override
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
-            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).add(this);
             return b;
         }
 
@@ -360,9 +360,9 @@ public sealed abstract class CoreOp extends Op {
             Body.Builder bodyC = Body.Builder.of(null, CoreType.FUNCTION_TYPE_VOID);
             Block.Builder entryBlock = bodyC.entryBlock();
             for (FuncOp f : functions) {
-                entryBlock.op(f);
+                entryBlock.add(f);
             }
-            entryBlock.op(CoreOp.unreachable());
+            entryBlock.add(CoreOp.unreachable());
 
             this(bodyC);
         }
@@ -386,7 +386,7 @@ public sealed abstract class CoreOp extends Op {
 
         @Override
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
-            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).add(this);
             return b;
         }
 
@@ -448,7 +448,7 @@ public sealed abstract class CoreOp extends Op {
                             calledFuncs.add(calledFunc);
                             funcNames.computeIfAbsent(calledFunc,
                                     f -> f.funcName() + "_" + funcNames.size());
-                            Op.Result result = blockBuilder.op(CoreOp.funcCall(
+                            Op.Result result = blockBuilder.add(CoreOp.funcCall(
                                     funcNames.get(calledFunc),
                                     calledFunc.invokableSignature(),
                                     blockBuilder.context().getValues(iop.operands())));
@@ -456,7 +456,7 @@ public sealed abstract class CoreOp extends Op {
                             return blockBuilder;
                         }
                     }
-                    blockBuilder.op(op);
+                    blockBuilder.add(op);
                     return blockBuilder;
                 }));
 
@@ -565,7 +565,7 @@ public sealed abstract class CoreOp extends Op {
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
             // and copy directly without lowering descendant operations
-            b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER).add(this);
             return b;
         }
 
@@ -1626,8 +1626,8 @@ public sealed abstract class CoreOp extends Op {
                                   Function<Block.Builder, Op> opFunc) {
         Body.Builder body = Body.Builder.of(connectedAncestorBody, CoreType.FUNCTION_TYPE_VOID);
         Block.Builder block = body.entryBlock();
-        block.op(core_yield(
-                block.op(opFunc.apply(block))));
+        block.add(core_yield(
+                block.add(opFunc.apply(block))));
         return new QuotedOp(body);
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
@@ -45,7 +45,7 @@ public final class Inliner {
      * An inline consumer that inserts a return operation with a value, if non-null.
      */
     public static final BiConsumer<Block.Builder, Value> INLINE_RETURN = (block, value) -> {
-        block.op(value != null ? return_(value) : CoreOp.return_());
+        block.add(value != null ? return_(value) : CoreOp.return_());
     };
 
     /**
@@ -134,13 +134,13 @@ public final class Inliner {
                     List<Value> arg = rop.returnValue() != null
                             ? List.of(block.context().getValue(rop.returnValue()))
                             : List.of();
-                    block.op(branch(returnBlock.reference(arg)));
+                    block.add(branch(returnBlock.reference(arg)));
                 }
 
                 return block;
             }
 
-            block.op(op);
+            block.add(op);
             return block;
         });
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
@@ -91,7 +91,7 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
                     // Merge the successor's target block with this block
                     mergeBlock(b, br.targetBlock());
                 } else {
-                    b.op(CoreOp.branch(b.context().getReferenceOrCreate(br)));
+                    b.add(CoreOp.branch(b.context().getReferenceOrCreate(br)));
                 }
 
                 // Remove the conditional dispatching block if all predecessor reference args are constants
@@ -108,21 +108,21 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
             case JavaOp.ExceptionRegionEnter ere -> {
                 // Cannot remove block parameters from exception handlers
                 removeUnusedBlockParameters(b, ere.startReference());
-                b.op(op);
+                b.add(op);
             }
             case JavaOp.ExceptionRegionExit ere -> {
                 // Cannot remove block parameters from exception handlers
                 removeUnusedBlockParameters(b, ere.endReference());
-                b.op(op);
+                b.add(op);
             }
             case Op.BlockTerminating _ -> {
                 for (Block.Reference successor : op.successors()) {
                     removeUnusedBlockParameters(b, successor);
                 }
-                b.op(op);
+                b.add(op);
             }
             default -> {
-                b.op(op);
+                b.add(op);
             }
         }
         return b;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/SSA.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/SSA.java
@@ -269,9 +269,9 @@ public final class SSA {
                         Block.Builder successorBlockBuilder = context.getBlock(successorBlock);
                         context.mapReference(successor, successorBlockBuilder.reference(values));
                     }
-                    block.op(op);
+                    block.add(op);
                 }
-                default -> block.op(op);
+                default -> block.add(op);
             }
             return block;
         }
@@ -451,9 +451,9 @@ public final class SSA {
                         }
                     }
 
-                    block.op(op);
+                    block.add(op);
                 } else {
-                    block.op(op);
+                    block.add(op);
                 }
 
                 return block;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ConstantExpressionTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ConstantExpressionTransformer.java
@@ -49,10 +49,10 @@ public class ConstantExpressionTransformer implements CodeTransformer {
     public Block.Builder acceptOp(Block.Builder b, Op op) {
         Optional<Object> v = constantExpressionEvaluator.evaluate(op.result());
         if (v.isPresent()) {
-            Op.Result c = b.op(constant(op.resultType(), v.get()));
+            Op.Result c = b.add(constant(op.resultType(), v.get()));
             b.context().mapValue(op.result(), c);
         } else {
-            b.op(op);
+            b.add(op);
         }
         return b;
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -535,7 +535,7 @@ public sealed abstract class JavaOp extends Op {
         @Override
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> _ignore) {
             // Isolate body with respect to ancestor transformations
-            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).op(this);
+            b.withContextAndTransformer(b.context(), CodeTransformer.LOWERING_TRANSFORMER).add(this);
             return b;
         }
 
@@ -666,7 +666,7 @@ public sealed abstract class JavaOp extends Op {
                 int idx = this.invokableSignature().parameterTypes().size();
                 for (Value v : capturedValues()) {
                     Block.Parameter p = builder.parameters().get(idx++);
-                    Value functionValue = v.type() instanceof VarType ? builder.op(CoreOp.var(p)) : p;
+                    Value functionValue = v.type() instanceof VarType ? builder.add(CoreOp.var(p)) : p;
                     builder.context().mapValue(v, functionValue);
                 }
                 List<Block.Parameter> outputValues = builder.parameters().subList(0, this.invokableSignature().parameterTypes().size());
@@ -2748,7 +2748,7 @@ public sealed abstract class JavaOp extends Op {
             Op opt = target();
             BranchTarget t = BranchTarget.getBranchTarget(b.context(), opt);
             if (t != null) {
-                b.op(branch(f.apply(t).reference()));
+                b.add(branch(f.apply(t).reference()));
             } else {
                 throw new IllegalStateException("No branch target for operation: " + opt);
             }
@@ -2893,7 +2893,7 @@ public sealed abstract class JavaOp extends Op {
             Op opt = target();
             BranchTarget t = BranchTarget.getBranchTarget(b.context(), opt);
             if (t != null) {
-                b.op(branch(f.apply(t).reference(b.context().getValue(yieldOperand()))));
+                b.add(branch(f.apply(t).reference(b.context().getValue(yieldOperand()))));
             } else {
                 throw new IllegalStateException("No branch target for operation: " + opt);
             }
@@ -2986,7 +2986,7 @@ public sealed abstract class JavaOp extends Op {
 
             b.transformBody(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
-                    block.op(branch(exit.reference()));
+                    block.add(branch(exit.reference()));
                     return block;
                 } else {
                     return null;
@@ -3086,7 +3086,7 @@ public sealed abstract class JavaOp extends Op {
             Value monitorTarget = b.parameters().get(0);
 
             // Monitor enter
-            b.op(monitorEnter(monitorTarget));
+            b.add(monitorEnter(monitorTarget));
 
             Block.Builder exit = b.block();
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
@@ -3094,17 +3094,17 @@ public sealed abstract class JavaOp extends Op {
             // Exception region for the body
             Block.Builder syncRegionEnter = b.block();
             Block.Builder catcherFinally = b.block();
-            b.op(exceptionRegionEnter(
+            b.add(exceptionRegionEnter(
                     syncRegionEnter.reference(), catcherFinally.reference()));
 
             BiFunction<Block.Builder, Op, Block.Builder> syncExitTransformer = composeFirst(inherited, (block, op) -> {
                 if (op instanceof CoreOp.ReturnOp ||
                     (op instanceof StatementTargetOp lop && ifExitFromSynchronized(lop))) {
                     // Monitor exit
-                    block.op(monitorExit(monitorTarget));
+                    block.add(monitorExit(monitorTarget));
                     // Exit the exception region
                     Block.Builder exitRegion = block.block();
-                    block.op(exceptionRegionExit(exitRegion.reference(), catcherFinally.reference()));
+                    block.add(exceptionRegionExit(exitRegion.reference(), catcherFinally.reference()));
                     return exitRegion;
                 } else {
                     return block;
@@ -3114,9 +3114,9 @@ public sealed abstract class JavaOp extends Op {
             syncRegionEnter.transformBody(blockBody, List.of(), loweringTransformer(syncExitTransformer, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     // Monitor exit
-                    block.op(monitorExit(monitorTarget));
+                    block.add(monitorExit(monitorTarget));
                     // Exit the exception region
-                    block.op(exceptionRegionExit(exit.reference(), catcherFinally.reference()));
+                    block.add(exceptionRegionExit(exit.reference(), catcherFinally.reference()));
                     return block;
                 } else {
                     return null;
@@ -3125,18 +3125,18 @@ public sealed abstract class JavaOp extends Op {
 
             // The catcher, with an exception region back branching to itself
             Block.Builder catcherFinallyRegionEnter = b.block();
-            catcherFinally.op(exceptionRegionEnter(
+            catcherFinally.add(exceptionRegionEnter(
                     catcherFinallyRegionEnter.reference(), catcherFinally.reference()));
 
             // Monitor exit
-            catcherFinallyRegionEnter.op(monitorExit(monitorTarget));
+            catcherFinallyRegionEnter.add(monitorExit(monitorTarget));
             Block.Builder catcherFinallyRegionExit = b.block();
             // Exit the exception region
-            catcherFinallyRegionEnter.op(exceptionRegionExit(
+            catcherFinallyRegionEnter.add(exceptionRegionExit(
                     catcherFinallyRegionExit.reference(), catcherFinally.reference()));
             // Rethrow outside of region
             Block.Parameter t = catcherFinally.parameter(type(Throwable.class));
-            catcherFinallyRegionExit.op(throw_(t));
+            catcherFinallyRegionExit.add(throw_(t));
 
             return exit;
         }
@@ -3146,7 +3146,7 @@ public sealed abstract class JavaOp extends Op {
             b.transformBody(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value monitorTarget = block.context().getValue(yop.yieldValue());
-                    block.op(branch(exprExit.reference(monitorTarget)));
+                    block.add(branch(exprExit.reference(monitorTarget)));
                     return block;
                 } else {
                     return null;
@@ -3265,7 +3265,7 @@ public sealed abstract class JavaOp extends Op {
                 }
 
                 if (op instanceof CoreOp.YieldOp) {
-                    block.op(branch(exit.reference()));
+                    block.add(branch(exit.reference()));
                     return block;
                 } else {
                     return null;
@@ -3365,7 +3365,7 @@ public sealed abstract class JavaOp extends Op {
              */
             public ElseIfBuilder then() {
                 Body.Builder body = Body.Builder.of(connectedAncestorBody, ACTION_SIGNATURE);
-                body.entryBlock().op(core_yield());
+                body.entryBlock().add(core_yield());
                 bodies.add(body);
 
                 return new ElseIfBuilder(connectedAncestorBody, bodies);
@@ -3418,7 +3418,7 @@ public sealed abstract class JavaOp extends Op {
              */
             public IfOp else_() {
                 Body.Builder body = Body.Builder.of(connectedAncestorBody, ACTION_SIGNATURE);
-                body.entryBlock().op(core_yield());
+                body.entryBlock().add(core_yield());
                 bodies.add(body);
 
                 return new IfOp(bodies);
@@ -3459,7 +3459,7 @@ public sealed abstract class JavaOp extends Op {
                 bodyCs = new ArrayList<>(bodyCs);
                 Body.Builder end = Body.Builder.of(bodyCs.get(0).connectedAncestorBody(),
                         CoreType.FUNCTION_TYPE_VOID);
-                end.entryBlock().op(core_yield());
+                end.entryBlock().add(core_yield());
                 bodyCs.add(end);
             }
 
@@ -3522,7 +3522,7 @@ public sealed abstract class JavaOp extends Op {
 
                     pred.transformBody(predBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp yo) {
-                            block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
+                            block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
                                     action.reference(), next.reference()));
                             return block;
                         } else {
@@ -3533,7 +3533,7 @@ public sealed abstract class JavaOp extends Op {
 
                 action.transformBody(actionBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
-                        block.op(branch(exit.reference()));
+                        block.add(branch(exit.reference()));
                         return block;
                     } else {
                         return null;
@@ -3600,15 +3600,15 @@ public sealed abstract class JavaOp extends Op {
             // if no case null, add one that throws NPE
             if (!(selectorExpression.type() instanceof PrimitiveType) && !haveNullCase()) {
                 Block.Builder throwBlock = b.block();
-                throwBlock.op(throw_(
-                        throwBlock.op(new_(MethodRef.constructor(NullPointerException.class)))
+                throwBlock.add(throw_(
+                        throwBlock.add(new_(MethodRef.constructor(NullPointerException.class)))
                 ));
 
                 Block.Builder continueBlock = b.block();
 
-                Result p = b.op(invoke(MethodRef.method(Objects.class, "equals", boolean.class, Object.class, Object.class),
-                        selectorExpression, b.op(constant(J_L_OBJECT, null))));
-                b.op(conditionalBranch(p, throwBlock.reference(), continueBlock.reference()));
+                Result p = b.add(invoke(MethodRef.method(Objects.class, "equals", boolean.class, Object.class, Object.class),
+                        selectorExpression, b.add(constant(J_L_OBJECT, null))));
+                b.add(conditionalBranch(p, throwBlock.reference(), continueBlock.reference()));
 
                 b = continueBlock;
             }
@@ -3685,7 +3685,7 @@ public sealed abstract class JavaOp extends Op {
                                 } else {
                                     falseTarget = exit.reference();
                                 }
-                                block.op(conditionalBranch(block.context().getValue(yop.yieldValue()),
+                                block.add(conditionalBranch(block.context().getValue(yop.yieldValue()),
                                         statement.reference(), falseTarget));
                                 yield block;
                             }
@@ -3696,7 +3696,7 @@ public sealed abstract class JavaOp extends Op {
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 List<Value> args = yop.yieldValue() == null ? List.of() : List.of(block.context().getValue(yop.yieldValue()));
-                                block.op(branch(exit.reference(args)));
+                                block.add(branch(exit.reference(args)));
                                 yield block;
                             }
                             default -> null;
@@ -3708,7 +3708,7 @@ public sealed abstract class JavaOp extends Op {
                         (block, op) -> switch (op) {
                             case CoreOp.YieldOp yop -> {
                                 List<Value> args = yop.yieldValue() == null ? List.of() : List.of(block.context().getValue(yop.yieldValue()));
-                                block.op(branch(exit.reference(args)));
+                                block.add(branch(exit.reference(args)));
                                 yield block;
                             }
                             default -> null;
@@ -3866,7 +3866,7 @@ public sealed abstract class JavaOp extends Op {
         Block.Builder lower(Block.Builder b, Function<BranchTarget, Block.Builder> f) {
             BranchTarget t = BranchTarget.getBranchTarget(b.context(), ancestorBody());
             if (t != null) {
-                b.op(branch(f.apply(t).reference()));
+                b.add(branch(f.apply(t).reference()));
             } else {
                 throw new IllegalStateException("No branch target for operation: " + this);
             }
@@ -4120,13 +4120,13 @@ public sealed abstract class JavaOp extends Op {
                     boolean isResult = op.result().uses().size() == 1 &&
                             op.result().uses().stream().allMatch(r -> r.op() instanceof CoreOp.YieldOp);
                     if (!isResult) {
-                        block.op(op);
+                        block.add(op);
                     }
                     yield block;
                 }
                 case CoreOp.YieldOp yop -> {
                     if (yop.yieldValue() == null) {
-                        block.op(branch(header.reference()));
+                        block.add(branch(header.reference()));
                         yield block;
                     } else if (yop.yieldValue() instanceof Result or) {
                         if (or.op() instanceof TupleOp top) {
@@ -4134,7 +4134,7 @@ public sealed abstract class JavaOp extends Op {
                         } else {
                             initValues.addAll(block.context().getValues(yop.operands()));
                         }
-                        block.op(branch(header.reference()));
+                        block.add(branch(header.reference()));
                         yield block;
                     }
 
@@ -4145,7 +4145,7 @@ public sealed abstract class JavaOp extends Op {
 
             header.transformBody(condBody, initValues, loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
-                    block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
+                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
                     return block;
                 } else {
@@ -4159,7 +4159,7 @@ public sealed abstract class JavaOp extends Op {
 
             update.transformBody(this.updateBody, initValues, loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
-                    block.op(branch(header.reference()));
+                    block.add(branch(header.reference()));
                     return block;
                 } else {
                     return null;
@@ -4394,7 +4394,7 @@ public sealed abstract class JavaOp extends Op {
             b.transformBody(exprBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop) {
                     Value loopSource = block.context().getValue(yop.yieldValue());
-                    block.op(branch(preHeader.reference(loopSource)));
+                    block.add(branch(preHeader.reference(loopSource)));
                     return block;
                 } else {
                     return null;
@@ -4403,20 +4403,20 @@ public sealed abstract class JavaOp extends Op {
 
             if (isArray) {
                 Value array = preHeader.parameters().get(0);
-                Value arrayLength = preHeader.op(arrayLength(array));
-                Value i = preHeader.op(constant(INT, 0));
-                preHeader.op(branch(header.reference(i)));
+                Value arrayLength = preHeader.add(arrayLength(array));
+                Value i = preHeader.add(constant(INT, 0));
+                preHeader.add(branch(header.reference(i)));
 
                 i = header.parameters().get(0);
-                Value p = header.op(lt(i, arrayLength));
-                header.op(conditionalBranch(p, init.reference(), exit.reference()));
+                Value p = header.add(lt(i, arrayLength));
+                header.add(conditionalBranch(p, init.reference(), exit.reference()));
 
-                Value e = init.op(arrayLoadOp(array, i));
+                Value e = init.add(arrayLoadOp(array, i));
                 List<Value> initValues = new ArrayList<>();
                 init.transformBody(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
-                        block.op(branch(body.reference()));
+                        block.add(branch(body.reference()));
                         return block;
                     } else {
                         return null;
@@ -4428,22 +4428,22 @@ public sealed abstract class JavaOp extends Op {
 
                 body.transformBody(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
 
-                i = update.op(add(i, update.op(constant(INT, 1))));
-                update.op(branch(header.reference(i)));
+                i = update.add(add(i, update.add(constant(INT, 1))));
+                update.add(branch(header.reference(i)));
             } else {
                 JavaType iterable = parameterized(type(Iterator.class), elementType);
-                Value iterator = preHeader.op(invoke(iterable, ITERABLE_ITERATOR, preHeader.parameters().get(0)));
-                preHeader.op(branch(header.reference()));
+                Value iterator = preHeader.add(invoke(iterable, ITERABLE_ITERATOR, preHeader.parameters().get(0)));
+                preHeader.add(branch(header.reference()));
 
-                Value p = header.op(invoke(ITERATOR_HAS_NEXT, iterator));
-                header.op(conditionalBranch(p, init.reference(), exit.reference()));
+                Value p = header.add(invoke(ITERATOR_HAS_NEXT, iterator));
+                header.add(conditionalBranch(p, init.reference(), exit.reference()));
 
-                Value e = init.op(invoke(elementType, ITERATOR_NEXT, iterator));
+                Value e = init.add(invoke(elementType, ITERATOR_NEXT, iterator));
                 List<Value> initValues = new ArrayList<>();
                 init.transformBody(this.initBody, List.of(e), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         initValues.addAll(block.context().getValues(yop.operands()));
-                        block.op(branch(body.reference()));
+                        block.add(branch(body.reference()));
                         return block;
                     } else {
                         return null;
@@ -4601,11 +4601,11 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder body = b.block();
             Block.Builder exit = b.block();
 
-            b.op(branch(header.reference()));
+            b.add(branch(header.reference()));
 
             header.transformBody(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
-                    block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
+                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
                     return block;
                 } else {
@@ -4763,7 +4763,7 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder header = b.block();
             Block.Builder exit = b.block();
 
-            b.op(branch(body.reference()));
+            b.add(branch(body.reference()));
 
             BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
@@ -4771,7 +4771,7 @@ public sealed abstract class JavaOp extends Op {
 
             header.transformBody(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
-                    block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
+                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             body.reference(), exit.reference()));
                     return block;
                 } else {
@@ -4846,7 +4846,7 @@ public sealed abstract class JavaOp extends Op {
                     bodyTransformer = loweringTransformer(before, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp yop) {
                             Value p = block.context().getValue(yop.yieldValue());
-                            block.op(branch(exit.reference(p)));
+                            block.add(branch(exit.reference(p)));
                             return block;
                         } else {
                             return null;
@@ -4858,9 +4858,9 @@ public sealed abstract class JavaOp extends Op {
                         if (op instanceof CoreOp.YieldOp yop) {
                             Value p = block.context().getValue(yop.yieldValue());
                             if (cop instanceof ConditionalAndOp) {
-                                block.op(conditionalBranch(p, nextPred.reference(), exit.reference(p)));
+                                block.add(conditionalBranch(p, nextPred.reference(), exit.reference(p)));
                             } else {
-                                block.op(conditionalBranch(p, exit.reference(p), nextPred.reference()));
+                                block.add(conditionalBranch(p, exit.reference(p), nextPred.reference()));
                             }
                             return block;
                         } else {
@@ -5120,7 +5120,7 @@ public sealed abstract class JavaOp extends Op {
             List<Block.Builder> builders = List.of(b.block(), b.block());
             b.transformBody(bodies.get(0), List.of(), loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yo) {
-                    block.op(conditionalBranch(block.context().getValue(yo.yieldValue()),
+                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
                             builders.get(0).reference(), builders.get(1).reference()));
                     return block;
                 } else {
@@ -5131,7 +5131,7 @@ public sealed abstract class JavaOp extends Op {
             for (int i = 0; i < 2; i++) {
                 builders.get(i).transformBody(bodies.get(i + 1), List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
-                        block.op(branch(exit.reference(block.context().getValue(yop.yieldValue()))));
+                        block.add(branch(exit.reference(block.context().getValue(yop.yieldValue()))));
                         return block;
                     } else {
                         return null;
@@ -5436,7 +5436,7 @@ public sealed abstract class JavaOp extends Op {
                         b.context().getValues(capturedValues()),
                         loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
-                        block.op(branch(exit.reference()));
+                        block.add(branch(exit.reference()));
                         return block;
                     } else {
                         return null;
@@ -5449,7 +5449,7 @@ public sealed abstract class JavaOp extends Op {
             if (catchBodies.isEmpty() && finallyBody == null) {
                 b.transformBody(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
-                        block.op(branch(exit.reference()));
+                        block.add(branch(exit.reference()));
                         return block;
                     } else {
                         return null;
@@ -5478,7 +5478,7 @@ public sealed abstract class JavaOp extends Op {
             List<Block.Reference> exitHandlers = catchers.stream()
                     .map(Block.Builder::reference)
                     .toList();
-            b.op(exceptionRegionEnter(tryRegionEnter.reference(), exitHandlers.reversed()));
+            b.add(exceptionRegionEnter(tryRegionEnter.reference(), exitHandlers.reversed()));
 
             BiFunction<Block.Builder, Op, Block.Builder> tryExitTransformer;
             if (finallyBody != null) {
@@ -5495,7 +5495,7 @@ public sealed abstract class JavaOp extends Op {
                     if (op instanceof CoreOp.ReturnOp ||
                             (op instanceof StatementTargetOp lop && ifExitFromTry(lop))) {
                         Block.Builder tryRegionReturnExit = block.block();
-                        block.op(exceptionRegionExit(tryRegionReturnExit.reference(), exitHandlers));
+                        block.add(exceptionRegionExit(tryRegionReturnExit.reference(), exitHandlers));
                         return tryRegionReturnExit;
                     } else {
                         return block;
@@ -5507,7 +5507,7 @@ public sealed abstract class JavaOp extends Op {
             tryRegionEnter.transformBody(body, List.of(), loweringTransformer(tryExitTransformer, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     hasTryRegionExit.set(true);
-                    block.op(branch(tryRegionExit.reference()));
+                    block.add(branch(tryRegionExit.reference()));
                     return block;
                 } else {
                     return null;
@@ -5519,11 +5519,11 @@ public sealed abstract class JavaOp extends Op {
                 finallyEnter = b.block();
                 if (hasTryRegionExit.get()) {
                     // Exit the try exception region
-                    tryRegionExit.op(exceptionRegionExit(finallyEnter.reference(), exitHandlers));
+                    tryRegionExit.add(exceptionRegionExit(finallyEnter.reference(), exitHandlers));
                 }
             } else if (hasTryRegionExit.get()) {
                 // Exit the try exception region
-                tryRegionExit.op(exceptionRegionExit(exit.reference(), exitHandlers));
+                tryRegionExit.add(exceptionRegionExit(exit.reference(), exitHandlers));
             }
 
             // Inline the catch bodies
@@ -5538,7 +5538,7 @@ public sealed abstract class JavaOp extends Op {
                     Block.Builder catchRegionExit = b.block();
 
                     // Enter the catch exception region
-                    Result catchExceptionRegion = catcher.op(
+                    Result catchExceptionRegion = catcher.add(
                             exceptionRegionEnter(catchRegionEnter.reference(), catcherFinally.reference()));
 
                     BiFunction<Block.Builder, Op, Block.Builder> catchExitTransformer = composeFirst(inherited, (block, op) -> {
@@ -5555,7 +5555,7 @@ public sealed abstract class JavaOp extends Op {
                     catchRegionEnter.transformBody(catcherBody, List.of(t), loweringTransformer(catchExitTransformer, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
                             hasCatchRegionExit.set(true);
-                            block.op(branch(catchRegionExit.reference()));
+                            block.add(branch(catchRegionExit.reference()));
                             return block;
                         } else {
                             return null;
@@ -5565,13 +5565,13 @@ public sealed abstract class JavaOp extends Op {
                     // Exit the catch exception region
                     if (hasCatchRegionExit.get()) {
                         hasTryRegionExit.set(true);
-                        catchRegionExit.op(exceptionRegionExit(finallyEnter.reference(), catcherFinally.reference()));
+                        catchRegionExit.add(exceptionRegionExit(finallyEnter.reference(), catcherFinally.reference()));
                     }
                 } else {
                     // Inline the catch body
                     catcher.transformBody(catcherBody, List.of(t), loweringTransformer(inherited, (block, op) -> {
                         if (op instanceof CoreOp.YieldOp) {
-                            block.op(branch(exit.reference()));
+                            block.add(branch(exit.reference()));
                             return block;
                         } else {
                             return null;
@@ -5584,7 +5584,7 @@ public sealed abstract class JavaOp extends Op {
                 // Inline the finally body
                 finallyEnter.transformBody(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
-                        block.op(branch(exit.reference()));
+                        block.add(branch(exit.reference()));
                         return block;
                     } else {
                         return null;
@@ -5599,7 +5599,7 @@ public sealed abstract class JavaOp extends Op {
 
                 catcherFinally.transformBody(finallyBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
-                        block.op(throw_(t));
+                        block.add(throw_(t));
                         return block;
                     } else {
                         return null;
@@ -5701,22 +5701,22 @@ public sealed abstract class JavaOp extends Op {
                     return normalizeExtendedTryWithResources(block.parentBody(), block.context(), new ArrayList<>());
                 };
                 if (catchBodies.isEmpty() && finallyBody == null) {
-                    entryBlock.op(normalizedTry.apply(entryBlock));
+                    entryBlock.add(normalizedTry.apply(entryBlock));
                 } else {
                     CatchBuilder catchBuilder = try_(entryBlock.parentBody(), tryB -> {
-                        tryB.op(normalizedTry.apply(tryB));
-                        tryB.op(core_yield());
+                        tryB.add(normalizedTry.apply(tryB));
+                        tryB.add(core_yield());
                     });
                     for (Body catcher : catchBodies) {
                         catchBuilder.catch_(catcher.bodySignature().parameterTypes().getFirst(), catchB ->
                                 catchB.transformBody(catcher, catchB.parameters(), entryBlock.context(), CodeTransformer.COPYING_TRANSFORMER));
                     }
-                    entryBlock.op(finallyBody == null
+                    entryBlock.add(finallyBody == null
                             ? catchBuilder.noFinalizer()
                             : catchBuilder.finally_(finB ->
                                     finB.transformBody(finallyBody, List.of(), entryBlock.context(), CodeTransformer.COPYING_TRANSFORMER)));
                 }
-                entryBlock.op(core_yield());
+                entryBlock.add(core_yield());
             });
         }
 
@@ -5754,48 +5754,48 @@ public sealed abstract class JavaOp extends Op {
                 Block.Builder afterAcquire = entryBlock.block(resourceType);
                 entryBlock.transformBody(resourcesBodies.getFirst(), List.of(), (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
-                        block.op(branch(afterAcquire.reference(block.context().getValue(yop.yieldValue()))));
+                        block.add(branch(afterAcquire.reference(block.context().getValue(yop.yieldValue()))));
                     } else {
-                        block.op(op);
+                        block.add(op);
                     }
                     return block;
                 });
                 Value resource = afterAcquire.parameters().getFirst();
-                Value primaryExceptionVar = afterAcquire.op(var(afterAcquire.op(constant(type(Throwable.class), null))));
+                Value primaryExceptionVar = afterAcquire.add(var(afterAcquire.add(constant(type(Throwable.class), null))));
                 // @@@ following builder code may be refactored into a reflected template method transformation
-                afterAcquire.op(try_(entryBlock.parentBody(), tryEntry -> {
+                afterAcquire.add(try_(entryBlock.parentBody(), tryEntry -> {
                     tryEntry.transformBody(body, List.of(resource), afterAcquire.context(), CodeTransformer.COPYING_TRANSFORMER);
                 }).catch_(type(Throwable.class), catchB -> {
                     Block.Parameter thrown = catchB.parameters().getFirst();
-                    catchB.op(varStore(primaryExceptionVar, thrown));
-                    catchB.op(throw_(thrown));
+                    catchB.add(varStore(primaryExceptionVar, thrown));
+                    catchB.add(throw_(thrown));
                 }).finally_(finB -> {
-                    Value nullObj = finB.op(constant(J_L_OBJECT, null));
-                    finB.op(if_(finB.parentBody()).if_(predB -> {
-                                predB.op(core_yield(predB.op(neq(resource, nullObj))));
+                    Value nullObj = finB.add(constant(J_L_OBJECT, null));
+                    finB.add(if_(finB.parentBody()).if_(predB -> {
+                                predB.add(core_yield(predB.add(neq(resource, nullObj))));
                     }).then(closeB -> {
-                        Value primaryException = closeB.op(varLoad(primaryExceptionVar));
-                        closeB.op(if_(closeB.parentBody()).if_(predB -> {
-                            predB.op(core_yield(predB.op(neq(primaryException, nullObj))));
+                        Value primaryException = closeB.add(varLoad(primaryExceptionVar));
+                        closeB.add(if_(closeB.parentBody()).if_(predB -> {
+                            predB.add(core_yield(predB.add(neq(primaryException, nullObj))));
                         }).then(suppB -> {
-                            suppB.op(try_(suppB.parentBody(), tryB -> {
-                                tryB.op(invoke(AUTO_CLOSEABLE_CLOSE_METHOD, resource));
-                                tryB.op(core_yield());
+                            suppB.add(try_(suppB.parentBody(), tryB -> {
+                                tryB.add(invoke(AUTO_CLOSEABLE_CLOSE_METHOD, resource));
+                                tryB.add(core_yield());
                             }).catch_(type(Throwable.class), catchB -> {
                                 Block.Parameter closeException = catchB.parameters().getFirst();
-                                catchB.op(invoke(THROWABLE_ADD_SUPPRESSED_METHOD, primaryException, closeException));
-                                catchB.op(core_yield());
+                                catchB.add(invoke(THROWABLE_ADD_SUPPRESSED_METHOD, primaryException, closeException));
+                                catchB.add(core_yield());
                             }).noFinalizer());
-                            suppB.op(core_yield());
+                            suppB.add(core_yield());
                         }).else_(normB -> {
-                            normB.op(invoke(AUTO_CLOSEABLE_CLOSE_METHOD, resource));
-                            normB.op(core_yield());
+                            normB.add(invoke(AUTO_CLOSEABLE_CLOSE_METHOD, resource));
+                            normB.add(core_yield());
                         }));
-                        closeB.op(core_yield());
+                        closeB.add(core_yield());
                     }).else_());
-                    finB.op(core_yield());
+                    finB.add(core_yield());
                 }));
-                afterAcquire.op(core_yield());
+                afterAcquire.add(core_yield());
             });
         }
 
@@ -5812,8 +5812,8 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder bodyB = basicBody.entryBlock();
             resourceValues.add(bodyB.parameters().getFirst());
             if (resourceValues.size() < resourcesBodies.size()) {
-                bodyB.op(normalizeExtendedTryWithResources(basicBody, cc, resourceValues));
-                bodyB.op(core_yield());
+                bodyB.add(normalizeExtendedTryWithResources(basicBody, cc, resourceValues));
+                bodyB.add(core_yield());
             } else {
                 bodyB.transformBody(body, resourceValues, cc, CodeTransformer.COPYING_TRANSFORMER);
             }
@@ -5838,12 +5838,12 @@ public sealed abstract class JavaOp extends Op {
             Block.Builder finallyEnter = block1.block();
             Block.Builder finallyExit = block1.block();
 
-            block1.op(exceptionRegionExit(finallyEnter.reference(), tryHandlers));
+            block1.add(exceptionRegionExit(finallyEnter.reference(), tryHandlers));
 
             // Inline the finally body
             finallyEnter.transformBody(finallyBody, List.of(), loweringTransformer(inherited, (block2, op2) -> {
                 if (op2 instanceof CoreOp.YieldOp) {
-                    block2.op(branch(finallyExit.reference()));
+                    block2.add(branch(finallyExit.reference()));
                     return block2;
                 } else {
                     return null;
@@ -6255,19 +6255,19 @@ public sealed abstract class JavaOp extends Op {
                         patternValues,
                         rootPatternValue.op(),
                         b.context().getValue(targetOperand()));
-                currentBlock.op(branch(endMatchBlock.reference()));
+                currentBlock.add(branch(endMatchBlock.reference()));
 
                 // No match block
                 // Pass false
-                endNoMatchBlock.op(branch(endBlock.reference(
-                        endNoMatchBlock.op(constant(BOOLEAN, false)))));
+                endNoMatchBlock.add(branch(endBlock.reference(
+                        endNoMatchBlock.add(constant(BOOLEAN, false)))));
 
                 // Match block
                 // Lower match body and pass true
                 endMatchBlock.transformBody(matchBody, patternValues, loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
-                        block.op(branch(endBlock.reference(
-                                block.op(constant(BOOLEAN, true)))));
+                        block.add(branch(endBlock.reference(
+                                block.add(constant(BOOLEAN, true)))));
                         return block;
                     } else {
                         return null;
@@ -6296,19 +6296,19 @@ public sealed abstract class JavaOp extends Op {
                 Block.Builder nextBlock = currentBlock.block();
 
                 // Check if instance of target type
-                Op.Result isInstance = currentBlock.op(instanceOf(targetType, target));
-                currentBlock.op(conditionalBranch(isInstance, nextBlock.reference(), endNoMatchBlock.reference()));
+                Op.Result isInstance = currentBlock.add(instanceOf(targetType, target));
+                currentBlock.add(conditionalBranch(isInstance, nextBlock.reference(), endNoMatchBlock.reference()));
 
                 currentBlock = nextBlock;
 
-                target = currentBlock.op(cast(targetType, target));
+                target = currentBlock.add(cast(targetType, target));
 
                 // Access component values of record and match on each as nested target
                 List<Value> dArgs = rpOp.operands();
                 for (int i = 0; i < dArgs.size(); i++) {
                     Op.Result nestedPattern = (Op.Result) dArgs.get(i);
                     // @@@ Handle exceptions?
-            Value nestedTarget = currentBlock.op(invoke(rpOp.recordReference().methodForComponent(i), target));
+            Value nestedTarget = currentBlock.add(invoke(rpOp.recordReference().methodForComponent(i), target));
 
                     currentBlock = lower(endNoMatchBlock, currentBlock, bindings, nestedPattern.op(), nestedTarget);
                 }
@@ -6380,10 +6380,10 @@ public sealed abstract class JavaOp extends Op {
                     if (p != null) {
                         // p != null, we need to perform type check at runtime
                         Block.Builder nextBlock = currentBlock.block();
-                        currentBlock.op(conditionalBranch(currentBlock.op(p), nextBlock.reference(), endNoMatchBlock.reference()));
+                        currentBlock.add(conditionalBranch(currentBlock.add(p), nextBlock.reference(), endNoMatchBlock.reference()));
                         currentBlock = nextBlock;
                     }
-                    target = currentBlock.op(c);
+                    target = currentBlock.add(c);
                 }
 
                 bindings.add(target);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/StringConcatTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/StringConcatTransformer.java
@@ -50,16 +50,16 @@ public final class StringConcatTransformer implements CodeTransformer {
         switch (op) {
             case JavaOp.ConcatOp cz when isRootConcat(cz) -> {
                 // Create a string builder and build by traversing tree of operands
-                Op.Result builder = block.op(JavaOp.new_(MethodRef.constructor(J_L_STRING_BUILDER)));
+                Op.Result builder = block.add(JavaOp.new_(MethodRef.constructor(J_L_STRING_BUILDER)));
                 buildFromTree(block, builder, cz);
                 // Convert to string
-                Value s = block.op(JavaOp.invoke(SB_TO_STRING_REF, builder));
+                Value s = block.add(JavaOp.invoke(SB_TO_STRING_REF, builder));
                 block.context().mapValue(cz.result(), s);
             }
             case JavaOp.ConcatOp _ -> {
                 // Process later when building from root concat
             }
-            default -> block.op(op);
+            default -> block.add(op);
         }
         return block;
     }
@@ -86,7 +86,7 @@ public final class StringConcatTransformer implements CodeTransformer {
         } else {
             // Leaf of tree, append value to builder
             // Note leaf can be the result of a ConcatOp with multiple uses
-            block.op(append(block, builder, block.context().getValue(v)));
+            block.add(append(block, builder, block.context().getValue(v)));
         }
     }
 
@@ -97,7 +97,7 @@ public final class StringConcatTransformer implements CodeTransformer {
         if (type instanceof PrimitiveType) {
             //Widen Short and Byte to Int.
             if (type.equals(JavaType.BYTE) || type.equals(JavaType.SHORT)) {
-                arg = block.op(JavaOp.conv(JavaType.INT, arg));
+                arg = block.add(JavaOp.conv(JavaType.INT, arg));
                 type = JavaType.INT;
             }
         } else if (!type.equals(JavaType.J_L_STRING)){

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpParser.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/OpParser.java
@@ -233,10 +233,10 @@ public final class OpParser {
             for (OpNode on : bn.ops) {
                 ValueNode r = on.result;
                 if (r != null) {
-                    Op.Result v = b.op(nodeToOp(on, r.type, c, body));
+                    Op.Result v = b.add(nodeToOp(on, r.type, c, body));
                     c.putValue(r.name, v);
                 } else {
-                    b.op(nodeToOp(on, VOID, c, body));
+                    b.add(nodeToOp(on, VOID, c, body));
                 }
             }
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/OpBuilder.java
@@ -72,7 +72,7 @@ public class OpBuilder {
     static final MethodRef BLOCK_BUILDER_REFERENCE = MethodRef.method(Block.Builder.class, "reference",
             Block.Reference.class, Value[].class);
 
-    static final MethodRef BLOCK_BUILDER_OP = MethodRef.method(Block.Builder.class, "op",
+    static final MethodRef BLOCK_BUILDER_ADD = MethodRef.method(Block.Builder.class, "add",
             Op.Result.class, Op.class);
 
     // instance varargs
@@ -238,11 +238,11 @@ public class OpBuilder {
                 func(LIST_BUILDER_F_NAME, LIST_BUILDER_F_TYPE).body(bb -> {
                     Block.Builder b0 = bb.entryBlock(), b1 = b0.block(), b2 = b0.block(), b3 = b0.block(), b4 = b0.block();
                     Value arg = b0.parameters().get(0);
-                    b0.op(conditionalBranch(b0.op(eq(arg, b0.op(constant(J_L_OBJECT, null)))), b1.reference(), b2.reference()));
-                    b1.op(return_(b1.op(invoke(LIST_EMPTY))));
-                    b2.op(conditionalBranch(b2.op(instanceOf(J_U_LIST, arg)), b3.reference(), b4.reference()));
-                    b3.op(return_(b3.op(cast(J_U_LIST, arg))));
-                    b4.op(return_(b4.op(invoke(LIST_OF_OBJECT, arg))));
+                    b0.add(conditionalBranch(b0.add(eq(arg, b0.add(constant(J_L_OBJECT, null)))), b1.reference(), b2.reference()));
+                    b1.add(return_(b1.add(invoke(LIST_EMPTY))));
+                    b2.add(conditionalBranch(b2.add(instanceOf(J_U_LIST, arg)), b3.reference(), b4.reference()));
+                    b3.add(return_(b3.add(cast(J_U_LIST, arg))));
+                    b4.add(return_(b4.add(invoke(LIST_OF_OBJECT, arg))));
                 }),
                 // static Map $map(Object o) {
                 //     if (o == null) return Map.of();
@@ -252,11 +252,11 @@ public class OpBuilder {
                 func(MAP_BUILDER_F_NAME, MAP_BUILDER_F_TYPE).body(bb -> {
                     Block.Builder b0 = bb.entryBlock(), b1 = b0.block(), b2 = b0.block(), b3 = b0.block(), b4 = b0.block();
                     Value arg = b0.parameters().get(0);
-                    b0.op(conditionalBranch(b0.op(eq(arg, b0.op(constant(J_L_OBJECT, null)))), b1.reference(), b2.reference()));
-                    b1.op(return_(b1.op(invoke(MAP_EMPTY))));
-                    b2.op(conditionalBranch(b2.op(instanceOf(J_U_MAP, arg)), b3.reference(), b4.reference()));
-                    b3.op(return_(b3.op(cast(J_U_MAP, arg))));
-                    b4.op(return_(b4.op(invoke(MAP_OF_OBJECT_OBJECT, b4.op(constant(J_L_STRING, "")), arg))));
+                    b0.add(conditionalBranch(b0.add(eq(arg, b0.add(constant(J_L_OBJECT, null)))), b1.reference(), b2.reference()));
+                    b1.add(return_(b1.add(invoke(MAP_EMPTY))));
+                    b2.add(conditionalBranch(b2.add(instanceOf(J_U_MAP, arg)), b3.reference(), b4.reference()));
+                    b3.add(return_(b3.add(cast(J_U_MAP, arg))));
+                    b4.add(return_(b4.add(invoke(MAP_OF_OBJECT_OBJECT, b4.add(constant(J_L_STRING, "")), arg))));
                 }),
                 // static Op $op1(String name,
                 //                Location location,
@@ -277,16 +277,16 @@ public class OpBuilder {
                 func(OP_BUILDER_F_NAME_1, OP_BUILDER_F_OVERRIDE_1).body(bb -> {
                     Block.Builder b = bb.entryBlock();
                     List<Block.Parameter> args = b.parameters();
-                    b.op(return_(b.op(invoke(OP_FACTORY_CONSTRUCT,
-                            b.op(invoke(DIALECT_FACTORY_OP_FACTORY, dialectFactoryF.apply(b))),
-                            b.op(new_(MethodRef.constructor(EXTERNALIZED_OP_F_TYPE),
+                    b.add(return_(b.add(invoke(OP_FACTORY_CONSTRUCT,
+                            b.add(invoke(DIALECT_FACTORY_OP_FACTORY, dialectFactoryF.apply(b))),
+                            b.add(new_(MethodRef.constructor(EXTERNALIZED_OP_F_TYPE),
                                     args.get(0),
                                     args.get(1),
-                                    b.op(funcCall(LIST_BUILDER_F_NAME, LIST_BUILDER_F_TYPE, args.get(2))),
-                                    b.op(funcCall(LIST_BUILDER_F_NAME, LIST_BUILDER_F_TYPE, args.get(3))),
-                                    b.op(funcCall(TYPE_BUILDER_F_NAME, TYPE_BUILDER_F_TYPE, args.get(4))),
-                                    b.op(funcCall(MAP_BUILDER_F_NAME, MAP_BUILDER_F_TYPE, args.get(5))),
-                                    b.op(funcCall(LIST_BUILDER_F_NAME, LIST_BUILDER_F_TYPE, args.get(6)))))))));
+                                    b.add(funcCall(LIST_BUILDER_F_NAME, LIST_BUILDER_F_TYPE, args.get(2))),
+                                    b.add(funcCall(LIST_BUILDER_F_NAME, LIST_BUILDER_F_TYPE, args.get(3))),
+                                    b.add(funcCall(TYPE_BUILDER_F_NAME, TYPE_BUILDER_F_TYPE, args.get(4))),
+                                    b.add(funcCall(MAP_BUILDER_F_NAME, MAP_BUILDER_F_TYPE, args.get(5))),
+                                    b.add(funcCall(LIST_BUILDER_F_NAME, LIST_BUILDER_F_TYPE, args.get(6)))))))));
                 }),
                 // static Op.Result $op2(Block.Builder b,
                 //                       String name,
@@ -307,9 +307,9 @@ public class OpBuilder {
                 func(OP_BUILDER_F_NAME_2, OP_BUILDER_F_OVERRIDE_2).body(bb -> {
                     Block.Builder b = bb.entryBlock();
                     List<Block.Parameter> args = b.parameters();
-                    b.op(return_(b.op(invoke(BLOCK_BUILDER_OP,
+                    b.add(return_(b.add(invoke(BLOCK_BUILDER_ADD,
                             args.get(0),
-                            b.op(funcCall(OP_BUILDER_F_NAME_1, OP_BUILDER_F_OVERRIDE_1,
+                            b.add(funcCall(OP_BUILDER_F_NAME_1, OP_BUILDER_F_OVERRIDE_1,
                                     args.get(1),
                                     args.get(2),
                                     args.get(3),
@@ -339,10 +339,10 @@ public class OpBuilder {
                 func(OP_BUILDER_F_NAME_3, OP_BUILDER_F_OVERRIDE_3).body(bb -> {
                     Block.Builder b = bb.entryBlock();
                     List<Block.Parameter> args = b.parameters();
-                    b.op(return_(b.op(funcCall(OP_BUILDER_F_NAME_2, OP_BUILDER_F_OVERRIDE_2,
+                    b.add(return_(b.add(funcCall(OP_BUILDER_F_NAME_2, OP_BUILDER_F_OVERRIDE_2,
                             args.get(0),
                             args.get(1),
-                            b.op(new_(MethodRef.constructor(Op.Location.class, int.class, int.class), args.get(2), args.get(3))),
+                            b.add(new_(MethodRef.constructor(Op.Location.class, int.class, int.class), args.get(2), args.get(3))),
                             args.get(4),
                             args.get(5),
                             args.get(6),
@@ -354,32 +354,32 @@ public class OpBuilder {
                 //  }
                 func(TYPE_BUILDER_F_NAME, CoreType.functionType(type(CodeType.class))).body(b -> {
                     var i = b.parameter(INT);
-                    var codeTypeFactory = b.op(invoke(DIALECT_FACTORY_CODE_TYPE_FACTORY, dialectFactoryF.apply(b)));
-                    var exCodeType = b.op(funcCall(EXTER_TYPE_BUILDER_F_NAME, EXTER_TYPE_BUILDER_F_TYPE, i));
-                    var codeType = b.op(invoke(MethodRef.method(CodeTypeFactory.class, "constructType", CodeType.class, ExternalizedCodeType.class), codeTypeFactory, exCodeType));
-                    b.op(return_(codeType));
+                    var codeTypeFactory = b.add(invoke(DIALECT_FACTORY_CODE_TYPE_FACTORY, dialectFactoryF.apply(b)));
+                    var exCodeType = b.add(funcCall(EXTER_TYPE_BUILDER_F_NAME, EXTER_TYPE_BUILDER_F_TYPE, i));
+                    var codeType = b.add(invoke(MethodRef.method(CodeTypeFactory.class, "constructType", CodeType.class, ExternalizedCodeType.class), codeTypeFactory, exCodeType));
+                    b.add(return_(codeType));
                 }),
                 func(JAVA_VERSION_CHECKER_F_NAME, FunctionType.FUNCTION_TYPE_VOID).body(b -> {
                     var compiletimeVersion = Runtime.version().feature();
                     // runtimeVersion = Runtime.version().feature()
-                    var version = b.op(invoke(MethodRef.method(Runtime.class, "version", Runtime.Version.class)));
-                    var runtimeVersion = b.op(invoke(MethodRef.method(Runtime.Version.class, "feature", int.class), version));
+                    var version = b.add(invoke(MethodRef.method(Runtime.class, "version", Runtime.Version.class)));
+                    var runtimeVersion = b.add(invoke(MethodRef.method(Runtime.Version.class, "feature", int.class), version));
                     IfOp ifop = if_(b.parentBody()).if_(c -> {
-                        var p = c.op(neq(runtimeVersion, b.op(constant(INT, compiletimeVersion))));
-                        c.op(core_yield(p));
+                        var p = c.add(neq(runtimeVersion, b.add(constant(INT, compiletimeVersion))));
+                        c.add(core_yield(p));
                     }).then(t -> {
                         var s = "The Java version used at compile time to generate and store the code model, Java " + compiletimeVersion +
                                 ", is not the same as the Java version used at runtime to load the code model, Java ";
-                        var errMessage = t.op(concat(
-                                t.op(constant(J_L_STRING, s)),
+                        var errMessage = t.add(concat(
+                                t.add(constant(J_L_STRING, s)),
                                 runtimeVersion
                         ));
-                        t.op(throw_(
-                                t.op(new_(MethodRef.constructor(UnsupportedOperationException.class, String.class), errMessage))
+                        t.add(throw_(
+                                t.add(new_(MethodRef.constructor(UnsupportedOperationException.class, String.class), errMessage))
                         ));
                     }).else_();
-                    b.op(ifop);
-                    b.op(return_());
+                    b.add(ifop);
+                    b.add(return_());
                 })
         );
     }
@@ -408,15 +408,15 @@ public class OpBuilder {
                     Body.Builder l = Body.Builder.of(b.parentBody(), functionType(BOOLEAN));
                     Block.Parameter target = l.entryBlock().parameter(INT);
                     Integer typeIndex = e.getValue().getLast();
-                    Result p = l.entryBlock().op(eq(target, l.entryBlock().op(constant(INT, typeIndex))));
-                    l.entryBlock().op(core_yield(p));
+                    Result p = l.entryBlock().add(eq(target, l.entryBlock().add(constant(INT, typeIndex))));
+                    l.entryBlock().add(core_yield(p));
 
                     Body.Builder expr = Body.Builder.of(b.parentBody(), EXTER_TYPE_BUILDER_F_TYPE);
                     List<Value> args = new ArrayList<>();
-                    args.add(expr.entryBlock().op(constant(J_L_STRING, e.getKey().identifier())));
+                    args.add(expr.entryBlock().add(constant(J_L_STRING, e.getKey().identifier())));
                     for (int j = 0; j < e.getValue().size() - 1; j++) {
-                        Value index = expr.entryBlock().op(constant(INT, e.getValue().get(j)));
-                        Result opr = expr.entryBlock().op(funcCall(EXTER_TYPE_BUILDER_F_NAME, EXTER_TYPE_BUILDER_F_TYPE, index));
+                        Value index = expr.entryBlock().add(constant(INT, e.getValue().get(j)));
+                        Result opr = expr.entryBlock().add(funcCall(EXTER_TYPE_BUILDER_F_NAME, EXTER_TYPE_BUILDER_F_TYPE, index));
                         args.add(opr);
                     }
                     MethodRef mr;
@@ -426,11 +426,11 @@ public class OpBuilder {
                         params.add(String.class);
                         params.addAll(Collections.nCopies(e.getKey().arguments().size(), ExternalizedCodeType.class));
                         mr = MethodRef.method(ExternalizedCodeType.class, "of", ExternalizedCodeType.class, params);
-                        type = expr.entryBlock().op(invoke(mr, args));
+                        type = expr.entryBlock().add(invoke(mr, args));
                     } else {
-                        type = expr.entryBlock().op(invoke(InvokeOp.InvokeKind.STATIC, true, EX_TYPE_ELEM, EX_TYPE_ELEM_OF_ARRAY, args));
+                        type = expr.entryBlock().add(invoke(InvokeOp.InvokeKind.STATIC, true, EX_TYPE_ELEM, EX_TYPE_ELEM_OF_ARRAY, args));
                     }
-                    expr.entryBlock().op(core_yield(type));
+                    expr.entryBlock().add(core_yield(type));
 
                     swBodies.add(l);
                     swBodies.add(expr);
@@ -439,20 +439,20 @@ public class OpBuilder {
                 // default case
                 Body.Builder dl = Body.Builder.of(b.parentBody(), functionType(BOOLEAN));
                 dl.entryBlock().parameter(INT);
-                dl.entryBlock().op(core_yield(dl.entryBlock().op(constant(BOOLEAN, true))));
+                dl.entryBlock().add(core_yield(dl.entryBlock().add(constant(BOOLEAN, true))));
                 Body.Builder de = Body.Builder.of(b.parentBody(), EXTER_TYPE_BUILDER_F_TYPE);
                 if (typesEnntryIterator.hasNext()) {
                     // forward to a follow-up builder method (we are over TYPE_LIMIT)
-                    de.entryBlock().op(core_yield(de.entryBlock().op(funcCall(followUpBuilderName, EXTER_TYPE_BUILDER_F_TYPE, i))));
+                    de.entryBlock().add(core_yield(de.entryBlock().add(funcCall(followUpBuilderName, EXTER_TYPE_BUILDER_F_TYPE, i))));
                 } else {
                     // throw
-                    de.entryBlock().op(throw_(de.entryBlock().op(new_(MethodRef.constructor(IllegalStateException.class)))));
+                    de.entryBlock().add(throw_(de.entryBlock().add(new_(MethodRef.constructor(IllegalStateException.class)))));
                 }
                 swBodies.add(dl);
                 swBodies.add(de);
 
-                var r = b.op(switchExpression(i, swBodies));
-                b.op(return_(r));
+                var r = b.add(switchExpression(i, swBodies));
+                b.add(return_(r));
             }));
             methodCounter++;
         } while (typesEnntryIterator.hasNext());
@@ -470,20 +470,20 @@ public class OpBuilder {
     }
 
     FuncOp build(String name, Op op) {
-        Value ancestorBody = builder.op(constant(type(Body.Builder.class), null));
+        Value ancestorBody = builder.add(constant(type(Body.Builder.class), null));
         // check if java version at compile time matches the java version at runtime
-        builder.op(funcCall(JAVA_VERSION_CHECKER_F_NAME, FunctionType.FUNCTION_TYPE_VOID));
+        builder.add(funcCall(JAVA_VERSION_CHECKER_F_NAME, FunctionType.FUNCTION_TYPE_VOID));
         Value result = buildOp(null, ancestorBody, op);
         // build as root op
-        builder.op(invoke(MethodRef.method(Op.class, "buildAsRoot", void.class), result));
-        builder.op(return_(result));
+        builder.add(invoke(MethodRef.method(Op.class, "buildAsRoot", void.class), result));
+        builder.add(return_(result));
 
         // return from lambdas on stack
         while (!lambdaStack.isEmpty()) {
             var lambdaBuilder = builder;
             builder = lambdaStack.pop();
-            var l = builder.op(lambda(JavaType.parameterized(JavaType.type(Supplier.class), JavaType.type(Op.class)), lambdaBuilder.parentBody()));
-            builder.op(return_(builder.op(cast(JavaType.type(Op.class), builder.op(invoke(MethodRef.method(Supplier.class, "get", Object.class), l))))));
+            var l = builder.add(lambda(JavaType.parameterized(JavaType.type(Supplier.class), JavaType.type(Op.class)), lambdaBuilder.parentBody()));
+            builder.add(return_(builder.add(cast(JavaType.type(Op.class), builder.add(invoke(MethodRef.method(Supplier.class, "get", Object.class), l))))));
         }
 
         return func(name, builder.parentBody());
@@ -521,7 +521,7 @@ public class OpBuilder {
             List<Value> args = new ArrayList<>();
             args.add(referencedBlock);
             args.addAll(successorArgs);
-            Value successor = builder.op(invoke(
+            Value successor = builder.add(invoke(
                     InvokeOp.InvokeKind.INSTANCE, true,
                     BLOCK_BUILDER_REFERENCE.signature().returnType(),
                     BLOCK_BUILDER_REFERENCE, args));
@@ -557,26 +557,26 @@ public class OpBuilder {
         if (bb) {
             args.add(blockBuilder);
         }
-        args.add(builder.op(constant(J_L_STRING, name)));
+        args.add(builder.add(constant(J_L_STRING, name)));
         if (simpleLoc) {
-            args.add(builder.op(constant(INT, location.line())));
-            args.add(builder.op(constant(INT, location.column())));
+            args.add(builder.add(constant(INT, location.line())));
+            args.add(builder.add(constant(INT, location.column())));
         } else {
             args.add(buildLocation(location));
         }
         args.add(buildFlexibleList(type(Value.class), operands));
         args.add(buildFlexibleList(type(Block.Reference.class), successors));
-        args.add(builder.op(constant(INT, registerType(resultType.externalize()))));
+        args.add(builder.add(constant(INT, registerType(resultType.externalize()))));
         args.add(buildAttributeMap(inputOp, attributes));
         args.add(buildFlexibleList(type(Body.Builder.class), bodies));
-        return builder.op(bb ? simpleLoc ? funcCall(OP_BUILDER_F_NAME_3, OP_BUILDER_F_OVERRIDE_3, args)
+        return builder.add(bb ? simpleLoc ? funcCall(OP_BUILDER_F_NAME_3, OP_BUILDER_F_OVERRIDE_3, args)
                                          : funcCall(OP_BUILDER_F_NAME_2, OP_BUILDER_F_OVERRIDE_2, args)
                              : funcCall(OP_BUILDER_F_NAME_1, OP_BUILDER_F_OVERRIDE_1, args));
     }
 
     Value buildFlexibleList(JavaType javaType, List<Value> elements) {
         return switch (elements.size()) {
-            case 0 -> builder.op(constant(javaType, null));
+            case 0 -> builder.add(constant(javaType, null));
             case 1 -> elements.getFirst();
             default -> buildList(javaType, elements);
         };
@@ -584,31 +584,31 @@ public class OpBuilder {
 
     Value buildLocation(Op.Location l) {
         if (l == null) {
-            return builder.op(constant(J_C_LOCATION, null));
+            return builder.add(constant(J_C_LOCATION, null));
         } else {
-            return builder.op(new_(MethodRef.constructor(Op.Location.class, String.class, int.class, int.class),
-                    builder.op(constant(J_L_STRING, l.sourceRef())),
-                    builder.op(constant(INT, l.line())),
-                    builder.op(constant(INT, l.column()))));
+            return builder.add(new_(MethodRef.constructor(Op.Location.class, String.class, int.class, int.class),
+                    builder.add(constant(J_L_STRING, l.sourceRef())),
+                    builder.add(constant(INT, l.line())),
+                    builder.add(constant(INT, l.column()))));
         }
     }
 
     Value buildBody(Value ancestorBodyValue, Body inputBody) {
         Value yieldType = buildType(inputBody.yieldType());
-        Value bodyType = builder.op(invoke(
+        Value bodyType = builder.add(invoke(
                 InvokeOp.InvokeKind.STATIC, true,
                 FUNCTION_TYPE_FUNCTION_TYPE.signature().returnType(),
                 FUNCTION_TYPE_FUNCTION_TYPE, List.of(yieldType)));
-        Value body = builder.op(invoke(BODY_BUILDER_OF, ancestorBodyValue, bodyType));
+        Value body = builder.add(invoke(BODY_BUILDER_OF, ancestorBodyValue, bodyType));
 
         Value entryBlock = null;
         for (Block inputBlock : inputBody.blocks()) {
             Value block;
             if (inputBlock.isEntryBlock()) {
-                block = entryBlock = builder.op(invoke(BODY_BUILDER_ENTRY_BLOCK, body));
+                block = entryBlock = builder.add(invoke(BODY_BUILDER_ENTRY_BLOCK, body));
             } else {
                 assert entryBlock != null;
-                block = builder.op(invoke(InvokeOp.InvokeKind.INSTANCE, true,
+                block = builder.add(invoke(InvokeOp.InvokeKind.INSTANCE, true,
                         BLOCK_BUILDER_BLOCK.signature().returnType(),
                         BLOCK_BUILDER_BLOCK, List.of(entryBlock)));
             }
@@ -616,7 +616,7 @@ public class OpBuilder {
 
             for (Block.Parameter inputP : inputBlock.parameters()) {
                 Value type = buildType(inputP.type());
-                Value blockParameter = builder.op(invoke(BLOCK_BUILDER_PARAMETER, block, type));
+                Value blockParameter = builder.add(invoke(BLOCK_BUILDER_PARAMETER, block, type));
                 valueMap.put(inputP, blockParameter);
             }
         }
@@ -646,21 +646,21 @@ public class OpBuilder {
     Value buildType(CodeType _t) {
         return codeTypeMap.computeIfAbsent(_t, t -> {
             int typeIndex = registerType(_t.externalize());
-            Op.Result i = builder.op(constant(INT, typeIndex));
-            return builder.op(funcCall(TYPE_BUILDER_F_NAME, CoreType.functionType(type(CodeType.class)), i));
+            Op.Result i = builder.add(constant(INT, typeIndex));
+            return builder.add(funcCall(TYPE_BUILDER_F_NAME, CoreType.functionType(type(CodeType.class)), i));
         });
     }
 
     Value buildAttributeMap(Op inputOp, Map<String, Object> attributes) {
         if (attributes.isEmpty()) {
-            return builder.op(constant(type(Map.class), null));
+            return builder.add(constant(type(Map.class), null));
         }
         if (attributes.size() == 1 && attributes.get("") instanceof Object o) {
             return buildAttributeValue(o);
         }
         List<Value> keysAndValues = new ArrayList<>();
         for (Map.Entry<String, Object> entry : attributes.entrySet()) {
-            Value key = builder.op(constant(J_L_STRING, entry.getKey()));
+            Value key = builder.add(constant(J_L_STRING, entry.getKey()));
             Value value = buildAttributeValue(entry.getValue());
             keysAndValues.add(key);
             keysAndValues.add(value);
@@ -669,39 +669,39 @@ public class OpBuilder {
     }
 
     private Value box(CodeType to, Value v) {
-        return builder.op(invoke(MethodRef.method(to, "valueOf", to, v.type()), v));
+        return builder.add(invoke(MethodRef.method(to, "valueOf", to, v.type()), v));
     }
 
     Value buildAttributeValue(Object value) {
         return switch (value) {
             case Boolean _ ->
-                box(J_L_BOOLEAN, builder.op(constant(BOOLEAN, value)));
+                box(J_L_BOOLEAN, builder.add(constant(BOOLEAN, value)));
             case Byte _ ->
-                box(J_L_BYTE, builder.op(constant(BYTE, value)));
+                box(J_L_BYTE, builder.add(constant(BYTE, value)));
             case Short _ ->
-                box(J_L_SHORT, builder.op(constant(SHORT, value)));
+                box(J_L_SHORT, builder.add(constant(SHORT, value)));
             case Character _ ->
-                box(J_L_CHARACTER, builder.op(constant(CHAR, value)));
+                box(J_L_CHARACTER, builder.add(constant(CHAR, value)));
             case Integer _ ->
-                box(J_L_INTEGER, builder.op(constant(INT, value)));
+                box(J_L_INTEGER, builder.add(constant(INT, value)));
             case Long _ ->
-                box(J_L_LONG, builder.op(constant(LONG, value)));
+                box(J_L_LONG, builder.add(constant(LONG, value)));
             case Float _ ->
-                box(J_L_FLOAT, builder.op(constant(FLOAT, value)));
+                box(J_L_FLOAT, builder.add(constant(FLOAT, value)));
             case Double _ ->
-                box(J_L_DOUBLE, builder.op(constant(DOUBLE, value)));
+                box(J_L_DOUBLE, builder.add(constant(DOUBLE, value)));
             case Class<?> v ->
                 buildType(JavaType.type(v));
             case String s ->
-                builder.op(constant(J_L_STRING, value));
+                builder.add(constant(J_L_STRING, value));
             case CodeType f ->
                 buildType(f);
             case InvokeOp.InvokeKind ik -> {
                 FieldRef enumValueRef = FieldRef.field(InvokeOp.InvokeKind.class, ik.name(), InvokeOp.InvokeKind.class);
-                yield builder.op(fieldLoad(enumValueRef));
+                yield builder.add(fieldLoad(enumValueRef));
             }
             case Object o when value == ExternalizedOp.NULL_ATTRIBUTE_VALUE ->
-                builder.op(fieldLoad(FieldRef.field(ExternalizedOp.class,
+                builder.add(fieldLoad(FieldRef.field(ExternalizedOp.class,
                         "NULL_ATTRIBUTE_VALUE", Object.class)));
             default -> {
                 // @@@ use the result of value.toString()?
@@ -716,18 +716,18 @@ public class OpBuilder {
         if (keysAndValues.size() < 21) {
             MethodRef mapOf = MethodRef.method(J_U_MAP, "of",
                     J_U_MAP, Collections.nCopies(keysAndValues.size(), J_L_OBJECT));
-            return builder.op(invoke(mapType, mapOf, keysAndValues));
+            return builder.add(invoke(mapType, mapOf, keysAndValues));
         } else {
             JavaType mapEntryType = parameterized(J_U_MAP_ENTRY, keyType, valueType);
             List<Value> elements = new ArrayList<>(keysAndValues.size() / 2);
             for (int i = 0; i < keysAndValues.size(); i += 2) {
                 Value key = keysAndValues.get(i);
                 Value value = keysAndValues.get(i + 1);
-                Value entry = builder.op(invoke(mapEntryType, MAP_ENTRY, key, value));
+                Value entry = builder.add(invoke(mapEntryType, MAP_ENTRY, key, value));
                 elements.add(entry);
             }
             Value array = buildArray(mapEntryType, elements);
-            return builder.op(invoke(mapType, MAP_OF_ARRAY, array));
+            return builder.add(invoke(mapType, MAP_OF_ARRAY, array));
         }
     }
 
@@ -737,21 +737,21 @@ public class OpBuilder {
         if (elements.size() < 11) {
             MethodRef listOf = MethodRef.method(J_U_LIST, "of",
                     J_U_LIST, Collections.nCopies(elements.size(), J_L_OBJECT));
-            return builder.op(invoke(listType, listOf, elements));
+            return builder.add(invoke(listType, listOf, elements));
         } else {
             Value array = buildArray(javaType, elements);
-            return builder.op(invoke(listType, LIST_OF_ARRAY, array));
+            return builder.add(invoke(listType, LIST_OF_ARRAY, array));
         }
     }
 
 
     Value buildArray(JavaType javaType, List<Value> elements) {
-        Value array = builder.op(newArray(JavaType.array(javaType),
-                builder.op(constant(INT, elements.size()))));
+        Value array = builder.add(newArray(JavaType.array(javaType),
+                builder.add(constant(INT, elements.size()))));
         for (int i = 0; i < elements.size(); i++) {
-            builder.op(arrayStoreOp(
+            builder.add(arrayStoreOp(
                     array,
-                    builder.op(constant(INT, i)),
+                    builder.add(constant(INT, i)),
                     elements.get(i)));
         }
         return array;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -688,7 +688,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         private Op.Result append(Op op, Op.Location l, BodyStack stack) {
             lastOp = op;
             op.setLocation(l);
-            return stack.block.op(op);
+            return stack.block.add(op);
         }
 
         Op.Location generateLocation(DiagnosticPosition pos, boolean includeSourceReference) {
@@ -1394,9 +1394,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
             for (int i = 0; i < variables.size(); i++) {
                 Value v = matchBuilder.parameters().get(i);
                 Value var = variablesStack.localToOp.get(variables.get(i).sym);
-                matchBuilder.op(CoreOp.varStore(var, v));
+                matchBuilder.add(CoreOp.varStore(var, v));
             }
-            matchBuilder.op(CoreOp.core_yield());
+            matchBuilder.add(CoreOp.core_yield());
 
             // Create the match operation
             return append(JavaOp.match(target, patternBody, matchBody));
@@ -2765,7 +2765,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                 CoreOp.ModuleOp module = OpBuilder.createBuilderFunctions(
                         rmcdef.ops,
-                        b -> b.op(JavaOp.fieldLoad(
+                        b -> b.add(JavaOp.fieldLoad(
                                 FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))));
                 byte[] data = BytecodeGenerator.generateClassData(MethodHandles.lookup(), classDesc, module);
                 // inject InnerClassesAttribute and NestHostAttribute

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/RemoveUnusedConstantTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/RemoveUnusedConstantTransformer.java
@@ -43,7 +43,7 @@ public class RemoveUnusedConstantTransformer implements CodeTransformer {
         if (op instanceof CoreOp.ConstantOp && op.result() != null && op.result().uses().isEmpty()) {
             return builder;
         }
-        builder.op(op);
+        builder.add(op);
         return builder;
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -433,21 +433,21 @@
 ///
 ///         // int a
 ///         VarOp varOpA = var("a", builder.parameters().get(0)); // @link substring="var(" target="jdk.incubator.code.dialect.core.CoreOp#var"
-///         Op.Result varA = builder.op(varOpA); // @link substring="builder.op(" target="jdk.incubator.code.Block.Builder#op"
+///         Op.Result varA = builder.add(varOpA); // @link substring="builder.add(" target="jdk.incubator.code.Block.Builder#op"
 ///
 ///         // int b
 ///         VarOp varOpB = var("b", builder.parameters().get(1));
-///         Op.Result varB = builder.op(varOpB);
+///         Op.Result varB = builder.add(varOpB);
 ///
 ///         // IO.println("Example:method:add")
-///         builder.op(invoke(PRINTLN, // // @link substring="invoke(" target="jdk.incubator.code.dialect.java.JavaOp#invoke"
-///                 builder.op(constant(JavaType.J_L_STRING, "Example:method:add"))));
+///         builder.add(invoke(PRINTLN, // // @link substring="invoke(" target="jdk.incubator.code.dialect.java.JavaOp#invoke"
+///                 builder.add(constant(JavaType.J_L_STRING, "Example:method:add"))));
 ///
 ///         // return a + b;
-///         builder.op(return_(
-///                 builder.op(add( // @link substring="add(" target="jdk.incubator.code.dialect.java.JavaOp#add"
-///                         builder.op(varLoad(varA)),
-///                         builder.op(varLoad(varB))))));
+///         builder.add(return_(
+///                 builder.add(add( // @link substring="add(" target="jdk.incubator.code.dialect.java.JavaOp#add"
+///                         builder.add(varLoad(varA)),
+///                         builder.add(varLoad(varB))))));
 ///     });
 /// IO.println(builtCodeModel.toText());
 ///}
@@ -568,13 +568,13 @@
 ///             // Get output operands mapped to input op's operands
 ///             List<Value> outputOperands = builder.context().getValues(inputOp.operands());
 ///
-///             Op.Result r = builder.op(invoke(SUM, outputOperands));
+///             Op.Result r = builder.add(invoke(SUM, outputOperands));
 ///
 ///             // Map input op's result to output result of invocation operation
 ///             builder.context().mapValue(inputOp.result(), r);
 ///         }
 ///         // Copy operation
-///         default -> builder.op(inputOp);
+///         default -> builder.add(inputOp);
 ///     }
 ///     // Return the block builder to continue building from for next operation
 ///     return builder;

--- a/test/jdk/jdk/incubator/code/TestBlockIndexes.java
+++ b/test/jdk/jdk/incubator/code/TestBlockIndexes.java
@@ -63,10 +63,10 @@ public class TestBlockIndexes {
                 // Create some blocks without predecessors
                 for (int i = 0; i < 5; i++) {
                     Block.Builder redundant = block.block();
-                    redundant.op(CoreOp.return_());
+                    redundant.add(CoreOp.return_());
                 }
             }
-            block.op(op);
+            block.add(op);
             return block;
         });
         assertBlockIndexes(f);

--- a/test/jdk/jdk/incubator/code/TestBlockParameters.java
+++ b/test/jdk/jdk/incubator/code/TestBlockParameters.java
@@ -45,13 +45,13 @@ public class TestBlockParameters {
                 .body(fe -> {
                     JavaOp.LambdaOp lop = JavaOp.lambda(fe.parentBody(), functionType(INT, INT), JavaType.type(FunctionType.class))
                             .body(le -> {
-                                le.op(return_(le.parameters().get(0)));
+                                le.add(return_(le.parameters().get(0)));
                             });
-                    fe.op(lop);
+                    fe.add(lop);
                     Block.Builder b = fe.block(INT, INT);
-                    fe.op(branch(b.reference(fe.parameters())));
+                    fe.add(branch(b.reference(fe.parameters())));
 
-                    b.op(return_(b.parameters().get(0)));
+                    b.add(return_(b.parameters().get(0)));
                 });
     }
 

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -85,7 +85,7 @@ public class TestBuild {
 
         var freturnOp = f.body().entryBlock().terminatingOp();
         // Unmapped built value that is operand of the built return op
-        Assertions.assertThrows(IllegalArgumentException.class, () -> block.op(freturnOp));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> block.add(freturnOp));
     }
 
     @Test
@@ -109,14 +109,14 @@ public class TestBuild {
 
         var a = block.parameters().get(0);
         var b = block.parameters().get(1);
-        var result = block.op(JavaOp.add(a, b));
+        var result = block.add(JavaOp.add(a, b));
         // Map the built value used as the operand to the built return op to
         // the above value
         block.context().mapValue(f.body().entryBlock().firstOp().result(), result);
 
         var freturnOp = f.body().entryBlock().terminatingOp();
         // No error since values (operands) are mapped
-        block.op(freturnOp);
+        block.add(freturnOp);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class TestBuild {
 
         Block.Parameter a = block.parameters().get(0);
         Block.Parameter b = block.parameters().get(1);
-        Op.Result result = block.op(JavaOp.add(a, b));
+        Op.Result result = block.add(JavaOp.add(a, b));
 
         // Declaring block is being built
         Assertions.assertThrows(IllegalStateException.class, a::declaringBlock);
@@ -137,7 +137,7 @@ public class TestBuild {
         // Access to set of users while declaring block is being built
         Assertions.assertThrows(IllegalStateException.class, a::uses);
 
-        block.op(return_(result));
+        block.add(return_(result));
 
         func("f", body);
 
@@ -159,12 +159,12 @@ public class TestBuild {
         Block.Reference successor = anotherBlock.reference(a, b);
         // Target block is being built
         Assertions.assertThrows(IllegalStateException.class, successor::targetBlock);
-        block.op(branch(anotherBlock.reference(a, b)));
+        block.add(branch(anotherBlock.reference(a, b)));
 
         a = anotherBlock.parameters().get(0);
         b = anotherBlock.parameters().get(1);
-        var result = anotherBlock.op(JavaOp.add(a, b));
-        anotherBlock.op(return_(result));
+        var result = anotherBlock.add(JavaOp.add(a, b));
+        anotherBlock.add(return_(result));
 
         func("f", body);
 
@@ -183,7 +183,7 @@ public class TestBuild {
 
         // Operation uses values from another model
         var addOp = JavaOp.add(aa, ab);
-        Assertions.assertThrows(IllegalStateException.class, () -> bblock.op(addOp));
+        Assertions.assertThrows(IllegalStateException.class, () -> bblock.add(addOp));
     }
 
     @Test
@@ -196,7 +196,7 @@ public class TestBuild {
 
         // Operation uses header with target block from another model
         var brOp = branch(ablock.reference());
-        Assertions.assertThrows(IllegalStateException.class, () -> bblock.op(brOp));
+        Assertions.assertThrows(IllegalStateException.class, () -> bblock.add(brOp));
     }
 
     @Test
@@ -210,7 +210,7 @@ public class TestBuild {
     public void testBuiltBodyBuilder() {
         var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block = body.entryBlock();
-        block.op(return_());
+        block.add(return_());
         func("f", body);
 
         // Body is built
@@ -221,7 +221,7 @@ public class TestBuild {
     public void testBodyBuilderWithBuiltAncestor() {
         var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block = body.entryBlock();
-        block.op(return_());
+        block.add(return_());
         func("f", body);
 
         // ancestor body is built
@@ -232,7 +232,7 @@ public class TestBuild {
     public void testBodyBuilderWithUnbuiltChildren() {
         var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block = body.entryBlock();
-        block.op(return_());
+        block.add(return_());
 
         Body.Builder.of(body, FUNCTION_TYPE_VOID);
 
@@ -244,11 +244,11 @@ public class TestBuild {
     public void testBodyBuilderWithUnplacedOperation() {
         var body1 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block1 = body1.entryBlock();
-        block1.op(return_());
+        block1.add(return_());
 
         var body2 = Body.Builder.of(body1, FUNCTION_TYPE_VOID);
         var block2 = body2.entryBlock();
-        block2.op(return_());
+        block2.add(return_());
         CoreOp.func("f", body2);
 
         // Great-grandchild body is child of unplaced operation
@@ -259,7 +259,7 @@ public class TestBuild {
     public void testFailedBodyBuilder() {
         var body1 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block1 = body1.entryBlock();
-        block1.op(return_());
+        block1.add(return_());
 
         var body2 = Body.Builder.of(body1, FUNCTION_TYPE_VOID);
         var block2 = body2.entryBlock();
@@ -279,11 +279,11 @@ public class TestBuild {
 
         var body2 = Body.Builder.of(anotherBody, FUNCTION_TYPE_VOID);
         var block2 = body2.entryBlock();
-        block2.op(return_());
+        block2.add(return_());
         var lambdaOp = JavaOp.lambda(type(Runnable.class), body2);
 
         // lambdaOp's grandparent body is not parent body of block1
-        Assertions.assertThrows(IllegalStateException.class, () -> block1.op(lambdaOp));
+        Assertions.assertThrows(IllegalStateException.class, () -> block1.add(lambdaOp));
     }
 
     @Test
@@ -293,11 +293,11 @@ public class TestBuild {
 
         var body2 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block2 = body2.entryBlock();
-        block2.op(return_());
+        block2.add(return_());
         var lambdaOp = JavaOp.lambda(type(Runnable.class), body2);
 
-        Assertions.assertDoesNotThrow(() -> block1.op(lambdaOp));
-        block1.op(return_());
+        Assertions.assertDoesNotThrow(() -> block1.add(lambdaOp));
+        block1.add(return_());
         Assertions.assertDoesNotThrow(() -> func("f", body1));
     }
 
@@ -306,29 +306,29 @@ public class TestBuild {
         var body1 = Body.Builder.of(null, functionType(VOID, INT));
         var block1 = body1.entryBlock();
         var p = block1.parameters().get(0);
-        block1.op(return_());
+        block1.add(return_());
 
         var body2 = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block2 = body2.entryBlock();
         // Value p is not reachable from block2
-        Assertions.assertThrows(IllegalStateException.class, () -> block2.op(JavaOp.neg(p)));
+        Assertions.assertThrows(IllegalStateException.class, () -> block2.add(JavaOp.neg(p)));
     }
 
     @Test
     public void testAppendAfterTerminatingOperation() {
         var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block = body.entryBlock();
-        block.op(return_());
+        block.add(return_());
 
         // Append operation after terminating operation
-        Assertions.assertThrows(IllegalStateException.class, () -> block.op(return_()));
+        Assertions.assertThrows(IllegalStateException.class, () -> block.add(return_()));
     }
 
     @Test
     public void testNoTerminatingOperation() {
         var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block = body.entryBlock();
-        block.op(constant(INT, 0));
+        block.add(constant(INT, 0));
 
         // No terminating operation
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
@@ -338,7 +338,7 @@ public class TestBuild {
     public void testUnreferencedBlocksRemoved() {
         var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block = body.entryBlock();
-        block.op(return_());
+        block.add(return_());
 
         // Create empty blocks
         block.block();
@@ -362,7 +362,7 @@ public class TestBuild {
         var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var block = body.entryBlock();
         // No terminating op
-        block.op(constant(INT, 0));
+        block.add(constant(INT, 0));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }
@@ -374,7 +374,7 @@ public class TestBuild {
         // Create empty block
         var block = entryBlock.block();
         // Branch to empty block
-        entryBlock.op(branch(block.reference()));
+        entryBlock.add(branch(block.reference()));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }
@@ -386,9 +386,9 @@ public class TestBuild {
         // Create empty block
         var block = entryBlock.block();
         // Branch to empty block
-        entryBlock.op(branch(block.reference()));
+        entryBlock.add(branch(block.reference()));
         // No terminating op
-        block.op(constant(INT, 0));
+        block.add(constant(INT, 0));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }

--- a/test/jdk/jdk/incubator/code/TestBuildDominatingUse.java
+++ b/test/jdk/jdk/incubator/code/TestBuildDominatingUse.java
@@ -46,12 +46,12 @@ public class TestBuildDominatingUse {
         Block.Builder entryBlock = body.entryBlock();
         Block.Builder block1 = entryBlock.block();
 
-        Op.Result zeroValue = block1.op(CoreOp.constant(JavaType.INT, 0));
-        block1.op(return_());
+        Op.Result zeroValue = block1.add(CoreOp.constant(JavaType.INT, 0));
+        block1.add(return_());
 
         // Use of operation result as operand is not dominated by its declaration
-        entryBlock.op(JavaOp.neg(zeroValue));
-        entryBlock.op(branch(block1.reference()));
+        entryBlock.add(JavaOp.neg(zeroValue));
+        entryBlock.add(branch(block1.reference()));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }
@@ -64,10 +64,10 @@ public class TestBuildDominatingUse {
         Block.Builder block1 = entryBlock.block(JavaType.INT);
         Block.Parameter p = block1.parameters().getFirst();
 
-        block1.op(return_());
+        block1.add(return_());
 
         // Use of block parameter as block argument is not dominated by its declaration
-        entryBlock.op(branch(block1.reference(p)));
+        entryBlock.add(branch(block1.reference(p)));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }
@@ -79,16 +79,16 @@ public class TestBuildDominatingUse {
         Block.Builder entryBlock = body.entryBlock();
         Block.Builder block1 = entryBlock.block();
 
-        Op.Result zeroValue = block1.op(CoreOp.constant(JavaType.INT, 0));
-        block1.op(return_());
+        Op.Result zeroValue = block1.add(CoreOp.constant(JavaType.INT, 0));
+        block1.add(return_());
 
-        entryBlock.op(JavaOp.lambda(body, FUNCTION_TYPE_VOID, JavaType.type(Runnable.class))
+        entryBlock.add(JavaOp.lambda(body, FUNCTION_TYPE_VOID, JavaType.type(Runnable.class))
                 .body(block2 -> {
                     // Use of operation result as operand is not dominated by its declaration
-                    block2.op(JavaOp.neg(zeroValue));
-                    block2.op(return_());
+                    block2.add(JavaOp.neg(zeroValue));
+                    block2.add(return_());
                 }));
-        entryBlock.op(branch(block1.reference()));
+        entryBlock.add(branch(block1.reference()));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }
@@ -101,18 +101,18 @@ public class TestBuildDominatingUse {
         Block.Builder block1 = entryBlock.block(JavaType.INT);
         Block.Parameter p = block1.parameters().getFirst();
 
-        block1.op(return_());
+        block1.add(return_());
 
-        entryBlock.op(JavaOp.lambda(body, FUNCTION_TYPE_VOID, JavaType.type(Runnable.class))
+        entryBlock.add(JavaOp.lambda(body, FUNCTION_TYPE_VOID, JavaType.type(Runnable.class))
                 .body(block2 -> {
                     Block.Builder block3 = block2.block(JavaType.INT);
-                    block3.op(return_());
+                    block3.add(return_());
 
                     // Use of block parameter as block argument is not dominated by its declaration
-                    block2.op(branch(block3.reference(p)));
+                    block2.add(branch(block3.reference(p)));
                 }));
-        Op.Result zero = entryBlock.op(constant(JavaType.INT, 0));
-        entryBlock.op(branch(block1.reference(zero)));
+        Op.Result zero = entryBlock.add(constant(JavaType.INT, 0));
+        entryBlock.add(branch(block1.reference(zero)));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }

--- a/test/jdk/jdk/incubator/code/TestBuildOp.java
+++ b/test/jdk/jdk/incubator/code/TestBuildOp.java
@@ -75,7 +75,7 @@ public class TestBuildOp {
     @Test
     void testBuildAsRoot() {
         CoreOp.FuncOp funcOp = CoreOp.func("f", FunctionType.FUNCTION_TYPE_VOID).body(b -> {
-            b.op(CoreOp.return_());
+            b.add(CoreOp.return_());
         });
 
         Assertions.assertFalse(funcOp.isRoot());
@@ -102,8 +102,8 @@ public class TestBuildOp {
     @Test
     void testOpPlaced() {
         Body.Builder body = Body.Builder.of(null, FunctionType.FUNCTION_TYPE_VOID);
-        Op.Result r = body.entryBlock().op(CoreOp.constant(JavaType.DOUBLE, 1d));
-        body.entryBlock().op(CoreOp.return_());
+        Op.Result r = body.entryBlock().add(CoreOp.constant(JavaType.DOUBLE, 1d));
+        body.entryBlock().add(CoreOp.return_());
 
         Assertions.assertThrows(IllegalStateException.class, () -> r.op().buildAsRoot());
         Assertions.assertTrue(r.op().isPlacedInBlock());
@@ -128,8 +128,8 @@ public class TestBuildOp {
 
     void assertOpIsCopiedWhenAddedToBlock(Op op) {
         Body.Builder body = Body.Builder.of(null, FunctionType.FUNCTION_TYPE_VOID);
-        body.entryBlock().op(op);
-        body.entryBlock().op(CoreOp.return_());
+        body.entryBlock().add(op);
+        body.entryBlock().add(CoreOp.return_());
         CoreOp.FuncOp funcOp = CoreOp.func("t", body);
         boolean b = funcOp.body().entryBlock().ops().stream().allMatch(o -> o != op);
         Assertions.assertTrue(b);

--- a/test/jdk/jdk/incubator/code/TestBuildUnreachableBlocks.java
+++ b/test/jdk/jdk/incubator/code/TestBuildUnreachableBlocks.java
@@ -58,7 +58,7 @@ public class TestBuildUnreachableBlocks {
         CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
 
         CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
-            b.op(CoreOp.return_());
+            b.add(CoreOp.return_());
 
             Block.Builder unreachableBlock1 = b.block();
             unreachableBlock1.transformBody(f.body(), List.of(), CodeTransformer.COPYING_TRANSFORMER);
@@ -78,7 +78,7 @@ public class TestBuildUnreachableBlocks {
         CoreOp.FuncOp f = Op.ofMethod(m).orElseThrow();
 
         CoreOp.FuncOp g = CoreOp.func("g", CoreType.functionType(JavaType.VOID)).body(b -> {
-            b.op(CoreOp.return_());
+            b.add(CoreOp.return_());
 
             CoreOp.FuncOp fLowered = f.transform(CodeTransformer.LOWERING_TRANSFORMER);
 
@@ -98,15 +98,15 @@ public class TestBuildUnreachableBlocks {
         CoreOp.FuncOp f = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
             Block.Builder reachableBlock1 = b.block();
 
-            b.op(branch(reachableBlock1.reference()));
+            b.add(branch(reachableBlock1.reference()));
 
-            reachableBlock1.op(CoreOp.return_());
+            reachableBlock1.add(CoreOp.return_());
 
             Block.Builder unreachableBlock1 = b.block();
-            unreachableBlock1.op(branch(reachableBlock1.reference()));
+            unreachableBlock1.add(branch(reachableBlock1.reference()));
 
             Block.Builder unreachableBlock2 = b.block();
-            unreachableBlock2.op(branch(reachableBlock1.reference()));
+            unreachableBlock2.add(branch(reachableBlock1.reference()));
         });
 
         Assertions.assertEquals(2, f.body().blocks().size());
@@ -119,13 +119,13 @@ public class TestBuildUnreachableBlocks {
     public void testUnobservableUnreachableBlocks() {
         List<Op.Result> results = new ArrayList<>();
         CoreOp.FuncOp f = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
-            b.op(CoreOp.return_());
+            b.add(CoreOp.return_());
 
             Block.Builder unreachableBlock1 = b.block();
-            results.add(unreachableBlock1.op(return_()));
+            results.add(unreachableBlock1.add(return_()));
 
             Block.Builder unreachableBlock2 = b.block();
-            results.add(unreachableBlock2.op(return_()));
+            results.add(unreachableBlock2.add(return_()));
         });
 
         Assertions.assertEquals(1, f.body().blocks().size());
@@ -140,20 +140,20 @@ public class TestBuildUnreachableBlocks {
     @Test
     public void testNestedUsesInUnreachableBlock() {
         CoreOp.FuncOp g = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
-            Op.Result zeroValue = b.op(CoreOp.constant(JavaType.INT, 0));
-            Op.Result oneValue = b.op(CoreOp.constant(JavaType.INT, 1));
-            b.op(CoreOp.return_());
+            Op.Result zeroValue = b.add(CoreOp.constant(JavaType.INT, 0));
+            Op.Result oneValue = b.add(CoreOp.constant(JavaType.INT, 1));
+            b.add(CoreOp.return_());
 
             JavaType.type(Runnable.class);
 
             Block.Builder unreachableBlock1 = b.block();
             JavaOp.LambdaOp lop = JavaOp.lambda(b.parentBody(), FunctionType.FUNCTION_TYPE_VOID, JavaType.type(Runnable.class)).body(lb -> {
-                lb.op(JavaOp.neg(zeroValue));
-                lb.op(JavaOp.neg(oneValue));
-                lb.op(CoreOp.return_());
+                lb.add(JavaOp.neg(zeroValue));
+                lb.add(JavaOp.neg(oneValue));
+                lb.add(CoreOp.return_());
             });
-            unreachableBlock1.op(lop);
-            unreachableBlock1.op(CoreOp.return_());
+            unreachableBlock1.add(lop);
+            unreachableBlock1.add(CoreOp.return_());
         });
 
         Assertions.assertEquals(1, g.body().blocks().size());
@@ -169,19 +169,19 @@ public class TestBuildUnreachableBlocks {
     @Test
     public void testUsesInUnreachableBlocks() {
         CoreOp.FuncOp g = CoreOp.func("f", CoreType.functionType(JavaType.VOID)).body(b -> {
-            Op.Result zeroValue = b.op(CoreOp.constant(JavaType.INT, 0));
-            Op.Result oneValue = b.op(CoreOp.constant(JavaType.INT, 1));
-            b.op(CoreOp.return_());
+            Op.Result zeroValue = b.add(CoreOp.constant(JavaType.INT, 0));
+            Op.Result oneValue = b.add(CoreOp.constant(JavaType.INT, 1));
+            b.add(CoreOp.return_());
 
             Block.Builder unreachableBlock1 = b.block();
-            unreachableBlock1.op(JavaOp.neg(zeroValue));
-            unreachableBlock1.op(JavaOp.neg(oneValue));
-            unreachableBlock1.op(CoreOp.return_());
+            unreachableBlock1.add(JavaOp.neg(zeroValue));
+            unreachableBlock1.add(JavaOp.neg(oneValue));
+            unreachableBlock1.add(CoreOp.return_());
 
             Block.Builder unreachableBlock2 = b.block();
-            unreachableBlock2.op(JavaOp.neg(zeroValue));
-            unreachableBlock2.op(JavaOp.neg(oneValue));
-            unreachableBlock2.op(CoreOp.return_());
+            unreachableBlock2.add(JavaOp.neg(zeroValue));
+            unreachableBlock2.add(JavaOp.neg(oneValue));
+            unreachableBlock2.add(CoreOp.return_());
         });
 
         Assertions.assertEquals(1, g.body().blocks().size());
@@ -201,12 +201,12 @@ public class TestBuildUnreachableBlocks {
         Block.Builder entryBlock = body.entryBlock();
 
         Block.Builder unreachableBlock = entryBlock.block();
-        Op.Result zeroValue = unreachableBlock.op(CoreOp.constant(JavaType.INT, 0));
-        unreachableBlock.op(return_());
+        Op.Result zeroValue = unreachableBlock.add(CoreOp.constant(JavaType.INT, 0));
+        unreachableBlock.add(return_());
 
         // Uses operation result declared in unreachable block
-        entryBlock.op(JavaOp.neg(zeroValue));
-        entryBlock.op(return_());
+        entryBlock.add(JavaOp.neg(zeroValue));
+        entryBlock.add(return_());
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }
@@ -218,11 +218,11 @@ public class TestBuildUnreachableBlocks {
         Block.Builder entryBlock = body.entryBlock();
 
         Block.Builder unreachableBlock = entryBlock.block(JavaType.INT);
-        unreachableBlock.op(return_());
+        unreachableBlock.add(return_());
 
         // Uses block parameter declared in unreachable block
-        entryBlock.op(JavaOp.neg(unreachableBlock.parameters().getFirst()));
-        entryBlock.op(return_());
+        entryBlock.add(JavaOp.neg(unreachableBlock.parameters().getFirst()));
+        entryBlock.add(return_());
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
     }

--- a/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
+++ b/test/jdk/jdk/incubator/code/TestConstantExpressionEvaluation.java
@@ -360,9 +360,9 @@ public class TestConstantExpressionEvaluation {
 
     static CoreOp.FuncOp conversionModel(CodeType source, CodeType target) {
         return CoreOp.func("conv", CoreType.functionType(target)).body(b -> {
-            var v = b.op(CoreOp.constant(source, valueOne(source)));
-            var r = b.op(JavaOp.conv(target, v));
-            b.op(CoreOp.return_(r));
+            var v = b.add(CoreOp.constant(source, valueOne(source)));
+            var r = b.add(JavaOp.conv(target, v));
+            b.add(CoreOp.return_(r));
         });
     }
 
@@ -411,10 +411,10 @@ public class TestConstantExpressionEvaluation {
     void testInvalidConversion() {
         CoreOp.FuncOp funcOp = CoreOp.func("ic", CoreType.FUNCTION_TYPE_VOID).body(b -> {
             // String -> int
-            b.op(JavaOp.conv(INT, b.op(CoreOp.constant(J_L_STRING, "A"))));
+            b.add(JavaOp.conv(INT, b.add(CoreOp.constant(J_L_STRING, "A"))));
             // int -> String
-            b.op(JavaOp.conv(J_L_STRING, b.op(CoreOp.constant(INT, 1))));
-            b.op(CoreOp.return_());
+            b.add(JavaOp.conv(J_L_STRING, b.add(CoreOp.constant(INT, 1))));
+            b.add(CoreOp.return_());
         });
 
         List<Op> convOps = funcOp.body().entryBlock().ops().stream().filter(op -> op instanceof JavaOp.ConvOp).toList();
@@ -428,12 +428,12 @@ public class TestConstantExpressionEvaluation {
     void testInvalidConstants() {
         CoreOp.FuncOp funcOp = CoreOp.func("ic", CoreType.FUNCTION_TYPE_VOID).body(b -> {
             // valid constant op result type but invalid values
-            b.op(CoreOp.constant(J_L_STRING, null));
-            b.op(CoreOp.constant(INT, new Object()));
+            b.add(CoreOp.constant(J_L_STRING, null));
+            b.add(CoreOp.constant(INT, new Object()));
             // invalid constant op result type but valid values
-            b.op(CoreOp.constant(J_L_OBJECT, 1));
-            b.op(CoreOp.constant(J_L_BOOLEAN, true));
-            b.op(CoreOp.return_());
+            b.add(CoreOp.constant(J_L_OBJECT, 1));
+            b.add(CoreOp.constant(J_L_BOOLEAN, true));
+            b.add(CoreOp.return_());
         });
 
         List<Op> constantOps = funcOp.body().entryBlock().ops().stream().filter(op -> op instanceof CoreOp.ConstantOp).toList();
@@ -450,8 +450,8 @@ public class TestConstantExpressionEvaluation {
             // we can have cast to String but the value we cast has a non-type String
             // this will not be allowed by the Java language
             // e.g. String s = (String) 1;
-            b.op(JavaOp.cast(J_L_STRING, b.op(CoreOp.constant(INT, 1))));
-            b.op(CoreOp.return_());
+            b.add(JavaOp.cast(J_L_STRING, b.add(CoreOp.constant(INT, 1))));
+            b.add(CoreOp.return_());
         });
         List<JavaOp.CastOp> castOps = iv.body().entryBlock().ops().stream().filter(op -> op instanceof JavaOp.CastOp)
                 .map(op -> (JavaOp.CastOp) op).toList();
@@ -463,12 +463,12 @@ public class TestConstantExpressionEvaluation {
         // valid
         CoreOp.FuncOp v = CoreOp.func("vc", CoreType.FUNCTION_TYPE_VOID).body(b -> {
             // cast of str literal
-            b.op(JavaOp.cast(J_L_STRING, b.op(CoreOp.constant(J_L_STRING, "1"))));
+            b.add(JavaOp.cast(J_L_STRING, b.add(CoreOp.constant(J_L_STRING, "1"))));
             // cast of value of type String
-            b.op(JavaOp.cast(J_L_STRING,
-                    b.op(JavaOp.concat(
-                            b.op(CoreOp.constant(INT, 1)), b.op(CoreOp.constant(J_L_STRING, "2"))))));
-            b.op(CoreOp.return_());
+            b.add(JavaOp.cast(J_L_STRING,
+                    b.add(JavaOp.concat(
+                            b.add(CoreOp.constant(INT, 1)), b.add(CoreOp.constant(J_L_STRING, "2"))))));
+            b.add(CoreOp.return_());
         });
         List<JavaOp.CastOp> castOps2 = v.body().entryBlock().ops().stream().filter(op -> op instanceof JavaOp.CastOp)
                 .map(op -> (JavaOp.CastOp) op).toList();

--- a/test/jdk/jdk/incubator/code/TestDominate.java
+++ b/test/jdk/jdk/incubator/code/TestDominate.java
@@ -56,14 +56,14 @@ public class TestDominate {
             Block.Builder elseBlock = entry.block();
             Block.Builder end = entry.block();
 
-            Op.Result p = entry.op(constant(JavaType.BOOLEAN, true));
-            entry.op(conditionalBranch(p, ifBlock.reference(), elseBlock.reference()));
+            Op.Result p = entry.add(constant(JavaType.BOOLEAN, true));
+            entry.add(conditionalBranch(p, ifBlock.reference(), elseBlock.reference()));
 
-            ifBlock.op(branch(end.reference()));
+            ifBlock.add(branch(end.reference()));
 
-            elseBlock.op(branch(end.reference()));
+            elseBlock.add(branch(end.reference()));
 
-            end.op(CoreOp.return_());
+            end.add(CoreOp.return_());
         });
 
         Map<Block, Block> idoms = f.body().immediateDominators();
@@ -86,14 +86,14 @@ public class TestDominate {
             Block.Builder elseBlock = entry.block();
             Block.Builder end = entry.block();
 
-            Op.Result p = entry.op(constant(JavaType.BOOLEAN, true));
-            entry.op(conditionalBranch(p, ifBlock.reference(), elseBlock.reference()));
+            Op.Result p = entry.add(constant(JavaType.BOOLEAN, true));
+            entry.add(conditionalBranch(p, ifBlock.reference(), elseBlock.reference()));
 
-            ifBlock.op(branch(end.reference()));
+            ifBlock.add(branch(end.reference()));
 
-            elseBlock.op(branch(end.reference()));
+            elseBlock.add(branch(end.reference()));
 
-            end.op(CoreOp.return_());
+            end.add(CoreOp.return_());
         });
 
         boolean[][] bvs = new boolean[][]{
@@ -115,18 +115,18 @@ public class TestDominate {
             Block.Builder b4 = entry.block();
             Block.Builder b5 = entry.block();
 
-            Op.Result p = entry.op(constant(JavaType.BOOLEAN, true));
-            entry.op(conditionalBranch(p, b4.reference(), b2.reference()));
+            Op.Result p = entry.add(constant(JavaType.BOOLEAN, true));
+            entry.add(conditionalBranch(p, b4.reference(), b2.reference()));
 
-            b4.op(conditionalBranch(p, b5.reference(), b3.reference()));
+            b4.add(conditionalBranch(p, b5.reference(), b3.reference()));
 
-            b2.op(conditionalBranch(p, b5.reference(), b1.reference()));
+            b2.add(conditionalBranch(p, b5.reference(), b1.reference()));
 
-            b5.op(CoreOp.return_());
+            b5.add(CoreOp.return_());
 
-            b3.op(branch(b1.reference()));
+            b3.add(branch(b1.reference()));
 
-            b1.op(CoreOp.return_());
+            b1.add(CoreOp.return_());
         });
 
         System.out.println(f.toText());
@@ -150,16 +150,16 @@ public class TestDominate {
             Block.Builder update = entry.block();
             Block.Builder end = entry.block();
 
-            Op.Result p = entry.op(constant(JavaType.BOOLEAN, true));
-            entry.op(branch(cond.reference()));
+            Op.Result p = entry.add(constant(JavaType.BOOLEAN, true));
+            entry.add(branch(cond.reference()));
 
-            cond.op(conditionalBranch(p, body.reference(), end.reference()));
+            cond.add(conditionalBranch(p, body.reference(), end.reference()));
 
-            body.op(branch(update.reference()));
+            body.add(branch(update.reference()));
 
-            update.op(branch(cond.reference()));
+            update.add(branch(cond.reference()));
 
-            end.op(CoreOp.return_());
+            end.add(CoreOp.return_());
 
         });
 
@@ -195,20 +195,20 @@ public class TestDominate {
             Block.Builder b2 = entry.block();
             Block.Builder b1 = entry.block();
 
-            Op.Result p = entry.op(constant(JavaType.BOOLEAN, true));
-            entry.op(branch(b6.reference()));
+            Op.Result p = entry.add(constant(JavaType.BOOLEAN, true));
+            entry.add(branch(b6.reference()));
 
-            b6.op(conditionalBranch(p, b5.reference(), b4.reference()));
+            b6.add(conditionalBranch(p, b5.reference(), b4.reference()));
 
-            b5.op(branch(b1.reference()));
+            b5.add(branch(b1.reference()));
 
-            b4.op(conditionalBranch(p, b2.reference(), b3.reference()));
+            b4.add(conditionalBranch(p, b2.reference(), b3.reference()));
 
-            b1.op(branch(b2.reference()));
+            b1.add(branch(b2.reference()));
 
-            b2.op(conditionalBranch(p, b1.reference(), b3.reference()));
+            b2.add(conditionalBranch(p, b1.reference(), b3.reference()));
 
-            b3.op(branch(b2.reference()));
+            b3.add(branch(b2.reference()));
         });
         System.out.println(f.toText());
         Map<Block, Block> idoms = f.body().immediateDominators();
@@ -248,35 +248,35 @@ public class TestDominate {
             Block.Builder b2 = entry.block();
             Block.Builder b1 = entry.block();
 
-            Op.Result p = entry.op(constant(JavaType.BOOLEAN, true));
+            Op.Result p = entry.add(constant(JavaType.BOOLEAN, true));
 
-            entry.op(conditionalBranch(p, exit.reference(), b1.reference()));
+            entry.add(conditionalBranch(p, exit.reference(), b1.reference()));
 
-            b1.op(branch(b2.reference()));
+            b1.add(branch(b2.reference()));
 
-            b2.op(conditionalBranch(p, b3.reference(), b7.reference()));
+            b2.add(conditionalBranch(p, b3.reference(), b7.reference()));
 
-            b3.op(conditionalBranch(p, b4.reference(), b5.reference()));
+            b3.add(conditionalBranch(p, b4.reference(), b5.reference()));
 
-            b4.op(branch(b6.reference()));
+            b4.add(branch(b6.reference()));
 
-            b5.op(branch(b6.reference()));
+            b5.add(branch(b6.reference()));
 
-            b6.op(branch(b8.reference()));
+            b6.add(branch(b8.reference()));
 
-            b7.op(branch(b8.reference()));
+            b7.add(branch(b8.reference()));
 
-            b8.op(branch(b9.reference()));
+            b8.add(branch(b9.reference()));
 
-            b9.op(conditionalBranch(p, b10.reference(), b11.reference()));
+            b9.add(conditionalBranch(p, b10.reference(), b11.reference()));
 
-            b10.op(branch(b11.reference()));
+            b10.add(branch(b11.reference()));
 
-            b11.op(conditionalBranch(p, b12.reference(), b9.reference()));
+            b11.add(conditionalBranch(p, b12.reference(), b9.reference()));
 
-            b12.op(conditionalBranch(p, exit.reference(), b2.reference()));
+            b12.add(conditionalBranch(p, exit.reference(), b2.reference()));
 
-            exit.op(CoreOp.return_());
+            exit.add(CoreOp.return_());
         });
 
         System.out.println(f.toText());

--- a/test/jdk/jdk/incubator/code/TestExceptionRegionOps.java
+++ b/test/jdk/jdk/incubator/code/TestExceptionRegionOps.java
@@ -75,31 +75,31 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    fblock.op(exceptionRegionEnter(
+                    fblock.add(exceptionRegionEnter(
                             enterER1.reference(),
                             catchER1IAE.reference(), catchER1ISE.reference()));
 
                     // Start of exception region
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, 0))));
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, -1))));
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, 0))));
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, -1))));
                     // End of exception region
-                    enterER1.op(exceptionRegionExit(end.reference(),
+                    enterER1.add(exceptionRegionExit(end.reference(),
                         catchER1ISE.reference(), catchER1IAE.reference()));
 
                     // First catch block for exception region
-                    catchER1ISE.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.op(constant(INT, 1))));
-                    catchER1ISE.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.op(constant(INT, -1))));
-                    catchER1ISE.op(branch(end.reference()));
+                    catchER1ISE.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.add(constant(INT, 1))));
+                    catchER1ISE.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.add(constant(INT, -1))));
+                    catchER1ISE.add(branch(end.reference()));
 
                     // Second catch for exception region
-                    catchER1IAE.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1IAE.op(constant(INT, 2))));
-                    catchER1IAE.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1IAE.op(constant(INT, -1))));
-                    catchER1IAE.op(branch(end.reference()));
+                    catchER1IAE.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1IAE.add(constant(INT, 2))));
+                    catchER1IAE.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1IAE.add(constant(INT, -1))));
+                    catchER1IAE.add(branch(end.reference()));
 
                     //
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, 3))));
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, -1))));
-                    end.op(CoreOp.return_());
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, 3))));
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, -1))));
+                    end.add(CoreOp.return_());
                 });
 
         System.out.println(f.toText());
@@ -159,31 +159,31 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    fblock.op(exceptionRegionEnter(
+                    fblock.add(exceptionRegionEnter(
                             enterER1.reference(),
                             catchER1T.reference(), catchER1ISE.reference()));
 
                     // Start of exception region
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, 0))));
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, -1))));
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, 0))));
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, -1))));
                     // End of exception region
-                    enterER1.op(exceptionRegionExit(end.reference(),
+                    enterER1.add(exceptionRegionExit(end.reference(),
                         catchER1ISE.reference(), catchER1T.reference()));
 
                     // First catch block for exception region
-                    catchER1ISE.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.op(constant(INT, 1))));
-                    catchER1ISE.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.op(constant(INT, -1))));
-                    catchER1ISE.op(branch(end.reference()));
+                    catchER1ISE.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.add(constant(INT, 1))));
+                    catchER1ISE.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1ISE.add(constant(INT, -1))));
+                    catchER1ISE.add(branch(end.reference()));
 
                     // Second catch for exception region
-                    catchER1T.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1T.op(constant(INT, 2))));
-                    catchER1T.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1T.op(constant(INT, -1))));
-                    catchER1T.op(branch(end.reference()));
+                    catchER1T.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1T.add(constant(INT, 2))));
+                    catchER1T.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1T.add(constant(INT, -1))));
+                    catchER1T.add(branch(end.reference()));
 
                     //
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, 3))));
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, -1))));
-                    end.op(return_());
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, 3))));
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, -1))));
+                    end.add(return_());
                 });
 
         System.out.println(f.toText());
@@ -248,44 +248,44 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    fblock.op(exceptionRegionEnter(
+                    fblock.add(exceptionRegionEnter(
                             enterER1.reference(),
                             catchER1.reference()));
 
                     // Start of first exception region
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, 0))));
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, -1))));
-                    enterER1.op(exceptionRegionEnter(
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, 0))));
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, -1))));
+                    enterER1.add(exceptionRegionEnter(
                             enterER2.reference(),
                             catchER2.reference()));
 
                     // Start of second exception region
-                    enterER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.op(constant(INT, 1))));
-                    enterER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.op(constant(INT, -1))));
+                    enterER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.add(constant(INT, 1))));
+                    enterER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.add(constant(INT, -1))));
                     // End of second exception region
-                    enterER2.op(exceptionRegionExit(b3.reference(),
+                    enterER2.add(exceptionRegionExit(b3.reference(),
                         catchER2.reference()));
 
                     // Catch block for second exception region
-                    catchER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER2.op(constant(INT, 2))));
-                    catchER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER2.op(constant(INT, -1))));
-                    catchER2.op(branch(b3.reference()));
+                    catchER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER2.add(constant(INT, 2))));
+                    catchER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER2.add(constant(INT, -1))));
+                    catchER2.add(branch(b3.reference()));
 
-                    b3.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b3.op(constant(INT, 3))));
-                    b3.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b3.op(constant(INT, -1))));
+                    b3.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b3.add(constant(INT, 3))));
+                    b3.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, b3.add(constant(INT, -1))));
                     // End of first exception region
-                    b3.op(exceptionRegionExit(end.reference(),
+                    b3.add(exceptionRegionExit(end.reference(),
                         catchER1.reference()));
 
                     // Catch block for first exception region
-                    catchER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1.op(constant(INT, 4))));
-                    catchER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1.op(constant(INT, -1))));
-                    catchER1.op(branch(end.reference()));
+                    catchER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1.add(constant(INT, 4))));
+                    catchER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchER1.add(constant(INT, -1))));
+                    catchER1.add(branch(end.reference()));
 
                     //
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, 5))));
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, -1))));
-                    end.op(CoreOp.return_());
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, 5))));
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, -1))));
+                    end.add(CoreOp.return_());
                 });
 
         System.out.println(f.toText());
@@ -360,45 +360,45 @@ public class TestExceptionRegionOps {
 
                     //
                     var c = fblock.parameters().get(0);
-                    fblock.op(exceptionRegionEnter(
+                    fblock.add(exceptionRegionEnter(
                             enterER1.reference(),
                             catchAll.reference(), catchRE.reference()));
 
                     // Start of exception region
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, 0))));
-                    enterER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.op(constant(INT, -1))));
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, 0))));
+                    enterER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER1.add(constant(INT, -1))));
                     // End of exception region
-                    enterER1.op(exceptionRegionExit(exitER1.reference(),
+                    enterER1.add(exceptionRegionExit(exitER1.reference(),
                         catchRE.reference(), catchAll.reference()));
                     // Inline finally
-                    exitER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER1.op(constant(INT, 2))));
-                    exitER1.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER1.op(constant(INT, -1))));
-                    exitER1.op(branch(end.reference()));
+                    exitER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER1.add(constant(INT, 2))));
+                    exitER1.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER1.add(constant(INT, -1))));
+                    exitER1.add(branch(end.reference()));
 
                     // Catch block for RuntimeException
-                    catchRE.op(exceptionRegionEnter(
+                    catchRE.add(exceptionRegionEnter(
                             enterER2.reference(),
                             catchAll.reference()));
                     // Start of exception region
-                    enterER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.op(constant(INT, 1))));
-                    enterER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.op(constant(INT, -1))));
+                    enterER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.add(constant(INT, 1))));
+                    enterER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, enterER2.add(constant(INT, -1))));
                     // End of exception region
-                    enterER2.op(exceptionRegionExit(exitER2.reference(),
+                    enterER2.add(exceptionRegionExit(exitER2.reference(),
                         catchAll.reference()));
                     // Inline finally
-                    exitER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER2.op(constant(INT, 2))));
-                    exitER2.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER2.op(constant(INT, -1))));
-                    exitER2.op(branch(end.reference()));
+                    exitER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER2.add(constant(INT, 2))));
+                    exitER2.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, exitER2.add(constant(INT, -1))));
+                    exitER2.add(branch(end.reference()));
 
                     // Catch all block for finally
-                    catchAll.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchAll.op(constant(INT, 2))));
-                    catchAll.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchAll.op(constant(INT, -1))));
-                    catchAll.op(throw_(catchAll.parameters().get(0)));
+                    catchAll.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchAll.add(constant(INT, 2))));
+                    catchAll.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, catchAll.add(constant(INT, -1))));
+                    catchAll.add(throw_(catchAll.parameters().get(0)));
 
                     //
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, 3))));
-                    end.op(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.op(constant(INT, -1))));
-                    end.op(CoreOp.return_());
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, 3))));
+                    end.add(JavaOp.invoke(INT_CONSUMER_ACCEPT_METHOD, c, end.add(constant(INT, -1))));
+                    end.add(CoreOp.return_());
                 });
 
         System.out.println(f.toText());

--- a/test/jdk/jdk/incubator/code/TestInline.java
+++ b/test/jdk/jdk/incubator/code/TestInline.java
@@ -58,7 +58,7 @@ public class TestInline {
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
-                    Op.Result fortyTwo = fblock.op(constant(INT, 42));
+                    Op.Result fortyTwo = fblock.add(constant(INT, 42));
 
                     var cb = Inliner.inline(fblock, cop, List.of(i, fortyTwo), Inliner.INLINE_RETURN);
                     Assertions.assertEquals(cb, fblock);
@@ -80,16 +80,16 @@ public class TestInline {
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
-                    Op.Result fortyTwo = fblock.op(constant(INT, 42));
+                    Op.Result fortyTwo = fblock.add(constant(INT, 42));
 
-                    Op.Result v = fblock.op(var(fblock.op(constant(INT, 0))));
+                    Op.Result v = fblock.add(var(fblock.add(constant(INT, 0))));
 
                     var cb = Inliner.inline(fblock, cop, List.of(i, fortyTwo), (b, value) -> {
-                        b.op(varStore(v, value));
+                        b.add(varStore(v, value));
                     });
                     Assertions.assertEquals(cb, fblock);
 
-                    fblock.op(return_(fblock.op(varLoad(v))));
+                    fblock.add(return_(fblock.add(varLoad(v))));
                 });
 
         System.out.println(f.toText());
@@ -117,7 +117,7 @@ public class TestInline {
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
-                    Op.Result fortyTwo = fblock.op(constant(INT, 42));
+                    Op.Result fortyTwo = fblock.add(constant(INT, 42));
 
                     var cb = Inliner.inline(fblock, lcop, List.of(i, fortyTwo), Inliner.INLINE_RETURN);
                     Assertions.assertNotEquals(fblock, cb);
@@ -146,16 +146,16 @@ public class TestInline {
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
-                    Op.Result fortyTwo = fblock.op(constant(INT, 42));
+                    Op.Result fortyTwo = fblock.add(constant(INT, 42));
 
-                    Op.Result v = fblock.op(var(fblock.op(constant(INT, 0))));
+                    Op.Result v = fblock.add(var(fblock.add(constant(INT, 0))));
 
                     var cb = Inliner.inline(fblock, lcop, List.of(i, fortyTwo), (b, value) -> {
-                        b.op(varStore(v, value));
+                        b.add(varStore(v, value));
                     });
                     Assertions.assertNotEquals(fblock, cb);
 
-                    cb.op(return_(cb.op(varLoad(v))));
+                    cb.add(return_(cb.add(varLoad(v))));
                 });
         System.out.println(f.toText());
 
@@ -178,7 +178,7 @@ public class TestInline {
                 .body(fblock -> {
                     Block.Parameter i = fblock.parameters().get(0);
 
-                    Op.Result fortyTwo = fblock.op(constant(INT, 42));
+                    Op.Result fortyTwo = fblock.add(constant(INT, 42));
 
                     var cb = Inliner.inline(fblock, cop, List.of(i, fortyTwo), Inliner.INLINE_RETURN);
                     Assertions.assertEquals(cb, fblock);

--- a/test/jdk/jdk/incubator/code/TestLambdaOps.java
+++ b/test/jdk/jdk/incubator/code/TestLambdaOps.java
@@ -84,16 +84,16 @@ public class TestLambdaOps {
                                 .body(lblock -> {
                                     Block.Parameter li = lblock.parameters().get(0);
 
-                                    lblock.op(return_(
+                                    lblock.add(return_(
                                             // capture i from function's body
-                                            lblock.op(JavaOp.add(i, li))
+                                            lblock.add(JavaOp.add(i, li))
                                     ));
                                 });
                     });
-                    Op.Result lquoted = block.op(qop);
+                    Op.Result lquoted = block.add(qop);
 
-                    Op.Result or = block.op(JavaOp.invoke(Builder.ACCEPT_METHOD, lquoted));
-                    block.op(return_(or));
+                    Op.Result or = block.add(JavaOp.invoke(Builder.ACCEPT_METHOD, lquoted));
+                    block.add(return_(or));
                 });
 
         System.out.println(f.toText());
@@ -121,14 +121,14 @@ public class TestLambdaOps {
                             .body(lblock -> {
                                 Block.Parameter li = lblock.parameters().get(0);
 
-                                lblock.op(return_(
-                                        lblock.op(JavaOp.add(i, li))));
+                                lblock.add(return_(
+                                        lblock.add(JavaOp.add(i, li))));
                             });
-                    Op.Result fi = block.op(lambda);
+                    Op.Result fi = block.add(lambda);
 
-                    Op.Result fortyTwo = block.op(constant(INT, 42));
-                    Op.Result or = block.op(JavaOp.invoke(INT_UNARY_OPERATOR_METHOD, fi, fortyTwo));
-                    block.op(return_(or));
+                    Op.Result fortyTwo = block.add(constant(INT, 42));
+                    Op.Result or = block.add(JavaOp.invoke(INT_UNARY_OPERATOR_METHOD, fi, fortyTwo));
+                    block.add(return_(or));
                 });
 
         System.out.println(f.toText());

--- a/test/jdk/jdk/incubator/code/TestLocalTransformationsAdaption.java
+++ b/test/jdk/jdk/incubator/code/TestLocalTransformationsAdaption.java
@@ -132,7 +132,7 @@ public class TestLocalTransformationsAdaption {
                 default:
             }
 
-            block.op(op);
+            block.add(op);
 
             return block;
         });
@@ -153,9 +153,9 @@ public class TestLocalTransformationsAdaption {
     }
 
     static void printConstantString(Block.Builder opBuilder, String s) {
-        Op.Result c = opBuilder.op(constant(J_L_STRING, s));
-        Value System_out = opBuilder.op(fieldLoad(FieldRef.field(System.class, "out", PrintStream.class)));
-        opBuilder.op(JavaOp.invoke(method(PrintStream.class, "println", void.class, String.class), System_out, c));
+        Op.Result c = opBuilder.add(constant(J_L_STRING, s));
+        Value System_out = opBuilder.add(fieldLoad(FieldRef.field(System.class, "out", PrintStream.class)));
+        opBuilder.add(JavaOp.invoke(method(PrintStream.class, "println", void.class, String.class), System_out, c));
     }
 
     static Op getNearestInvokeableAncestorOp(Op op) {
@@ -176,14 +176,14 @@ public class TestLocalTransformationsAdaption {
                 case JavaOp.InvokeOp invokeOp when invokeOp.invokeReference().equals(ADD_METHOD): {
                     // Get the adapted operands, and pass those to the new call method
                     List<Value> adaptedOperands = block.context().getValues(op.operands());
-                    Op.Result adaptedResult = block.op(JavaOp.invoke(ADD_WITH_PRINT_METHOD, adaptedOperands));
+                    Op.Result adaptedResult = block.add(JavaOp.invoke(ADD_WITH_PRINT_METHOD, adaptedOperands));
                     // Map the old call result to the new call result, so existing operations can be
                     // adapted to use the new result
                     block.context().mapValue(invokeOp.result(), adaptedResult);
                     break;
                 }
                 default: {
-                    block.op(op);
+                    block.add(op);
                 }
             }
             return block;
@@ -210,7 +210,7 @@ public class TestLocalTransformationsAdaption {
                     break;
                 }
                 default: {
-                    block.op(op);
+                    block.add(op);
                 }
             }
             return block;
@@ -229,58 +229,58 @@ public class TestLocalTransformationsAdaption {
 
         String prefix = "ENTER";
 
-        Value arrayLength = opBuilder.op(
+        Value arrayLength = opBuilder.add(
                 constant(INT, adaptedInvokeOperands.size()));
-        Value formatArray = opBuilder.op(
+        Value formatArray = opBuilder.add(
                 newArray(type(Object[].class), arrayLength));
 
         Value indexZero = null;
         for (int i = 0; i < adaptedInvokeOperands.size(); i++) {
             Value operand = adaptedInvokeOperands.get(i);
 
-            Value index = opBuilder.op(
+            Value index = opBuilder.add(
                     constant(INT, i));
             if (i == 0) {
                 indexZero = index;
             }
 
             if (operand.type().equals(INT)) {
-                operand = opBuilder.op(
+                operand = opBuilder.add(
                         JavaOp.invoke(method(Integer.class, "valueOf", Integer.class, int.class), operand));
                 // @@@ Other primitive types
             }
-            opBuilder.op(
+            opBuilder.add(
                     arrayStoreOp(formatArray, index, operand));
         }
 
-        Op.Result formatString = opBuilder.op(
+        Op.Result formatString = opBuilder.add(
                 constant(J_L_STRING,
                         prefix + ": " + invokeOp.invokeReference() + "(" + formatString(adaptedInvokeOperands) + ")%n"));
-        Value System_out = opBuilder.op(fieldLoad(FieldRef.field(System.class, "out", PrintStream.class)));
-        opBuilder.op(
+        Value System_out = opBuilder.add(fieldLoad(FieldRef.field(System.class, "out", PrintStream.class)));
+        opBuilder.add(
                 JavaOp.invoke(method(PrintStream.class, "printf", PrintStream.class, String.class, Object[].class),
                         System_out, formatString, formatArray));
 
         // Method call
 
-        Op.Result adaptedInvokeResult = opBuilder.op(invokeOp);
+        Op.Result adaptedInvokeResult = opBuilder.add(invokeOp);
 
         // After method call
 
         prefix = "EXIT";
 
         if (adaptedInvokeResult.type().equals(INT)) {
-            adaptedInvokeResult = opBuilder.op(
+            adaptedInvokeResult = opBuilder.add(
                     JavaOp.invoke(method(Integer.class, "valueOf", Integer.class, int.class), adaptedInvokeResult));
             // @@@ Other primitive types
         }
-        opBuilder.op(
+        opBuilder.add(
                 arrayStoreOp(formatArray, indexZero, adaptedInvokeResult));
 
-        formatString = opBuilder.op(
+        formatString = opBuilder.add(
                 constant(J_L_STRING,
                         prefix + ": " + invokeOp.invokeReference() + " -> " + formatString(adaptedInvokeResult.type()) + "%n"));
-        opBuilder.op(
+        opBuilder.add(
                 JavaOp.invoke(method(PrintStream.class, "printf", PrintStream.class, String.class, Object[].class),
                         System_out, formatString, formatArray));
     }

--- a/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
@@ -400,21 +400,21 @@ public class TestPrimitiveTypePatterns {
 
             var paramVal = fblock.parameters().get(0);
 
-            var patternVar = fblock.op(var(fblock.op(constant(targetType, defaultValue(targetType)))));
+            var patternVar = fblock.add(var(fblock.add(constant(targetType, defaultValue(targetType)))));
 
             var pattern = Body.Builder.of(fblock.parentBody(), functionType(JavaOp.Pattern.bindingType(targetType)));
-            pattern.entryBlock().op(core_yield(
-                    pattern.entryBlock().op(typePattern(targetType, null))
+            pattern.entryBlock().add(core_yield(
+                    pattern.entryBlock().add(typePattern(targetType, null))
             ));
 
             var match = Body.Builder.of(fblock.parentBody(), functionType(JavaType.VOID, targetType));
             var binding = match.entryBlock().parameters().get(0);
-            match.entryBlock().op(varStore(patternVar, binding));
-            match.entryBlock().op(core_yield());
+            match.entryBlock().add(varStore(patternVar, binding));
+            match.entryBlock().add(core_yield());
 
-            var result = fblock.op(match(paramVal, pattern, match));
+            var result = fblock.add(match(paramVal, pattern, match));
 
-            fblock.op(return_(result));
+            fblock.add(return_(result));
         });
     }
 

--- a/test/jdk/jdk/incubator/code/TestRemoveFinalVars.java
+++ b/test/jdk/jdk/incubator/code/TestRemoveFinalVars.java
@@ -83,7 +83,7 @@ public class TestRemoveFinalVars {
             // Is the variable stored to? If not we can remove it
             // otherwise, it's not considered final and we copy it
             if (isValueUsedWithOp(varOp.result(), o -> o instanceof VarStoreOp)) {
-                block.op(varOp);
+                block.add(varOp);
             }
         } else if (op instanceof VarLoadOp varLoadOp) {
             // If the variable is not stored to
@@ -94,10 +94,10 @@ public class TestRemoveFinalVars {
                 CodeContext cc = block.context();
                 cc.mapValue(varLoadOp.result(), cc.getValue(varLoadOp.varOp().operands().get(0)));
             } else {
-                block.op(varLoadOp);
+                block.add(varLoadOp);
             }
         } else {
-            block.op(op);
+            block.add(op);
         }
         return block;
     }

--- a/test/jdk/jdk/incubator/code/TestSuccessorValidation.java
+++ b/test/jdk/jdk/incubator/code/TestSuccessorValidation.java
@@ -43,9 +43,9 @@ public class TestSuccessorValidation {
     private static CoreOp.FuncOp numArgsGtNumParams() {
         return CoreOp.func("invalid", CoreType.functionType(JavaType.INT, JavaType.INT)).body(eb -> {
             Block.Builder b1 = eb.block(JavaType.INT);
-            b1.op(CoreOp.return_(b1.parameters().get(0)));
+            b1.add(CoreOp.return_(b1.parameters().get(0)));
 
-            eb.op(CoreOp.branch(b1.reference(eb.parameters().get(0), eb.parameters().get(0))));
+            eb.add(CoreOp.branch(b1.reference(eb.parameters().get(0), eb.parameters().get(0))));
         });
     }
 
@@ -58,9 +58,9 @@ public class TestSuccessorValidation {
         return CoreOp.func("valid", CoreType.functionType(JavaType.INT, JavaType.INT, JavaType.BOOLEAN))
                 .body(eb -> {
                     Block.Builder b1 = eb.block(JavaType.INT);
-                    b1.op(CoreOp.return_(b1.parameters().get(0)));
+                    b1.add(CoreOp.return_(b1.parameters().get(0)));
 
-                    eb.op(CoreOp.conditionalBranch(
+                    eb.add(CoreOp.conditionalBranch(
                             eb.parameters().get(1),
                             b1.reference(eb.parameters().get(0)),
                             b1.reference()

--- a/test/jdk/jdk/incubator/code/TestTransformQuotedOp.java
+++ b/test/jdk/jdk/incubator/code/TestTransformQuotedOp.java
@@ -59,15 +59,15 @@ public class TestTransformQuotedOp {
                                 .body(lblock -> {
                                     Block.Parameter li = lblock.parameters().get(0);
 
-                                    lblock.op(return_(
+                                    lblock.add(return_(
                                             // capture i from function's body
-                                            lblock.op(JavaOp.add(i, li))
+                                            lblock.add(JavaOp.add(i, li))
                                     ));
                                 });
                     });
-                    Op.Result lquoted = block.op(qop);
+                    Op.Result lquoted = block.add(qop);
 
-                    block.op(return_(lquoted));
+                    block.add(return_(lquoted));
                 });
 
         System.out.println(f.toText());

--- a/test/jdk/jdk/incubator/code/TestTransitiveInvokeModule.java
+++ b/test/jdk/jdk/incubator/code/TestTransitiveInvokeModule.java
@@ -125,7 +125,7 @@ public class TestTransitiveInvokeModule {
                             work.push(call);
 
                             // Replace invocation with function call
-                            Op.Result result = block.op(CoreOp.funcCall(
+                            Op.Result result = block.add(CoreOp.funcCall(
                                     call.r.toString(),
                                     call.f.invokableSignature(),
                                     block.context().getValues(iop.operands())));
@@ -135,7 +135,7 @@ public class TestTransitiveInvokeModule {
                         }
                     }
                 }
-                block.op(op);
+                block.add(op);
                 return block;
             });
             funcs.add(tf);

--- a/test/jdk/jdk/incubator/code/TestUninitializedVariable.java
+++ b/test/jdk/jdk/incubator/code/TestUninitializedVariable.java
@@ -91,7 +91,7 @@ public class TestUninitializedVariable {
             if (op instanceof CoreOp.VarAccessOp.VarStoreOp vop && !b.getAndSet(true)) {
                 // Drop first encountered var store
             } else {
-                block.op(op);
+                block.add(op);
             }
             return block;
         });

--- a/test/jdk/jdk/incubator/code/TestVarOp.java
+++ b/test/jdk/jdk/incubator/code/TestVarOp.java
@@ -75,10 +75,10 @@ public class TestVarOp {
         f = f.transform((block, op) -> {
             if (op instanceof CoreOp.VarOp vop) {
                 Value init = block.context().getValue(vop.initOperand());
-                Op.Result v = block.op(CoreOp.var(init));
+                Op.Result v = block.add(CoreOp.var(init));
                 block.context().mapValue(vop.result(), v);
             } else {
-                block.op(op);
+                block.add(op);
             }
             return block;
         });

--- a/test/jdk/jdk/incubator/code/Unreflect.java
+++ b/test/jdk/jdk/incubator/code/Unreflect.java
@@ -183,7 +183,7 @@ public final class Unreflect {
             bb.context().mapValues(funcOp.parameters(), bb.parameters().subList(0, capturedValues));
             for (int i = 0; i < ops.size() - 2; i++) {
                 Op o = ops.get(i);
-                bb.context().mapValue(o.result(), bb.op(o));
+                bb.context().mapValue(o.result(), bb.add(o));
             }
             bb.transformBody(lambda.body(),
                     bb.parameters().subList(capturedValues, bb.parameters().size()),

--- a/test/jdk/jdk/incubator/code/ad/ExpressionElimination.java
+++ b/test/jdk/jdk/incubator/code/ad/ExpressionElimination.java
@@ -77,7 +77,7 @@ public final class ExpressionElimination {
 
                     as.put(ms.op().result(), (block, op) -> {
                         CodeContext cc = block.context();
-                        Op.Result r = block.op(sub(cc.getValue(y), cc.getValue(x)));
+                        Op.Result r = block.add(sub(cc.getValue(y), cc.getValue(x)));
                         cc.mapValue(ms.op().result(), r);
                     });
                     return as;
@@ -90,7 +90,7 @@ public final class ExpressionElimination {
             if (a != null) {
                 a.accept(block, op);
             } else {
-                block.op(op);
+                block.add(op);
             }
             return block;
         });
@@ -111,7 +111,7 @@ public final class ExpressionElimination {
             // Remove unused ops
             ef = ef.transform(CodeContext.create(), (block, op) -> {
                 if (!unused.contains(op)) {
-                    block.op(op);
+                    block.add(op);
                 }
                 return block;
             });

--- a/test/jdk/jdk/incubator/code/ad/ForwardDifferentiation.java
+++ b/test/jdk/jdk/incubator/code/ad/ForwardDifferentiation.java
@@ -91,7 +91,7 @@ public final class ForwardDifferentiation {
                         // so that it can be used when differentiating subsequent operations
                         diffValueMapping.put(op.result(), dor);
                     } else {
-                        block.op(op);
+                        block.add(op);
                     }
                     return block;
                 });
@@ -101,9 +101,9 @@ public final class ForwardDifferentiation {
 
     void processBlocks(Block.Builder block) {
         // Declare constants at start
-        zero = block.op(constant(ind.type(), 0.0d));
+        zero = block.add(constant(ind.type(), 0.0d));
         // The differential of ind is 1
-        Value one = block.op(constant(ind.type(), 1.0d));
+        Value one = block.add(constant(ind.type(), 1.0d));
         diffValueMapping.put(ind, one);
 
         // Append differential block parameters to blocks
@@ -132,27 +132,27 @@ public final class ForwardDifferentiation {
         return switch (op) {
             case JavaOp.NegOp _ -> {
                 // Copy input operation
-                block.op(op);
+                block.add(op);
 
                 // -diff(expr)
                 Value a = op.operands().get(0);
                 Value da = diffValueMapping.getOrDefault(a, zero);
-                yield block.op(JavaOp.neg(da));
+                yield block.add(JavaOp.neg(da));
             }
             case JavaOp.AddOp _ -> {
                 // Copy input operation
-                block.op(op);
+                block.add(op);
 
                 // diff(l) + diff(r)
                 Value lhs = op.operands().get(0);
                 Value rhs = op.operands().get(1);
                 Value dlhs = diffValueMapping.getOrDefault(lhs, zero);
                 Value drhs = diffValueMapping.getOrDefault(rhs, zero);
-                yield block.op(JavaOp.add(dlhs, drhs));
+                yield block.add(JavaOp.add(dlhs, drhs));
             }
             case JavaOp.MulOp _ -> {
                 // Copy input operation
-                block.op(op);
+                block.add(op);
 
                 // Product rule
                 // diff(l) * r + l * diff(r)
@@ -162,13 +162,13 @@ public final class ForwardDifferentiation {
                 Value drhs = diffValueMapping.getOrDefault(rhs, zero);
                 Value outputLhs = block.context().getValue(lhs);
                 Value outputRhs = block.context().getValue(rhs);
-                yield block.op(JavaOp.add(
-                        block.op(JavaOp.mul(dlhs, outputRhs)),
-                        block.op(JavaOp.mul(outputLhs, drhs))));
+                yield block.add(JavaOp.add(
+                        block.add(JavaOp.mul(dlhs, outputRhs)),
+                        block.add(JavaOp.mul(outputLhs, drhs))));
             }
             case CoreOp.ConstantOp _ -> {
                 // Copy input operation
-                block.op(op);
+                block.add(op);
                 // Differential of constant is zero
                 yield zero;
             }
@@ -181,15 +181,15 @@ public final class ForwardDifferentiation {
                 // Differentiate sin(x)
                 if ("sin".equals(operationName)) {
                     // Copy input operation
-                    block.op(op);
+                    block.add(op);
 
                     // Chain rule
                     // cos(expr) * diff(expr)
                     Value a = op.operands().get(0);
                     Value da = diffValueMapping.getOrDefault(a, zero);
                     Value outputA = block.context().getValue(a);
-                    Op.Result cosx = block.op(JavaOp.invoke(J_L_MATH_COS, outputA));
-                    yield block.op(JavaOp.mul(cosx, da));
+                    Op.Result cosx = block.add(JavaOp.invoke(J_L_MATH_COS, outputA));
+                    yield block.add(JavaOp.mul(cosx, da));
                 } else {
                     throw new UnsupportedOperationException("Operation not supported: " + op);
                 }
@@ -198,12 +198,12 @@ public final class ForwardDifferentiation {
                 // Replace with return of differentiated value
                 Value a = op.operands().get(0);
                 Value da = diffValueMapping.getOrDefault(a, zero);
-                yield block.op(return_(da));
+                yield block.add(return_(da));
             }
             case Op.BlockTerminating _ -> {
                 // Update with differentiated block arguments
                 op.successors().forEach(s -> adaptSuccessor(block.context(), s));
-                yield block.op(op);
+                yield block.add(op);
             }
             default -> throw new UnsupportedOperationException("Operation not supported: " + op);
         };

--- a/test/jdk/jdk/incubator/code/anf/AnfTransformer.java
+++ b/test/jdk/jdk/incubator/code/anf/AnfTransformer.java
@@ -100,7 +100,7 @@ public class AnfTransformer {
         var letBody = Body.Builder.of(newBodyBuilder, CoreType.functionType(blockReturnType, List.of()), CodeContext.create(newBodyBuilder.entryBlock().context()));
 
         AnfDialect.AnfLetOp let = transformOps(b, letBody);
-        newBodyBuilder.entryBlock().op(let);
+        newBodyBuilder.entryBlock().add(let);
         return AnfDialect.func(b.toString(), newBodyBuilder);
     }
 
@@ -132,7 +132,7 @@ public class AnfTransformer {
         List<Block> dominates = idomMap.idominates(b);
         for (Block dblock : dominates) {
             var res = transformDomBlock(dblock, letrecBody);
-            var fval = letrecBody.entryBlock().op(res);
+            var fval = letrecBody.entryBlock().add(res);
             funMap2.put(dblock, fval);
         }
 
@@ -140,10 +140,10 @@ public class AnfTransformer {
         transformBlockOps(b, letBody.entryBlock());
         var let = AnfDialect.let(letBody);
 
-        letrecBody.entryBlock().op(let);
+        letrecBody.entryBlock().add(let);
 
         var letrec = AnfDialect.letrec(letrecBody);
-        funcBodyBuilder.entryBlock().op(letrec);
+        funcBodyBuilder.entryBlock().add(letrec);
         return AnfDialect.func(b.toString(), funcBodyBuilder);
 
     }
@@ -216,7 +216,7 @@ public class AnfTransformer {
                             .if_((bodyBuilder) -> bindFunApp(bodyBuilder, trueArgs, c.trueBranch().targetBlock()))
                             .else_((bodyBuilder) -> bindFunApp(bodyBuilder, falseArgs, c.falseBranch().targetBlock()));
 
-                    b.op(ifExp);
+                    b.add(ifExp);
 
                     return b;
                 }
@@ -232,12 +232,12 @@ public class AnfTransformer {
                 }
                 case CoreOp.ReturnOp ro -> {
                     var rval = b.context().getValue(ro.returnValue());
-                    b.op(CoreOp.core_yield(rval));
+                    b.add(CoreOp.core_yield(rval));
                     return b;
                 }
                 case CoreOp.YieldOp y ->  {
                     var rval = b.context().getValue(y.yieldValue());
-                    b.op(CoreOp.core_yield(rval));
+                    b.add(CoreOp.core_yield(rval));
                     return b;
                 }
                 default -> {
@@ -245,7 +245,7 @@ public class AnfTransformer {
                 }
             }
         } else {
-            b.op(op);
+            b.add(op);
             return b;
         }
     }
@@ -259,7 +259,7 @@ public class AnfTransformer {
         synthArgs.addAll(args);
         synthArgs.addFirst(funMap.get(target));
         try {
-            b.op(AnfDialect.apply(synthArgs));
+            b.add(AnfDialect.apply(synthArgs));
             return;
         } catch (RuntimeException e) {}
 
@@ -267,7 +267,7 @@ public class AnfTransformer {
         synthArgs.addFirst(funMap2.get(target));
 
         try {
-            b.op(AnfDialect.apply(synthArgs));
+            b.add(AnfDialect.apply(synthArgs));
         } catch (RuntimeException e) {
             throw new IllegalStateException("No valid mapping to FuncOp for apply");
         }

--- a/test/jdk/jdk/incubator/code/bytecode/TestSlotOps.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestSlotOps.java
@@ -60,39 +60,39 @@ public class TestSlotOps {
 
             // Entry block
             {
-                Value nullConstant = b.op(CoreOp.constant(JavaType.J_L_OBJECT, null));
-                b.op(SlotOp.store(0, nullConstant));
+                Value nullConstant = b.add(CoreOp.constant(JavaType.J_L_OBJECT, null));
+                b.add(SlotOp.store(0, nullConstant));
 
-                b.op(CoreOp.conditionalBranch(b.op(CoreOp.constant(JavaType.BOOLEAN, true)),
+                b.add(CoreOp.conditionalBranch(b.add(CoreOp.constant(JavaType.BOOLEAN, true)),
                         trueBlock.reference(), falseBlock.reference()));
             }
 
             // True block
             {
-                Value oneConstant = trueBlock.op(CoreOp.constant(JavaType.INT, 1));
-                trueBlock.op(SlotOp.store(0, oneConstant));
+                Value oneConstant = trueBlock.add(CoreOp.constant(JavaType.INT, 1));
+                trueBlock.add(SlotOp.store(0, oneConstant));
 
-                Value loadValue = trueBlock.op(SlotOp.load(0, JavaType.INT));
-                trueBlock.op(JavaOp.invoke(MethodRef.method(TestSlots.class, "m", void.class, int.class), loadValue));
+                Value loadValue = trueBlock.add(SlotOp.load(0, JavaType.INT));
+                trueBlock.add(JavaOp.invoke(MethodRef.method(TestSlots.class, "m", void.class, int.class), loadValue));
 
-                Value stringConstant = trueBlock.op(CoreOp.constant(JavaType.J_L_STRING, "TRUE"));
-                trueBlock.op(SlotOp.store(0, stringConstant));
+                Value stringConstant = trueBlock.add(CoreOp.constant(JavaType.J_L_STRING, "TRUE"));
+                trueBlock.add(SlotOp.store(0, stringConstant));
 
-                trueBlock.op(CoreOp.branch(exitBlock.reference()));
+                trueBlock.add(CoreOp.branch(exitBlock.reference()));
             }
 
             // False block
             {
-                Value stringConstant = falseBlock.op(CoreOp.constant(JavaType.J_L_STRING, "FALSE"));
-                falseBlock.op(SlotOp.store(0, stringConstant));
+                Value stringConstant = falseBlock.add(CoreOp.constant(JavaType.J_L_STRING, "FALSE"));
+                falseBlock.add(SlotOp.store(0, stringConstant));
 
-                falseBlock.op(CoreOp.branch(exitBlock.reference()));
+                falseBlock.add(CoreOp.branch(exitBlock.reference()));
             }
 
             // Exit block
             {
-                Value loadValue = exitBlock.op(SlotOp.load(0, JavaType.J_L_STRING));
-                exitBlock.op(CoreOp.return_(loadValue));
+                Value loadValue = exitBlock.add(SlotOp.load(0, JavaType.J_L_STRING));
+                exitBlock.add(CoreOp.return_(loadValue));
             }
         });
     }

--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -156,7 +156,7 @@ public final class BytecodeLift {
     }
 
     private Op.Result op(Op op) {
-        return currentBlock.op(op);
+        return currentBlock.add(op);
     }
 
     // Lift to core dialect
@@ -482,13 +482,13 @@ public final class BytecodeLift {
                         } else {
                             // lambda call to a MH
                             stack.push(op(lambda.body(eb -> {
-                                Op.Result ret = eb.op(JavaOp.invoke(
+                                Op.Result ret = eb.add(JavaOp.invoke(
                                         MethodRef.method(JavaType.type(dmhd.owner()),
                                                          dmhd.methodName(),
                                                          lambdaFunc.returnType(),
                                                          lambdaFunc.parameterTypes()),
                                         Stream.concat(Arrays.stream(capturedValues), eb.parameters().stream()).toArray(Value[]::new)));
-                                eb.op(ret.type().equals(JavaType.VOID) ? CoreOp.return_() : CoreOp.return_(ret));
+                                eb.add(ret.type().equals(JavaType.VOID) ? CoreOp.return_() : CoreOp.return_(ret));
                             })));
                         }
                     } else if (bsmOwner.equals(CD_StringConcatFactory)) {
@@ -893,7 +893,7 @@ public final class BytecodeLift {
 
         if (transits.isEmpty()) {
             // Join with branch
-            initialBlock.op(CoreOp.branch(targetBlock.reference(values)));
+            initialBlock.add(CoreOp.branch(targetBlock.reference(values)));
         } else {
             // Insert ERE transitions
             Block.Builder currentBlock = initialBlock;
@@ -915,7 +915,7 @@ public final class BytecodeLift {
         Block.Reference catcher = (ehi == targetExceptionHandlerIndex
                 ? initialBlock
                 : targetBlockForExceptionHandler(handlerEreStack, ehi)).reference();
-        currentBlock.op(enter ? JavaOp.exceptionRegionEnter(ref, catcher) : JavaOp.exceptionRegionExit(ref, catcher));
+        currentBlock.add(enter ? JavaOp.exceptionRegionEnter(ref, catcher) : JavaOp.exceptionRegionExit(ref, catcher));
     }
 
     Block.Reference successorWithStack(Block.Builder next) {

--- a/test/jdk/jdk/incubator/code/bytecode/lift/SlotToVarTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/SlotToVarTransformer.java
@@ -192,7 +192,7 @@ final class SlotToVarTransformer {
                 for (var it = toInitialize.iterator(); it.hasNext();) {
                     Var var = it.next();
                     if (var.parentBody == op.ancestorBody()) {
-                        var.value = block.op(CoreOp.var(toCodeType(var.typeKind)));
+                        var.value = block.add(CoreOp.var(toCodeType(var.typeKind)));
                         it.remove();
                     }
                 }
@@ -205,7 +205,7 @@ final class SlotToVarTransformer {
                         System.out.println(slo);
                         throw new AssertionError();
                     }
-                    cc.mapValue(op.result(), var.single ? var.value : block.op(CoreOp.varLoad(var.value)));
+                    cc.mapValue(op.result(), var.single ? var.value : block.add(CoreOp.varLoad(var.value)));
                 }
                 case SlotOp.SlotStoreOp sso -> {
                     Var var = varMap.get(sso);
@@ -219,13 +219,13 @@ final class SlotToVarTransformer {
                             case UnresolvedType.Int _ -> UnresolvedType.unresolvedInt();
                             default -> val.type();
                         };
-                        var.value = block.op(CoreOp.var(null, varType, val));
+                        var.value = block.add(CoreOp.var(null, varType, val));
                     } else {
-                        block.op(CoreOp.varStore(var.value, val));
+                        block.add(CoreOp.varStore(var.value, val));
                     }
                 }
                 default ->
-                    block.op(op);
+                    block.add(op);
             }
             return block;
         });

--- a/test/jdk/jdk/incubator/code/bytecode/lift/UnresolvedTypesTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/UnresolvedTypesTransformer.java
@@ -287,7 +287,7 @@ final class UnresolvedTypesTransformer {
 
             @Override
             public Block.Builder acceptOp(Block.Builder block, Op op) {
-                block.op(op);
+                block.add(op);
                 return block;
             }
         };
@@ -298,21 +298,21 @@ final class UnresolvedTypesTransformer {
             CodeContext cc = block.context();
             switch (op) {
                 case CoreOp.ConstantOp cop when op.resultType() instanceof UnresolvedType ut ->
-                    cc.mapValue(op.result(), block.op(CoreOp.constant(resolvedMap.get(ut), convertValue(ut, cop.value()))));
+                    cc.mapValue(op.result(), block.add(CoreOp.constant(resolvedMap.get(ut), convertValue(ut, cop.value()))));
                 case CoreOp.VarOp vop when vop.varValueType() instanceof UnresolvedType ut ->
-                    cc.mapValue(op.result(), block.op(vop.isUninitialized()
+                    cc.mapValue(op.result(), block.add(vop.isUninitialized()
                             ? CoreOp.var(vop.varName(), resolvedMap.get(ut))
                             : CoreOp.var(vop.varName(), resolvedMap.get(ut), cc.queryValue(vop.initOperand()).orElse(vop.initOperand()))));
                 case JavaOp.ArrayAccessOp.ArrayLoadOp alop when op.resultType() instanceof UnresolvedType -> {
                     List<Value> opers = alop.operands();
                     Value array = opers.getFirst();
                     Value index = opers.getLast();
-                    cc.mapValue(op.result(), block.op(JavaOp.arrayLoadOp(
+                    cc.mapValue(op.result(), block.add(JavaOp.arrayLoadOp(
                             cc.queryValue(array).orElse(array),
                             cc.queryValue(index).orElse(index))));
                 }
                 default ->
-                    block.op(op);
+                    block.add(op);
             }
             return block;
         };
@@ -328,7 +328,7 @@ final class UnresolvedTypesTransformer {
                 case JavaOp.BinaryOp _ ->
                     unify(block, op, op.resultType(), op.resultType());
                 default ->
-                    block.op(op);
+                    block.add(op);
             }
             return block;
         };
@@ -340,18 +340,18 @@ final class UnresolvedTypesTransformer {
         Value first = operands.getFirst();
         boolean changed = false;
         if (first.type() instanceof PrimitiveType && !first.type().equals(firstType)) {
-            cc.mapValue(first, block.op(JavaOp.conv(firstType, cc.queryValue(first).orElse(first))));
+            cc.mapValue(first, block.add(JavaOp.conv(firstType, cc.queryValue(first).orElse(first))));
             changed = true;
         }
         Value second = operands.get(1);
         if (second.type() instanceof PrimitiveType && !second.type().equals(secondType)) {
-            cc.mapValue(second, block.op(JavaOp.conv(secondType, cc.queryValue(second).orElse(second))));
+            cc.mapValue(second, block.add(JavaOp.conv(secondType, cc.queryValue(second).orElse(second))));
             changed = true;
         }
         if (changed) {
-            block.context().mapValue(op.result(), block.op(op.transform(cc, CodeTransformer.COPYING_TRANSFORMER)));
+            block.context().mapValue(op.result(), block.add(op.transform(cc, CodeTransformer.COPYING_TRANSFORMER)));
         } else {
-            block.op(op);
+            block.add(op);
         }
     }
 }

--- a/test/jdk/jdk/incubator/code/interpreter/TestExceptionRegionReEntry.java
+++ b/test/jdk/jdk/incubator/code/interpreter/TestExceptionRegionReEntry.java
@@ -69,15 +69,15 @@ public class TestExceptionRegionReEntry {
             var catchBlock = entry.block(type(RuntimeException.class));
             var retry = entry.block();
             var done = entry.block();
-            var v = entry.op(var(entry.op(constant(BOOLEAN, false))));
-            entry.op(exceptionRegionEnter(tryBlock.reference(), catchBlock.reference()));
-            tryBlock.op(throw_(tryBlock.op(new_(MethodRef.constructor(RuntimeException.class)))));
-            var seen = catchBlock.op(varLoad(v));
-            var t = catchBlock.op(constant(BOOLEAN, true));
-            catchBlock.op(varStore(v, t));
-            catchBlock.op(conditionalBranch(seen, done.reference(), retry.reference()));
-            retry.op(exceptionRegionEnter(tryBlock.reference(), catchBlock.reference()));
-            done.op(return_(seen));
+            var v = entry.add(var(entry.add(constant(BOOLEAN, false))));
+            entry.add(exceptionRegionEnter(tryBlock.reference(), catchBlock.reference()));
+            tryBlock.add(throw_(tryBlock.add(new_(MethodRef.constructor(RuntimeException.class)))));
+            var seen = catchBlock.add(varLoad(v));
+            var t = catchBlock.add(constant(BOOLEAN, true));
+            catchBlock.add(varStore(v, t));
+            catchBlock.add(conditionalBranch(seen, done.reference(), retry.reference()));
+            retry.add(exceptionRegionEnter(tryBlock.reference(), catchBlock.reference()));
+            done.add(return_(seen));
         });
 
         System.out.println(funcOp.toText());

--- a/test/jdk/jdk/incubator/code/linq/Queryable.java
+++ b/test/jdk/jdk/incubator/code/linq/Queryable.java
@@ -68,13 +68,13 @@ public interface Queryable<T> {
         FuncOp nextQueryExpression = func("query",
                 functionType(queryableType, queryExpression.invokableSignature().parameterTypes()))
                 .body(b -> Inliner.inline(b, queryExpression, b.parameters(), (block, query) -> {
-                    Op.Result fi = block.op(lambdaOp);
+                    Op.Result fi = block.add(lambdaOp);
 
                     MethodRef md = method(Queryable.TYPE, methodName,
                             functionType(Queryable.TYPE, ((ClassType) lambdaOp.functionalInterface()).rawType()));
-                    Op.Result queryable = block.op(JavaOp.invoke(queryableType, md, query, fi));
+                    Op.Result queryable = block.add(JavaOp.invoke(queryableType, md, query, fi));
 
-                    block.op(return_(queryable));
+                    block.add(return_(queryable));
                 }));
 
         return provider().createQuery(elementType, nextQueryExpression);
@@ -101,9 +101,9 @@ public interface Queryable<T> {
                 .body(b -> Inliner.inline(b, queryExpression, b.parameters(), (block, query) -> {
                     MethodRef md = method(Queryable.TYPE, methodName,
                             functionType(QueryResult.TYPE));
-                    Op.Result queryResult = block.op(JavaOp.invoke(queryResultType, md, query));
+                    Op.Result queryResult = block.add(JavaOp.invoke(queryResultType, md, query));
 
-                    block.op(return_(queryResult));
+                    block.add(return_(queryResult));
                 }));
 
         return provider().createQueryResult(resultType, queryResultExpression);

--- a/test/jdk/jdk/incubator/code/linq/TestQueryProvider.java
+++ b/test/jdk/jdk/incubator/code/linq/TestQueryProvider.java
@@ -62,7 +62,7 @@ public final class TestQueryProvider extends QueryProvider {
             // Initial expression is an identity function
             var funType = functionType(queryableType, queryableType);
             this.expression = func("query", funType)
-                    .body(b -> b.op(return_(b.parameters().get(0))));
+                    .body(b -> b.add(return_(b.parameters().get(0))));
         }
 
         TestQueryable(JavaType elementType, TestQueryProvider provider, CoreOp.FuncOp expression) {

--- a/test/jdk/jdk/incubator/code/parser/TestParse.java
+++ b/test/jdk/jdk/incubator/code/parser/TestParse.java
@@ -68,14 +68,14 @@ public class TestParse {
                                 Block.Builder lblock = lbody.entryBlock();
                                 Block.Parameter li = lblock.parameters().get(0);
 
-                                lblock.op(return_(
-                                        lblock.op(add(i, li))));
+                                lblock.add(return_(
+                                        lblock.add(add(i, li))));
                             });
 
-                    Op.Result fi = block.op(lambda);
-                    Op.Result fortyTwo = block.op(constant(INT, 42));
-                    Op.Result or = block.op(JavaOp.invoke(INT_UNARY_OPERATOR_METHOD, fi, fortyTwo));
-                    block.op(return_(or));
+                    Op.Result fi = block.add(lambda);
+                    Op.Result fortyTwo = block.add(constant(INT, 42));
+                    Op.Result or = block.add(JavaOp.invoke(INT_UNARY_OPERATOR_METHOD, fi, fortyTwo));
+                    block.add(return_(or));
                 });
 
         List<Op> ops = OpParser.fromText(JavaOp.JAVA_DIALECT_FACTORY, f.toText());

--- a/test/jdk/jdk/incubator/code/pe/CodeReflectionTester.java
+++ b/test/jdk/jdk/incubator/code/pe/CodeReflectionTester.java
@@ -113,7 +113,7 @@ public class CodeReflectionTester {
         while (f.elements().skip(1).anyMatch(ce -> ce instanceof Op op && unused.test(op))) {
             f = f.transform((block, op) -> {
                 if (!unused.test(op)) {
-                    block.op(op);
+                    block.add(op);
                 }
                 return block;
             });

--- a/test/jdk/jdk/incubator/code/pe/PartialEvaluator.java
+++ b/test/jdk/jdk/incubator/code/pe/PartialEvaluator.java
@@ -230,15 +230,15 @@ final class PartialEvaluator {
                     if (op instanceof CoreOp.VarOp) {
                         // @@@ Do not turn into constant to avoid conflicts with the interpreter
                         // and its runtime representation of vars
-                        outBlock.op(op);
+                        outBlock.add(op);
                     } else {
                         // Result was evaluated, replace with constant operation
-                        Op.Result constantResult = outBlock.op(CoreOp.constant(op.resultType(), result));
+                        Op.Result constantResult = outBlock.add(CoreOp.constant(op.resultType(), result));
                         outBlock.context().mapValue(op.result(), constantResult);
                     }
                 } else {
                     // Copy unevaluated operation
-                    Op.Result r = outBlock.op(op);
+                    Op.Result r = outBlock.add(op);
                     // Explicitly remap result, since the op can be copied more than once in pealed loops
                     // @@@ See comment Block.op code which implicitly limits this
                     outBlock.context().mapValue(op.result(), r);
@@ -269,13 +269,13 @@ final class PartialEvaluator {
 
                         processBlock(bc, inBlock, nextInBlock, outBlock);
 
-                        outBlock.op(CoreOp.branch(outBlock.context().getReferenceOrCreate(nextInBlockRef)));
+                        outBlock.add(CoreOp.branch(outBlock.context().getReferenceOrCreate(nextInBlockRef)));
                     } else {
                         // @@@ might be non-constant latch to loop
                         processBlock(bc, inBlock, cb.falseBranch().targetBlock(), outBlock);
                         processBlock(bc, inBlock, cb.trueBranch().targetBlock(), outBlock);
 
-                        outBlock.op(to);
+                        outBlock.add(to);
                     }
                 }
                 case CoreOp.BranchOp b -> {
@@ -294,9 +294,9 @@ final class PartialEvaluator {
 
                     processBlock(bc, inBlock, nextInBlock, outBlock);
 
-                    outBlock.op(b);
+                    outBlock.add(b);
                 }
-                case CoreOp.ReturnOp _ -> outBlock.op(to);
+                case CoreOp.ReturnOp _ -> outBlock.add(to);
                 default -> throw evaluationException(
                         new UnsupportedOperationException("Unsupported terminating operation: " + to));
             }

--- a/test/jdk/jdk/incubator/code/stream/StreamFuser.java
+++ b/test/jdk/jdk/incubator/code/stream/StreamFuser.java
@@ -101,10 +101,10 @@ public final class StreamFuser {
                                                          Value iterable) {
             return enhancedFor(ancestorBody, iterable.type(), elementType)
                     .expression(b -> {
-                        b.op(core_yield(iterable));
+                        b.add(core_yield(iterable));
                     })
                     .definition(b -> {
-                        b.op(core_yield(b.parameters().get(0)));
+                        b.add(core_yield(b.parameters().get(0)));
                     });
         }
 
@@ -147,10 +147,10 @@ public final class StreamFuser {
                     Block.Builder _else = continueBlock;
                     if (continueBlock == null) {
                         _else = block.block();
-                        _else.op(JavaOp.continue_());
+                        _else.add(JavaOp.continue_());
                     }
 
-                    block.op(conditionalBranch(p, _if.reference(), _else.reference()));
+                    block.add(conditionalBranch(p, _if.reference(), _else.reference()));
 
                     fuseIntermediateOperation(i + 1, _if, element, _else, terminalConsumer);
                 });
@@ -159,10 +159,10 @@ public final class StreamFuser {
                     EnhancedForOp forOp = enhancedFor(block.parentBody(),
                             iterable.type(), ((ClassType) iterable.type()).typeArguments().get(0))
                             .expression(b -> {
-                                b.op(core_yield(iterable));
+                                b.add(core_yield(iterable));
                             })
                             .definition(b -> {
-                                b.op(core_yield(b.parameters().get(0)));
+                                b.add(core_yield(b.parameters().get(0)));
                             })
                             .body(b -> {
                                 fuseIntermediateOperation(i + 1,
@@ -171,8 +171,8 @@ public final class StreamFuser {
                                         null, terminalConsumer);
                             });
 
-                    block.op(forOp);
-                    block.op(JavaOp.continue_());
+                    block.add(forOp);
+                    block.add(JavaOp.continue_());
                 });
             }
         }
@@ -194,12 +194,12 @@ public final class StreamFuser {
                                         Inliner.inline(terminalBlock, consumer, List.of(resultValue),
                                                 (_, _) -> {
                                                 });
-                                        terminalBlock.op(JavaOp.continue_());
+                                        terminalBlock.add(JavaOp.continue_());
                                     });
 
                                 });
-                        b.op(sourceLoop);
-                        b.op(return_());
+                        b.add(sourceLoop);
+                        b.add(return_());
                     });
         }
 
@@ -227,11 +227,11 @@ public final class StreamFuser {
                                             Inliner.inline(terminalBlock, accumulator, List.of(collect, resultValue),
                                                     (_, _) -> {
                                                     });
-                                            terminalBlock.op(JavaOp.continue_());
+                                            terminalBlock.add(JavaOp.continue_());
                                         });
                                     });
-                            block.op(sourceLoop);
-                            block.op(return_(collect));
+                            block.add(sourceLoop);
+                            block.add(return_(collect));
                         });
                     });
         }

--- a/test/jdk/jdk/incubator/code/transform/TestTransform.java
+++ b/test/jdk/jdk/incubator/code/transform/TestTransform.java
@@ -91,11 +91,11 @@ public class TestTransform {
             switch (op) {
                 case JavaOp.AddOp _ -> {
                     List<Value> values = builder.context().getValues(op.operands());
-                    Op.Result r = builder.op(JavaOp.invoke(MethodRef.method(fAdd), values));
+                    Op.Result r = builder.add(JavaOp.invoke(MethodRef.method(fAdd), values));
                     builder.context().mapValue(op.result(), r);
                 }
                 default ->
-                        builder.op(op);
+                        builder.add(op);
             }
             return builder;
         };
@@ -162,7 +162,7 @@ public class TestTransform {
                     if (uses.size() == 1 && uses.iterator().next().op() instanceof JavaOp.AddOp) {
                         // Drop, this will be replaced later
                     } else {
-                        builder.op(op);
+                        builder.add(op);
                     }
                 }
                 case JavaOp.AddOp _ -> {
@@ -176,17 +176,17 @@ public class TestTransform {
                         // with the constant op which was dropped
                         Assertions.assertNull(operands.get(1));
 
-                        rhs = builder.op(CoreOp.constant(JavaType.INT, - (int) cop.value()));
+                        rhs = builder.add(CoreOp.constant(JavaType.INT, - (int) cop.value()));
                     } else {
                         Assertions.assertNotNull(operands.get(1));
 
-                        rhs = builder.op(JavaOp.neg(operands.get(1)));
+                        rhs = builder.add(JavaOp.neg(operands.get(1)));
                     }
-                    Op.Result result = builder.op(JavaOp.sub(operands.get(0), rhs));
+                    Op.Result result = builder.add(JavaOp.sub(operands.get(0), rhs));
                     builder.context().mapValue(op.result(), result);
                 }
                 default ->
-                        builder.op(op);
+                        builder.add(op);
             }
             return builder;
         };

--- a/test/jdk/jdk/incubator/code/writer/TestCodeBuilder.java
+++ b/test/jdk/jdk/incubator/code/writer/TestCodeBuilder.java
@@ -126,7 +126,7 @@ public class TestCodeBuilder {
 
     static void test(CoreOp.FuncOp fExpected) {
         CoreOp.ModuleOp module = OpBuilder.createBuilderFunctions(new LinkedHashMap<>(Map.of(fExpected.funcName(), fExpected)),
-                b -> b.op(JavaOp.fieldLoad(
+                b -> b.add(JavaOp.fieldLoad(
                         FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))));
         CoreOp.FuncOp fActual = (CoreOp.FuncOp) Interpreter.invoke(MethodHandles.lookup(),
                 module.transform(CodeTransformer.LOWERING_TRANSFORMER).functionTable().get(fExpected.funcName()));

--- a/test/langtools/tools/javac/reflect/CodeReflectionTester.java
+++ b/test/langtools/tools/javac/reflect/CodeReflectionTester.java
@@ -150,9 +150,9 @@ public class CodeReflectionTester {
             // captured values mapped to the function's parameters
             // are reachable
             cc.mapBlock(qOp.ancestorBody().entryBlock(), fblock);
-            fblock.op(qOp);
+            fblock.add(qOp);
 
-            fblock.op(CoreOp.return_());
+            fblock.add(CoreOp.return_());
         });
     }
 }


### PR DESCRIPTION
Rename `Block.Builder.op` to `add`, which is more descriptive and only one character more.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1045/head:pull/1045` \
`$ git checkout pull/1045`

Update a local copy of the PR: \
`$ git checkout pull/1045` \
`$ git pull https://git.openjdk.org/babylon.git pull/1045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1045`

View PR using the GUI difftool: \
`$ git pr show -t 1045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1045.diff">https://git.openjdk.org/babylon/pull/1045.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1045#issuecomment-4513769802)
</details>
