### PR TITLE
Structural ops primary validation

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -40,6 +40,8 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static jdk.incubator.code.internal.Util.*;
+
 /**
  * The top-level operation class for core operations.
  * <p>
@@ -122,17 +124,14 @@ public sealed abstract class CoreOp extends Op {
         final Body body;
 
         FuncOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalStateException("Bad op " + def.name());
-            }
+            requireNoOperands(def);
+            Object v = requireAttribute(def, ATTRIBUTE_FUNC_NAME, true);
+            String funcName = switch (v) {
+                case String s -> s;
+                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_FUNC_NAME, v);
+            };
 
-            String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
-                    v -> switch (v) {
-                        case String s -> s;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
-                    });
-
-            this(funcName, def.bodyDefinitions().get(0));
+            this(funcName, requireSingleBody(def));
         }
 
         FuncOp(FuncOp that, CodeContext cc, CodeTransformer ct) {
@@ -241,11 +240,11 @@ public sealed abstract class CoreOp extends Op {
         final CodeType resultType;
 
         FuncCallOp(ExternalizedOp def) {
-            String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
-                    v -> switch (v) {
-                        case String s -> s;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
-                    });
+            Object v = requireAttribute(def, ATTRIBUTE_FUNC_NAME, true);
+            String funcName = switch (v) {
+                case String s -> s;
+                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_FUNC_NAME, v);
+            };
 
             this(funcName, def.resultType(), def.operands());
         }
@@ -308,11 +307,8 @@ public sealed abstract class CoreOp extends Op {
         final Body body;
 
         ModuleOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalStateException("Bad op " + def.name());
-            }
-
-            this(def.bodyDefinitions().get(0));
+            requireNoOperands(def);
+            this(requireSingleBody(def));
         }
 
         ModuleOp(ModuleOp that, CodeContext cc, CodeTransformer ct) {
@@ -527,7 +523,8 @@ public sealed abstract class CoreOp extends Op {
         final Op quotedOp;
 
         QuotedOp(ExternalizedOp def) {
-            this(def.bodyDefinitions().get(0));
+            requireNoOperands(def);
+            this(requireSingleBody(def));
         }
 
         QuotedOp(QuotedOp that, CodeContext cc, CodeTransformer ct) {
@@ -602,9 +599,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "return";
 
         ReturnOp(ExternalizedOp def) {
-            if (def.operands().size() > 1) {
-                throw new IllegalArgumentException("Operation must have zero or one operand " + def.name());
-            }
+            requireOperands(def, 0, 1);
 
             this(def.operands().isEmpty() ? null : def.operands().get(0));
         }
@@ -655,10 +650,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "unreachable";
 
         UnreachableOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalArgumentException("Operation must zero operands " + def.name());
-            }
-
+            requireNoOperands(def);
             this();
         }
 
@@ -695,9 +687,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "yield";
 
         YieldOp(ExternalizedOp def) {
-            if (def.operands().size() > 1) {
-                throw new IllegalArgumentException("Operation must have zero or one operand " + def.name());
-            }
+            requireOperands(def, 0, 1);
 
             this(def.operands());
         }
@@ -753,9 +743,8 @@ public sealed abstract class CoreOp extends Op {
         final Block.Reference branch;
 
         BranchOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty() || def.successors().size() != 1) {
-                throw new IllegalArgumentException("Operation must have zero arguments and one successor" + def.name());
-            }
+            requireNoOperands(def);
+            requireSuccessors(def, 1);
 
             this(def.successors().get(0));
         }
@@ -815,9 +804,8 @@ public sealed abstract class CoreOp extends Op {
         final Block.Reference falseBranch;
 
         ConditionalBranchOp(ExternalizedOp def) {
-            if (def.operands().size() != 1 || def.successors().size() != 2) {
-                throw new IllegalArgumentException("Operation must one operand and two successors" + def.name());
-            }
+            requireOperands(def, 1);
+            requireSuccessors(def, 2);
 
             this(def.operands().getFirst(), def.successors().get(0), def.successors().get(1));
         }
@@ -896,17 +884,12 @@ public sealed abstract class CoreOp extends Op {
         final CodeType resultType;
 
         ConstantOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalArgumentException("Operation must have zero operands");
-            }
-
-            Object value = def.extractAttributeValue(ATTRIBUTE_CONSTANT_VALUE, true,
-                    v -> processConstantValue(def.resultType(), v));
-
-            this(def.resultType(), value);
+            requireNoOperands(def);
+            Object v = requireAttribute(def, ATTRIBUTE_CONSTANT_VALUE, true);
+            this(def.resultType(), processConstantValue(def, def.resultType(), v));
         }
 
-        static Object processConstantValue(CodeType t, Object value) {
+        static Object processConstantValue(ExternalizedOp def, CodeType t, Object value) {
             if (t.equals(JavaType.BOOLEAN) && value instanceof Boolean) {
                 return value;
             } else if (t.equals(JavaType.BYTE) && value instanceof Number n) {
@@ -933,7 +916,7 @@ public sealed abstract class CoreOp extends Op {
                 return null; // null constant
             }
 
-            throw new UnsupportedOperationException("Unsupported constant type and value: " + t + " " + value);
+            throw unsupportedAttributeValueException(def, ATTRIBUTE_CONSTANT_VALUE, value);
         }
 
         ConstantOp(ConstantOp that, CodeContext cc) {
@@ -1028,22 +1011,22 @@ public sealed abstract class CoreOp extends Op {
         final VarType resultType;
 
         VarOp(ExternalizedOp def) {
-            if (def.operands().size() > 1) {
-                throw new IllegalStateException("Operation must have zero or one operand");
-            }
-
+            requireOperands(def, 0, 1);
             String name = def.extractAttributeValue(ATTRIBUTE_NAME, true,
                     v -> switch (v) {
-                        case String s -> s;
-                        case null -> "";
-                        default -> throw new UnsupportedOperationException("Unsupported var name value:" + v);
-                    });
+                case String s -> s;
+                case null -> "";
+                default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_NAME, v);
+            });
 
             // @@@ Cannot use canonical constructor because type is wrapped
             super(def.operands());
 
             this.varName = name;
-            this.resultType = (VarType) def.resultType();
+            if (!(def.resultType() instanceof VarType vt)) {
+                throw structuralException(def, "invalid result type: " + def.resultType());
+            }
+            this.resultType = vt;
         }
 
         VarOp(VarOp that, CodeContext cc) {
@@ -1169,9 +1152,10 @@ public sealed abstract class CoreOp extends Op {
             return (VarOp) varValue.op();
         }
 
-        static void checkIsVarOp(Value varValue) {
+        static void checkIsVarOp(ExternalizedOp opdef) {
+            Value varValue = opdef.operands().getFirst();
             if (!(varValue.type() instanceof VarType)) {
-                throw new IllegalArgumentException("Value's type is not a variable type: " + varValue);
+                throw structuralException(opdef, "value's type is not a variable type: " + varValue);
             }
         }
 
@@ -1191,10 +1175,8 @@ public sealed abstract class CoreOp extends Op {
             static final String NAME = "var.load";
 
             VarLoadOp(ExternalizedOp opdef) {
-                if (opdef.operands().size() != 1) {
-                    throw new IllegalArgumentException("Operation must have one operand");
-                }
-                checkIsVarOp(opdef.operands().get(0));
+                requireOperands(opdef, 1);
+                checkIsVarOp(opdef);
 
                 this(opdef.operands().get(0));
             }
@@ -1235,10 +1217,8 @@ public sealed abstract class CoreOp extends Op {
             static final String NAME = "var.store";
 
             VarStoreOp(ExternalizedOp opdef) {
-                if (opdef.operands().size() != 2) {
-                    throw new IllegalArgumentException("Operation must have two operands");
-                }
-                checkIsVarOp(opdef.operands().get(0));
+                requireOperands(opdef, 2);
+                checkIsVarOp(opdef);
 
                 this(opdef.operands().get(0), opdef.operands().get(1));
             }
@@ -1337,15 +1317,12 @@ public sealed abstract class CoreOp extends Op {
         final int index;
 
         TupleLoadOp(ExternalizedOp def) {
-            if (def.operands().size() != 1) {
-                throw new IllegalStateException("Operation must have one operand");
-            }
-
-            int index = def.extractAttributeValue(ATTRIBUTE_INDEX, true,
-                    v -> switch (v) {
-                        case Integer i -> i;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported tuple index value:" + v);
-                    });
+            requireOperands(def, 1);
+            Object v = requireAttribute(def, ATTRIBUTE_INDEX, true);
+            int index = switch (v) {
+                case Integer i -> i;
+                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INDEX, v);
+            };
 
             this(def.operands().get(0), index);
         }
@@ -1417,15 +1394,13 @@ public sealed abstract class CoreOp extends Op {
         final int index;
 
         TupleWithOp(ExternalizedOp def) {
-            if (def.operands().size() != 2) {
-                throw new IllegalStateException("Operation must have two operands");
-            }
+            requireOperands(def, 2);
 
-            int index = def.extractAttributeValue(ATTRIBUTE_INDEX, true,
-                    v -> switch (v) {
-                        case Integer i -> i;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported tuple index value:" + v);
-                    });
+            Object v = requireAttribute(def, ATTRIBUTE_INDEX, true);
+            int index = switch (v) {
+                case Integer i -> i;
+                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INDEX, v);
+            };
 
             this(def.operands().get(0), index, def.operands().get(1));
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -587,9 +587,8 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "return";
 
         ReturnOp(ExternalizedOp def) {
-            requireOperands(def, 0, 1);
-
-            this(def.operands().isEmpty() ? null : def.operands().get(0));
+            List<Value> operands = requireOperands(def, 0, 1);
+            this(operands.isEmpty() ? null : operands.getFirst());
         }
 
         ReturnOp(ReturnOp that, CodeContext cc) {
@@ -994,16 +993,15 @@ public sealed abstract class CoreOp extends Op {
         final VarType resultType;
 
         VarOp(ExternalizedOp def) {
-            requireOperands(def, 0, 1);
-            String name = def.extractAttributeValue(ATTRIBUTE_NAME, true,
-                    v -> switch (v) {
+            List<Value> operands = requireOperands(def, 0, 1);
+            String name = def.extractAttributeValue(ATTRIBUTE_NAME, true, v -> switch (v) {
                 case String s -> s;
                 case null -> "";
                 default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_NAME, v);
             });
 
             // @@@ Cannot use canonical constructor because type is wrapped
-            super(def.operands());
+            super(operands);
 
             this.varName = name;
             if (!(def.resultType() instanceof VarType vt)) {
@@ -1135,8 +1133,7 @@ public sealed abstract class CoreOp extends Op {
             return (VarOp) varValue.op();
         }
 
-        static void checkIsVarOp(ExternalizedOp opdef) {
-            Value varValue = opdef.operands().getFirst();
+        static void checkIsVarOp(ExternalizedOp opdef, Value varValue) {
             if (!(varValue.type() instanceof VarType)) {
                 throw structuralException(opdef, "value's type is not a variable type: " + varValue);
             }
@@ -1158,9 +1155,9 @@ public sealed abstract class CoreOp extends Op {
             static final String NAME = "var.load";
 
             VarLoadOp(ExternalizedOp opdef) {
-                checkIsVarOp(opdef);
-
-                this(requireSingleOperand(opdef));
+                Value varValue = requireSingleOperand(opdef);
+                checkIsVarOp(opdef, varValue);
+                this(varValue);
             }
 
             VarLoadOp(VarLoadOp that, CodeContext cc) {
@@ -1200,8 +1197,7 @@ public sealed abstract class CoreOp extends Op {
 
             VarStoreOp(ExternalizedOp opdef) {
                 List<Value> operands = requireOperands(opdef, 2);
-                checkIsVarOp(opdef);
-
+                checkIsVarOp(opdef, operands.getFirst());
                 super(operands);
             }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -40,7 +40,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static jdk.incubator.code.internal.Util.*;
+import static jdk.incubator.code.internal.StructuralPreconditions.*;
 
 /**
  * The top-level operation class for core operations.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -125,13 +125,7 @@ public sealed abstract class CoreOp extends Op {
 
         FuncOp(ExternalizedOp def) {
             requireNoOperands(def);
-            Object v = requireAttribute(def, ATTRIBUTE_FUNC_NAME, true);
-            String funcName = switch (v) {
-                case String s -> s;
-                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_FUNC_NAME, v);
-            };
-
-            this(funcName, requireSingleBody(def));
+            this(requireAttribute(def, ATTRIBUTE_FUNC_NAME, true, String.class), requireSingleBody(def));
         }
 
         FuncOp(FuncOp that, CodeContext cc, CodeTransformer ct) {
@@ -240,13 +234,7 @@ public sealed abstract class CoreOp extends Op {
         final CodeType resultType;
 
         FuncCallOp(ExternalizedOp def) {
-            Object v = requireAttribute(def, ATTRIBUTE_FUNC_NAME, true);
-            String funcName = switch (v) {
-                case String s -> s;
-                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_FUNC_NAME, v);
-            };
-
-            this(funcName, def.resultType(), def.operands());
+            this(requireAttribute(def, ATTRIBUTE_FUNC_NAME, true, String.class), def.resultType(), def.operands());
         }
 
         FuncCallOp(FuncCallOp that, CodeContext cc) {
@@ -744,9 +732,7 @@ public sealed abstract class CoreOp extends Op {
 
         BranchOp(ExternalizedOp def) {
             requireNoOperands(def);
-            requireSuccessors(def, 1);
-
-            this(def.successors().get(0));
+            this(requireSingleSuccessor(def));
         }
 
         BranchOp(BranchOp that, CodeContext cc) {
@@ -804,10 +790,8 @@ public sealed abstract class CoreOp extends Op {
         final Block.Reference falseBranch;
 
         ConditionalBranchOp(ExternalizedOp def) {
-            requireOperands(def, 1);
-            requireSuccessors(def, 2);
-
-            this(def.operands().getFirst(), def.successors().get(0), def.successors().get(1));
+            List<Block.Reference> succ = requireSuccessors(def, 2);
+            this(requireSingleOperand(def), succ.get(0), succ.get(1));
         }
 
         ConditionalBranchOp(ConditionalBranchOp that, CodeContext cc) {
@@ -915,7 +899,6 @@ public sealed abstract class CoreOp extends Op {
             } else if (value == ExternalizedOp.NULL_ATTRIBUTE_VALUE) {
                 return null; // null constant
             }
-
             throw unsupportedAttributeValueException(def, ATTRIBUTE_CONSTANT_VALUE, value);
         }
 
@@ -1175,10 +1158,9 @@ public sealed abstract class CoreOp extends Op {
             static final String NAME = "var.load";
 
             VarLoadOp(ExternalizedOp opdef) {
-                requireOperands(opdef, 1);
                 checkIsVarOp(opdef);
 
-                this(opdef.operands().get(0));
+                this(requireSingleOperand(opdef));
             }
 
             VarLoadOp(VarLoadOp that, CodeContext cc) {
@@ -1217,18 +1199,14 @@ public sealed abstract class CoreOp extends Op {
             static final String NAME = "var.store";
 
             VarStoreOp(ExternalizedOp opdef) {
-                requireOperands(opdef, 2);
+                List<Value> operands = requireOperands(opdef, 2);
                 checkIsVarOp(opdef);
 
-                this(opdef.operands().get(0), opdef.operands().get(1));
+                super(operands);
             }
 
             VarStoreOp(VarStoreOp that, CodeContext cc) {
                 super(that, cc);
-            }
-
-            VarStoreOp(List<Value> values) {
-                super(values);
             }
 
             @Override
@@ -1317,14 +1295,7 @@ public sealed abstract class CoreOp extends Op {
         final int index;
 
         TupleLoadOp(ExternalizedOp def) {
-            requireOperands(def, 1);
-            Object v = requireAttribute(def, ATTRIBUTE_INDEX, true);
-            int index = switch (v) {
-                case Integer i -> i;
-                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INDEX, v);
-            };
-
-            this(def.operands().get(0), index);
+            this(requireSingleOperand(def), requireAttribute(def, ATTRIBUTE_INDEX, true, Integer.class));
         }
 
         TupleLoadOp(TupleLoadOp that, CodeContext cc) {
@@ -1394,15 +1365,8 @@ public sealed abstract class CoreOp extends Op {
         final int index;
 
         TupleWithOp(ExternalizedOp def) {
-            requireOperands(def, 2);
-
-            Object v = requireAttribute(def, ATTRIBUTE_INDEX, true);
-            int index = switch (v) {
-                case Integer i -> i;
-                case null, default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INDEX, v);
-            };
-
-            this(def.operands().get(0), index, def.operands().get(1));
+            super(requireOperands(def, 2));
+            this.index = requireAttribute(def, ATTRIBUTE_INDEX, true, Integer.class);
         }
 
         TupleWithOp(TupleWithOp that, CodeContext cc) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -1133,7 +1133,7 @@ public sealed abstract class CoreOp extends Op {
             return (VarOp) varValue.op();
         }
 
-        static void checkIsVarOp(ExternalizedOp opdef, Value varValue) {
+        static void requireVarOp(ExternalizedOp opdef, Value varValue) {
             if (!(varValue.type() instanceof VarType)) {
                 throw structuralException(opdef, "value's type is not a variable type: " + varValue);
             }
@@ -1156,7 +1156,7 @@ public sealed abstract class CoreOp extends Op {
 
             VarLoadOp(ExternalizedOp opdef) {
                 Value varValue = requireSingleOperand(opdef);
-                checkIsVarOp(opdef, varValue);
+                requireVarOp(opdef, varValue);
                 this(varValue);
             }
 
@@ -1197,7 +1197,7 @@ public sealed abstract class CoreOp extends Op {
 
             VarStoreOp(ExternalizedOp opdef) {
                 List<Value> operands = requireOperands(opdef, 2);
-                checkIsVarOp(opdef, operands.getFirst());
+                requireVarOp(opdef, operands.getFirst());
                 super(operands);
             }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -490,7 +490,8 @@ public sealed abstract class JavaOp extends Op {
             boolean isReflectable = def.extractAttributeValue(ATTRIBUTE_LAMBDA_IS_REFLECTABLE,
                     false, v -> switch (v) {
                         case Boolean b -> b;
-                        case null, default -> false;
+                        case null -> false;
+                        default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_LAMBDA_IS_REFLECTABLE, v);
                     });
 
             this(def.resultType(), requireSingleBody(def), isReflectable);
@@ -998,7 +999,8 @@ public sealed abstract class JavaOp extends Op {
             boolean isVarArgs = def.extractAttributeValue(ATTRIBUTE_INVOKE_VARARGS,
                     false, v -> switch (v) {
                         case Boolean b -> b;
-                        case null, default -> false;
+                        case null -> false;
+                        default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_VARARGS, v);
                     });
 
             // If not present and is not varargs defaults to class or instance invocation
@@ -1007,7 +1009,7 @@ public sealed abstract class JavaOp extends Op {
                     false, v -> switch (v) {
                         case String s -> InvokeKind.valueOf(s);
                         case InvokeKind k -> k;
-                        case null, default -> {
+                        case null -> {
                             if (isVarArgs) {
                                 // If varargs then we cannot infer invoke kind
                                 throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_KIND, v);
@@ -1018,6 +1020,7 @@ public sealed abstract class JavaOp extends Op {
                                     ? InvokeKind.INSTANCE
                                     : InvokeKind.STATIC;
                         }
+                        default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_KIND, v);
                     });
 
 
@@ -1231,7 +1234,8 @@ public sealed abstract class JavaOp extends Op {
             boolean isVarArgs = def.extractAttributeValue(ATTRIBUTE_NEW_VARARGS,
                     false, v -> switch (v) {
                         case Boolean b -> b;
-                        case null, default -> false;
+                        case null -> false;
+                        default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_NEW_VARARGS, v);
                     });
 
             this(isVarArgs, def.resultType(), constructorRef, def.operands());
@@ -1586,9 +1590,8 @@ public sealed abstract class JavaOp extends Op {
             static final String NAME = "array.store";
 
             ArrayStoreOp(ExternalizedOp def) {
-                requireOperands(def, 3);
-
-                this(def.operands().get(0), def.operands().get(1), def.operands().get(2));
+                List<Value> operands = requireOperands(def, 3);
+                this(operands.get(0), operands.get(1), operands.get(2));
             }
 
             ArrayStoreOp(ArrayStoreOp that, CodeContext cc) {
@@ -1832,7 +1835,7 @@ public sealed abstract class JavaOp extends Op {
 
         ExceptionRegionExit(ExternalizedOp def) {
             Value enter = requireSingleOperand(def);
-            if (!(enter.asResult().op() instanceof ExceptionRegionEnter)) {
+            if (!(enter instanceof Op.Result or && or.op() instanceof ExceptionRegionEnter)) {
                 throw structuralException(def, "Value's is not an exception region entry: " + def.operands().getFirst());
             }
             this(enter, requireSingleSuccessor(def));
@@ -1898,8 +1901,8 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConcatOp(ExternalizedOp def) {
-            requireOperands(def, 2);
-            this(def.operands().get(0), def.operands().get(1));
+            List<Value> operands = requireOperands(def, 2);
+            this(operands.get(0), operands.get(1));
         }
 
         ConcatOp(Value lhs, Value rhs) {
@@ -5207,11 +5210,13 @@ public sealed abstract class JavaOp extends Op {
         final Body finallyBody;
 
         TryOp(ExternalizedOp def) {
-            //@@@ The scan must first require at least one body and handle "no void body" structurally.
             List<Body.Builder> bodies = requireMinBodies(def, 1);
             int bodyIndex = 0;
-            while (!bodies.get(bodyIndex).bodySignature().returnType().equals(VOID)) {
+            while (bodyIndex < bodies.size() && !bodies.get(bodyIndex).bodySignature().returnType().equals(VOID)) {
                 bodyIndex++;
+            }
+            if (bodyIndex == bodies.size()) {
+                throw structuralException(def, "no void try body found");
             }
             List<Body.Builder> resources = bodies.subList(0, bodyIndex);
             Body.Builder body = bodies.get(bodyIndex);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -52,7 +52,7 @@ import static jdk.incubator.code.dialect.core.CoreOp.*;
 import static jdk.incubator.code.dialect.java.JavaType.*;
 import static jdk.incubator.code.dialect.java.JavaType.VOID;
 import static jdk.incubator.code.internal.ArithmeticAndConvOpImpls.*;
-import static jdk.incubator.code.internal.Util.*;
+import static jdk.incubator.code.internal.StructuralPreconditions.*;
 
 /**
  * The top-level operation class for Java operations.

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -52,6 +52,7 @@ import static jdk.incubator.code.dialect.core.CoreOp.*;
 import static jdk.incubator.code.dialect.java.JavaType.*;
 import static jdk.incubator.code.dialect.java.JavaType.VOID;
 import static jdk.incubator.code.internal.ArithmeticAndConvOpImpls.*;
+import static jdk.incubator.code.internal.Util.*;
 
 /**
  * The top-level operation class for Java operations.
@@ -492,7 +493,7 @@ public sealed abstract class JavaOp extends Op {
                         case null, default -> false;
                     });
 
-            this(def.resultType(), def.bodyDefinitions().get(0), isReflectable);
+            this(def.resultType(), requireSingleBody(def), isReflectable);
         }
 
         LambdaOp(LambdaOp that, CodeContext cc, CodeTransformer ct) {
@@ -767,11 +768,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "throw";
 
         ThrowOp(ExternalizedOp def) {
-            if (def.operands().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one operand " + def.name());
-            }
-
-            this(def.operands().get(0));
+            this(requireSingleOperand(def));
         }
 
         ThrowOp(ThrowOp that, CodeContext cc) {
@@ -822,7 +819,7 @@ public sealed abstract class JavaOp extends Op {
         private final List<Body> bodies;
 
         AssertOp(ExternalizedOp def) {
-            this(def.bodyDefinitions());
+            this(requireBodies(def, 1, 2));
         }
 
         AssertOp(List<Body.Builder> bodies) {
@@ -901,11 +898,7 @@ public sealed abstract class JavaOp extends Op {
             static final String NAME = "monitor.enter";
 
             MonitorEnterOp(ExternalizedOp def) {
-                if (def.operands().size() != 1) {
-                    throw new IllegalArgumentException("Operation must have one operand " + def.name());
-                }
-
-                this(def.operands().get(0));
+                this(requireSingleOperand(def));
             }
 
             MonitorEnterOp(MonitorEnterOp that, CodeContext cc) {
@@ -930,11 +923,7 @@ public sealed abstract class JavaOp extends Op {
             static final String NAME = "monitor.exit";
 
             MonitorExitOp(ExternalizedOp def) {
-                if (def.operands().size() != 1) {
-                    throw new IllegalArgumentException("Operation must have one operand " + def.name());
-                }
-
-                this(def.operands().get(0));
+                this(requireSingleOperand(def));
             }
 
             MonitorExitOp(MonitorExitOp that, CodeContext cc) {
@@ -1003,12 +992,7 @@ public sealed abstract class JavaOp extends Op {
 
         InvokeOp(ExternalizedOp def) {
             // Required attribute
-            MethodRef invokeRef = def.extractAttributeValue(ATTRIBUTE_INVOKE_REF,
-                    true, v -> switch (v) {
-                        case MethodRef md -> md;
-                        case null, default ->
-                                throw new UnsupportedOperationException("Unsupported invoke reference value:" + v);
-                    });
+            MethodRef invokeRef = requireAttribute(def, ATTRIBUTE_INVOKE_REF, true, MethodRef.class);
 
             // If not present defaults to false
             boolean isVarArgs = def.extractAttributeValue(ATTRIBUTE_INVOKE_VARARGS,
@@ -1026,7 +1010,7 @@ public sealed abstract class JavaOp extends Op {
                         case null, default -> {
                             if (isVarArgs) {
                                 // If varargs then we cannot infer invoke kind
-                                throw new UnsupportedOperationException("Unsupported invoke kind value:" + v);
+                                throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_KIND, v);
                             }
                             int paramCount = invokeRef.signature().parameterTypes().size();
                             int argCount = def.operands().size();
@@ -1178,7 +1162,7 @@ public sealed abstract class JavaOp extends Op {
         final CodeType resultType;
 
         ConvOp(ExternalizedOp def) {
-            this(def.resultType(), def.operands().get(0));
+            this(def.resultType(), requireSingleOperand(def));
         }
 
         ConvOp(ConvOp that, CodeContext cc) {
@@ -1241,12 +1225,7 @@ public sealed abstract class JavaOp extends Op {
 
         NewOp(ExternalizedOp def) {
             // Required attribute
-            MethodRef constructorRef = def.extractAttributeValue(ATTRIBUTE_NEW_REF,
-                    true, v -> switch (v) {
-                        case MethodRef cd -> cd;
-                        case null, default ->
-                                throw new UnsupportedOperationException("Unsupported constructor reference value:" + v);
-                    });
+            MethodRef constructorRef = requireAttribute(def, ATTRIBUTE_NEW_REF, true, MethodRef.class);
 
             // If not present defaults to false
             boolean isVarArgs = def.extractAttributeValue(ATTRIBUTE_NEW_VARARGS,
@@ -1388,19 +1367,7 @@ public sealed abstract class JavaOp extends Op {
             final CodeType resultType;
 
             FieldLoadOp(ExternalizedOp def) {
-                if (def.operands().size() > 1) {
-                    throw new IllegalArgumentException("Operation must accept zero or one operand");
-                }
-
-                FieldRef fieldRef = def.extractAttributeValue(ATTRIBUTE_FIELD_REF, true,
-                        v -> switch (v) {
-                            case FieldRef fd -> fd;
-                            case null, default ->
-                                    throw new UnsupportedOperationException("Unsupported field reference value:" + v);
-                        });
-
-                super(def.operands(), fieldRef);
-
+                super(requireOperands(def, 0, 1), requireAttribute(def, ATTRIBUTE_FIELD_REF, true, FieldRef.class));
                 this.resultType = def.resultType();
             }
 
@@ -1449,18 +1416,7 @@ public sealed abstract class JavaOp extends Op {
             static final String NAME = "field.store";
 
             FieldStoreOp(ExternalizedOp def) {
-                if (def.operands().isEmpty() || def.operands().size() > 2) {
-                    throw new IllegalArgumentException("Operation must accept one or two operands");
-                }
-
-                FieldRef fieldRef = def.extractAttributeValue(ATTRIBUTE_FIELD_REF, true,
-                        v -> switch (v) {
-                            case FieldRef fd -> fd;
-                            case null, default ->
-                                    throw new UnsupportedOperationException("Unsupported field reference value:" + v);
-                        });
-
-                super(def.operands(), fieldRef);
+                super(requireOperands(def, 1, 2),  requireAttribute(def, ATTRIBUTE_FIELD_REF, true, FieldRef.class));
             }
 
             FieldStoreOp(FieldStoreOp that, CodeContext cc) {
@@ -1511,7 +1467,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "array.length";
 
         ArrayLengthOp(ExternalizedOp def) {
-            this(def.operands().get(0));
+            this(requireSingleOperand(def));
         }
 
         ArrayLengthOp(ArrayLengthOp that, CodeContext cc) {
@@ -1555,14 +1511,8 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        ArrayAccessOp(Value array, Value index, Value v) {
-            super(operands(array, index, v));
-        }
-
-        static List<Value> operands(Value array, Value index, Value v) {
-            return v == null
-                    ? List.of(array, index)
-                    : List.of(array, index, v);
+        ArrayAccessOp(List<Value> operands) {
+            super(operands);
         }
 
         /**
@@ -1592,11 +1542,8 @@ public sealed abstract class JavaOp extends Op {
             final CodeType componentType;
 
             ArrayLoadOp(ExternalizedOp def) {
-                if (def.operands().size() != 2) {
-                    throw new IllegalArgumentException("Operation must have two operands");
-                }
-
-                this(def.operands().get(0), def.operands().get(1), def.resultType());
+                super(requireOperands(def, 2));
+                this.componentType = def.resultType();
             }
 
             ArrayLoadOp(ArrayLoadOp that, CodeContext cc) {
@@ -1615,7 +1562,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             ArrayLoadOp(Value array, Value index, CodeType componentType) {
-                super(array, index, null);
+                super(List.of(array, index));
                 this.componentType = componentType;
             }
 
@@ -1639,9 +1586,7 @@ public sealed abstract class JavaOp extends Op {
             static final String NAME = "array.store";
 
             ArrayStoreOp(ExternalizedOp def) {
-                if (def.operands().size() != 3) {
-                    throw new IllegalArgumentException("Operation must have two operands");
-                }
+                requireOperands(def, 3);
 
                 this(def.operands().get(0), def.operands().get(1), def.operands().get(2));
             }
@@ -1656,7 +1601,7 @@ public sealed abstract class JavaOp extends Op {
             }
 
             ArrayStoreOp(Value array, Value index, Value v) {
-                super(array, index, v);
+                super(List.of(array, index, v));
             }
 
             /**
@@ -1692,17 +1637,7 @@ public sealed abstract class JavaOp extends Op {
         final CodeType targetType;
 
         InstanceOfOp(ExternalizedOp def) {
-            if (def.operands().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one operand " + def.name());
-            }
-
-            CodeType targetType = def.extractAttributeValue(ATTRIBUTE_INSTANCEOF_TYPE, true,
-                    v -> switch (v) {
-                        case JavaType td -> td;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported type value:" + v);
-                    });
-
-            this(targetType, def.operands().get(0));
+            this(requireAttribute(def, ATTRIBUTE_INSTANCEOF_TYPE, true, JavaType.class), requireSingleOperand(def));
         }
 
         InstanceOfOp(InstanceOfOp that, CodeContext cc) {
@@ -1766,17 +1701,7 @@ public sealed abstract class JavaOp extends Op {
         final CodeType targetType;
 
         CastOp(ExternalizedOp def) {
-            if (def.operands().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one operand " + def.name());
-            }
-
-            CodeType type = def.extractAttributeValue(ATTRIBUTE_CAST_TYPE, true,
-                    v -> switch (v) {
-                        case JavaType td -> td;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported type value:" + v);
-                    });
-
-            this(def.resultType(), type, def.operands().get(0));
+            this(def.resultType(), requireAttribute(def, ATTRIBUTE_CAST_TYPE, true, JavaType.class), requireSingleOperand(def));
         }
 
         CastOp(CastOp that, CodeContext cc) {
@@ -1841,7 +1766,7 @@ public sealed abstract class JavaOp extends Op {
         final List<Block.Reference> references;
 
         ExceptionRegionEnter(ExternalizedOp def) {
-            this(def.successors());
+            this(requireMinSuccessors(def, 2));
         }
 
         ExceptionRegionEnter(ExceptionRegionEnter that, CodeContext cc) {
@@ -1906,19 +1831,11 @@ public sealed abstract class JavaOp extends Op {
         final Block.Reference end;
 
         ExceptionRegionExit(ExternalizedOp def) {
-            if (def.operands().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one operand" + def.name());
+            Value enter = requireSingleOperand(def);
+            if (!(enter.asResult().op() instanceof ExceptionRegionEnter)) {
+                throw structuralException(def, "Value's is not an exception region entry: " + def.operands().getFirst());
             }
-
-            if (!(def.operands().getFirst().asResult().op() instanceof ExceptionRegionEnter)) {
-                throw new IllegalArgumentException("Value's is not an exception region entry: " + def.operands().getFirst());
-            }
-
-            if (def.successors().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one successor" + def.name());
-            }
-
-            this(def.operands().getFirst(), def.successors().getFirst());
+            this(enter, requireSingleSuccessor(def));
         }
 
         ExceptionRegionExit(ExceptionRegionExit that, CodeContext cc) {
@@ -1981,10 +1898,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConcatOp(ExternalizedOp def) {
-            if (def.operands().size() != 2) {
-                throw new IllegalArgumentException("Concatenation Operation must have two operands.");
-            }
-
+            requireOperands(def, 2);
             this(def.operands().get(0), def.operands().get(1));
         }
 
@@ -2043,6 +1957,10 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
+        BinaryOp(ExternalizedOp def) {
+            super(requireOperands(def, 2));
+        }
+
         BinaryOp(Value lhs, Value rhs) {
             super(List.of(lhs, rhs));
         }
@@ -2078,6 +1996,10 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
+        UnaryOp(ExternalizedOp def) {
+            super(requireOperands(def, 1));
+        }
+
         UnaryOp(Value v) {
             super(List.of(v));
         }
@@ -2103,6 +2025,11 @@ public sealed abstract class JavaOp extends Op {
     public sealed static abstract class CompareOp extends ArithmeticOperation {
         CompareOp(CompareOp that, CodeContext cc) {
             super(that, cc);
+        }
+
+        //@@@ as BinaryOp; resultType remains the parent-specific BOOLEAN behavior.
+        CompareOp(ExternalizedOp def) {
+            super(requireOperands(def, 2));
         }
 
         CompareOp(Value lhs, Value rhs) {
@@ -2139,7 +2066,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "add";
 
         AddOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         AddOp(AddOp that, CodeContext cc) {
@@ -2166,7 +2093,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "sub";
 
         SubOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         SubOp(SubOp that, CodeContext cc) {
@@ -2193,7 +2120,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "mul";
 
         MulOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         MulOp(MulOp that, CodeContext cc) {
@@ -2220,7 +2147,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "div";
 
         DivOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         DivOp(DivOp that, CodeContext cc) {
@@ -2247,7 +2174,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "mod";
 
         ModOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         ModOp(ModOp that, CodeContext cc) {
@@ -2275,7 +2202,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "or";
 
         OrOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         OrOp(OrOp that, CodeContext cc) {
@@ -2303,7 +2230,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "and";
 
         AndOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         AndOp(AndOp that, CodeContext cc) {
@@ -2331,7 +2258,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "xor";
 
         XorOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         XorOp(XorOp that, CodeContext cc) {
@@ -2358,7 +2285,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "lshl";
 
         LshlOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         LshlOp(LshlOp that, CodeContext cc) {
@@ -2385,7 +2312,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "ashr";
 
         AshrOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         AshrOp(AshrOp that, CodeContext cc) {
@@ -2412,7 +2339,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "lshr";
 
         LshrOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         LshrOp(LshrOp that, CodeContext cc) {
@@ -2439,7 +2366,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "neg";
 
         NegOp(ExternalizedOp def) {
-            this(def.operands().get(0));
+            super(def);
         }
 
         NegOp(NegOp that, CodeContext cc) {
@@ -2466,7 +2393,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "compl";
 
         ComplOp(ExternalizedOp def) {
-            this(def.operands().get(0));
+            super(def);
         }
 
         ComplOp(ComplOp that, CodeContext cc) {
@@ -2493,7 +2420,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "not";
 
         NotOp(ExternalizedOp def) {
-            this(def.operands().get(0));
+            super(def);
         }
 
         NotOp(NotOp that, CodeContext cc) {
@@ -2521,7 +2448,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "eq";
 
         EqOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         EqOp(EqOp that, CodeContext cc) {
@@ -2549,7 +2476,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "neq";
 
         NeqOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         NeqOp(NeqOp that, CodeContext cc) {
@@ -2576,7 +2503,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "gt";
 
         GtOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         GtOp(GtOp that, CodeContext cc) {
@@ -2604,7 +2531,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "ge";
 
         GeOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         GeOp(GeOp that, CodeContext cc) {
@@ -2632,7 +2559,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "lt";
 
         LtOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         LtOp(LtOp that, CodeContext cc) {
@@ -2660,7 +2587,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "le";
 
         LeOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.operands().get(1));
+            super(def);
         }
 
         LeOp(LeOp that, CodeContext cc) {
@@ -2692,6 +2619,10 @@ public sealed abstract class JavaOp extends Op {
             implements Op.Lowerable, Op.BodyTerminating, JavaStatement {
         StatementTargetOp(StatementTargetOp that, CodeContext cc) {
             super(that, cc);
+        }
+
+        StatementTargetOp(ExternalizedOp def) {
+            super(requireOperands(def, 0, 1));
         }
 
         StatementTargetOp(Value label) {
@@ -2788,7 +2719,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.break";
 
         BreakOp(ExternalizedOp def) {
-            this(def.operands().isEmpty() ? null : def.operands().get(0));
+            super(def);
         }
 
         BreakOp(BreakOp that, CodeContext cc) {
@@ -2822,7 +2753,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.continue";
 
         ContinueOp(ExternalizedOp def) {
-            this(def.operands().isEmpty() ? null : def.operands().get(0));
+            super(def);
         }
 
         ContinueOp(ContinueOp that, CodeContext cc) {
@@ -2859,11 +2790,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.yield";
 
         YieldOp(ExternalizedOp def) {
-            if (def.operands().size() != 1) {
-                throw new IllegalArgumentException("Operation must have one operand " + def.name());
-            }
-
-            this(def.operands().get(0));
+            this(requireSingleOperand(def));
         }
 
         YieldOp(YieldOp that, CodeContext cc) {
@@ -2944,11 +2871,7 @@ public sealed abstract class JavaOp extends Op {
         final Body body;
 
         BlockOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalStateException("Operation must have no operands");
-            }
-
-            this(def.bodyDefinitions().get(0));
+            this(requireSingleBody(def));
         }
 
         BlockOp(BlockOp that, CodeContext cc, CodeTransformer ct) {
@@ -3031,7 +2954,8 @@ public sealed abstract class JavaOp extends Op {
         final Body blockBody;
 
         SynchronizedOp(ExternalizedOp def) {
-            this(def.bodyDefinitions().get(0), def.bodyDefinitions().get(1));
+            List<Body.Builder> bodies = requireBodies(def, 2);
+            this(bodies.get(0), bodies.get(1));
         }
 
         SynchronizedOp(SynchronizedOp that, CodeContext cc, CodeTransformer ct) {
@@ -3195,11 +3119,8 @@ public sealed abstract class JavaOp extends Op {
         final Body body;
 
         LabeledOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalStateException("Operation must have no operands");
-            }
-
-            this(def.bodyDefinitions().get(0));
+            requireNoOperands(def);
+            this(requireSingleBody(def));
         }
 
         LabeledOp(LabeledOp that, CodeContext cc, CodeTransformer ct) {
@@ -3438,11 +3359,9 @@ public sealed abstract class JavaOp extends Op {
         final List<Body> bodies;
 
         IfOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalStateException("Operation must have no operands");
-            }
-
-            this(def.bodyDefinitions());
+            //@@@ Body.Builder list; avoid checking in the external path and again after building.
+            requireNoOperands(def);
+            this(requireMinBodies(def, 2));
         }
 
         IfOp(IfOp that, CodeContext cc, CodeTransformer ct) {
@@ -3588,6 +3507,7 @@ public sealed abstract class JavaOp extends Op {
         JavaSwitchOp(Value target, List<Body.Builder> bodyCs) {
             super(List.of(target));
 
+            //@@@ Externalized switch expression/statement constructors should pass validated target and body pairs here.
             // Each case is modeled as a contiguous pair of bodies
             // The first body models the case labels, and the second models the case statements
             // The labels body has a parameter whose type is target operand's type and returns a boolean value
@@ -3770,7 +3690,7 @@ public sealed abstract class JavaOp extends Op {
         final CodeType resultType;
 
         SwitchExpressionOp(ExternalizedOp def) {
-            this(def.resultType(), def.operands().get(0), def.bodyDefinitions());
+            this(def.resultType(), requireSingleOperand(def), requireBodyPairs(def));
         }
 
         SwitchExpressionOp(SwitchExpressionOp that, CodeContext cc, CodeTransformer ct) {
@@ -3811,7 +3731,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.switch.statement";
 
         SwitchStatementOp(ExternalizedOp def) {
-            this(def.operands().get(0), def.bodyDefinitions());
+            this(requireSingleOperand(def), requireBodyPairs(def));
         }
 
         SwitchStatementOp(SwitchStatementOp that, CodeContext cc, CodeTransformer ct) {
@@ -4040,10 +3960,8 @@ public sealed abstract class JavaOp extends Op {
         final Body loopBody;
 
         ForOp(ExternalizedOp def) {
-            this(def.bodyDefinitions().get(0),
-                    def.bodyDefinitions().get(1),
-                    def.bodyDefinitions().get(2),
-                    def.bodyDefinitions().get(3));
+            List<Body.Builder> bodies = requireBodies(def, 4);
+            this(bodies.get(0), bodies.get(1), bodies.get(2), bodies.get(3));
         }
 
         ForOp(ForOp that, CodeContext cc, CodeTransformer ct) {
@@ -4069,7 +3987,6 @@ public sealed abstract class JavaOp extends Op {
             this.initBody = initC.build(this);
 
             this.condBody = condC.build(this);
-
             this.updateBody = updateC.build(this);
             if (!updateBody.bodySignature().returnType().equals(VOID)) {
                 throw new IllegalArgumentException("Update should return void: " + updateBody.bodySignature());
@@ -4314,9 +4231,8 @@ public sealed abstract class JavaOp extends Op {
         final Body loopBody;
 
         EnhancedForOp(ExternalizedOp def) {
-            this(def.bodyDefinitions().get(0),
-                    def.bodyDefinitions().get(1),
-                    def.bodyDefinitions().get(2));
+            List<Body.Builder> bodies = requireBodies(def, 3);
+            this(bodies.get(0), bodies.get(1), bodies.get(2));
         }
 
         EnhancedForOp(EnhancedForOp that, CodeContext cc, CodeTransformer ct) {
@@ -4544,7 +4460,7 @@ public sealed abstract class JavaOp extends Op {
         private final List<Body> bodies;
 
         WhileOp(ExternalizedOp def) {
-            this(def.bodyDefinitions());
+            this(requireBodies(def, 2));
         }
 
         WhileOp(List<Body.Builder> bodyCs) {
@@ -4707,7 +4623,7 @@ public sealed abstract class JavaOp extends Op {
         private final List<Body> bodies;
 
         DoWhileOp(ExternalizedOp def) {
-            this(def.bodyDefinitions());
+            this(requireBodies(def, 2));
         }
 
         DoWhileOp(List<Body.Builder> bodyCs) {
@@ -4813,6 +4729,10 @@ public sealed abstract class JavaOp extends Op {
 
             // Copy body
             this.bodies = that.bodies.stream().map(b -> b.transform(cc, ct).build(this)).toList();
+        }
+
+        JavaConditionalOp(ExternalizedOp def) {
+            this(requireMinBodies(def, 2));
         }
 
         JavaConditionalOp(List<Body.Builder> bodyCs) {
@@ -4942,7 +4862,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.cand";
 
         ConditionalAndOp(ExternalizedOp def) {
-            this(def.bodyDefinitions());
+            super(def);
         }
 
         ConditionalAndOp(ConditionalAndOp that, CodeContext cc, CodeTransformer ct) {
@@ -5011,7 +4931,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.cor";
 
         ConditionalOrOp(ExternalizedOp def) {
-            this(def.bodyDefinitions());
+            super(def);
         }
 
         ConditionalOrOp(ConditionalOrOp that, CodeContext cc, CodeTransformer ct) {
@@ -5054,11 +4974,7 @@ public sealed abstract class JavaOp extends Op {
         final List<Body> bodies;
 
         ConditionalExpressionOp(ExternalizedOp def) {
-            if (!def.operands().isEmpty()) {
-                throw new IllegalStateException("Operation must have no operands");
-            }
-
-            this(def.resultType(), def.bodyDefinitions());
+            this(def.resultType(), requireBodies(def, 3));
         }
 
         ConditionalExpressionOp(ConditionalExpressionOp that, CodeContext cc, CodeTransformer ct) {
@@ -5291,7 +5207,8 @@ public sealed abstract class JavaOp extends Op {
         final Body finallyBody;
 
         TryOp(ExternalizedOp def) {
-            List<Body.Builder> bodies = def.bodyDefinitions();
+            //@@@ The scan must first require at least one body and handle "no void body" structurally.
+            List<Body.Builder> bodies = requireMinBodies(def, 1);
             int bodyIndex = 0;
             while (!bodies.get(bodyIndex).bodySignature().returnType().equals(VOID)) {
                 bodyIndex++;
@@ -6003,7 +5920,7 @@ public sealed abstract class JavaOp extends Op {
                         v -> switch (v) {
                             case String s -> s;
                             case null -> null;
-                            default -> throw new UnsupportedOperationException("Unsupported pattern binding name value:" + v);
+                            default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_BINDING_NAME, v);
                         });
                 // @@@ Cannot use canonical constructor because it wraps the given type
                 this.resultType = def.resultType();
@@ -6073,14 +5990,7 @@ public sealed abstract class JavaOp extends Op {
             final RecordTypeRef recordReference;
 
             RecordPatternOp(ExternalizedOp def) {
-                RecordTypeRef recordRef = def.extractAttributeValue(ATTRIBUTE_RECORD_REF, true,
-                        v -> switch (v) {
-                            case RecordTypeRef rtd -> rtd;
-                            case null, default ->
-                                    throw new UnsupportedOperationException("Unsupported record type reference value:" + v);
-                        });
-
-                this(recordRef, def.operands());
+                this(requireAttribute(def, ATTRIBUTE_RECORD_REF, true, RecordTypeRef.class), def.operands());
             }
 
             RecordPatternOp(RecordPatternOp that, CodeContext cc) {
@@ -6189,8 +6099,8 @@ public sealed abstract class JavaOp extends Op {
             final Body matchBody;
 
             MatchOp(ExternalizedOp def) {
-                this(def.operands().get(0),
-                        def.bodyDefinitions().get(0), def.bodyDefinitions().get(1));
+                List<Body.Builder> bodies = requireBodies(def, 2);
+                this(requireSingleOperand(def), bodies.get(0), bodies.get(1));
             }
 
             MatchOp(MatchOp that, CodeContext cc, CodeTransformer ct) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -2030,7 +2030,6 @@ public sealed abstract class JavaOp extends Op {
             super(that, cc);
         }
 
-        //@@@ as BinaryOp; resultType remains the parent-specific BOOLEAN behavior.
         CompareOp(ExternalizedOp def) {
             super(requireOperands(def, 2));
         }
@@ -3362,7 +3361,6 @@ public sealed abstract class JavaOp extends Op {
         final List<Body> bodies;
 
         IfOp(ExternalizedOp def) {
-            //@@@ Body.Builder list; avoid checking in the external path and again after building.
             requireNoOperands(def);
             this(requireMinBodies(def, 2));
         }
@@ -3510,7 +3508,6 @@ public sealed abstract class JavaOp extends Op {
         JavaSwitchOp(Value target, List<Body.Builder> bodyCs) {
             super(List.of(target));
 
-            //@@@ Externalized switch expression/statement constructors should pass validated target and body pairs here.
             // Each case is modeled as a contiguous pair of bodies
             // The first body models the case labels, and the second models the case statements
             // The labels body has a parameter whose type is target operand's type and returns a boolean value

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
@@ -31,9 +31,9 @@ import jdk.incubator.code.Body;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.extern.ExternalizedOp;
 
-public final class Util {
+public final class StructuralPreconditions {
 
-    private Util() {
+    private StructuralPreconditions() {
     }
 
     public static void requireNoOperands(ExternalizedOp def) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/Util.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/Util.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.incubator.code.internal;
+
+import jdk.incubator.code.Body;
+import jdk.incubator.code.extern.ExternalizedOp;
+
+public final class Util {
+
+    private Util() {
+    }
+
+    public static void requireNoOperands(ExternalizedOp def) {
+        int count = def.operands().size();
+        if (count != 0) {
+            throw structuralException(def, "requires no operands, found %d".formatted(count));
+        }
+    }
+
+    public static void requireOperands(ExternalizedOp def, int expCount) {
+        int count = def.operands().size();
+        if (count != expCount) {
+            throw structuralException(def, "requires %d operand%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", count));
+        }
+    }
+
+    public static void requireOperands(ExternalizedOp def, int expCount1, int expCount2) {
+        int count = def.operands().size();
+        if (count != expCount1 && count != expCount2) {
+            throw structuralException(def, "requires %d or %d operands, found %d".formatted(expCount1, expCount2, count));
+        }
+    }
+
+    public static Body.Builder requireSingleBody(ExternalizedOp def) {
+        var bd = def.bodyDefinitions();
+        if (bd.size() != 1) {
+            throw structuralException(def, "requires single body, found %d".formatted(bd.size()));
+        }
+        return bd.getFirst();
+    }
+
+    public static void requireBodies(ExternalizedOp def, int expCount) {
+        int count = def.bodyDefinitions().size();
+        if (count != expCount) {
+            throw structuralException(def, "requires %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", count));
+        }
+    }
+
+    public static void requireMinBodies(ExternalizedOp def, int expCount) {
+        int count = def.bodyDefinitions().size();
+        if (count < expCount) {
+            throw structuralException(def, "requires at least %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", count));
+        }
+    }
+
+    public static void requireBodies(ExternalizedOp def, int expCount1, int expCount2) {
+        int count = def.bodyDefinitions().size();
+        if (count != expCount1 && count != expCount2) {
+            throw structuralException(def, "requires %d or %d bodies, found %d".formatted(expCount1, expCount2, count));
+        }
+    }
+
+    public static void requireBodyPairs(ExternalizedOp def) {
+        int count = def.bodyDefinitions().size();
+        if (count < 2 || count % 2 == 1) {
+            throw structuralException(def, "requires one or more body pairs, found %d".formatted(count));
+        }
+    }
+
+    public static void requireSuccessors(ExternalizedOp def, int expCount) {
+        int count = def.successors().size();
+        if (count != expCount) {
+            throw structuralException(def, "requires %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", count));
+        }
+    }
+
+    public static void requireMinSuccessors(ExternalizedOp def, int expCount) {
+        int count = def.successors().size();
+        if (count < expCount) {
+            throw structuralException(def, "requires at least %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", count));
+        }
+    }
+
+    public static Object requireAttribute(ExternalizedOp def, String attributeName, boolean isDefaultAttribute) {
+        if (isDefaultAttribute && def.attributes().containsKey("")) {
+            return def.attributes().get("");
+        }
+        if (def.attributes().containsKey(attributeName)) {
+            return def.attributes().get(attributeName);
+        }
+        throw structuralException(def, "requires attribute %s".formatted(attributeName));
+    }
+
+    public static IllegalStateException structuralException(ExternalizedOp def, String msg) {
+        return new IllegalStateException("Operation " + def.name() + " " + msg);
+    }
+
+    public static UnsupportedOperationException unsupportedAttributeValueException(ExternalizedOp def, String attributeName, Object value) {
+        return new UnsupportedOperationException(
+                "Operation %s attribute %s has unsupported value: %s" .formatted(def.name(), attributeName, value));
+    }
+}

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/Util.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/Util.java
@@ -25,7 +25,10 @@
 
 package jdk.incubator.code.internal;
 
+import java.util.List;
+import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;
+import jdk.incubator.code.Value;
 import jdk.incubator.code.extern.ExternalizedOp;
 
 public final class Util {
@@ -34,74 +37,93 @@ public final class Util {
     }
 
     public static void requireNoOperands(ExternalizedOp def) {
-        int count = def.operands().size();
-        if (count != 0) {
-            throw structuralException(def, "requires no operands, found %d".formatted(count));
-        }
+        requireOperands(def, 0);
     }
 
-    public static void requireOperands(ExternalizedOp def, int expCount) {
-        int count = def.operands().size();
-        if (count != expCount) {
-            throw structuralException(def, "requires %d operand%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", count));
-        }
+    public static Value requireSingleOperand(ExternalizedOp def) {
+        return requireOperands(def, 1).getFirst();
     }
 
-    public static void requireOperands(ExternalizedOp def, int expCount1, int expCount2) {
+    public static List<Value> requireOperands(ExternalizedOp def, int expCount) {
+        List<Value> operands = def.operands();
+        if (operands.size() != expCount) {
+            throw structuralException(def, "requires %d operand%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", operands.size()));
+        }
+        return operands;
+    }
+
+    public static List<Value> requireOperands(ExternalizedOp def, int expCount1, int expCount2) {
         int count = def.operands().size();
         if (count != expCount1 && count != expCount2) {
             throw structuralException(def, "requires %d or %d operands, found %d".formatted(expCount1, expCount2, count));
         }
+        return def.operands();
     }
 
     public static Body.Builder requireSingleBody(ExternalizedOp def) {
-        var bd = def.bodyDefinitions();
-        if (bd.size() != 1) {
-            throw structuralException(def, "requires single body, found %d".formatted(bd.size()));
-        }
-        return bd.getFirst();
+        return requireBodies(def, 1).getFirst();
     }
 
-    public static void requireBodies(ExternalizedOp def, int expCount) {
-        int count = def.bodyDefinitions().size();
-        if (count != expCount) {
-            throw structuralException(def, "requires %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", count));
+    public static List<Body.Builder> requireBodies(ExternalizedOp def, int expCount) {
+        List<Body.Builder> bodies = def.bodyDefinitions();
+        if (bodies.size() != expCount) {
+            throw structuralException(def, "requires %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
         }
+        return bodies;
     }
 
-    public static void requireMinBodies(ExternalizedOp def, int expCount) {
-        int count = def.bodyDefinitions().size();
-        if (count < expCount) {
-            throw structuralException(def, "requires at least %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", count));
+    public static List<Body.Builder> requireMinBodies(ExternalizedOp def, int expCount) {
+        List<Body.Builder> bodies = def.bodyDefinitions();
+        if (bodies.size() < expCount) {
+            throw structuralException(def, "requires at least %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
         }
+        return bodies;
     }
 
-    public static void requireBodies(ExternalizedOp def, int expCount1, int expCount2) {
-        int count = def.bodyDefinitions().size();
+    public static List<Body.Builder> requireBodies(ExternalizedOp def, int expCount1, int expCount2) {
+        List<Body.Builder> bodies = def.bodyDefinitions();
+        int count = bodies.size();
         if (count != expCount1 && count != expCount2) {
             throw structuralException(def, "requires %d or %d bodies, found %d".formatted(expCount1, expCount2, count));
         }
+        return bodies;
     }
 
-    public static void requireBodyPairs(ExternalizedOp def) {
-        int count = def.bodyDefinitions().size();
+    public static List<Body.Builder> requireBodyPairs(ExternalizedOp def) {
+        List<Body.Builder> bodies = def.bodyDefinitions();
+        int count = bodies.size();
         if (count < 2 || count % 2 == 1) {
             throw structuralException(def, "requires one or more body pairs, found %d".formatted(count));
         }
+        return bodies;
     }
 
-    public static void requireSuccessors(ExternalizedOp def, int expCount) {
-        int count = def.successors().size();
-        if (count != expCount) {
-            throw structuralException(def, "requires %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", count));
-        }
+    public static Block.Reference requireSingleSuccessor(ExternalizedOp def) {
+        return requireSuccessors(def, 1).getFirst();
     }
 
-    public static void requireMinSuccessors(ExternalizedOp def, int expCount) {
-        int count = def.successors().size();
-        if (count < expCount) {
-            throw structuralException(def, "requires at least %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", count));
+    public static List<Block.Reference> requireSuccessors(ExternalizedOp def, int expCount) {
+        List<Block.Reference> succ = def.successors();
+        if (succ.size() != expCount) {
+            throw structuralException(def, "requires %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", succ.size()));
         }
+        return succ;
+    }
+
+    public static List<Block.Reference> requireMinSuccessors(ExternalizedOp def, int expCount) {
+        List<Block.Reference> succ = def.successors();
+        if (succ.size() < expCount) {
+            throw structuralException(def, "requires at least %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", succ.size()));
+        }
+        return succ;
+    }
+
+    public static <T> T requireAttribute(ExternalizedOp def, String attributeName, boolean isDefaultAttribute, Class<T> attributeType) {
+        Object attr = requireAttribute(def, attributeName, isDefaultAttribute);
+        if (attributeType.isInstance(attr)) {
+            return attributeType.cast(attr);
+        }
+        throw unsupportedAttributeValueException(def, attributeName, attr);
     }
 
     public static Object requireAttribute(ExternalizedOp def, String attributeName, boolean isDefaultAttribute) {
@@ -120,6 +142,6 @@ public final class Util {
 
     public static UnsupportedOperationException unsupportedAttributeValueException(ExternalizedOp def, String attributeName, Object value) {
         return new UnsupportedOperationException(
-                "Operation %s attribute %s has unsupported value: %s" .formatted(def.name(), attributeName, value));
+                "Operation %s attribute %s has unsupported value: %s".formatted(def.name(), attributeName, value));
     }
 }


### PR DESCRIPTION
This phase consolidates primary structural validation by making Util helpers return validated operands, bodies, successors, and attributes, then moving repeated leaf checks into common constructor frontiers where possible.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [1d0d7563](https://git.openjdk.org/babylon/pull/1064/files/1d0d7563854f7e135e20b1d7e95dc689c8bb1a47)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1064/head:pull/1064` \
`$ git checkout pull/1064`

Update a local copy of the PR: \
`$ git checkout pull/1064` \
`$ git pull https://git.openjdk.org/babylon.git pull/1064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1064`

View PR using the GUI difftool: \
`$ git pr show -t 1064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1064.diff">https://git.openjdk.org/babylon/pull/1064.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1064#issuecomment-4751732975)
</details>
