### PR TITLE
Make builders inoperable after building finishes

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -506,6 +506,7 @@ public final class Block implements CodeElement<Block, Op> {
         }
 
         Block target() {
+            check();
             return Block.this;
         }
 
@@ -513,6 +514,7 @@ public final class Block implements CodeElement<Block, Op> {
          * {@return this block builder's code transformer}
          */
         public CodeTransformer transformer() {
+            check();
             return ct;
         }
 
@@ -520,6 +522,7 @@ public final class Block implements CodeElement<Block, Op> {
          * {@return this block builder's code context}
          */
         public CodeContext context() {
+            check();
             return cc;
         }
 
@@ -527,6 +530,7 @@ public final class Block implements CodeElement<Block, Op> {
          * {@return this block builder's parent body builder}
          */
         public Body.Builder parentBody() {
+            check();
             return parentBody;
         }
 
@@ -538,6 +542,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the entry block builder of this builder's parent body builder
          */
         public Block.Builder entryBlock() {
+            check();
             return parentBody.entryBlock.withContextAndTransformer(cc, ct);
         }
 
@@ -545,6 +550,7 @@ public final class Block implements CodeElement<Block, Op> {
          * {@return true if this block builder builds the entry block of its parent body}
          */
         public boolean isEntryBlock() {
+            check();
             return Block.this == parentBody.target().entryBlock();
         }
 
@@ -560,6 +566,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the block builder with the given code context and code transformer
          */
         public Block.Builder withContextAndTransformer(CodeContext cc, CodeTransformer ct) {
+            check();
             return this.cc == cc && this.ct == ct
                     ? this
                     : this.target().new Builder(parentBody(), cc, ct);
@@ -588,6 +595,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the new block builder
          */
         public Block.Builder block(List<CodeType> params) {
+            check();
             return parentBody.block(params, cc, ct);
         }
 
@@ -597,6 +605,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the unmodifiable list of this block's parameters
          */
         public List<Parameter> parameters() {
+            check();
             return Collections.unmodifiableList(parameters);
         }
 
@@ -636,6 +645,8 @@ public final class Block implements CodeElement<Block, Op> {
          * @throws IllegalArgumentException if any argument's declaring block is built.
          */
         public Reference reference(List<? extends Value> args) {
+            check();
+
             if (isEntryBlock()) {
                 throw new IllegalStateException("Entry block cannot be referenced and targeted as a successor");
             }
@@ -781,12 +792,14 @@ public final class Block implements CodeElement<Block, Op> {
          */
         @Override
         public boolean equals(Object o) {
+            check();
             if (this == o) return true;
             return o instanceof Builder that && Block.this == that.target();
         }
 
         @Override
         public int hashCode() {
+            check();
             return Block.this.hashCode();
         }
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -477,9 +477,9 @@ public final class Block implements CodeElement<Block, Op> {
      * of building its parent body. The block is not <a href="Body.Builder.html#body-building-observability">observable</a>
      * until the parent body builder <a href="Body.Builder.html#body-building-finishing">finishes</a>.
      * After <a href="Body.Builder.html#body-building-finishing">building finishes</a>,
-     * the block and its parent body become observable, and the block builder and its parent body builder become inoperable,
+     * the block becomes observable, and the block builder becomes inoperable,
      * regardless of whether building succeeds or fails with an exception.
-     * Further attempts to operate on the builders throw an {@link IllegalStateException}.
+     * Further attempts to operate on the block builder throws an {@link IllegalStateException}.
      * <p>
      * A block builder has a code {@link #context() context} and code {@link #transformer() transformer}. These are used
      * to perform <i>transform-on-append</i> when {@link #add appending} a placed operation. Any sibling block builder

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -476,6 +476,10 @@ public final class Block implements CodeElement<Block, Op> {
      * A block builder builds one block as part of the <a href="Body.Builder.html#body-building-process">building process</a>
      * of building its parent body. The block is not <a href="Body.Builder.html#body-building-observability">observable</a>
      * until the parent body builder <a href="Body.Builder.html#body-building-finishing">finishes</a>.
+     * After <a href="Body.Builder.html#body-building-finishing">building finishes</a>,
+     * the block and its parent body become observable, and the block builder and its parent body builder become inoperable,
+     * regardless of whether building succeeds or fails with an exception.
+     * Further attempts to operate on the builders throw an {@link IllegalStateException}.
      * <p>
      * A block builder has a code {@link #context() context} and code {@link #transformer() transformer}. These are used
      * to perform <i>transform-on-append</i> when {@link #add appending} a placed operation. Any sibling block builder

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -488,7 +488,7 @@ public final class Body implements CodeElement<Body, Block> {
      * <a id="body-building-finishing"></a>
      * After building finishes, the body and its child blocks become observable, and the body builder and its block
      * builders all become inoperable, regardless of whether building succeeds or fails with an exception.
-     * Further attempts to operate on the builders throw an exception.
+     * Further attempts to operate on the builders throw an {@link IllegalStateException}.
      * <p>
      * A body builder may be connected to its {@link #connectedAncestorBody() nearest ancestor} body builder. This
      * connection constrains the order in which the connected builders can finish building, ancestors cannot finish

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -861,6 +861,7 @@ public final class Body implements CodeElement<Body, Block> {
          * @return the body builder's signature
          */
         public FunctionType bodySignature() {
+            check();
             CodeType returnType = Body.this.yieldType();
             Block eb = Body.this.entryBlock();
             return CoreType.functionType(returnType, eb.parameterTypes());
@@ -871,6 +872,7 @@ public final class Body implements CodeElement<Body, Block> {
          * <a href="#connected-builder">connected</a>, otherwise {@code null} if this body builder is isolated}
          */
         public Builder connectedAncestorBody() {
+            check();
             return connectedAncestorBody;
         }
 
@@ -878,17 +880,20 @@ public final class Body implements CodeElement<Body, Block> {
          * {@return this body builder's entry block builder}
          */
         public Block.Builder entryBlock() {
+            check();
             return entryBlock;
         }
 
         @Override
         public boolean equals(Object o) {
+            check();
             if (this == o) return true;
             return o instanceof Builder that && Body.this == that.target();
         }
 
         @Override
         public int hashCode() {
+            check();
             return Body.this.hashCode();
         }
 

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -439,7 +439,7 @@ public class TestBuild {
                     } else if (parameterType == Object.class) {
                         arg = null;
                     } else {
-                        throw new AssertionError("Unhandled type: " + parameterType);
+                        throw new AssertionError("Unhandled parameter type " + parameterType + ", in the method " + m);
                     }
                     args.add(arg);
                 }

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -23,19 +23,22 @@
 
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;
-import jdk.incubator.code.Reflect;
+import jdk.incubator.code.CodeContext;
+import jdk.incubator.code.CodeTransformer;
+import jdk.incubator.code.CodeType;
 import jdk.incubator.code.Op;
+import jdk.incubator.code.Reflect;
+import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.core.CoreOp;
-import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.SSA;
 import jdk.incubator.code.dialect.java.JavaOp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.AccessFlag;
-import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntBinaryOperator;
 
@@ -401,33 +404,47 @@ public class TestBuild {
 
     @Test
     void testBuilderInoperableAfterBuildFinishes() {
-        var bodyBuilder = Body.Builder.of(null, CoreType.functionType(INT));
+        var bodyBuilder = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var entryBlockBuilder = bodyBuilder.entryBlock();
-        var value = entryBlockBuilder.add(constant(INT, 1));
-        entryBlockBuilder.add(return_(value));
+        var blockBuilder = entryBlockBuilder.block();
+        blockBuilder.add(return_());
+        entryBlockBuilder.add(branch(blockBuilder.reference()));
 
         var fop = func("f", bodyBuilder);
 
-        for (Object r : List.of(bodyBuilder, entryBlockBuilder)) {
+        for (Object r : List.of(bodyBuilder, blockBuilder)) {
             for (Method m : r.getClass().getDeclaredMethods()) {
                 if (m.accessFlags().contains(AccessFlag.STATIC) || !m.accessFlags().contains(AccessFlag.PUBLIC)) {
                     continue;
                 }
-                Object[] args = new Object[m.getParameterCount()];
-                int i = 0;
+                List<Object> args = new ArrayList<>();
                 for (Class<?> parameterType : m.getParameterTypes()) {
-                    // methods like Block.Builder.block or Body.Builder.build will throw NPE if null is passed as argument
-                    // not what we want, so make sure to pass arguments that will pass the null check
-                    if (parameterType.isArray()) {
-                        args[i] = Array.newInstance(parameterType.componentType(), 0);
+                    Object arg;
+                    if (parameterType == Value[].class) {
+                        arg = new Value[]{};
+                    } else if (parameterType == CodeType[].class) {
+                        arg = new CodeType[]{};
+                    } else if (parameterType == CodeType.class) {
+                        arg = INT;
+                    } else if (parameterType == List.class) {
+                        arg = List.of();
+                    } else if (parameterType == CodeContext.class) {
+                        arg = CodeContext.create();
+                    } else if (parameterType == CodeTransformer.class) {
+                        arg = CodeTransformer.COPYING_TRANSFORMER;
+                    } else if (parameterType == Body.class) {
+                        arg = fop.body();
                     } else if (parameterType == Op.class) {
-                        args[i] = fop;
+                        arg = fop;
+                    } else if (parameterType == Object.class) {
+                        arg = null;
                     } else {
-                        args[i] = null;
+                        throw new AssertionError("Unhandled type: " + parameterType);
                     }
-                    i++;
+                    args.add(arg);
                 }
-                var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class, () -> m.invoke(r, args));
+                var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class,
+                        () -> m.invoke(r, args.toArray()));
                 Assertions.assertInstanceOf(IllegalStateException.class, wrapperException.getCause());
             }
         }

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -26,11 +26,17 @@ import jdk.incubator.code.Body;
 import jdk.incubator.code.Reflect;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.SSA;
 import jdk.incubator.code.dialect.java.JavaOp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.AccessFlag;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
 import java.util.function.IntBinaryOperator;
 
 import static jdk.incubator.code.dialect.core.CoreOp.*;
@@ -391,5 +397,39 @@ public class TestBuild {
         block.add(constant(INT, 0));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+
+    @Test
+    void testBuilderInoperableAfterBuildFinishes() {
+        var bodyBuilder = Body.Builder.of(null, CoreType.functionType(INT));
+        var entryBlockBuilder = bodyBuilder.entryBlock();
+        var value = entryBlockBuilder.add(constant(INT, 1));
+        entryBlockBuilder.add(return_(value));
+
+        var fop = func("f", bodyBuilder);
+
+        for (Object r : List.of(bodyBuilder, entryBlockBuilder)) {
+            for (Method m : r.getClass().getDeclaredMethods()) {
+                if (m.accessFlags().contains(AccessFlag.STATIC) || !m.accessFlags().contains(AccessFlag.PUBLIC)) {
+                    continue;
+                }
+                Object[] args = new Object[m.getParameterCount()];
+                int i = 0;
+                for (Class<?> parameterType : m.getParameterTypes()) {
+                    // methods like Block.Builder.block or Body.Builder.build will throw NPE if null is passed as argument
+                    // not what we want, so make sure to pass arguments that will pass the null check
+                    if (parameterType.isArray()) {
+                        args[i] = Array.newInstance(parameterType.componentType(), 0);
+                    } else if (parameterType == Op.class) {
+                        args[i] = fop;
+                    } else {
+                        args[i] = null;
+                    }
+                    i++;
+                }
+                var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class, () -> m.invoke(r, args));
+                Assertions.assertInstanceOf(IllegalStateException.class, wrapperException.getCause());
+            }
+        }
     }
 }


### PR DESCRIPTION
We add check to the methods of `Body.Builder` and `Block.Builder`, the check throws if building is finished.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [451bf46a](https://git.openjdk.org/babylon/pull/1065/files/451bf46a5d3ff92971aee5b5afc9aaf8b6d7174f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1065/head:pull/1065` \
`$ git checkout pull/1065`

Update a local copy of the PR: \
`$ git checkout pull/1065` \
`$ git pull https://git.openjdk.org/babylon.git pull/1065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1065`

View PR using the GUI difftool: \
`$ git pr show -t 1065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1065.diff">https://git.openjdk.org/babylon/pull/1065.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1065#issuecomment-4746087420)
</details>
