### PR TITLE
Lifting of exception regions decomposed

### DIFF
--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -91,8 +91,6 @@ public final class BytecodeLift {
     private final Block.Builder entryBlock;
     private final List<Value> initialValues;
     private final ClassModel classModel;
-    // All try ranges with their exception table handlers
-    private final List<ExceptionRegion> exceptionRegions;
     // Cached blocks that enter a handler from a region stack
     private final Map<CatchTargetKey, Block.Builder> exceptionHandlerBlocks;
     // Cached blocks that enter regions at a bytecode index
@@ -108,7 +106,6 @@ public final class BytecodeLift {
     private final List<CodeElement> elements;
     private final Deque<Value> stack;
     private final Deque<ClassDesc> newStack;
-    private final List<ExceptionCatch> ecs;
     // Bytecode index for each exception table handler
     private final List<Integer> handlerBcis;
     // Converts classfile labels to bytecode indexes
@@ -135,11 +132,10 @@ public final class BytecodeLift {
                 sma.entries().stream().collect(Collectors.toUnmodifiableMap(
                         smfi -> label2Bci.applyAsInt(smfi.target()),
                         smfi -> entryBlock.block(toBlockParams(smfi.stack()))))).orElseGet(Map::of);
-        this.ecs = codeModel.exceptionHandlers();
         this.handlerBcis = new ArrayList<>();
         record RegionKey(int start, int end) {}
         Map<RegionKey, List<Integer>> grouped = new LinkedHashMap<>();
-        for (ExceptionCatch ec : ecs) {
+        for (ExceptionCatch ec : codeModel.exceptionHandlers()) {
             int handler = handlerBcis.size();
             handlerBcis.add(label2Bci.applyAsInt(ec.handler()));
             grouped.computeIfAbsent(new RegionKey(label2Bci.applyAsInt(ec.tryStart()), label2Bci.applyAsInt(ec.tryEnd())), _ -> new ArrayList<>())
@@ -149,13 +145,12 @@ public final class BytecodeLift {
         for (var c : grouped.entrySet()) {
             regions.add(new ExceptionRegion(regions.size(), c.getKey().start(), c.getKey().end(), c.getValue()));
         }
-        this.exceptionRegions = regions;
         this.exceptionRegionsMap = new HashMap<>();
         List<ExceptionRegion> previous = List.of();
         for (CodeElement e : elements) {
             if (e instanceof LabelTarget lt) {
                 int bci = label2Bci.applyAsInt(lt.label());
-                List<ExceptionRegion> next = exceptionRegions.stream()
+                List<ExceptionRegion> next = regions.stream()
                         .filter(er -> er.start() <= bci && bci < er.end())
                         .sorted()
                         .toList();
@@ -181,7 +176,7 @@ public final class BytecodeLift {
     }
 
     // Cache key for a handler reached from a concrete region stack
-    record CatchTargetKey(int erIndex, int handler, List<Op.Result> enteredRegions) {}
+    record CatchTargetKey(int handler, List<Op.Result> enteredRegions) {}
     // Find where the active region stack changes in bytecode
 
 
@@ -264,16 +259,16 @@ public final class BytecodeLift {
                         if (target != null) {
                             if (currentBlock != null) {
                                 // Transition to a branch target or a handler
-                                exitRegions(actualEreStack, currentBlock, targetEntryBlock(bci, target), stackValues(target));
+                                exitRegions(actualEreStack, currentBlock, targetEntryBlock(bci), stackValues(target));
                             }
                             actualEreStack = enteredRegionStacks.getOrDefault(target, List.of());
                             currentBlock = target;
                             stack.clear();
                             stack.addAll(target.parameters());
-                        } else if (currentBlock != null && !activeRegions(actualEreStack).equals(newEreStack)) {
+                        } else if (currentBlock != null && !actualEreStack.stream().map(enteredRegionMap::get).toList().equals(newEreStack)) {
                             // Transition to a block with a different ERE stack
                             Block.Builder next = entryBlock.block();
-                            actualEreStack = ereTransit(actualEreStack, newEreStack, currentBlock, next, List.of());
+                            actualEreStack = ereTransit(newEreStack, next);
                             currentBlock = next;
                         }
                     }
@@ -281,9 +276,7 @@ public final class BytecodeLift {
                 case BranchInstruction inst when isUnconditionalBranch(inst.opcode()) -> {
                     int targetBci = label2Bci.applyAsInt(inst.target());
                     Block.Builder target = blockMap.get(targetBci);
-                    if (target != null) {
-                        exitRegions(actualEreStack, currentBlock, targetEntryBlock(targetBci, target), stackValues(target));
-                    }
+                    exitRegions(actualEreStack, currentBlock, targetEntryBlock(targetBci), stackValues(target));
                     endOfFlow();
                 }
                 case BranchInstruction inst -> {
@@ -308,7 +301,7 @@ public final class BytecodeLift {
                         case IF_ACMPNE -> JavaOp.eq(stack.pop(), operand);
                         default -> throw new UnsupportedOperationException("Unsupported branch instruction: " + inst);
                     };
-                    Block.Builder branch = targetBlockForBranch(inst.target());
+                    Block.Builder branch = transitionBlockForTarget(actualEreStack, label2Bci.applyAsInt(inst.target()));
                     Block.Builder next = entryBlock.block();
                     op(CoreOp.conditionalBranch(op(cop),
                             next.reference(),
@@ -848,18 +841,18 @@ public final class BytecodeLift {
             v = op(JavaOp.conv(PrimitiveType.INT, v));
         }
         SwitchCase last = cases.getLast();
-        Block.Builder def = targetBlockForBranch(defaultTarget);
+        Block.Builder def = transitionBlockForTarget(actualEreStack, label2Bci.applyAsInt(defaultTarget));
         for (SwitchCase sc : cases) {
             if (sc == last) {
                 op(CoreOp.conditionalBranch(
                         op(JavaOp.eq(v, liftConstant(sc.caseValue()))),
-                        successorWithStack(targetBlockForBranch(sc.target())),
+                        successorWithStack(transitionBlockForTarget(actualEreStack, label2Bci.applyAsInt(sc.target()))),
                         successorWithStack(def)));
             } else {
                 Block.Builder next = entryBlock.block();
                 op(CoreOp.conditionalBranch(
                         op(JavaOp.eq(v, liftConstant(sc.caseValue()))),
-                        successorWithStack(targetBlockForBranch(sc.target())),
+                        successorWithStack(transitionBlockForTarget(actualEreStack, label2Bci.applyAsInt(sc.target()))),
                         next.reference()));
                 currentBlock = next;
             }
@@ -878,133 +871,111 @@ public final class BytecodeLift {
         actualEreStack = List.of();
     }
 
-    // Return a cached transition block for one exception handler
-    private Block.Builder targetBlockForExceptionHandler(List<Op.Result> initialEreStack, int erIndex, int handler) {
-        CatchTargetKey key = new CatchTargetKey(erIndex, handler, List.copyOf(initialEreStack));
-        Block.Builder target = exceptionHandlerBlocks.get(key);
-        if (target == null) { // Avoid ConcurrentModificationException
-            target = transitionBlockForTarget(initialEreStack, handlerBcis.get(handler));
-            exceptionHandlerBlocks.put(key, target);
-        }
-        return target;
-    }
-
-    private Block.Builder targetBlockForBranch(Label targetLabel) {
-        return transitionBlockForTarget(actualEreStack, label2Bci.applyAsInt(targetLabel));
-    }
-
     // Create a block that exits regions before it reaches the target
     private Block.Builder transitionBlockForTarget(List<Op.Result> initialEreStack, int targetBci) {
         Block.Builder targetBlock = blockMap.get(targetBci);
         if (targetBlock == null) return null;
         Block.Builder transitionBlock = newBlock(targetBlock.parameters());
-        exitRegions(initialEreStack, transitionBlock, targetEntryBlock(targetBci, targetBlock), transitionBlock.parameters());
+        exitRegions(initialEreStack, transitionBlock, targetEntryBlock(targetBci), transitionBlock.parameters());
         return transitionBlock;
     }
 
     // Return a block that enters regions needed by the target
-    private Block.Builder targetEntryBlock(int bci, Block.Builder targetBlock) {
+    private Block.Builder targetEntryBlock(int bci) {
+        Block.Builder targetBlock = blockMap.get(bci);
         List<ExceptionRegion> targetEreStack = exceptionRegionsMap.getOrDefault(bci, List.of());
         if (targetEreStack.isEmpty()) {
             enteredRegionStacks.putIfAbsent(targetBlock, List.of());
             return targetBlock;
         }
         Block.Builder enterBlock = labelEntryBlocks.get(bci);
-        if (enterBlock != null) {
-            return enterBlock;
+        if (enterBlock == null) {  // Avoid ConcurrentModificationException
+            enterBlock = newBlock(targetBlock.parameters());
+            labelEntryBlocks.put(bci, enterBlock);
+            List<Op.Result> ereStack = new ArrayList<>();
+            Block.Builder currentBlock = enterBlock;
+            for (int i = 0; i < targetEreStack.size(); i++) {
+                boolean last = i == targetEreStack.size() - 1;
+                Block.Builder nextBlock = last ? targetBlock : newBlock(targetBlock.parameters());
+                Block.Reference nextReference = nextBlock.reference(currentBlock.parameters());
+                ExceptionRegion entered = targetEreStack.get(i);
+                Op.Result enter = currentBlock.add(JavaOp.exceptionRegionEnter(nextReference, catchReferences(ereStack, entered)));
+                enteredRegionMap.put(enter, entered);
+                ereStack.add(enter);
+                currentBlock = nextBlock;
+            }
+            enteredRegionStacks.putIfAbsent(targetBlock, List.copyOf(ereStack));
         }
-        enterBlock = newBlock(targetBlock.parameters());
-        labelEntryBlocks.put(bci, enterBlock);
-        List<Op.Result> ereStack = new ArrayList<>();
-        Block.Builder currentBlock = enterBlock;
-        for (int i = 0; i < targetEreStack.size(); i++) {
-            boolean last = i == targetEreStack.size() - 1;
-            Block.Builder nextBlock = last ? targetBlock : newBlock(targetBlock.parameters());
-            Block.Reference nextReference = nextBlock.reference(currentBlock.parameters());
-            ExceptionRegion entered = targetEreStack.get(i);
-            Op.Result enter = currentBlock.add(JavaOp.exceptionRegionEnter(
-                    nextReference,
-                    catchReferences(ereStack, entered)));
-            enteredRegionMap.put(enter, entered);
-            ereStack.add(enter);
-            currentBlock = nextBlock;
-        }
-        enteredRegionStacks.putIfAbsent(targetBlock, List.copyOf(ereStack));
         return enterBlock;
     }
 
     // Emit exits from innermost region to outermost region
-    private void exitRegions(List<Op.Result> initialEreStack, Block.Builder initialBlock,
-                             Block.Builder targetBlock, List<? extends Value> values) {
+    private void exitRegions(List<Op.Result> initialEreStack, Block.Builder initialBlock, Block.Builder targetBlock,
+                             List<? extends Value> values) {
         if (initialEreStack.isEmpty()) {
             initialBlock.add(CoreOp.branch(targetBlock.reference(values)));
-            return;
-        }
-
-        Block.Builder currentBlock = initialBlock;
-        for (int i = initialEreStack.size() - 1; i >= 0; i--) {
-            boolean last = i == 0;
-            Block.Builder nextBlock = last ? targetBlock : entryBlock.block();
-            Block.Reference nextReference = last ? nextBlock.reference(values) : nextBlock.reference();
-            currentBlock.add(JavaOp.exceptionRegionExit(initialEreStack.get(i), nextReference));
-            currentBlock = nextBlock;
+        } else {
+            Block.Builder currentBlock = initialBlock;
+            for (int i = initialEreStack.size() - 1; i >= 0; i--) {
+                boolean last = i == 0;
+                Block.Builder nextBlock = last ? targetBlock : entryBlock.block();
+                Block.Reference nextReference = last ? nextBlock.reference(values) : nextBlock.reference();
+                currentBlock.add(JavaOp.exceptionRegionExit(initialEreStack.get(i), nextReference));
+                currentBlock = nextBlock;
+            }
         }
     }
 
     // Move from one region stack to another
-    private List<Op.Result> ereTransit(List<Op.Result> initialEreStack, List<ExceptionRegion> targetEreStack,
-                                       Block.Builder initialBlock, Block.Builder targetBlock, List<? extends Value> values) {
+    private List<Op.Result> ereTransit(List<ExceptionRegion> targetEreStack, Block.Builder targetBlock) {
         int common = 0;
-        int limit = Math.min(initialEreStack.size(), targetEreStack.size());
-        while (common < limit && enteredRegionMap.get(initialEreStack.get(common)) == targetEreStack.get(common)) {
+        int limit = Math.min(actualEreStack.size(), targetEreStack.size());
+        while (common < limit && enteredRegionMap.get(actualEreStack.get(common)) == targetEreStack.get(common)) {
             common++;
         }
-        int exits = initialEreStack.size() - common;
+        int exits = actualEreStack.size() - common;
         int enters = targetEreStack.size() - common;
         if (exits == 0 && enters == 0) {
             // Join with branch
-            initialBlock.add(CoreOp.branch(targetBlock.reference(values)));
-            enteredRegionStacks.putIfAbsent(targetBlock, initialEreStack);
-            return initialEreStack;
+            currentBlock.add(CoreOp.branch(targetBlock.reference()));
+            enteredRegionStacks.putIfAbsent(targetBlock, actualEreStack);
+            return actualEreStack;
         }
-        List<Op.Result> ereStack = new ArrayList<>(initialEreStack);
-        Block.Builder currentBlock = initialBlock;
+        List<Op.Result> ereStack = new ArrayList<>(actualEreStack);
+        Block.Builder block = currentBlock;
         int transitionCount = exits + enters;
         for (int t = 0; t < transitionCount; t++) {
             boolean last = t == transitionCount - 1;
             Block.Builder nextBlock = last ? targetBlock : entryBlock.block();
-            Block.Reference nextReference = last ? nextBlock.reference(values) : nextBlock.reference();
+            Block.Reference nextReference = nextBlock.reference();
             if (t < exits) {
-                Op.Result exited = ereStack.removeLast();
-                currentBlock.add(JavaOp.exceptionRegionExit(exited, nextReference));
+                block.add(JavaOp.exceptionRegionExit(ereStack.removeLast(), nextReference));
             } else {
                 ExceptionRegion entered = targetEreStack.get(common + t - exits);
-                Op.Result enter = currentBlock.add(JavaOp.exceptionRegionEnter(nextReference,
-                                                                              catchReferences(ereStack, entered)));
+                Op.Result enter = block.add(JavaOp.exceptionRegionEnter(nextReference, catchReferences(ereStack, entered)));
                 enteredRegionMap.put(enter, entered);
                 ereStack.add(enter);
             }
-            currentBlock = nextBlock;
+            block = nextBlock;
         }
-        List<Op.Result> enteredStack = List.copyOf(ereStack);
-        enteredRegionStacks.putIfAbsent(targetBlock, enteredStack);
-        return enteredStack;
+        enteredRegionStacks.putIfAbsent(targetBlock, ereStack);
+        return ereStack;
     }
 
     // Build catch targets for one enter op
     private List<Block.Reference> catchReferences(List<Op.Result> initialEreStack, ExceptionRegion enteredRegion) {
         List<Block.Reference> catchReferences = new ArrayList<>();
+        List<Op.Result> enteredRegions = List.copyOf(initialEreStack);
         for (int handler : enteredRegion.handlers().reversed()) {
-            catchReferences.add(targetBlockForExceptionHandler(initialEreStack, enteredRegion.index, handler).reference());
+            CatchTargetKey key = new CatchTargetKey(handler, enteredRegions);
+            Block.Builder target = exceptionHandlerBlocks.get(key);
+            if (target == null) { // Avoid ConcurrentModificationException
+                target = transitionBlockForTarget(enteredRegions, handlerBcis.get(handler));
+                exceptionHandlerBlocks.put(key, target);
+            }
+            catchReferences.add(target.reference());
         }
         return catchReferences;
-    }
-
-    // Convert enter results to their regions
-    private List<ExceptionRegion> activeRegions(List<Op.Result> enteredRegions) {
-        return enteredRegions.stream().map((Op.Result enter) -> {
-            return enteredRegionMap.get(enter);
-        }).toList();
     }
 
     Block.Reference successorWithStack(Block.Builder next) {

--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -968,10 +968,11 @@ public final class BytecodeLift {
         List<Block.Reference> catchReferences = new ArrayList<>();
         List<Op.Result> enteredRegions = List.copyOf(initialEreStack);
         for (int handler : enteredRegion.handlers().reversed()) {
+            int handlerBci = handlerBcis.get(handler);
             CatchTargetKey key = new CatchTargetKey(handler, enteredRegions);
             Block.Builder target = exceptionHandlerBlocks.get(key);
             if (target == null) { // Avoid ConcurrentModificationException
-                target = transitionBlockForTarget(enteredRegions, handlerBcis.get(handler));
+                target = transitionBlockForTarget(enteredRegions, handlerBci);
                 exceptionHandlerBlocks.put(key, target);
             }
             catchReferences.add(target.reference());

--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -228,14 +228,15 @@ public final class BytecodeLift {
         if (!methodModel.flags().has(AccessFlag.STATIC)) {
             mDesc = mDesc.insertParameterTypes(0, classModel.thisClass().asSymbol());
         }
-        return NormalizeBlocksTransformer.transform(
-                UnresolvedTypesTransformer.transform(
-                    SlotToVarTransformer.transform(
-                        CoreOp.func(methodModel.methodName().stringValue(),
-                                    MethodRef.ofNominalDescriptor(mDesc)).body(entryBlock ->
-                                            new BytecodeLift(entryBlock,
-                                                             classModel,
-                                                             methodModel.code().orElseThrow()).liftBody()))));
+        return ExceptionRegionsTransformer.transform(
+                NormalizeBlocksTransformer.transform(
+                    UnresolvedTypesTransformer.transform(
+                        SlotToVarTransformer.transform(
+                            CoreOp.func(methodModel.methodName().stringValue(),
+                                        MethodRef.ofNominalDescriptor(mDesc)).body(entryBlock ->
+                                                new BytecodeLift(entryBlock,
+                                                                 classModel,
+                                                                 methodModel.code().orElseThrow()).liftBody())))));
     }
 
     private void liftBody() {

--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -228,7 +228,7 @@ public final class BytecodeLift {
         if (!methodModel.flags().has(AccessFlag.STATIC)) {
             mDesc = mDesc.insertParameterTypes(0, classModel.thisClass().asSymbol());
         }
-        return ExceptionRegionsTransformer.transform(
+        return NormalizeExceptionRegionsTransformer.transform(
                 NormalizeBlocksTransformer.transform(
                     UnresolvedTypesTransformer.transform(
                         SlotToVarTransformer.transform(

--- a/test/jdk/jdk/incubator/code/bytecode/lift/ExceptionRegionsTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/ExceptionRegionsTransformer.java
@@ -27,6 +27,35 @@ import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.JavaOp;
 
+/// Normalizes consecutive lifted fragments of the same original exception region
+///
+/// Lifted:
+///           entry
+///             |
+///     enter R#1 handler H
+///        /          \
+/// protected A    protected B
+///      |              |
+///   exit R#1       exit R#1
+///      |              |
+/// branch adapter branch adapter
+///        \          /
+///     enter R#2 handler H
+///             |
+///        protected C
+///             |
+///          exit R#2
+///
+/// Normalized:
+///           entry
+///             |
+///     enter R handler H
+///        /         \
+/// protected A   protected B
+///        \         /
+///        protected C
+///             |
+///           exit R
 final class ExceptionRegionsTransformer implements CodeTransformer {
 
     private boolean modified;
@@ -34,6 +63,7 @@ final class ExceptionRegionsTransformer implements CodeTransformer {
     static CoreOp.FuncOp transform(CoreOp.FuncOp func) {
         var t = new ExceptionRegionsTransformer();
         do {
+            // Nested regions are exposed after the top are collapsed
             t.modified = false;
             func = func.transform(t);
         } while (t.modified);
@@ -42,6 +72,7 @@ final class ExceptionRegionsTransformer implements CodeTransformer {
 
     @Override
     public void acceptBlock(Block.Builder builder, Block b) {
+        // Skip blocks whose terminating op was mapped by a previous collapse
         if (!builder.context().queryValue(b.terminatingOp().result()).isPresent()) {
             CodeTransformer.super.acceptBlock(builder, b);
         }
@@ -49,25 +80,80 @@ final class ExceptionRegionsTransformer implements CodeTransformer {
 
     @Override
     public Block.Builder acceptOp(Block.Builder builder, Op op) {
-        if (op instanceof JavaOp.ExceptionRegionExit exit
-                && exit.endReference().targetBlock().ops().size() == 1
-                && exit.endReference().targetBlock().terminatingOp() instanceof JavaOp.ExceptionRegionEnter enter
-                && !exit.endReference().targetBlock().predecessors().isEmpty()
-                && exit.endReference().targetBlock().predecessors().stream().allMatch(predecessor ->
-                    predecessor.terminatingOp() instanceof JavaOp.ExceptionRegionExit e
-                            && e.endReference().targetBlock() == exit.endReference().targetBlock()
-                            && e.enterOp() == exit.enterOp())
-                && exit.enterOp().catchReferences().stream().map(Block.Reference::targetBlock).toList()
-                        .equals(enter.catchReferences().stream().map(Block.Reference::targetBlock).toList())
-                && enter.result().isDominatedBy(exit.enterOp().result())) {
-            var cc = builder.context();
-            cc.mapValue(enter.result(), cc.getValue(exit.enterOp().result()));
-            cc.mapValues(exit.endReference().targetBlock().parameters(), cc.getValues(exit.endReference().arguments()));
-            builder.add(CoreOp.branch(cc.getReferenceOrCreate(enter.startReference())));
-            modified = true;
-        } else {
+        // Collapse matching exit/re-enter boundaries
+        if (!(op instanceof JavaOp.ExceptionRegionExit exit) || !collapseExitToReenter(builder, exit)) {
             builder.add(op);
         }
         return builder;
+    }
+
+    private boolean collapseExitToReenter(Block.Builder builder, JavaOp.ExceptionRegionExit exit) {
+        // Match exit -> optional branch adapter -> re-enter
+        JavaOp.ExceptionRegionEnter exitedEnter = exit.enterOp();
+        Block exitTarget = exit.endReference().targetBlock();
+        CoreOp.BranchOp adapterBranch = asBranchAdapter(exitTarget);
+        Block enterBlock = adapterBranch == null ? exitTarget : adapterBranch.branch().targetBlock();
+
+        if (enterBlock.ops().size() != 1
+                || !(enterBlock.terminatingOp() instanceof JavaOp.ExceptionRegionEnter reenter)
+                || !isExitTargetOf(exitTarget, exitedEnter)
+                || (adapterBranch != null && !isOnlyReachedByExitAdapters(enterBlock, exitedEnter))
+                || !sameCatchTargets(exitedEnter, reenter)
+                || !reenter.result().isDominatedBy(exitedEnter.result())) {
+            return false;
+        }
+
+        // Reuse the old enter result and skip the adapter blocks
+        var cc = builder.context();
+        cc.mapValue(reenter.result(), cc.getValue(exitedEnter.result()));
+        cc.mapValues(exitTarget.parameters(), cc.getValues(exit.endReference().arguments()));
+        if (adapterBranch != null) {
+            cc.mapValues(enterBlock.parameters(), cc.getValues(adapterBranch.branch().arguments()));
+        }
+        Op.Result result = builder.add(CoreOp.branch(cc.getReferenceOrCreate(reenter.startReference())));
+        if (adapterBranch != null) {
+            cc.mapValue(adapterBranch.result(), result);
+        }
+        modified = true;
+        return true;
+    }
+
+    // Return a pure branch adapter, if this block is one
+    private static CoreOp.BranchOp asBranchAdapter(Block block) {
+        return block.ops().size() == 1 && block.terminatingOp() instanceof CoreOp.BranchOp branch
+                ? branch
+                : null;
+    }
+
+    // All predecessors must exit the same enter
+    private static boolean isExitTargetOf(Block block, JavaOp.ExceptionRegionEnter enter) {
+        return !block.predecessors().isEmpty()
+                && block.predecessors().stream().allMatch(predecessor ->
+                        predecessor.terminatingOp() instanceof JavaOp.ExceptionRegionExit e
+                                && e.endReference().targetBlock() == block
+                                && e.enterOp() == enter);
+    }
+
+    // Several branch adapters may feed the same re-enter block
+    private static boolean isOnlyReachedByExitAdapters(Block block, JavaOp.ExceptionRegionEnter enter) {
+        return block.predecessors().stream().allMatch(predecessor ->
+                predecessor.terminatingOp() instanceof CoreOp.BranchOp branch
+                        && branch.branch().targetBlock() == block
+                        && isExitTargetOf(predecessor, enter));
+    }
+
+    // Compare real handler targets, not adapter blocks
+    private static boolean sameCatchTargets(JavaOp.ExceptionRegionEnter first, JavaOp.ExceptionRegionEnter second) {
+        return first.catchReferences().stream().map(ExceptionRegionsTransformer::skipBranchAdapter).toList()
+                .equals(second.catchReferences().stream().map(ExceptionRegionsTransformer::skipBranchAdapter).toList());
+    }
+
+    // Peel one branch adapter
+    private static Block skipBranchAdapter(Block.Reference reference) {
+        Block target = reference.targetBlock();
+        CoreOp.BranchOp adapterBranch = asBranchAdapter(target);
+        return adapterBranch != null
+                ? adapterBranch.branch().targetBlock()
+                : target;
     }
 }

--- a/test/jdk/jdk/incubator/code/bytecode/lift/ExceptionRegionsTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/ExceptionRegionsTransformer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.code.Block;
+import jdk.incubator.code.CodeTransformer;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.java.JavaOp;
+
+final class ExceptionRegionsTransformer implements CodeTransformer {
+
+    private boolean modified;
+
+    static CoreOp.FuncOp transform(CoreOp.FuncOp func) {
+        var t = new ExceptionRegionsTransformer();
+        do {
+            t.modified = false;
+            func = func.transform(t);
+        } while (t.modified);
+        return func;
+    }
+
+    @Override
+    public void acceptBlock(Block.Builder builder, Block b) {
+        if (!builder.context().queryValue(b.terminatingOp().result()).isPresent()) {
+            CodeTransformer.super.acceptBlock(builder, b);
+        }
+    }
+
+    @Override
+    public Block.Builder acceptOp(Block.Builder builder, Op op) {
+        if (op instanceof JavaOp.ExceptionRegionExit exit
+                && exit.endReference().targetBlock().ops().size() == 1
+                && exit.endReference().targetBlock().terminatingOp() instanceof JavaOp.ExceptionRegionEnter enter
+                && !exit.endReference().targetBlock().predecessors().isEmpty()
+                && exit.endReference().targetBlock().predecessors().stream().allMatch(predecessor ->
+                    predecessor.terminatingOp() instanceof JavaOp.ExceptionRegionExit e
+                            && e.endReference().targetBlock() == exit.endReference().targetBlock()
+                            && e.enterOp() == exit.enterOp())
+                && exit.enterOp().catchReferences().stream().map(Block.Reference::targetBlock).toList()
+                        .equals(enter.catchReferences().stream().map(Block.Reference::targetBlock).toList())
+                && enter.result().isDominatedBy(exit.enterOp().result())) {
+            var cc = builder.context();
+            cc.mapValue(enter.result(), cc.getValue(exit.enterOp().result()));
+            cc.mapValues(exit.endReference().targetBlock().parameters(), cc.getValues(exit.endReference().arguments()));
+            builder.add(CoreOp.branch(cc.getReferenceOrCreate(enter.startReference())));
+            modified = true;
+        } else {
+            builder.add(op);
+        }
+        return builder;
+    }
+}

--- a/test/jdk/jdk/incubator/code/bytecode/lift/NormalizeExceptionRegionsTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/NormalizeExceptionRegionsTransformer.java
@@ -54,7 +54,7 @@ final class NormalizeExceptionRegionsTransformer implements CodeTransformer {
     static FuncOp transform(FuncOp func) {
         var t = new NormalizeExceptionRegionsTransformer();
         do {
-            // Nested regions are exposed after the top are collapsed
+            // Inner regions are exposed after the outer are collapsed
             t.modified = false;
             func = func.transform(t);
         } while (t.modified);

--- a/test/jdk/jdk/incubator/code/bytecode/lift/NormalizeExceptionRegionsTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/NormalizeExceptionRegionsTransformer.java
@@ -25,43 +25,34 @@ import jdk.incubator.code.Block;
 import jdk.incubator.code.CodeTransformer;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.core.CoreOp;
-import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.core.CoreOp.*;
+import jdk.incubator.code.dialect.java.JavaOp.*;
 
-/// Normalizes consecutive lifted fragments of the same original exception region
+/// Normalizes lifted fragments of the same exception region
 ///
-/// Lifted:
+/// ```
 ///           entry
 ///             |
 ///     enter R#1 handler H
-///        /          \
-/// protected A    protected B
-///      |              |
-///   exit R#1       exit R#1
-///      |              |
-/// branch adapter branch adapter
-///        \          /
-///     enter R#2 handler H
-///             |
+///        /          \                         entry
+/// protected A    protected B                    |
+///      |              |                 enter R handler H
+///   exit R#1       exit R#1                /         \
+///      |              |         ->  protected A   protected B
+/// branch adapter branch adapter             \         /
+///        \          /                       protected C
+///     enter R#2 handler H                       |
+///             |                               exit R
 ///        protected C
 ///             |
 ///          exit R#2
-///
-/// Normalized:
-///           entry
-///             |
-///     enter R handler H
-///        /         \
-/// protected A   protected B
-///        \         /
-///        protected C
-///             |
-///           exit R
-final class ExceptionRegionsTransformer implements CodeTransformer {
+/// ```
+final class NormalizeExceptionRegionsTransformer implements CodeTransformer {
 
     private boolean modified;
 
-    static CoreOp.FuncOp transform(CoreOp.FuncOp func) {
-        var t = new ExceptionRegionsTransformer();
+    static FuncOp transform(FuncOp func) {
+        var t = new NormalizeExceptionRegionsTransformer();
         do {
             // Nested regions are exposed after the top are collapsed
             t.modified = false;
@@ -81,28 +72,26 @@ final class ExceptionRegionsTransformer implements CodeTransformer {
     @Override
     public Block.Builder acceptOp(Block.Builder builder, Op op) {
         // Collapse matching exit/re-enter boundaries
-        if (!(op instanceof JavaOp.ExceptionRegionExit exit) || !collapseExitToReenter(builder, exit)) {
+        if (!(op instanceof ExceptionRegionExit exit) || !collapseExitToReenter(builder, exit)) {
             builder.add(op);
         }
         return builder;
     }
 
-    private boolean collapseExitToReenter(Block.Builder builder, JavaOp.ExceptionRegionExit exit) {
+    private boolean collapseExitToReenter(Block.Builder builder, ExceptionRegionExit exit) {
         // Match exit -> optional branch adapter -> re-enter
-        JavaOp.ExceptionRegionEnter exitedEnter = exit.enterOp();
+        ExceptionRegionEnter exitedEnter = exit.enterOp();
         Block exitTarget = exit.endReference().targetBlock();
-        CoreOp.BranchOp adapterBranch = asBranchAdapter(exitTarget);
+        BranchOp adapterBranch = asBranchAdapter(exitTarget);
         Block enterBlock = adapterBranch == null ? exitTarget : adapterBranch.branch().targetBlock();
-
         if (enterBlock.ops().size() != 1
-                || !(enterBlock.terminatingOp() instanceof JavaOp.ExceptionRegionEnter reenter)
+                || !(enterBlock.terminatingOp() instanceof ExceptionRegionEnter reenter)
                 || !isExitTargetOf(exitTarget, exitedEnter)
                 || (adapterBranch != null && !isOnlyReachedByExitAdapters(enterBlock, exitedEnter))
                 || !sameCatchTargets(exitedEnter, reenter)
                 || !reenter.result().isDominatedBy(exitedEnter.result())) {
             return false;
         }
-
         // Reuse the old enter result and skip the adapter blocks
         var cc = builder.context();
         cc.mapValue(reenter.result(), cc.getValue(exitedEnter.result()));
@@ -118,40 +107,40 @@ final class ExceptionRegionsTransformer implements CodeTransformer {
         return true;
     }
 
-    // Return a pure branch adapter, if this block is one
-    private static CoreOp.BranchOp asBranchAdapter(Block block) {
-        return block.ops().size() == 1 && block.terminatingOp() instanceof CoreOp.BranchOp branch
+    // Return a branch adapter, if this block is one
+    private static BranchOp asBranchAdapter(Block block) {
+        return block.ops().size() == 1 && block.terminatingOp() instanceof BranchOp branch
                 ? branch
                 : null;
     }
 
     // All predecessors must exit the same enter
-    private static boolean isExitTargetOf(Block block, JavaOp.ExceptionRegionEnter enter) {
+    private static boolean isExitTargetOf(Block block, ExceptionRegionEnter enter) {
         return !block.predecessors().isEmpty()
                 && block.predecessors().stream().allMatch(predecessor ->
-                        predecessor.terminatingOp() instanceof JavaOp.ExceptionRegionExit e
+                        predecessor.terminatingOp() instanceof ExceptionRegionExit e
                                 && e.endReference().targetBlock() == block
                                 && e.enterOp() == enter);
     }
 
     // Several branch adapters may feed the same re-enter block
-    private static boolean isOnlyReachedByExitAdapters(Block block, JavaOp.ExceptionRegionEnter enter) {
+    private static boolean isOnlyReachedByExitAdapters(Block block, ExceptionRegionEnter enter) {
         return block.predecessors().stream().allMatch(predecessor ->
-                predecessor.terminatingOp() instanceof CoreOp.BranchOp branch
+                predecessor.terminatingOp() instanceof BranchOp branch
                         && branch.branch().targetBlock() == block
                         && isExitTargetOf(predecessor, enter));
     }
 
-    // Compare real handler targets, not adapter blocks
-    private static boolean sameCatchTargets(JavaOp.ExceptionRegionEnter first, JavaOp.ExceptionRegionEnter second) {
-        return first.catchReferences().stream().map(ExceptionRegionsTransformer::skipBranchAdapter).toList()
-                .equals(second.catchReferences().stream().map(ExceptionRegionsTransformer::skipBranchAdapter).toList());
+    // Compare real handler targets
+    private static boolean sameCatchTargets(ExceptionRegionEnter first, ExceptionRegionEnter second) {
+        return first.catchReferences().stream().map(NormalizeExceptionRegionsTransformer::skipBranchAdapter).toList()
+                .equals(second.catchReferences().stream().map(NormalizeExceptionRegionsTransformer::skipBranchAdapter).toList());
     }
 
-    // Peel one branch adapter
+    // Skip one branch adapter
     private static Block skipBranchAdapter(Block.Reference reference) {
         Block target = reference.targetBlock();
-        CoreOp.BranchOp adapterBranch = asBranchAdapter(target);
+        BranchOp adapterBranch = asBranchAdapter(target);
         return adapterBranch != null
                 ? adapterBranch.branch().targetBlock()
                 : target;

--- a/test/jdk/jdk/incubator/code/bytecode/lift/NormalizeExceptionRegionsTransformer.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/NormalizeExceptionRegionsTransformer.java
@@ -118,17 +118,13 @@ final class NormalizeExceptionRegionsTransformer implements CodeTransformer {
     private static boolean isExitTargetOf(Block block, ExceptionRegionEnter enter) {
         return !block.predecessors().isEmpty()
                 && block.predecessors().stream().allMatch(predecessor ->
-                        predecessor.terminatingOp() instanceof ExceptionRegionExit e
-                                && e.endReference().targetBlock() == block
-                                && e.enterOp() == enter);
+                        predecessor.terminatingOp() instanceof ExceptionRegionExit e && e.enterOp() == enter);
     }
 
     // Several branch adapters may feed the same re-enter block
     private static boolean isOnlyReachedByExitAdapters(Block block, ExceptionRegionEnter enter) {
         return block.predecessors().stream().allMatch(predecessor ->
-                predecessor.terminatingOp() instanceof BranchOp branch
-                        && branch.branch().targetBlock() == block
-                        && isExitTargetOf(predecessor, enter));
+                predecessor.terminatingOp() instanceof BranchOp branch && isExitTargetOf(predecessor, enter));
     }
 
     // Compare real handler targets

--- a/test/jdk/jdk/incubator/code/bytecode/lift/TestBytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/TestBytecodeLift.java
@@ -638,7 +638,11 @@ public class TestBytecodeLift {
     @MethodSource("testMethods")
     public void testLift(TestData d) throws Throwable {
         CoreOp.FuncOp flift = lift(CLASS_DATA, d);
+        var errors = Verifier.verify(MethodHandles.lookup(), flift);
+        Assertions.assertTrue(errors.isEmpty(), errors.toString());
         CoreOp.FuncOp secondRound = lift(BytecodeGenerator.generateClassData(MethodHandles.lookup(), flift), d);
+        errors = Verifier.verify(MethodHandles.lookup(), secondRound);
+        Assertions.assertTrue(errors.isEmpty(), errors.toString());
         try {
             Object receiver1, receiver2, receiver3;
             if (d.testMethod.accessFlags().contains(AccessFlag.STATIC)) {

--- a/test/jdk/jdk/incubator/code/bytecode/lift/TestSmallCorpus.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/TestSmallCorpus.java
@@ -55,8 +55,6 @@ public class TestSmallCorpus {
     private static final String ROOT_PATH = "modules/java.base/";
     private static final String CLASS_NAME_SUFFIX = ".class";
     private static final String METHOD_NAME = null;
-    private static final int ROUNDS = 1;
-    private static final boolean TEST_STABILITY = false;
 
     private static final FileSystem JRT = FileSystems.getFileSystem(URI.create("jrt:/"));
     private static final ClassFile CF = ClassFile.of();
@@ -78,30 +76,38 @@ public class TestSmallCorpus {
     private Long[] stats = new Long[6];
 
     @Test
-    public void testRoundTripStability() throws Exception {
+    public void testRoundTrip() throws Exception {
+        for (Path p : Files.walk(JRT.getPath(ROOT_PATH))
+                .filter(p -> Files.isRegularFile(p) && p.toString().endsWith(CLASS_NAME_SUFFIX))
+                .toList()) {
+            testRoundTrips(p, false, 1);
+        }
+    }
+
+    @Test
+    @Disabled
+    public void testStability() throws Exception {
         stable = 0;
         unstable = 0;
         Arrays.fill(stats, 0l);
         for (Path p : Files.walk(JRT.getPath(ROOT_PATH))
                 .filter(p -> Files.isRegularFile(p) && p.toString().endsWith(CLASS_NAME_SUFFIX))
                 .toList()) {
-            testRoundTrips(p);
+            testRoundTrips(p, true, 3);
         }
+        System.out.println("""
+        statistics     original  generated
+        code length: %1$,10d %4$,10d
+        max locals:  %2$,10d %5$,10d
+        max stack:   %3$,10d %6$,10d
+        """.formatted((Object[])stats));
 
-        if (TEST_STABILITY) {
-            System.out.println("""
-            statistics     original  generated
-            code length: %1$,10d %4$,10d
-            max locals:  %2$,10d %5$,10d
-            max stack:   %3$,10d %6$,10d
-            """.formatted((Object[])stats));
-
-            // Roundtrip is 100% stable after 3 rounds, no exceptions, no verification errors
-            Assertions.assertTrue(stable > 54500 && unstable == 0, String.format("stable: %d unstable: %d", stable, unstable));
-        }
+        // 3-rounds stability is actually 85%, target is 95%
+        int stability = 100 * stable / (stable + unstable);
+        Assertions.assertTrue(stability > 95, "3-rounds stability is " + stability + "%");
     }
 
-    private void testRoundTrips(Path path) throws Exception {
+    private void testRoundTrips(Path path, boolean testStability, int rounds) throws Exception {
         var clm = CF.parse(path);
         for (var originalModel : clm.methods()) {
             if (originalModel.code().isPresent() && (METHOD_NAME == null || originalModel.methodName().equalsString(METHOD_NAME))) try {
@@ -109,7 +115,7 @@ public class TestSmallCorpus {
                 reflection = null;
                 MethodModel prevBytecode = null;
                 CoreOp.FuncOp prevReflection = null;
-                for (int round = 1; round <= ROUNDS; round++) try {
+                for (int round = 1; round <= rounds; round++) try {
                     prevBytecode = bytecode;
                     prevReflection = reflection;
                     lift();
@@ -122,14 +128,14 @@ public class TestSmallCorpus {
                     System.out.println(" at " + path + " " + originalModel.methodName() + originalModel.methodType() + " round " + round);
                     throw t;
                 }
-                if (TEST_STABILITY) {
+                if (testStability) {
                     var normPrevBytecode = normalize(prevBytecode);
                     var normBytecode = normalize(bytecode);
                     if (normPrevBytecode.equals(normBytecode)) {
                         stable++;
                     } else {
                         unstable++;
-                        System.out.println("Unstable code " + path + " " + originalModel.methodName() + originalModel.methodType() + " after " + ROUNDS +" round(s)");
+                        System.out.println("Unstable code " + path + " " + originalModel.methodName() + originalModel.methodType() + " after " + rounds +" round(s)");
                         if (prevReflection != null) printInColumns(prevReflection, reflection);
                         printInColumns(normPrevBytecode, normBytecode);
                         System.out.println();


### PR DESCRIPTION
This PR contains the following changes:

- `BytecodeLift` splits exception regions into basic fragments and transition adapter blocks
- `NormalizeExceptionRegionsTransformer` merges compatible fragments using dominance checks
- `TestBytecodeLift` now verifies lifted models
- `TestSmallCorpus` is split into `testRoundtrip` and temporarily disabled `testStability`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [d5881b48](https://git.openjdk.org/babylon/pull/1052/files/d5881b48d54fbafdcfc25ade52ea0c6339b819d3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1052/head:pull/1052` \
`$ git checkout pull/1052`

Update a local copy of the PR: \
`$ git checkout pull/1052` \
`$ git pull https://git.openjdk.org/babylon.git pull/1052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1052`

View PR using the GUI difftool: \
`$ git pr show -t 1052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1052.diff">https://git.openjdk.org/babylon/pull/1052.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1052#issuecomment-4611586426)
</details>
