### PR TITLE
add ffi-openclgl-example to allow us to run nbodygl

### DIFF
--- a/hat/.ffi-openclgl-example
+++ b/hat/.ffi-openclgl-example
@@ -1,0 +1,8 @@
+--enable-preview
+--add-modules=jdk.incubator.code 
+--enable-native-access=ALL-UNNAMED
+-Djava.library.path=build
+-XstartOnFirstThread
+ --class-path build/hat-optkl-1.0.jar:build/hat-core-1.0.jar:build/hat-backend-ffi-shared-1.0.jar:build/hat-backend-ffi-opencl-1.0.jar:build/hat-extracted-opengl-1.0.jar:build/hat-extracted-opencl-1.0.jar:build/hat-wrap-opengl-1.0.jar:build/hat-wrap-shared-1.0.jar:build/hat-wrap-opencl-1.0.jar:build/hat-example-nbodygl-1.0.jar
+
+

--- a/hat/wraps/pom.xml
+++ b/hat/wraps/pom.xml
@@ -33,6 +33,9 @@ questions.
     <artifactId>hat-root</artifactId>
     <version>1.0</version>
   </parent>
+  <modules>
+        <module>shared</module>
+  </modules>
   <profiles>
     <profile>
       <id>cuda</id>


### PR DESCRIPTION
Added ffi-openclgl-example which is needed to run nbodygl

This only works on Mac.
```
mvn clean package -Popencl,opengl
java @.ffi-openclgl-example nbodygl.Main
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1070/head:pull/1070` \
`$ git checkout pull/1070`

Update a local copy of the PR: \
`$ git checkout pull/1070` \
`$ git pull https://git.openjdk.org/babylon.git pull/1070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1070`

View PR using the GUI difftool: \
`$ git pr show -t 1070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1070.diff">https://git.openjdk.org/babylon/pull/1070.diff</a>

</details>
