### PR TITLE
Tighten the check in Op.buildAsRoot

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -592,16 +592,20 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * <p>
      * This method is idempotent.
      *
-     * @throws IllegalStateException if this operation is placed in a block, or one of its body is not isolated
-     * , or it has operands.
+     * @throws IllegalStateException if this operation is a {@link BlockTerminating}, is placed in a block,
+     * uses any values as operands, or any of its bodies is open.
      * @see #isRoot()
+     * @see Body#isIsolated
      */
     public final void buildAsRoot() {
-        if (bodies().stream().anyMatch(b -> !b.isIsolated())) {
-            throw new IllegalStateException("Operation body is not isolated");
+        if (!bodies().stream().allMatch(Body::isIsolated)) {
+            throw new IllegalStateException("One of the operation bodies is not isolated");
         }
         if (!operands().isEmpty()) {
             throw new IllegalStateException("Operation has operands");
+        }
+        if (this instanceof BlockTerminating) {
+            throw new IllegalStateException("Operation has successors");
         }
         if (result == Result.ROOT_RESULT) {
             return;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -598,6 +598,9 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @see Body#isIsolated
      */
     public final void buildAsRoot() {
+        if (result == Result.ROOT_RESULT) {
+            return;
+        }
         if (!bodies().stream().allMatch(Body::isIsolated)) {
             throw new IllegalStateException("One of the operation bodies is not isolated");
         }
@@ -606,9 +609,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
         if (!successors().isEmpty()) {
             throw new IllegalStateException("Operation has successors");
-        }
-        if (result == Result.ROOT_RESULT) {
-            return;
         }
         if (result != null) {
             throw new IllegalStateException("Operation is placed in a block");

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -592,10 +592,17 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * <p>
      * This method is idempotent.
      *
-     * @throws IllegalStateException if this operation is placed in a block.
+     * @throws IllegalStateException if this operation is placed in a block, or one of its body is not isolated
+     * , or it has operands.
      * @see #isRoot()
      */
     public final void buildAsRoot() {
+        if (bodies().stream().anyMatch(b -> !b.isIsolated())) {
+            throw new IllegalStateException("Operation body is not isolated");
+        }
+        if (!operands().isEmpty()) {
+            throw new IllegalStateException("Operation has operands");
+        }
         if (result == Result.ROOT_RESULT) {
             return;
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -592,7 +592,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * <p>
      * This method is idempotent.
      *
-     * @throws IllegalStateException if this operation is a {@link BlockTerminating}, is placed in a block,
+     * @throws IllegalStateException if this operation is placed in a block, has any successors,
      * uses any values as operands, or any of its bodies is open.
      * @see #isRoot()
      * @see Body#isIsolated
@@ -604,7 +604,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         if (!operands().isEmpty()) {
             throw new IllegalStateException("Operation has operands");
         }
-        if (this instanceof BlockTerminating) {
+        if (!successors().isEmpty()) {
             throw new IllegalStateException("Operation has successors");
         }
         if (result == Result.ROOT_RESULT) {

--- a/test/jdk/jdk/incubator/code/TestBuildOp.java
+++ b/test/jdk/jdk/incubator/code/TestBuildOp.java
@@ -129,7 +129,7 @@ public class TestBuildOp {
     }
 
     @Test
-    void testBuildAsRootForOpWithConnectedBody() {
+    void testBuildAsRootForOpWithOpenBody() {
         Body.Builder outer = Body.Builder.of(null, CoreType.functionType(JavaType.VOID, JavaType.INT));
         Block.Parameter p = outer.entryBlock().parameters().getFirst();
 
@@ -146,6 +146,15 @@ public class TestBuildOp {
         Body.Builder body = Body.Builder.of(null, CoreType.functionType(JavaType.VOID, JavaType.INT));
         Block.Parameter p = body.entryBlock().parameters().getFirst();
         Op op = JavaOp.neg(p);
+        Assertions.assertThrowsExactly(IllegalStateException.class, op::buildAsRoot);
+    }
+
+    @Test
+    void testBuildAsRootForOpWithSuccessor() {
+        Body.Builder body = Body.Builder.of(null, CoreType.functionType(JavaType.VOID, JavaType.INT));
+        Block.Parameter p = body.entryBlock().parameters().getFirst();
+        Block.Builder block2 = body.entryBlock().block();
+        Op op = CoreOp.branch(block2.reference());
         Assertions.assertThrowsExactly(IllegalStateException.class, op::buildAsRoot);
     }
 

--- a/test/jdk/jdk/incubator/code/TestBuildOp.java
+++ b/test/jdk/jdk/incubator/code/TestBuildOp.java
@@ -24,7 +24,9 @@
 import jdk.incubator.code.*;
 import jdk.incubator.code.Reflect;
 import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.FunctionType;
+import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -124,6 +126,27 @@ public class TestBuildOp {
         IntBinaryOperator q = (@Reflect IntBinaryOperator)(int a, int b) -> a + b;
         Quoted<?> quoted = Op.ofLambda(q).orElseThrow();
         Assertions.assertThrows(IllegalStateException.class, () -> quoted.op().setLocation(Op.Location.NO_LOCATION));
+    }
+
+    @Test
+    void testBuildAsRootForOpWithConnectedBody() {
+        Body.Builder outer = Body.Builder.of(null, CoreType.functionType(JavaType.VOID, JavaType.INT));
+        Block.Parameter p = outer.entryBlock().parameters().getFirst();
+
+        Body.Builder inner = Body.Builder.of(outer, CoreType.FUNCTION_TYPE_VOID);
+        inner.entryBlock().add(JavaOp.neg(p));
+        inner.entryBlock().add(CoreOp.return_());
+        JavaOp.LambdaOp lambdaOp = JavaOp.lambda(JavaType.type(Runnable.class), inner);
+
+        Assertions.assertThrowsExactly(IllegalStateException.class, lambdaOp::buildAsRoot);
+    }
+
+    @Test
+    void testBuildAsRootForOpWithOperands() {
+        Body.Builder body = Body.Builder.of(null, CoreType.functionType(JavaType.VOID, JavaType.INT));
+        Block.Parameter p = body.entryBlock().parameters().getFirst();
+        Op op = JavaOp.neg(p);
+        Assertions.assertThrowsExactly(IllegalStateException.class, op::buildAsRoot);
     }
 
     void assertOpIsCopiedWhenAddedToBlock(Op op) {


### PR DESCRIPTION
Before marking an operation as root, we check that all its bodies are isolated and that the operation has no operand.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1066/head:pull/1066` \
`$ git checkout pull/1066`

Update a local copy of the PR: \
`$ git checkout pull/1066` \
`$ git pull https://git.openjdk.org/babylon.git pull/1066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1066`

View PR using the GUI difftool: \
`$ git pr show -t 1066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1066.diff">https://git.openjdk.org/babylon/pull/1066.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1066#issuecomment-4752833145)
</details>
