### PR TITLE
Add matmul,fft,dft,tensors and experiments to example fat jars

### DIFF
--- a/hat/examples/ffi-cuda-examples/pom.xml
+++ b/hat/examples/ffi-cuda-examples/pom.xml
@@ -81,6 +81,36 @@ questions.
             <artifactId>hat-example-life</artifactId>
             <version>1.0</version>
         </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-matmul</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-tensors</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-dft</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-fft</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-shade</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-experiments</artifactId>
+            <version>1.0</version>
+        </dependency>
     </dependencies>
 
  <build>

--- a/hat/examples/ffi-opencl-examples/pom.xml
+++ b/hat/examples/ffi-opencl-examples/pom.xml
@@ -81,6 +81,36 @@ questions.
             <artifactId>hat-example-life</artifactId>
             <version>1.0</version>
         </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-matmul</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-tensors</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-dft</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-fft</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-shade</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>oracle.code</groupId>
+            <artifactId>hat-example-experiments</artifactId>
+            <version>1.0</version>
+        </dependency>
     </dependencies>
 
  <build>


### PR DESCRIPTION
I forgot to add all the examples to the fat example jars.  

So I added matmul,fft,dft,tensors and experiments  to the appropriate examples/ffi-<backend>-examples/pom.xml 

```
mvn clean package
java @.ffi-opencl-examples matmul.Main
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1071/head:pull/1071` \
`$ git checkout pull/1071`

Update a local copy of the PR: \
`$ git checkout pull/1071` \
`$ git pull https://git.openjdk.org/babylon.git pull/1071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1071`

View PR using the GUI difftool: \
`$ git pr show -t 1071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1071.diff">https://git.openjdk.org/babylon/pull/1071.diff</a>

</details>
