### PR TITLE
Update the specification of code model behavior for abrupt completion

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -716,16 +716,19 @@
 ///
 /// If the selected operation is a non-terminating operation then the non-terminating operation is executed:
 ///
-/// - If execution of the operation produces an operation result effect then the next operation becomes the selected
-/// operation, and the current environment is updated by binding the operation's result to the effect's run time value.
-/// Execution of the selected operation then proceeds as previously described.
+/// - If execution of the operation completes normally it produces an operation result effect. The next operation
+/// becomes the selected operation, and the current environment is updated by binding the operation's result to the
+/// effect's run time value. Execution of the selected operation then proceeds as previously described.
 ///
-/// - If execution of the operation produces a terminating operation effect then execution of the block completes and
-/// it produces that effect (passing the effect to execution of the parent body, which in turn passes the effect to the
-/// execution of the parent operation, and which may result in execution completing abruptly).
+/// - If execution of the operation completes abruptly it produces a terminating operation effect. The current
+/// environment is queried with the operation and the terminating operation effect to produce a block effect, and
+/// execution of the block completes abruptly with that block effect (passing the effect to execution of the parent
+/// body). When queried the environment will, according to the operation's specificed behavior, return the terminating
+/// operation effect it was given or translate it to a successor effect.
 ///
-/// If the selected operation is a terminating operation then the terminating operation is executed, producing an
-/// effect, and execution of the block completes with that effect (passing the effect to execution of the parent body).
+/// If the selected operation is a terminating operation then the terminating operation is executed, producing a
+/// block effect, and execution of the block completes with that effect (passing the effect to execution
+/// of the parent body).
 ///
 /// ### Implementing code model behavior
 ///
@@ -740,6 +743,7 @@
 ///     Env bind(Value symbolicValue, Object runtimeValue);
 ///     List<Object> valuesOf(List<? extends Value> symbolicValues);
 ///     Object valueOf(Value symbolicValue);
+///     BlockEffect onAbruptCompletion(Op op, TerminatingOpEffect eff);
 /// }
 /// }
 ///
@@ -796,11 +800,15 @@
 ///         switch (executeOp(op, e)) {
 ///             // operation completed normally, pass control to next operation
 ///             case OpResultEffect eff -> e = e.bind(op.result(), eff.result);
-///             // operation completed abruptly, pass control to parent body
-///             case TerminatingOpEffect eff -> { return eff; }
+///             // operation completed abruptly,
+///             // pass control to parent body or a sibling block
+///             case TerminatingOpEffect eff -> {
+///                 return e.onAbruptCompletion(op, eff);
+///             }
 ///         }
 ///     }
 ///
+///     // pass control to parent body or a sibling block
 ///     return executeTerminatingOp((Op & Op.Terminating) op, e);
 /// }
 /// }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -800,11 +800,8 @@
 ///         switch (executeOp(op, e)) {
 ///             // operation completed normally, pass control to next operation
 ///             case OpResultEffect eff -> e = e.bind(op.result(), eff.result);
-///             // operation completed abruptly,
-///             // pass control to parent body or a sibling block
-///             case TerminatingOpEffect eff -> {
-///                 return e.onAbruptCompletion(op, eff);
-///             }
+///             // operation completed abruptly, pass control to parent body or a sibling block
+///             case TerminatingOpEffect eff -> { return e.onAbruptCompletion(op, eff); }
 ///         }
 ///     }
 ///

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/package-info.java
@@ -723,12 +723,11 @@
 /// - If execution of the operation completes abruptly it produces a terminating operation effect. The current
 /// environment is queried with the operation and the terminating operation effect to produce a block effect, and
 /// execution of the block completes abruptly with that block effect (passing the effect to execution of the parent
-/// body). When queried the environment will, according to the operation's specificed behavior, return the terminating
+/// body). When queried the environment will, according to the operation's specified behavior, return the terminating
 /// operation effect it was given or translate it to a successor effect.
 ///
-/// If the selected operation is a terminating operation then the terminating operation is executed, producing a
-/// block effect, and execution of the block completes with that effect (passing the effect to execution
-/// of the parent body).
+/// If the selected operation is a terminating operation then the terminating operation is executed, producing a block
+/// effect, and execution of the block completes with that effect (passing the effect to execution of the parent body).
 ///
 /// ### Implementing code model behavior
 ///


### PR DESCRIPTION
Update the specification of code model behavior for abrupt completion of an operation.

If a non-terminating operation completes abruptly and produces a terminating operation effect then the current environment is queried with that operation and effect to produce a block effect. Querying may return the given effect or produce a successor effect.

This enhancement in behavior enables support for operations that complete abruptly with an exception and the operation is within an exception region. In such cases a successor effect is produced referencing the catch block that consumes the exception.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1050/head:pull/1050` \
`$ git checkout pull/1050`

Update a local copy of the PR: \
`$ git checkout pull/1050` \
`$ git pull https://git.openjdk.org/babylon.git pull/1050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1050`

View PR using the GUI difftool: \
`$ git pr show -t 1050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1050.diff">https://git.openjdk.org/babylon/pull/1050.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1050#issuecomment-4547035189)
</details>
