### PR TITLE
Remove ExternalizedOp.extractAttributeValue 

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxOp.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxOp.java
@@ -240,20 +240,18 @@ public abstract class OnnxOp extends Op {
         this.resultType = def.resultType();
 
         // @@@ Filter optional
-        this.optionalInputArguments = def.extractAttributeValue(ATTRIBUTE_OPTIONAL_INPUTS,
-                false, v -> switch (v) {
+        this.optionalInputArguments = switch (def.attributes().get(ATTRIBUTE_OPTIONAL_INPUTS)) {
                     case List<?> s -> (List<OnnxParameter>) s;
                     case null -> List.of();
                     default -> throw new UnsupportedOperationException();
-                });
+                };
 
         // @@@ Filter optional
-        this.optionalOutputParameters = def.extractAttributeValue(ATTRIBUTE_OPTIONAL_OUTPUTS,
-                false, v -> switch (v) {
+        this.optionalOutputParameters = switch (def.attributes().get(ATTRIBUTE_OPTIONAL_OUTPUTS)) {
                     case List<?> s -> (List<OnnxParameter>) s;
                     case null -> List.of();
                     default -> throw new UnsupportedOperationException();
-                });
+                };
     }
 
     OnnxOp(OnnxOp that, CodeContext cc) {

--- a/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
@@ -83,8 +83,7 @@ public class ArithMathOps {
                 throw new IllegalArgumentException("Operation must have zero operands");
             }
 
-            Object value = def.extractAttributeValue(ATTRIBUTE_CONSTANT_VALUE,true,
-                    v -> processConstantValue(def.resultType(), v));
+            Object value = processConstantValue(def.resultType(), getDefaultAttributeValue(def, ATTRIBUTE_CONSTANT_VALUE));
             return new ConstantOp(def, value);
         }
 
@@ -395,12 +394,12 @@ public class ArithMathOps {
         final CompareKind ck;
 
         public static CompareOp create(ExternalizedOp def) {
-            CompareKind ck = def.extractAttributeValue(ATTRIBUTE_PREDICATE, true,
-                    v -> switch (v) {
-                        case String s -> CompareKind.valueOf(s);
-                        case CompareKind k -> k;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported start value:" + v);
-                    });
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_PREDICATE);
+            CompareKind ck = switch (v) {
+                case String s -> CompareKind.valueOf(s);
+                case CompareKind k -> k;
+                case null, default -> throw new UnsupportedOperationException("Unsupported start value:" + v);
+            };
             return new CompareOp(def, ck);
         }
 
@@ -471,6 +470,11 @@ public class ArithMathOps {
         } else {
             throw new UnsupportedOperationException("Unsupported type: " + t);
         }
+    }
+
+    static Object getDefaultAttributeValue(ExternalizedOp def, String attributeName) {
+        var attrs = def.attributes();
+        return attrs.containsKey("") ? attrs.get("") : attrs.get(attributeName);
     }
 
     public static final OpFactory OP_FACTORY = def -> {

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -175,11 +175,11 @@ public class TritonOps {
                 throw new IllegalStateException("Bad op " + def.name());
             }
 
-            String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
-                    v -> switch (v) {
-                        case String s -> s;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
-                    });
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_FUNC_NAME);
+            String funcName = switch (v) {
+                case String s -> s;
+                case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+            };
             return new FuncOp(def, funcName);
         }
 
@@ -263,11 +263,11 @@ public class TritonOps {
         final String funcName;
 
         public static CallOp create(ExternalizedOp def) {
-            String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
-                    v -> switch (v) {
-                        case String s -> s;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
-                    });
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_FUNC_NAME);
+            String funcName = switch (v) {
+                case String s -> s;
+                case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+            };
 
             return new CallOp(def, funcName);
         }
@@ -337,11 +337,11 @@ public class TritonOps {
         final Body reducer;
 
         public static ReduceOp create(ExternalizedOp def) {
-            int axis = def.extractAttributeValue(ATTRIBUTE_AXIS, true,
-                    v -> switch (v) {
-                        case Integer i -> i;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
-                    });
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_AXIS);
+            int axis = switch (v) {
+                case Integer i -> i;
+                case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
+            };
             return new ReduceOp(def, axis);
         }
 
@@ -420,11 +420,11 @@ public class TritonOps {
         final int axis;
 
         public static GetProgramIdOp create(ExternalizedOp def) {
-            int axis = def.extractAttributeValue(ATTRIBUTE_AXIS, true,
-                    v -> switch (v) {
-                        case Integer i -> i;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
-                    });
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_AXIS);
+            int axis = switch (v) {
+                case Integer i -> i;
+                case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
+            };
             return new GetProgramIdOp(def, axis);
         }
 
@@ -471,16 +471,16 @@ public class TritonOps {
         final int end;
 
         public static MakeRangeOp create(ExternalizedOp def) {
-            int start = def.extractAttributeValue(ATTRIBUTE_START, false,
-                    v -> switch (v) {
+            Object sv = def.attributes().get(ATTRIBUTE_START);
+            int start = switch (sv) {
                         case Integer i -> i;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported start value:" + v);
-                    });
-            int end = def.extractAttributeValue(ATTRIBUTE_END, false,
-                    v -> switch (v) {
+                        case null, default -> throw new UnsupportedOperationException("Unsupported start value:" + sv);
+                    };
+            Object ev = def.attributes().get(ATTRIBUTE_END);
+            int end = switch (ev) {
                         case Integer i -> i;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported end value:" + v);
-                    });
+                        case null, default -> throw new UnsupportedOperationException("Unsupported end value:" + ev);
+                    };
             return new MakeRangeOp(def, start, end);
         }
 
@@ -530,11 +530,11 @@ public class TritonOps {
         final int axis;
 
         public static ExpandOp create(ExternalizedOp def) {
-            int axis = def.extractAttributeValue(ATTRIBUTE_AXIS, true,
-                    v -> switch (v) {
-                        case Integer i -> i;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
-                    });
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_AXIS);
+            int axis = switch (v) {
+                case Integer i -> i;
+                case null, default -> throw new UnsupportedOperationException("Unsupported axis value:" + v);
+            };
             return new ExpandOp(def, axis);
         }
 
@@ -733,6 +733,10 @@ public class TritonOps {
         }
     }
 
+    static Object getDefaultAttributeValue(ExternalizedOp def, String attributeName) {
+        var attrs = def.attributes();
+        return attrs.containsKey("") ? attrs.get("") : attrs.get(attributeName);
+    }
 
     public static ModuleOp module(FuncOp... functions) {
         return module(List.of(functions));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -993,17 +993,9 @@ public sealed abstract class CoreOp extends Op {
         final VarType resultType;
 
         VarOp(ExternalizedOp def) {
-            List<Value> operands = requireOperands(def, 0, 1);
-            String name = def.extractAttributeValue(ATTRIBUTE_NAME, true, v -> switch (v) {
-                case String s -> s;
-                case null -> "";
-                default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_NAME, v);
-            });
-
             // @@@ Cannot use canonical constructor because type is wrapped
-            super(operands);
-
-            this.varName = name;
+            super(requireOperands(def, 0, 1));
+            this.varName = optionalAttribute(def, ATTRIBUTE_NAME, true, String.class).orElse("");
             if (!(def.resultType() instanceof VarType vt)) {
                 throw structuralException(def, "invalid result type: " + def.resultType());
             }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -1214,7 +1214,8 @@ public sealed abstract class JavaOp extends Op {
         final CodeType resultType;
 
         NewOp(ExternalizedOp def) {
-            this(optionalBooleanAttribute(def, ATTRIBUTE_NEW_VARARGS), def.resultType(),
+            this(optionalBooleanAttribute(def, ATTRIBUTE_NEW_VARARGS),
+                 def.resultType(),
                  requireAttribute(def, ATTRIBUTE_NEW_REF, true, MethodRef.class),
                  def.operands());
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -487,14 +487,7 @@ public sealed abstract class JavaOp extends Op {
         final boolean isReflectable;
 
         LambdaOp(ExternalizedOp def) {
-            boolean isReflectable = def.extractAttributeValue(ATTRIBUTE_LAMBDA_IS_REFLECTABLE,
-                    false, v -> switch (v) {
-                        case Boolean b -> b;
-                        case null -> false;
-                        default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_LAMBDA_IS_REFLECTABLE, v);
-                    });
-
-            this(def.resultType(), requireSingleBody(def), isReflectable);
+            this(def.resultType(), requireSingleBody(def), optionalBooleanAttribute(def, ATTRIBUTE_LAMBDA_IS_REFLECTABLE));
         }
 
         LambdaOp(LambdaOp that, CodeContext cc, CodeTransformer ct) {
@@ -996,31 +989,25 @@ public sealed abstract class JavaOp extends Op {
             MethodRef invokeRef = requireAttribute(def, ATTRIBUTE_INVOKE_REF, true, MethodRef.class);
 
             // If not present defaults to false
-            boolean isVarArgs = def.extractAttributeValue(ATTRIBUTE_INVOKE_VARARGS,
-                    false, v -> switch (v) {
-                        case Boolean b -> b;
-                        case null -> false;
-                        default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_VARARGS, v);
-                    });
+            boolean isVarArgs = optionalBooleanAttribute(def, ATTRIBUTE_INVOKE_VARARGS);
 
             // If not present and is not varargs defaults to class or instance invocation
             // based on number of operands and parameters
-            InvokeKind ik = def.extractAttributeValue(ATTRIBUTE_INVOKE_KIND,
-                    false, v -> switch (v) {
+            InvokeKind ik = optionalAttribute(def, ATTRIBUTE_INVOKE_KIND, false, Object.class).map(v ->
+                    switch (v) {
                         case String s -> InvokeKind.valueOf(s);
                         case InvokeKind k -> k;
-                        case null -> {
-                            if (isVarArgs) {
-                                // If varargs then we cannot infer invoke kind
-                                throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_KIND, v);
-                            }
-                            int paramCount = invokeRef.signature().parameterTypes().size();
-                            int argCount = def.operands().size();
-                            yield (argCount == paramCount + 1)
-                                    ? InvokeKind.INSTANCE
-                                    : InvokeKind.STATIC;
-                        }
                         default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_KIND, v);
+                    }).orElseGet(() -> {
+                        if (isVarArgs) {
+                            // If varargs then we cannot infer invoke kind
+                            throw unsupportedAttributeValueException(def, ATTRIBUTE_INVOKE_KIND, null);
+                        }
+                        int paramCount = invokeRef.signature().parameterTypes().size();
+                        int argCount = def.operands().size();
+                        return (argCount == paramCount + 1)
+                                ? InvokeKind.INSTANCE
+                                : InvokeKind.STATIC;
                     });
 
 
@@ -1227,18 +1214,9 @@ public sealed abstract class JavaOp extends Op {
         final CodeType resultType;
 
         NewOp(ExternalizedOp def) {
-            // Required attribute
-            MethodRef constructorRef = requireAttribute(def, ATTRIBUTE_NEW_REF, true, MethodRef.class);
-
-            // If not present defaults to false
-            boolean isVarArgs = def.extractAttributeValue(ATTRIBUTE_NEW_VARARGS,
-                    false, v -> switch (v) {
-                        case Boolean b -> b;
-                        case null -> false;
-                        default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_NEW_VARARGS, v);
-                    });
-
-            this(isVarArgs, def.resultType(), constructorRef, def.operands());
+            this(optionalBooleanAttribute(def, ATTRIBUTE_NEW_VARARGS), def.resultType(),
+                 requireAttribute(def, ATTRIBUTE_NEW_REF, true, MethodRef.class),
+                 def.operands());
         }
 
         NewOp(NewOp that, CodeContext cc) {
@@ -5917,13 +5895,7 @@ public sealed abstract class JavaOp extends Op {
 
             TypePatternOp(ExternalizedOp def) {
                 super(List.of());
-
-                this.bindingName = def.extractAttributeValue(ATTRIBUTE_BINDING_NAME, true,
-                        v -> switch (v) {
-                            case String s -> s;
-                            case null -> null;
-                            default -> throw unsupportedAttributeValueException(def, ATTRIBUTE_BINDING_NAME, v);
-                        });
+                this.bindingName = optionalAttribute(def, ATTRIBUTE_BINDING_NAME, true, String.class).orElse(null);
                 // @@@ Cannot use canonical constructor because it wraps the given type
                 this.resultType = def.resultType();
             }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/ExternalizedOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/extern/ExternalizedOp.java
@@ -28,7 +28,6 @@ import jdk.incubator.code.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * An operation's externalized state (a record) that can be utilized to construct an instance
@@ -69,42 +68,6 @@ public record ExternalizedOp(String name,
      */
     public ExternalizedOp {
         attributes = Map.copyOf(attributes);
-    }
-
-    /**
-     * Gets an attribute value from the attributes map, converts the value by applying it
-     * to mapping function, and returns the result.
-     *
-     * <p>If the attribute is a default attribute then this method first attempts to
-     * get the attribute whose name is the empty string, otherwise if there is no such
-     * attribute present or the attribute is not a default attribute then this method
-     * attempts to get the attribute with the given name.
-     *
-     * <p>On successfully obtaining the attribute its value is converted by applying the value
-     * to the mapping function. A {@code null} value is represented by the value
-     * {@link ExternalizedOp#NULL_ATTRIBUTE_VALUE}.
-     *
-     * <p>If no attribute is present the {@code null} value is applied to the mapping function.
-     *
-     * @param name      the attribute name.
-     * @param isDefault true if the attribute is a default attribute
-     * @param mapper    the function used to convert the attribute value
-     * @param <T>       the converted attribute value type
-     * @return the converted attribute value
-     */
-    public <T> T extractAttributeValue(String name, boolean isDefault, Function<Object, T> mapper) {
-        Object value = null;
-        if (isDefault && attributes.containsKey("")) {
-            value = attributes.get("");
-            assert value != null;
-        }
-
-        if (value == null && attributes.containsKey(name)) {
-            value = attributes.get(name);
-            assert value != null;
-        }
-
-        return mapper.apply(value);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
@@ -26,6 +26,7 @@
 package jdk.incubator.code.internal;
 
 import java.util.List;
+import java.util.Optional;
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;
 import jdk.incubator.code.Value;
@@ -118,10 +119,11 @@ public final class StructuralPreconditions {
         return succ;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T requireAttribute(ExternalizedOp def, String attributeName, boolean isDefaultAttribute, Class<T> attributeType) {
         Object attr = requireAttribute(def, attributeName, isDefaultAttribute);
         if (attributeType.isInstance(attr)) {
-            return attributeType.cast(attr);
+            return (T)attr;
         }
         throw unsupportedAttributeValueException(def, attributeName, attr);
     }
@@ -134,6 +136,19 @@ public final class StructuralPreconditions {
             return def.attributes().get(attributeName);
         }
         throw structuralException(def, "requires attribute %s".formatted(attributeName));
+    }
+
+    public static boolean optionalBooleanAttribute(ExternalizedOp def, String attributeName) {
+        return optionalAttribute(def, attributeName, false, Boolean.class).orElse(false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<T> optionalAttribute(ExternalizedOp def, String attributeName, boolean isDefaultAttribute, Class<T> attributeType) {
+        Object attr = def.attributes().get(isDefaultAttribute && def.attributes().containsKey("") ? "" : attributeName);
+        if (attr == null || attributeType.isInstance(attr)) {
+            return Optional.ofNullable((T)attr);
+        }
+        throw unsupportedAttributeValueException(def, attributeName, attr);
     }
 
     public static IllegalStateException structuralException(ExternalizedOp def, String msg) {

--- a/test/jdk/jdk/incubator/code/anf/AnfDialect.java
+++ b/test/jdk/jdk/incubator/code/anf/AnfDialect.java
@@ -280,12 +280,11 @@ public final class AnfDialect {
             if (!def.operands().isEmpty()) {
                 throw new IllegalStateException("Bad op " + def.name());
             }
-
-            String funcName = def.extractAttributeValue(ATTRIBUTE_FUNC_NAME, true,
-                    v -> switch (v) {
-                        case String s -> s;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
-                    });
+            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_FUNC_NAME));
+            String funcName = switch (v) {
+                case String s -> s;
+                case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+            };
             return new AnfFuncOp(funcName, def.bodyDefinitions().get(0));
         }
 
@@ -389,11 +388,11 @@ public final class AnfDialect {
                 throw new IllegalStateException("Bad op " + def.name());
             }
 
-            String callsiteName = def.extractAttributeValue(ATTRIBUTE_CALLSITE_NAME, true,
-                    v -> switch (v) {
-                        case String s -> s;
-                        case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
-                    });
+            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_CALLSITE_NAME));
+            String callsiteName = switch (v) {
+                case String s -> s;
+                case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
+            };
             return new AnfApplyStub(callsiteName, def.operands(), def.resultType());
         }
 

--- a/test/jdk/jdk/incubator/code/anf/AnfDialect.java
+++ b/test/jdk/jdk/incubator/code/anf/AnfDialect.java
@@ -280,7 +280,7 @@ public final class AnfDialect {
             if (!def.operands().isEmpty()) {
                 throw new IllegalStateException("Bad op " + def.name());
             }
-            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_FUNC_NAME));
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_FUNC_NAME);
             String funcName = switch (v) {
                 case String s -> s;
                 case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
@@ -388,7 +388,7 @@ public final class AnfDialect {
                 throw new IllegalStateException("Bad op " + def.name());
             }
 
-            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_CALLSITE_NAME));
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_CALLSITE_NAME);
             String callsiteName = switch (v) {
                 case String s -> s;
                 case null, default -> throw new UnsupportedOperationException("Unsupported func name value:" + v);
@@ -445,6 +445,11 @@ public final class AnfDialect {
             op.setLocation(def.location());
         }
         return op;
+    }
+
+    static Object getDefaultAttributeValue(ExternalizedOp def, String attributeName) {
+        var attrs = def.attributes();
+        return attrs.containsKey("") ? attrs.get("") : attrs.get(attributeName);
     }
 
     static final OpFactory FACTORY = AnfDialect::createOp;

--- a/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
@@ -85,12 +85,12 @@ sealed abstract class SlotOp extends Op {
         final CodeType resultType;
 
         public SlotLoadOp(ExternalizedOp def) {
-            int slot = def.extractAttributeValue(ATTRIBUTE_SLOT, true,
-                    v -> switch (v) {
-                        case String s -> Integer.parseInt(s);
-                        case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported slot value:" + v);
-                    });
+            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_SLOT));
+            int slot = switch (v) {
+                case String s -> Integer.parseInt(s);
+                case Integer i -> i;
+                default -> throw new UnsupportedOperationException("Unsupported slot value:" + v);
+            };
             this(slot, def.resultType());
         }
 
@@ -135,12 +135,12 @@ sealed abstract class SlotOp extends Op {
         }
 
         public SlotStoreOp(ExternalizedOp def) {
-            int slot = def.extractAttributeValue(ATTRIBUTE_SLOT, true,
-                    v -> switch (v) {
-                        case String s -> Integer.parseInt(s);
-                        case Integer i -> i;
-                        default -> throw new UnsupportedOperationException("Unsupported slot value:" + v);
-                    });
+            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_SLOT));
+            int slot = switch (v) {
+                case String s -> Integer.parseInt(s);
+                case Integer i -> i;
+                default -> throw new UnsupportedOperationException("Unsupported slot value:" + v);
+            };
             this(slot, def.operands().getFirst());
         }
 

--- a/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
@@ -85,7 +85,7 @@ sealed abstract class SlotOp extends Op {
         final CodeType resultType;
 
         public SlotLoadOp(ExternalizedOp def) {
-            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_SLOT));
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_SLOT);
             int slot = switch (v) {
                 case String s -> Integer.parseInt(s);
                 case Integer i -> i;
@@ -135,7 +135,7 @@ sealed abstract class SlotOp extends Op {
         }
 
         public SlotStoreOp(ExternalizedOp def) {
-            Object v = def.attributes().getOrDefault("", def.attributes().get(ATTRIBUTE_SLOT));
+            Object v = getDefaultAttributeValue(def, ATTRIBUTE_SLOT);
             int slot = switch (v) {
                 case String s -> Integer.parseInt(s);
                 case Integer i -> i;
@@ -182,5 +182,11 @@ sealed abstract class SlotOp extends Op {
             default ->
                 TypeKind.REFERENCE;
         };
+    }
+
+
+    static Object getDefaultAttributeValue(ExternalizedOp def, String attributeName) {
+        var attrs = def.attributes();
+        return attrs.containsKey("") ? attrs.get("") : attrs.get(attributeName);
     }
 }


### PR DESCRIPTION
This PR redirects all remaining internal uses of `ExternalizedOp.extractAttributeValue` to `StructuralPreconditions` and proposes removing `ExternalizedOp.extractAttributeValue` from the public API.

The affected dialect operation construction in the tests and in `cr-examples/onnx` and `cr-examples/triton` has been updated accordingly.

Please review.

Thank you,
Adam

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1072/head:pull/1072` \
`$ git checkout pull/1072`

Update a local copy of the PR: \
`$ git checkout pull/1072` \
`$ git pull https://git.openjdk.org/babylon.git pull/1072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1072`

View PR using the GUI difftool: \
`$ git pr show -t 1072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1072.diff">https://git.openjdk.org/babylon/pull/1072.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1072#issuecomment-4808408911)
</details>
