### PR TITLE
[hat] Test-framework bailout if NaN numbers are found

### DIFF
--- a/hat/tests/src/main/java/hat/test/exceptions/HATAsserts.java
+++ b/hat/tests/src/main/java/hat/test/exceptions/HATAsserts.java
@@ -57,13 +57,15 @@ public class HATAsserts {
     }
 
     public static void assertEquals(float expected, float actual, float delta) {
-        if (Float.isNaN(expected) || Float.isNaN(actual) || Math.abs(expected - actual) > delta) {
+        float diff = Math.abs(expected - actual);
+        if (Float.isNaN(diff) || (diff > delta)) {
             throw new HATAssertionError("Expected: " + expected + " != actual: " + actual);
         }
     }
 
     public static void assertEquals(double expected, double actual, double delta) {
-        if (Double.isNaN(expected) || Double.isNaN(actual) || Math.abs(expected - actual) > delta) {
+        double diff = Math.abs(expected - actual);
+        if (Double.isNaN(diff) || (diff > delta)) {
             throw new HATAssertionError("Expected: " + expected + " != actual: " + actual);
         }
     }
@@ -71,24 +73,20 @@ public class HATAsserts {
     public static void assertEquals(Float4 expected, Float4 actual, float delta) {
         float[] arrayExpected = expected.toArray();
         float[] arrayActual = actual.toArray();
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < Float4.shape.lanes(); i++) {
             var expectedValue = arrayExpected[i];
             var actualValue = arrayActual[i];
-            if (Float.isNaN(expectedValue) || Float.isNaN(actualValue) || Math.abs(expectedValue - actualValue) > delta) {
-                throw new HATAssertionError("Expected: " + expectedValue + " != actual: " + actualValue);
-            }
+            assertEquals(expectedValue, actualValue, delta);
         }
     }
 
     public static void assertEquals(Float2 expected, Float2 actual, float delta) {
         float[] arrayExpected = expected.toArray();
         float[] arrayActual = actual.toArray();
-        for (int i = 0; i < 2; i++) {
+        for (int i = 0; i < Float2.shape.lanes(); i++) {
             var expectedValue = arrayExpected[i];
             var actualValue = arrayActual[i];
-            if (Float.isNaN(expectedValue) || Float.isNaN(actualValue) || Math.abs(expectedValue - actualValue) > delta) {
-                throw new HATAssertionError("Expected: " + expectedValue + " != actual: " + actualValue);
-            }
+            assertEquals(expectedValue, actualValue, delta);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/exceptions/HATAsserts.java
+++ b/hat/tests/src/main/java/hat/test/exceptions/HATAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,9 @@ public class HATAsserts {
     }
 
     public static void assertEquals(String expected, String actual) {
+        if (expected == null || actual == null) {
+            throw new HATAssertionError("Null values are not allowed");
+        }
         if (!expected.equals(actual)) {
             throw new HATAssertionError("Expected: " + expected + " != actual: " + actual);
         }
@@ -54,13 +57,13 @@ public class HATAsserts {
     }
 
     public static void assertEquals(float expected, float actual, float delta) {
-        if (Math.abs(expected - actual) > delta) {
+        if (Float.isNaN(expected) || Float.isNaN(actual) || Math.abs(expected - actual) > delta) {
             throw new HATAssertionError("Expected: " + expected + " != actual: " + actual);
         }
     }
 
     public static void assertEquals(double expected, double actual, double delta) {
-        if (Math.abs(expected - actual) > delta) {
+        if (Double.isNaN(expected) || Double.isNaN(actual) || Math.abs(expected - actual) > delta) {
             throw new HATAssertionError("Expected: " + expected + " != actual: " + actual);
         }
     }
@@ -71,7 +74,7 @@ public class HATAsserts {
         for (int i = 0; i < 4; i++) {
             var expectedValue = arrayExpected[i];
             var actualValue = arrayActual[i];
-            if (Math.abs(expectedValue - actualValue) > delta) {
+            if (Float.isNaN(expectedValue) || Float.isNaN(actualValue) || Math.abs(expectedValue - actualValue) > delta) {
                 throw new HATAssertionError("Expected: " + expectedValue + " != actual: " + actualValue);
             }
         }
@@ -83,7 +86,7 @@ public class HATAsserts {
         for (int i = 0; i < 2; i++) {
             var expectedValue = arrayExpected[i];
             var actualValue = arrayActual[i];
-            if (Math.abs(expectedValue - actualValue) > delta) {
+            if (Float.isNaN(expectedValue) || Float.isNaN(actualValue) || Math.abs(expectedValue - actualValue) > delta) {
                 throw new HATAssertionError("Expected: " + expectedValue + " != actual: " + actualValue);
             }
         }
@@ -100,4 +103,8 @@ public class HATAsserts {
             throw new HATAssertionError("Expected: " + isCorrect);
         }
     }
+
+    private HATAsserts() {
+    }
+
 }


### PR DESCRIPTION
Improve HAT test assertion handling for null strings and NaN numeric values.

- Make string assertions fail explicitly when null values are provided.
- Ensure float, double versions of the assertions fail when either expected or actual values are NaN.
- Add a private constructor to prevent instantiating the static assertion helper.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1048/head:pull/1048` \
`$ git checkout pull/1048`

Update a local copy of the PR: \
`$ git checkout pull/1048` \
`$ git pull https://git.openjdk.org/babylon.git pull/1048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1048`

View PR using the GUI difftool: \
`$ git pr show -t 1048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1048.diff">https://git.openjdk.org/babylon/pull/1048.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1048#issuecomment-4519473243)
</details>
