### PR TITLE
Remove unused code from javac

### DIFF
--- a/src/java.base/share/classes/jdk/internal/access/code/CodeModuleLayerInit.java
+++ b/src/java.base/share/classes/jdk/internal/access/code/CodeModuleLayerInit.java
@@ -1,10 +1,15 @@
 package jdk.internal.access.code;
 
+/**
+ * Intializes a module layer containing the incubating module jdk.incubator.code so that
+ * it can be used by the jdk.compiler module for compiling reflectable code.
+ * See use in com.sun.tools.javac.main.JavaCompiler of the jdk.compiler module.
+ */
 public class CodeModuleLayerInit {
     public static void initCodeModuleLayer(ModuleLayer layer) {
         Module codeReflectionModule = layer.findModule("jdk.incubator.code").get();
         Module jdkCompilerModule = CodeModuleLayerInit.class.getModule();
-        // We need to add exports all java.base packages so that the plugin can use them
+        // We need to add exports all java.base packages so that the jdk.incubator.code module can use them
         for (String packageName : jdkCompilerModule.getPackages()) {
             jdkCompilerModule.addExports(packageName, codeReflectionModule);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -291,7 +291,7 @@ public enum Source {
         PRIVATE_MEMBERS_IN_PERMITS_CLAUSE(JDK19),
         ERASE_POLY_SIG_RETURN_TYPE(JDK24),
         CAPTURE_MREF_RETURN_TYPE(JDK26),
-        REFLECT_METHODS(JDK22, Fragments.FeatureReflectMethods, DiagKind.NORMAL),
+        REFLECT_METHODS(JDK28, Fragments.FeatureReflectMethods, DiagKind.NORMAL),
         ;
 
         enum DiagKind {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/CodeReflectionTransformer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/CodeReflectionTransformer.java
@@ -31,16 +31,16 @@ import com.sun.tools.javac.util.Context;
 import java.io.IOException;
 
 /**
- * This is a proxy interface for the code reflection tree translator.
- * This compiler step is optionally enabled depending on whether
- * the incubating module jdk.incubator.code is part of the module graph.
+ * The service provider interface for the code reflection tree translator.
+ * The service provider implementation is provided by the incubating module
+ * jdk.incubator.code when it is present in the module graph.
+ * When present the compiler looks up the provider and invokes it during phases of the
+ * compilation process to generate code models for reflectable code and emit
+ * additional class files that store the code models.
  */
 public interface CodeReflectionTransformer {
     /**
-     * Analyze the code in the provided class, generating code models for the following program elements:
-     * <li>methods annotated with {@code CodeReflection};
-     * <li>lambdas or method references whose target type is a functional interface annotated with {@code CodeReflection}; and
-     * <li>lambdas or method references whose target is a cast that contains the {@code CodeReflection} annotation.
+     * Analyze the code in the provided class, generating code models for reflectable methods and lambda expressions
      * @param context the compiler context
      * @param tree the tree to analyze
      * @param make the tree maker

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -383,8 +383,6 @@ public class JavaCompiler {
 
     protected CompileStates compileStates;
 
-    private boolean hasCodeReflectionModule;
-
     /** Construct a new compiler using a shared context.
      */
     @SuppressWarnings("this-escape")
@@ -1064,14 +1062,6 @@ public class JavaCompiler {
 
     public List<JCCompilationUnit> initModules(List<JCCompilationUnit> roots) {
         modules.initModules(roots);
-
-        if (modules.modulesInitialized()) {
-            // This has to happen precisely here. At this point, we have all we need to
-            // determine whether jdk.incubator.module is part of the module graph
-            // but we have yet to trigger an ENTER event. This gives the code reflection plugin
-            // a window to check whether code reflection should be enabled for this compilation unit.
-            hasCodeReflectionModule = modules.getObservableModule(names.jdk_incubator_code) != null;
-        }
 
         if (roots.isEmpty()) {
             enterDone();
@@ -1761,20 +1751,24 @@ public class JavaCompiler {
                 // we are in an exploded build, so just use the boot layer
                 CODE_LAYER = ModuleLayer.boot();
             } else if (java.lang.module.ModuleFinder.ofSystem().find("jdk.incubator.code").isPresent()) {
-                // the code module is installed, but not in the boot layer, create a new layer which contains it
+                // The incubating jdk.incubator.code module is installed, but not in the boot layer
+                // The module needs to be resolved so the jdk.compiler module can find and use the service provider
+                // for CodeReflectionTransformer
                 ModuleLayer parent = ModuleLayer.boot();
+                // Create a new configuration from the boot layer configuration with the resolved jdk.incubator.code module
                 Configuration cf = parent.configuration()
                         .resolve(java.lang.module.ModuleFinder.of(), java.lang.module.ModuleFinder.ofSystem(), Set.of("jdk.incubator.code"));
                 ClassLoader scl = ClassLoader.getSystemClassLoader();
+                // Create the code module layer using the new configuration and the system class loader
                 CODE_LAYER = parent.defineModulesWithOneLoader(cf, scl);
                 Module codeReflectionModule = CODE_LAYER.findModule("jdk.incubator.code").get();
                 Module jdkCompilerModule = JavaCompiler.class.getModule();
-                // We need to add exports all jdk.compiler packages so that the plugin can use them
+                // Add exports to all jdk.compiler packages so that the jdk.incubator.code module can use them
                 for (String packageName : jdkCompilerModule.getPackages()) {
                     jdkCompilerModule.addExports(packageName, codeReflectionModule);
                 }
-                // We also need to add exports all java.base packages so that the plugin can use them
-                // But we need to do so by calling a method in java.base reflectively
+                // Add exports to all java.base packages so that the jdk.incubator.code module can use them
+                // We need to do so by calling a method in java.base reflectively
                 try {
                     Class<?> codeModuleLayerInit = Class.forName("jdk.internal.access.code.CodeModuleLayerInit");
                     Method initLayerMethod = codeModuleLayerInit.getDeclaredMethod("initCodeModuleLayer", ModuleLayer.class);
@@ -1783,7 +1777,7 @@ public class JavaCompiler {
                     throw new AssertionError(ex);
                 }
             } else {
-                // if we run in bootstrap mode, there might be no jdk.incubator.code
+                // If we run in bootstrap mode, there might be no jdk.incubator.code
                 CODE_LAYER = null;
             }
         }
@@ -1942,10 +1936,6 @@ public class JavaCompiler {
 
     public boolean isEnterDone() {
         return enterDone;
-    }
-
-    public boolean hasCodeReflectionModule() {
-        return hasCodeReflectionModule;
     }
 
     private Name readModuleName(JavaFileObject fo) {


### PR DESCRIPTION
Remove unused plugins related code from javac that was around before the service provider was used.

Clarify internal documentation.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1067/head:pull/1067` \
`$ git checkout pull/1067`

Update a local copy of the PR: \
`$ git checkout pull/1067` \
`$ git pull https://git.openjdk.org/babylon.git pull/1067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1067`

View PR using the GUI difftool: \
`$ git pr show -t 1067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1067.diff">https://git.openjdk.org/babylon/pull/1067.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1067#issuecomment-4774214787)
</details>
