### PR TITLE
BytecodeGenerator fix of unused join block parameter

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -1376,7 +1376,7 @@ public final class BytecodeGenerator {
             for (int i = 0; i < bargs.size(); i++) {
                 Block.Parameter barg = bargs.get(i);
                 Value value = sargs.get(i);
-                if (!barg.uses().isEmpty() && !barg.equals(value)) {
+                if (!barg.equals(value)) {
                     if (oprOnStack == value) {
                         oprOnStack = null;
                     } else {

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -25,10 +25,13 @@ import jdk.incubator.code.*;
 import jdk.incubator.code.Reflect;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
 import jdk.internal.classfile.components.ClassPrinter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -659,6 +662,59 @@ public class TestBytecode {
             });
             throw e;
         }
+    }
+
+    //func @"f" (%0 : java.type:"int")java.type:"int" -> {
+    //    %1 : java.type:"boolean" = constant @true;
+    //    cbranch %1 ^block_1 ^block_5;
+    //
+    //  ^block_1:
+    //    %2 : java.type:"boolean" = constant @true;
+    //    cbranch %2 ^block_2 ^block_3;
+    //
+    //  ^block_2:
+    //    %3 : java.type:"int" = constant @1;
+    //    %4 : java.type:"int" = add %0 %3;
+    //    branch ^block_4(%4);
+    //
+    //  ^block_3:
+    //    %5 : java.type:"int" = constant @0;
+    //    branch ^block_4(%5);
+    //
+    //  ^block_4(%6 : java.type:"int"):
+    //    branch ^block_6(%6);
+    //
+    //  ^block_5:
+    //    %7 : java.type:"int" = constant @0;
+    //    branch ^block_6(%7);
+    //
+    //  ^block_6(%8 : java.type:"int"):
+    //    %9 : java.type:"int" = constant @0;
+    //    return %9;
+    //};
+    //
+    //block_6 is a join with unused parameter, skipping assignment of %8 left %4 on stack
+    @Test
+    public void testUnusedJoinParameter() throws Throwable {
+        Assertions.assertEquals(0, (int)BytecodeGenerator.generate(MethodHandles.lookup(),
+                CoreOp.func("f", CoreType.functionType(JavaType.INT, JavaType.INT)).body(b -> {
+                    Block.Builder b1 = b.block(), b2 = b.block(), b3 = b.block(), b4 = b.block(JavaType.INT),
+                                  b5 = b.block(), b6 = b.block(JavaType.INT);
+                    b.add(CoreOp.conditionalBranch(
+                            b.add(CoreOp.constant(JavaType.BOOLEAN, true)), b1.reference(), b5.reference()));
+                    b1.add(CoreOp.conditionalBranch(
+                            b1.add(CoreOp.constant(JavaType.BOOLEAN, true)), b2.reference(), b3.reference()));
+                    b2.add(CoreOp.branch(b4.reference(
+                            b2.add(JavaOp.add(b.parameters().getFirst(),
+                                    b2.add(CoreOp.constant(JavaType.INT, 1)))))));
+                    b3.add(CoreOp.branch(b4.reference(
+                            b3.add(CoreOp.constant(JavaType.INT, 0)))));
+                    b4.add(CoreOp.branch(b6.reference(b4.parameters().getFirst())));
+                    b5.add(CoreOp.branch(b6.reference(
+                            b5.add(CoreOp.constant(JavaType.INT, 0)))));
+                    b6.add(CoreOp.return_(
+                            b6.add(CoreOp.constant(JavaType.INT, 0))));
+                })).invokeExact(1));
     }
 
     private static void assertEquals(Object expected, Object actual) {


### PR DESCRIPTION
Fixes bytecode generation when a value is passed to an unused join parameter.

The generator has to consume that incoming value or stack map generation fails on stack mismatch.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1062/head:pull/1062` \
`$ git checkout pull/1062`

Update a local copy of the PR: \
`$ git checkout pull/1062` \
`$ git pull https://git.openjdk.org/babylon.git pull/1062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1062`

View PR using the GUI difftool: \
`$ git pr show -t 1062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1062.diff">https://git.openjdk.org/babylon/pull/1062.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1062#issuecomment-4708773051)
</details>
