### PR TITLE
Structural checks consolidation part 2

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -560,14 +560,14 @@ public sealed abstract class CoreOp extends Op {
         }
 
         private Op getQuotedOp(Body quotedBody) {
-            if (quotedBody.blocks().size() > 1) {
-                throw new IllegalArgumentException();
+            if (quotedBody.blocks().size() != 1) {
+                throw structuralException(NAME, "quoted body requires single block, found %d".formatted(quotedBody.blocks().size()));
             }
             if (!(quotedBody.entryBlock().terminatingOp() instanceof YieldOp yop)) {
-                throw new IllegalArgumentException();
+                throw structuralException(NAME, "quoted body requires yield terminal operation, found %s".formatted(quotedBody.entryBlock().terminatingOp()));
             }
             if (!(yop.yieldValue() instanceof Result r)) {
-                throw new IllegalArgumentException();
+                throw structuralException(NAME, "quoted body yield value requires to be an operation result, found %s".formatted(yop.yieldValue()));
             }
             return r.op();
         }
@@ -674,9 +674,7 @@ public sealed abstract class CoreOp extends Op {
         static final String NAME = "yield";
 
         YieldOp(ExternalizedOp def) {
-            requireOperands(def, 0, 1);
-
-            this(def.operands());
+            this(requireOperands(def, 0, 1));
         }
 
         YieldOp(YieldOp that, CodeContext cc) {
@@ -997,7 +995,7 @@ public sealed abstract class CoreOp extends Op {
             super(requireOperands(def, 0, 1));
             this.varName = optionalAttribute(def, ATTRIBUTE_NAME, true, String.class).orElse("");
             if (!(def.resultType() instanceof VarType vt)) {
-                throw structuralException(def, "invalid result type: " + def.resultType());
+                throw structuralException(def.name(), "invalid result type: " + def.resultType());
             }
             this.resultType = vt;
         }
@@ -1125,9 +1123,9 @@ public sealed abstract class CoreOp extends Op {
             return (VarOp) varValue.op();
         }
 
-        static void requireVarOp(ExternalizedOp opdef, Value varValue) {
+        static void requireVarOp(String opName, Value varValue) {
             if (!(varValue.type() instanceof VarType)) {
-                throw structuralException(opdef, "value's type is not a variable type: " + varValue);
+                throw structuralException(opName, "value's type is not a variable type: " + varValue);
             }
         }
 
@@ -1148,7 +1146,7 @@ public sealed abstract class CoreOp extends Op {
 
             VarLoadOp(ExternalizedOp opdef) {
                 Value varValue = requireSingleOperand(opdef);
-                requireVarOp(opdef, varValue);
+                requireVarOp(opdef.name(), varValue);
                 this(varValue);
             }
 
@@ -1163,6 +1161,7 @@ public sealed abstract class CoreOp extends Op {
 
             // (Variable)VarType
             VarLoadOp(Value varValue) {
+                requireVarOp(NAME, varValue);
                 super(List.of(varValue));
             }
 
@@ -1189,7 +1188,7 @@ public sealed abstract class CoreOp extends Op {
 
             VarStoreOp(ExternalizedOp opdef) {
                 List<Value> operands = requireOperands(opdef, 2);
-                requireVarOp(opdef, operands.getFirst());
+                requireVarOp(opdef.name(), operands.getFirst());
                 super(operands);
             }
 
@@ -1204,6 +1203,7 @@ public sealed abstract class CoreOp extends Op {
 
             // (Variable, VarType)void
             VarStoreOp(Value varValue, Value v) {
+                requireVarOp(NAME, varValue);
                 super(List.of(varValue, v));
             }
 
@@ -1298,8 +1298,11 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleLoadOp(Value tupleValue, int index) {
+            if (!(tupleValue.type() instanceof TupleType tt)) {
+                throw structuralException(NAME, "requires tuple value type, found %s".formatted(tupleValue.type()));
+            }
+            Objects.checkIndex(index, tt.componentTypes().size());
             super(List.of(tupleValue));
-
             this.index = index;
         }
 
@@ -1369,9 +1372,11 @@ public sealed abstract class CoreOp extends Op {
         }
 
         TupleWithOp(Value tupleValue, int index, Value value) {
+            if (!(tupleValue.type() instanceof TupleType tt)) {
+                throw structuralException(NAME, "requires tuple value type, found %s".formatted(tupleValue.type()));
+            }
+            Objects.checkIndex(index, tt.componentTypes().size());
             super(List.of(tupleValue, value));
-
-            // @@@ Validate tuple type and index
             this.index = index;
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -1356,8 +1356,8 @@ public sealed abstract class CoreOp extends Op {
         final int index;
 
         TupleWithOp(ExternalizedOp def) {
-            super(requireOperands(def, 2));
-            this.index = requireAttribute(def, ATTRIBUTE_INDEX, true, Integer.class);
+            List<Value> operands = requireOperands(def, 2);
+            this(operands.get(0), requireAttribute(def, ATTRIBUTE_INDEX, true, Integer.class), operands.get(1));
         }
 
         TupleWithOp(TupleWithOp that, CodeContext cc) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -2951,13 +2951,7 @@ public sealed abstract class JavaOp extends Op {
         // @@@: builder?
         SynchronizedOp(Body.Builder exprC, Body.Builder bodyC) {
             super(List.of());
-            if (exprC.bodySignature().returnType().equals(VOID)) {
-                throw structuralException(NAME, "expression body requires to return non-void value");
-            }
-            if (!exprC.bodySignature().parameterTypes().isEmpty()) {
-                throw structuralException(NAME, "expression body requires no parameters, found: %s".formatted(exprC.bodySignature()));
-            }
-            this.exprBody = exprC.build(this);
+            this.exprBody = requireNonVoidReturnType(NAME + " expression", exprC, 0).build(this);
             this.blockBody = requireVoidBodySignature(NAME, bodyC).build(this);
         }
 
@@ -3322,7 +3316,7 @@ public sealed abstract class JavaOp extends Op {
 
         IfOp(ExternalizedOp def) {
             requireNoOperands(def);
-            this(requireMinBodies(def, 2));
+            this(def.bodyDefinitions());
         }
 
         IfOp(IfOp that, CodeContext cc, CodeTransformer ct) {
@@ -3339,6 +3333,12 @@ public sealed abstract class JavaOp extends Op {
         }
 
         IfOp(List<Body.Builder> bodyCs) {
+            if (bodyCs.size() < 2) {
+                throw structuralException(NAME, "requires 2 or more bodies, found %d".formatted(bodyCs.size()));
+            }
+            for (int i = 0; i < bodyCs.size(); i++) {
+                requireBodySignature(NAME, bodyCs.get(i), i % 2 == 0 && i < bodyCs.size() - 1 ? PREDICATE_SIGNATURE : ACTION_SIGNATURE);
+            }
             super(List.of());
 
             // Normalize by adding an empty else action
@@ -3350,27 +3350,7 @@ public sealed abstract class JavaOp extends Op {
                 end.entryBlock().add(core_yield());
                 bodyCs.add(end);
             }
-
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
-
-            if (bodies.size() < 2) {
-                throw new IllegalArgumentException("Incorrect number of bodies: " + bodies.size());
-            }
-            for (int i = 0; i < bodies.size(); i += 2) {
-                Body action;
-                if (i == bodies.size() - 1) {
-                    action = bodies.get(i);
-                } else {
-                    action = bodies.get(i + 1);
-                    Body fromPred = bodies.get(i);
-                    if (!fromPred.bodySignature().equals(CoreType.functionType(BOOLEAN))) {
-                throw new IllegalArgumentException("Illegal predicate body signature: " + fromPred.bodySignature());
-                    }
-                }
-                if (!action.bodySignature().equals(CoreType.FUNCTION_TYPE_VOID)) {
-                throw new IllegalArgumentException("Illegal action body signature: " + action.bodySignature());
-                }
-            }
         }
 
         @Override
@@ -3650,7 +3630,7 @@ public sealed abstract class JavaOp extends Op {
         final CodeType resultType;
 
         SwitchExpressionOp(ExternalizedOp def) {
-            this(def.resultType(), requireSingleOperand(def), requireBodyPairs(def));
+            this(def.resultType(), requireSingleOperand(def), def.bodyDefinitions());
         }
 
         SwitchExpressionOp(SwitchExpressionOp that, CodeContext cc, CodeTransformer ct) {
@@ -3665,8 +3645,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         SwitchExpressionOp(CodeType resultType, Value target, List<Body.Builder> bodyCs) {
-            super(target, bodyCs);
-
+            super(target, requireBodyPairs(NAME, bodyCs));
             this.resultType = resultType == null ? bodies.get(1).yieldType() : resultType;
         }
 
@@ -3691,7 +3670,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.switch.statement";
 
         SwitchStatementOp(ExternalizedOp def) {
-            this(requireSingleOperand(def), requireBodyPairs(def));
+            this(requireSingleOperand(def), def.bodyDefinitions());
         }
 
         SwitchStatementOp(SwitchStatementOp that, CodeContext cc, CodeTransformer ct) {
@@ -3704,7 +3683,7 @@ public sealed abstract class JavaOp extends Op {
         }
 
         SwitchStatementOp(Value target, List<Body.Builder> bodyCs) {
-            super(target, bodyCs);
+            super(target, requireBodyPairs(NAME, bodyCs));
         }
 
         @Override
@@ -3944,18 +3923,18 @@ public sealed abstract class JavaOp extends Op {
               Body.Builder bodyC) {
             super(List.of());
 
-            this.initBody = initC.build(this);
+            List<CodeType> varTypes = switch (initC.bodySignature().returnType()) {
+                case TupleType tt -> tt.componentTypes();
+                case PrimitiveType pt when pt.equals(VOID) -> List.of();
+                case CodeType t -> List.of(t);
+            };
+            FunctionType condType = CoreType.functionType(BOOLEAN, varTypes);
+            FunctionType bodyType = CoreType.functionType(VOID, varTypes);
 
-            this.condBody = condC.build(this);
-            this.updateBody = updateC.build(this);
-            if (!updateBody.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Update should return void: " + updateBody.bodySignature());
-            }
-
-            this.loopBody = bodyC.build(this);
-            if (!loopBody.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + loopBody.bodySignature());
-            }
+            this.initBody = requireNoParameters(NAME + " init", initC).build(this);
+            this.condBody = requireBodySignature(NAME + " predicate", condC, condType).build(this);
+            this.updateBody = requireBodySignature(NAME + " update", updateC, bodyType).build(this);
+            this.loopBody = requireBodySignature(NAME + " loop", bodyC, bodyType).build(this);
         }
 
         @Override
@@ -4211,29 +4190,9 @@ public sealed abstract class JavaOp extends Op {
         EnhancedForOp(Body.Builder expressionC, Body.Builder initC, Body.Builder bodyC) {
             super(List.of());
 
-            this.exprBody = expressionC.build(this);
-            if (exprBody.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Expression should return non-void value: " + exprBody.bodySignature());
-            }
-            if (!exprBody.bodySignature().parameterTypes().isEmpty()) {
-                throw new IllegalArgumentException("Expression should have zero parameters: " + exprBody.bodySignature());
-            }
-
-            this.initBody = initC.build(this);
-            if (initBody.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Initialization should return non-void value: " + initBody.bodySignature());
-            }
-            if (initBody.bodySignature().parameterTypes().size() != 1) {
-                throw new IllegalArgumentException("Initialization should have one parameter: " + initBody.bodySignature());
-            }
-
-            this.loopBody = bodyC.build(this);
-            if (!loopBody.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + loopBody.bodySignature());
-            }
-            if (loopBody.bodySignature().parameterTypes().size() != 1) {
-                throw new IllegalArgumentException("Body should have one parameter: " + loopBody.bodySignature());
-            }
+            this.exprBody = requireNonVoidReturnType(NAME + " expression", expressionC, 0).build(this);
+            this.initBody = requireNonVoidReturnType(NAME + " initilization", initC, 1).build(this);
+            this.loopBody = requireVoidReturnType(NAME + " loop", bodyC, 1).build(this);
         }
 
         @Override
@@ -4645,6 +4604,9 @@ public sealed abstract class JavaOp extends Op {
      */
     public sealed static abstract class JavaConditionalOp extends JavaOp
             implements Op.Nested, Op.Lowerable, JavaExpression {
+
+        static final FunctionType BODY_TYPE = CoreType.functionType(BOOLEAN);
+
         final List<Body> bodies;
 
         JavaConditionalOp(JavaConditionalOp that, CodeContext cc, CodeTransformer ct) {
@@ -4654,23 +4616,9 @@ public sealed abstract class JavaOp extends Op {
             this.bodies = that.bodies.stream().map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
-        JavaConditionalOp(ExternalizedOp def) {
-            this(requireMinBodies(def, 2));
-        }
-
         JavaConditionalOp(List<Body.Builder> bodyCs) {
             super(List.of());
-
-            if (bodyCs.isEmpty()) {
-                throw new IllegalArgumentException();
-            }
-
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
-            for (Body b : bodies) {
-                if (!b.bodySignature().equals(CoreType.functionType(BOOLEAN))) {
-                    throw new IllegalArgumentException("Body conditional body signature: " + b.bodySignature());
-                }
-            }
         }
 
         @Override
@@ -4785,7 +4733,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.cand";
 
         ConditionalAndOp(ExternalizedOp def) {
-            super(def);
+            this(def.bodyDefinitions());
         }
 
         ConditionalAndOp(ConditionalAndOp that, CodeContext cc, CodeTransformer ct) {
@@ -4798,6 +4746,10 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConditionalAndOp(List<Body.Builder> bodyCs) {
+            if (bodyCs.size() < 2) {
+                throw structuralException(NAME, "requires at least 2 bodies, found: %d".formatted(bodyCs.size()));
+            }
+            bodyCs.forEach(b -> requireBodySignature(NAME, b, BODY_TYPE));
             super(bodyCs);
         }
 
@@ -4854,7 +4806,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.cor";
 
         ConditionalOrOp(ExternalizedOp def) {
-            super(def);
+            this(def.bodyDefinitions());
         }
 
         ConditionalOrOp(ConditionalOrOp that, CodeContext cc, CodeTransformer ct) {
@@ -4867,6 +4819,10 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConditionalOrOp(List<Body.Builder> bodyCs) {
+            if (bodyCs.size() < 2) {
+                throw structuralException(NAME, "requires at least 2 bodies, found: %d".formatted(bodyCs.size()));
+            }
+            bodyCs.forEach(b -> requireBodySignature(NAME, b, BODY_TYPE));
             super(bodyCs);
         }
 
@@ -4897,7 +4853,8 @@ public sealed abstract class JavaOp extends Op {
         final List<Body> bodies;
 
         ConditionalExpressionOp(ExternalizedOp def) {
-            this(def.resultType(), requireBodies(def, 3));
+            List<Body.Builder> bodies = requireBodies(def, 3);
+            this(def.resultType(), bodies.get(0), bodies.get(1), bodies.get(2));
         }
 
         ConditionalExpressionOp(ConditionalExpressionOp that, CodeContext cc, CodeTransformer ct) {
@@ -4914,21 +4871,14 @@ public sealed abstract class JavaOp extends Op {
             return new ConditionalExpressionOp(this, cc, ct);
         }
 
-        ConditionalExpressionOp(CodeType expressionType, List<Body.Builder> bodyCs) {
+        ConditionalExpressionOp(CodeType expressionType, Body.Builder predicateBody, Body.Builder trueBody, Body.Builder falseBody) {
             super(List.of());
 
-            this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
+            this.bodies = List.of(requireBodySignature(NAME, predicateBody, CoreType.functionType(BOOLEAN)).build(this),
+                                  requireNoParameters(NAME, trueBody).build(this),
+                                  requireNoParameters(NAME, falseBody).build(this));
             // @@@ when expressionType is null, we assume truepart and falsepart have the same yieldType
             this.resultType = expressionType == null ? bodies.get(1).yieldType() : expressionType;
-
-            if (bodies.size() < 3) {
-                throw new IllegalArgumentException("Incorrect number of bodies: " + bodies.size());
-            }
-
-            Body cond = bodies.get(0);
-            if (!cond.bodySignature().equals(CoreType.functionType(BOOLEAN))) {
-                throw new IllegalArgumentException("Illegal cond body signature: " + cond.bodySignature());
-            }
         }
 
         @Override
@@ -5182,19 +5132,15 @@ public sealed abstract class JavaOp extends Op {
               Body.Builder finalizerC) {
             super(List.of());
 
-            this.resourcesBodies = resourcesC.stream().map(r -> r.build(this)).toList();
             List<CodeType> resourceTypes = new ArrayList<>();
-            for (Body _resource : resourcesBodies) {
-                if (_resource.bodySignature().returnType().equals(VOID)) {
-                    throw new IllegalArgumentException("Resource should not return void: " + _resource.bodySignature());
-                }
+            for (Body.Builder _resource : resourcesC) {
+                requireNonVoidReturnType(NAME + " resource", _resource, resourceTypes.size());
                 if (!_resource.bodySignature().parameterTypes().equals(resourceTypes)) {
-                    throw new IllegalArgumentException(
-                            "Resource should have parameters matching preceding resource yields: "
-                                    + _resource.bodySignature());
+                    throw structuralException(NAME, " resource requires %s parameter types, found %s".formatted(resourceTypes, _resource.bodySignature().parameterTypes()));
                 }
                 resourceTypes.add(_resource.bodySignature().returnType());
             }
+            this.resourcesBodies = resourcesC.stream().map(r -> r.build(this)).toList();
 
             this.body = bodyC.build(this);
             if (!body.bodySignature().returnType().equals(VOID)) {
@@ -5926,6 +5872,9 @@ public sealed abstract class JavaOp extends Op {
             RecordPatternOp(RecordTypeRef recordReference, List<Value> nestedPatterns) {
                 // The type of each value is a subtype of Pattern
                 // The number of values corresponds to the number of components of the record
+                if (recordReference.components().size() != nestedPatterns.size()) {
+                    throw structuralException(NAME, "requires %d nested pattern operands, found %d".formatted(recordReference.components().size(), nestedPatterns.size()));
+                }
                 super(List.copyOf(nestedPatterns));
 
                 this.recordReference = recordReference;
@@ -6037,7 +5986,7 @@ public sealed abstract class JavaOp extends Op {
             MatchOp(Value target, Body.Builder patternC, Body.Builder matchC) {
                 super(List.of(target));
 
-                this.patternBody = patternC.build(this);
+                this.patternBody = requireNoParameters(NAME + " pattern", patternC).build(this);
                 this.matchBody = matchC.build(this);
             }
 
@@ -7401,13 +7350,17 @@ public sealed abstract class JavaOp extends Op {
      * Creates a conditional operation
      *
      * @param expressionType the result type of the expression
-     * @param bodies         the body builders for the predicate, true, and false bodies
+     * @param predicateBody  the body builder for the predicate body
+     * @param trueBody       the body builder for the true body
+     * @param falseBody      the body builder for the false body
      * @return the conditional operation
      */
     public static ConditionalExpressionOp conditionalExpression(CodeType expressionType,
-                                                                List<Body.Builder> bodies) {
+                                                                Body.Builder predicateBody,
+                                                                Body.Builder trueBody,
+                                                                Body.Builder falseBody) {
         Objects.requireNonNull(expressionType);
-        return new ConditionalExpressionOp(expressionType, bodies);
+        return new ConditionalExpressionOp(expressionType, predicateBody, trueBody, falseBody);
     }
 
     /**
@@ -7415,11 +7368,15 @@ public sealed abstract class JavaOp extends Op {
      * <p>
      * The result type of the operation will be derived from the yield type of the true body.
      *
-     * @param bodies the body builders for the predicate, true, and false bodies
+     * @param predicateBody  the body builder for the predicate body
+     * @param trueBody       the body builder for the true body
+     * @param falseBody      the body builder for the false body
      * @return the conditional operation
      */
-    public static ConditionalExpressionOp conditionalExpression(List<Body.Builder> bodies) {
-        return new ConditionalExpressionOp(null, bodies);
+    public static ConditionalExpressionOp conditionalExpression(Body.Builder predicateBody,
+                                                                Body.Builder trueBody,
+                                                                Body.Builder falseBody) {
+        return new ConditionalExpressionOp(null, predicateBody, trueBody, falseBody);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -813,15 +813,14 @@ public sealed abstract class JavaOp extends Op {
         private final List<Body> bodies;
 
         AssertOp(ExternalizedOp def) {
-            this(requireBodies(def, 1, 2));
+            this(def.bodyDefinitions());
         }
 
         AssertOp(List<Body.Builder> bodies) {
-            super(List.of());
-
             if (bodies.size() != 1 && bodies.size() != 2) {
-                throw new IllegalArgumentException("Assert must have one or two bodies.");
+                throw structuralException(NAME, "requires 1 or 2 bodies, found %d".formatted(bodies.size()));
             }
+            super(List.of());
             this.bodies = bodies.stream().map(b -> b.build(this)).toList();
         }
 
@@ -1044,7 +1043,12 @@ public sealed abstract class JavaOp extends Op {
             int argCount = operands.size() - (invokeKind == InvokeKind.STATIC ? 0 : 1);
             if ((!isVarArgs && argCount != paramCount)
                     || argCount < paramCount - 1) {
-                throw new IllegalArgumentException(invokeKind + " " + isVarArgs + " " + invokeRef);
+                throw structuralException(NAME, "kind=%s, varargs=%s, requires %s%d operands, found=%d".formatted(
+                        invokeKind,
+                        isVarArgs,
+                        isVarArgs ? "at least " : "",
+                        isVarArgs ? paramCount - 1 : paramCount,
+                        argCount));
             }
         }
 
@@ -1234,13 +1238,11 @@ public sealed abstract class JavaOp extends Op {
         }
 
         NewOp(boolean isVarargs, CodeType resultType, MethodRef ctorRef, List<Value> args) {
-            super(args);
-
             validateArgCount(isVarargs, ctorRef, args);
             if (!ctorRef.isConstructor()) {
-                throw new IllegalArgumentException("Not a constructor reference: " + ctorRef);
+                throw structuralException(NAME, "requires a constructor reference, found %s".formatted(ctorRef));
             }
-
+            super(args);
             this.isVarArgs = isVarargs;
             this.constructorReference = ctorRef;
             this.resultType = resultType;
@@ -1251,7 +1253,11 @@ public sealed abstract class JavaOp extends Op {
             int argCount = operands.size();
             if ((!isVarArgs && argCount != paramCount)
                     || argCount < paramCount - 1) {
-                throw new IllegalArgumentException(isVarArgs + " " + ctorRef);
+                throw structuralException(NAME, "varargs=%s, requires %s%d operands, found=%d".formatted(
+                        isVarArgs,
+                        isVarArgs ? "at least " : "",
+                        isVarArgs ? paramCount - 1 : paramCount,
+                        argCount));
             }
         }
 
@@ -1748,7 +1754,7 @@ public sealed abstract class JavaOp extends Op {
         final List<Block.Reference> references;
 
         ExceptionRegionEnter(ExternalizedOp def) {
-            this(requireMinSuccessors(def, 2));
+            this(def.successors());
         }
 
         ExceptionRegionEnter(ExceptionRegionEnter that, CodeContext cc) {
@@ -1763,12 +1769,10 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ExceptionRegionEnter(List<Block.Reference> references) {
-            super(List.of());
-
             if (references.size() < 2) {
-                throw new IllegalArgumentException("Operation must have two or more successors " + this);
+                throw structuralException(NAME, "requires at least 2 successors, found %d".formatted(references.size()));
             }
-
+            super(List.of());
             this.references = List.copyOf(references);
         }
 
@@ -1813,11 +1817,7 @@ public sealed abstract class JavaOp extends Op {
         final Block.Reference end;
 
         ExceptionRegionExit(ExternalizedOp def) {
-            Value enter = requireSingleOperand(def);
-            if (!(enter instanceof Op.Result or && or.op() instanceof ExceptionRegionEnter)) {
-                throw structuralException(def, "Value's is not an exception region entry: " + def.operands().getFirst());
-            }
-            this(enter, requireSingleSuccessor(def));
+            this(requireSingleOperand(def), requireSingleSuccessor(def));
         }
 
         ExceptionRegionExit(ExceptionRegionExit that, CodeContext cc) {
@@ -1832,6 +1832,9 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ExceptionRegionExit(Value enter, Block.Reference end) {
+            if (!(enter instanceof Op.Result or && or.op() instanceof ExceptionRegionEnter)) {
+                throw structuralException(NAME, "Value's is not an exception region entry: " + enter);
+            }
             super(List.of(enter));
             this.end = end;
         }
@@ -2869,14 +2872,7 @@ public sealed abstract class JavaOp extends Op {
 
         BlockOp(Body.Builder bodyC) {
             super(List.of());
-
-            this.body = bodyC.build(this);
-            if (!body.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + body.bodySignature());
-            }
-            if (!body.bodySignature().parameterTypes().isEmpty()) {
-                throw new IllegalArgumentException("Body should have zero parameters: " + body.bodySignature());
-            }
+            this.body = requireVoidBodySignature(NAME, bodyC).build(this);
         }
 
         @Override
@@ -2955,22 +2951,14 @@ public sealed abstract class JavaOp extends Op {
         // @@@: builder?
         SynchronizedOp(Body.Builder exprC, Body.Builder bodyC) {
             super(List.of());
-
+            if (exprC.bodySignature().returnType().equals(VOID)) {
+                throw structuralException(NAME, "expression body requires to return non-void value");
+            }
+            if (!exprC.bodySignature().parameterTypes().isEmpty()) {
+                throw structuralException(NAME, "expression body requires no parameters, found: %s".formatted(exprC.bodySignature()));
+            }
             this.exprBody = exprC.build(this);
-            if (exprBody.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Expression body should return non-void value: " + exprBody.bodySignature());
-            }
-            if (!exprBody.bodySignature().parameterTypes().isEmpty()) {
-                throw new IllegalArgumentException("Expression body should have zero parameters: " + exprBody.bodySignature());
-            }
-
-            this.blockBody = bodyC.build(this);
-            if (!blockBody.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Block body should return void: " + blockBody.bodySignature());
-            }
-            if (!blockBody.bodySignature().parameterTypes().isEmpty()) {
-                throw new IllegalArgumentException("Block body should have zero parameters: " + blockBody.bodySignature());
-            }
+            this.blockBody = requireVoidBodySignature(NAME, bodyC).build(this);
         }
 
         @Override
@@ -3118,14 +3106,7 @@ public sealed abstract class JavaOp extends Op {
 
         LabeledOp(Body.Builder bodyC) {
             super(List.of());
-
-            this.body = bodyC.build(this);
-            if (!body.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Body should return void: " + body.bodySignature());
-            }
-            if (!body.bodySignature().parameterTypes().isEmpty()) {
-                throw new IllegalArgumentException("Body should have zero parameters: " + body.bodySignature());
-            }
+            this.body = requireVoidBodySignature(NAME, bodyC).build(this);
         }
 
         @Override
@@ -4430,7 +4411,7 @@ public sealed abstract class JavaOp extends Op {
                 Body.Builder body = Body.Builder.of(connectedAncestorBody, CoreType.FUNCTION_TYPE_VOID);
                 c.accept(body.entryBlock());
 
-                return new WhileOp(List.of(predicate, body));
+                return new WhileOp(predicate, body);
             }
         }
 
@@ -4439,34 +4420,14 @@ public sealed abstract class JavaOp extends Op {
         private final List<Body> bodies;
 
         WhileOp(ExternalizedOp def) {
-            this(requireBodies(def, 2));
-        }
-
-        WhileOp(List<Body.Builder> bodyCs) {
-            super(List.of());
-
-            this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
+            List<Body.Builder> bodies = requireBodies(def, 2);
+            this(bodies.get(0), bodies.get(1));
         }
 
         WhileOp(Body.Builder predicate, Body.Builder body) {
             super(List.of());
-
-            Objects.requireNonNull(body);
-
-            this.bodies = Stream.of(predicate, body).filter(Objects::nonNull)
-                    .map(bc -> bc.build(this)).toList();
-
-            // @@@ This will change with pattern bindings
-            if (!bodies.get(0).bodySignature().equals(CoreType.functionType(BOOLEAN))) {
-                throw new IllegalArgumentException(
-                        "Predicate body signature should be " + CoreType.functionType(BOOLEAN) +
-                                " but is " + bodies.get(0).bodySignature());
-            }
-            if (!bodies.get(1).bodySignature().equals(CoreType.FUNCTION_TYPE_VOID)) {
-                throw new IllegalArgumentException(
-                        "Body type should be " + CoreType.functionType(VOID) +
-                                " but is " + bodies.get(1).bodySignature());
-            }
+            this.bodies = List.of(requireBodySignature(NAME, predicate, CoreType.functionType(BOOLEAN)).build(this),
+                                  requireVoidBodySignature(NAME, body).build(this));
         }
 
         WhileOp(WhileOp that, CodeContext cc, CodeTransformer ct) {
@@ -4568,8 +4529,7 @@ public sealed abstract class JavaOp extends Op {
             public DoWhileOp predicate(Consumer<Block.Builder> c) {
                 Body.Builder predicate = Body.Builder.of(connectedAncestorBody, CoreType.functionType(BOOLEAN));
                 c.accept(predicate.entryBlock());
-
-                return new DoWhileOp(List.of(body, predicate));
+                return new DoWhileOp(body, predicate);
             }
         }
 
@@ -4602,13 +4562,8 @@ public sealed abstract class JavaOp extends Op {
         private final List<Body> bodies;
 
         DoWhileOp(ExternalizedOp def) {
-            this(requireBodies(def, 2));
-        }
-
-        DoWhileOp(List<Body.Builder> bodyCs) {
-            super(List.of());
-
-            this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
+            List<Body.Builder> bodies = requireBodies(def, 2);
+            this(bodies.get(0), bodies.get(1));
         }
 
         DoWhileOp(Body.Builder body, Body.Builder predicate) {
@@ -4616,19 +4571,8 @@ public sealed abstract class JavaOp extends Op {
 
             Objects.requireNonNull(body);
 
-            this.bodies = Stream.of(body, predicate).filter(Objects::nonNull)
-                    .map(bc -> bc.build(this)).toList();
-
-            if (!bodies.get(0).bodySignature().equals(CoreType.FUNCTION_TYPE_VOID)) {
-                throw new IllegalArgumentException(
-                        "Body type should be " + CoreType.functionType(VOID) +
-                                " but is " + bodies.get(1).bodySignature());
-            }
-            if (!bodies.get(1).bodySignature().equals(CoreType.functionType(BOOLEAN))) {
-                throw new IllegalArgumentException(
-                        "Predicate body signature should be " + CoreType.functionType(BOOLEAN) +
-                                " but is " + bodies.get(0).bodySignature());
-            }
+            this.bodies = List.of(requireVoidBodySignature(NAME, body).build(this),
+                                  requireBodySignature(NAME, predicate, CoreType.functionType(BOOLEAN)).build(this));
         }
 
         DoWhileOp(DoWhileOp that, CodeContext cc, CodeTransformer ct) {
@@ -5192,7 +5136,7 @@ public sealed abstract class JavaOp extends Op {
                 bodyIndex++;
             }
             if (bodyIndex == bodies.size()) {
-                throw structuralException(def, "no void try body found");
+                throw structuralException(def.name(), "no void try body found");
             }
             List<Body.Builder> resources = bodies.subList(0, bodyIndex);
             Body.Builder body = bodies.get(bodyIndex);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -820,6 +820,10 @@ public sealed abstract class JavaOp extends Op {
             if (bodies.size() != 1 && bodies.size() != 2) {
                 throw structuralException(NAME, "requires 1 or 2 bodies, found %d".formatted(bodies.size()));
             }
+            requireBodySignature(NAME + " predicate", bodies.get(0), CoreType.functionType(BOOLEAN));
+            if (bodies.size() > 1) {
+                requireNonVoidReturnType(NAME + " details", bodies.get(1), 0);
+            }
             super(List.of());
             this.bodies = bodies.stream().map(b -> b.build(this)).toList();
         }
@@ -1043,7 +1047,7 @@ public sealed abstract class JavaOp extends Op {
             int argCount = operands.size() - (invokeKind == InvokeKind.STATIC ? 0 : 1);
             if ((!isVarArgs && argCount != paramCount)
                     || argCount < paramCount - 1) {
-                throw structuralException(NAME, "kind=%s, varargs=%s, requires %s%d operands, found=%d".formatted(
+                throw structuralException(NAME, "kind=%s, varargs=%s, requires %s%d operands, found %d".formatted(
                         invokeKind,
                         isVarArgs,
                         isVarArgs ? "at least " : "",
@@ -1253,7 +1257,7 @@ public sealed abstract class JavaOp extends Op {
             int argCount = operands.size();
             if ((!isVarArgs && argCount != paramCount)
                     || argCount < paramCount - 1) {
-                throw structuralException(NAME, "varargs=%s, requires %s%d operands, found=%d".formatted(
+                throw structuralException(NAME, "varargs=%s, requires %s%d operands, found %d".formatted(
                         isVarArgs,
                         isVarArgs ? "at least " : "",
                         isVarArgs ? paramCount - 1 : paramCount,
@@ -1833,7 +1837,7 @@ public sealed abstract class JavaOp extends Op {
 
         ExceptionRegionExit(Value enter, Block.Reference end) {
             if (!(enter instanceof Op.Result or && or.op() instanceof ExceptionRegionEnter)) {
-                throw structuralException(NAME, "Value's is not an exception region entry: " + enter);
+                throw structuralException(NAME, "operand is not an exception region entry: " + enter);
             }
             super(List.of(enter));
             this.end = end;
@@ -2952,7 +2956,7 @@ public sealed abstract class JavaOp extends Op {
         SynchronizedOp(Body.Builder exprC, Body.Builder bodyC) {
             super(List.of());
             this.exprBody = requireNonVoidReturnType(NAME + " expression", exprC, 0).build(this);
-            this.blockBody = requireVoidBodySignature(NAME, bodyC).build(this);
+            this.blockBody = requireVoidBodySignature(NAME + " block", bodyC).build(this);
         }
 
         @Override
@@ -3337,7 +3341,7 @@ public sealed abstract class JavaOp extends Op {
                 throw structuralException(NAME, "requires 2 or more bodies, found %d".formatted(bodyCs.size()));
             }
             for (int i = 0; i < bodyCs.size(); i++) {
-                requireBodySignature(NAME, bodyCs.get(i), i % 2 == 0 && i < bodyCs.size() - 1 ? PREDICATE_SIGNATURE : ACTION_SIGNATURE);
+                requireBodySignature("%s body[%d]".formatted(NAME, i), bodyCs.get(i), i % 2 == 0 && i < bodyCs.size() - 1 ? PREDICATE_SIGNATURE : ACTION_SIGNATURE);
             }
             super(List.of());
 
@@ -4191,7 +4195,7 @@ public sealed abstract class JavaOp extends Op {
             super(List.of());
 
             this.exprBody = requireNonVoidReturnType(NAME + " expression", expressionC, 0).build(this);
-            this.initBody = requireNonVoidReturnType(NAME + " initilization", initC, 1).build(this);
+            this.initBody = requireNonVoidReturnType(NAME + " initialization", initC, 1).build(this);
             this.loopBody = requireVoidReturnType(NAME + " loop", bodyC, 1).build(this);
         }
 
@@ -4385,8 +4389,8 @@ public sealed abstract class JavaOp extends Op {
 
         WhileOp(Body.Builder predicate, Body.Builder body) {
             super(List.of());
-            this.bodies = List.of(requireBodySignature(NAME, predicate, CoreType.functionType(BOOLEAN)).build(this),
-                                  requireVoidBodySignature(NAME, body).build(this));
+            this.bodies = List.of(requireBodySignature(NAME + " predicate", predicate, CoreType.functionType(BOOLEAN)).build(this),
+                                  requireVoidBodySignature(NAME + " body", body).build(this));
         }
 
         WhileOp(WhileOp that, CodeContext cc, CodeTransformer ct) {
@@ -4530,8 +4534,8 @@ public sealed abstract class JavaOp extends Op {
 
             Objects.requireNonNull(body);
 
-            this.bodies = List.of(requireVoidBodySignature(NAME, body).build(this),
-                                  requireBodySignature(NAME, predicate, CoreType.functionType(BOOLEAN)).build(this));
+            this.bodies = List.of(requireVoidBodySignature(NAME + " body", body).build(this),
+                                  requireBodySignature(NAME + " predicate", predicate, CoreType.functionType(BOOLEAN)).build(this));
         }
 
         DoWhileOp(DoWhileOp that, CodeContext cc, CodeTransformer ct) {
@@ -4746,11 +4750,8 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConditionalAndOp(List<Body.Builder> bodyCs) {
-            if (bodyCs.size() < 2) {
-                throw structuralException(NAME, "requires at least 2 bodies, found: %d".formatted(bodyCs.size()));
-            }
             bodyCs.forEach(b -> requireBodySignature(NAME, b, BODY_TYPE));
-            super(bodyCs);
+            super(requireMinBodies(NAME, bodyCs, 2));
         }
 
         @Override
@@ -4819,11 +4820,8 @@ public sealed abstract class JavaOp extends Op {
         }
 
         ConditionalOrOp(List<Body.Builder> bodyCs) {
-            if (bodyCs.size() < 2) {
-                throw structuralException(NAME, "requires at least 2 bodies, found: %d".formatted(bodyCs.size()));
-            }
             bodyCs.forEach(b -> requireBodySignature(NAME, b, BODY_TYPE));
-            super(bodyCs);
+            super(requireMinBodies(NAME, bodyCs, 2));
         }
 
         @Override
@@ -4874,9 +4872,9 @@ public sealed abstract class JavaOp extends Op {
         ConditionalExpressionOp(CodeType expressionType, Body.Builder predicateBody, Body.Builder trueBody, Body.Builder falseBody) {
             super(List.of());
 
-            this.bodies = List.of(requireBodySignature(NAME, predicateBody, CoreType.functionType(BOOLEAN)).build(this),
-                                  requireNoParameters(NAME, trueBody).build(this),
-                                  requireNoParameters(NAME, falseBody).build(this));
+            this.bodies = List.of(requireBodySignature(NAME + " predicate", predicateBody, CoreType.functionType(BOOLEAN)).build(this),
+                                  requireNoParameters(NAME + " true body", trueBody).build(this),
+                                  requireNoParameters(NAME + " false body", falseBody).build(this));
             // @@@ when expressionType is null, we assume truepart and falsepart have the same yieldType
             this.resultType = expressionType == null ? bodies.get(1).yieldType() : expressionType;
         }
@@ -5080,7 +5078,10 @@ public sealed abstract class JavaOp extends Op {
         final Body finallyBody;
 
         TryOp(ExternalizedOp def) {
-            List<Body.Builder> bodies = requireMinBodies(def, 1);
+            List<Body.Builder> bodies = def.bodyDefinitions();
+            if (bodies.size() < 1) {
+                throw structuralException(def.name(), "requires at least 1 body");
+            }
             int bodyIndex = 0;
             while (bodyIndex < bodies.size() && !bodies.get(bodyIndex).bodySignature().returnType().equals(VOID)) {
                 bodyIndex++;
@@ -5136,39 +5137,15 @@ public sealed abstract class JavaOp extends Op {
             for (Body.Builder _resource : resourcesC) {
                 requireNonVoidReturnType(NAME + " resource", _resource, resourceTypes.size());
                 if (!_resource.bodySignature().parameterTypes().equals(resourceTypes)) {
-                    throw structuralException(NAME, " resource requires %s parameter types, found %s".formatted(resourceTypes, _resource.bodySignature().parameterTypes()));
+                    throw structuralException(NAME, "resource #%d requires %s parameter types, found %s".formatted(resourceTypes.size(), resourceTypes, _resource.bodySignature().parameterTypes()));
                 }
                 resourceTypes.add(_resource.bodySignature().returnType());
             }
             this.resourcesBodies = resourcesC.stream().map(r -> r.build(this)).toList();
-
-            this.body = bodyC.build(this);
-            if (!body.bodySignature().returnType().equals(VOID)) {
-                throw new IllegalArgumentException("Try should return void: " + body.bodySignature());
-            }
-            if (!body.bodySignature().parameterTypes().equals(resourceTypes)) {
-                throw new IllegalArgumentException("Try should have parameters matching resource yields: "
-                        + body.bodySignature());
-            }
-
-            this.catchBodies = catchersC.stream().map(c -> c.build(this)).toList();
-            for (Body _catch : catchBodies) {
-                if (!_catch.bodySignature().returnType().equals(VOID)) {
-                    throw new IllegalArgumentException("Catch should return void: " + _catch.bodySignature());
-                }
-                if (_catch.bodySignature().parameterTypes().size() != 1) {
-                    throw new IllegalArgumentException("Catch should have zero parameters: " + _catch.bodySignature());
-                }
-            }
-
+            this.body = requireBodySignature(NAME + " try", bodyC, CoreType.functionType(VOID, resourceTypes)).build(this);
+            this.catchBodies = catchersC.stream().map(c -> requireVoidReturnType(NAME + " catch", c, 1).build(this)).toList();
             if (finalizerC != null) {
-                this.finallyBody = finalizerC.build(this);
-                if (!finallyBody.bodySignature().returnType().equals(VOID)) {
-                    throw new IllegalArgumentException("Finally should return void: " + finallyBody.bodySignature());
-                }
-                if (!finallyBody.bodySignature().parameterTypes().isEmpty()) {
-                    throw new IllegalArgumentException("Finally should have zero parameters: " + finallyBody.bodySignature());
-                }
+                this.finallyBody = requireVoidBodySignature(NAME + " finalizer", finalizerC).build(this);
             } else {
                 this.finallyBody = null;
             }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2051,8 +2051,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitConditional(JCTree.JCConditional tree) {
-            List<Body.Builder> bodies = new ArrayList<>();
-
             JCTree.JCExpression cond = TreeInfo.skipParens(tree.cond);
 
             // Push condition
@@ -2061,7 +2059,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             Value condVal = toValue(cond);
             // Yield the boolean result of the condition
             append(CoreOp.core_yield(condVal));
-            bodies.add(stack.body);
+            Body.Builder predicateBody = stack.body;
 
             // Pop condition
             popBody();
@@ -2077,7 +2075,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             Value trueVal = toValue(truepart, condType);
             // Yield the result
             append(CoreOp.core_yield(trueVal));
-            bodies.add(stack.body);
+            Body.Builder trueBody = stack.body;
 
             // Pop true body
             popBody();
@@ -2091,12 +2089,12 @@ public class ReflectMethods extends TreeTranslatorPrev {
             Value falseVal = toValue(falsepart, condType);
             // Yield the result
             append(CoreOp.core_yield(falseVal));
-            bodies.add(stack.body);
+            Body.Builder falseBody = stack.body;
 
             // Pop false body
             popBody();
 
-            result = append(JavaOp.conditionalExpression(typeToCodeType(condType), bodies));
+            result = append(JavaOp.conditionalExpression(typeToCodeType(condType), predicateBody, trueBody, falseBody));
         }
 
         private Type condType(JCExpression tree, Type type) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
@@ -29,9 +29,11 @@ import java.util.List;
 import java.util.Optional;
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;
+import jdk.incubator.code.CodeType;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.FunctionType;
+import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.extern.ExternalizedOp;
 
 public final class StructuralPreconditions {
@@ -83,11 +85,10 @@ public final class StructuralPreconditions {
         return bodies;
     }
 
-    public static List<Body.Builder> requireBodyPairs(ExternalizedOp def) {
-        List<Body.Builder> bodies = def.bodyDefinitions();
+    public static List<Body.Builder> requireBodyPairs(String opName, List<Body.Builder> bodies) {
         int count = bodies.size();
         if (count < 2 || count % 2 == 1) {
-            throw structuralException(def.name(), "requires one or more body pairs, found %d".formatted(count));
+            throw structuralException(opName, "requires one or more body pairs, found %d".formatted(count));
         }
         return bodies;
     }
@@ -143,6 +144,33 @@ public final class StructuralPreconditions {
     public static Body.Builder requireBodySignature(String opName, Body.Builder bodyC, FunctionType signature) {
         if (!bodyC.bodySignature().equals(signature)) {
             throw structuralException(opName, "requires body signature %s, found %s".formatted(signature, bodyC.bodySignature()));
+        }
+        return bodyC;
+    }
+
+    public static Body.Builder requireNonVoidReturnType(String opName, Body.Builder bodyC, int parameters) {
+        if (bodyC.bodySignature().returnType().equals(JavaType.VOID)) {
+            throw structuralException(opName, "requires non-void return type");
+        }
+        if (bodyC.bodySignature().parameterTypes().size() != parameters) {
+            throw structuralException(opName, "requires %d parameters, found %d".formatted(parameters, bodyC.bodySignature().parameterTypes().size()));
+        }
+        return bodyC;
+    }
+
+    public static Body.Builder requireVoidReturnType(String opName, Body.Builder bodyC, int parameters) {
+        if (!bodyC.bodySignature().returnType().equals(JavaType.VOID)) {
+            throw structuralException(opName, "requires void return type, found: %s".formatted(bodyC.bodySignature().returnType()));
+        }
+        if (bodyC.bodySignature().parameterTypes().size() != parameters) {
+            throw structuralException(opName, "requires %d parameters, found %d".formatted(parameters, bodyC.bodySignature().parameterTypes().size()));
+        }
+        return bodyC;
+    }
+
+    public static Body.Builder requireNoParameters(String opName, Body.Builder bodyC) {
+        if (!bodyC.bodySignature().parameterTypes().isEmpty()) {
+            throw structuralException(opName, "requires no parameters, found %s".formatted(bodyC.bodySignature()));
         }
         return bodyC;
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
@@ -30,6 +30,8 @@ import java.util.Optional;
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;
 import jdk.incubator.code.Value;
+import jdk.incubator.code.dialect.core.CoreType;
+import jdk.incubator.code.dialect.core.FunctionType;
 import jdk.incubator.code.extern.ExternalizedOp;
 
 public final class StructuralPreconditions {
@@ -48,7 +50,7 @@ public final class StructuralPreconditions {
     public static List<Value> requireOperands(ExternalizedOp def, int expCount) {
         List<Value> operands = def.operands();
         if (operands.size() != expCount) {
-            throw structuralException(def, "requires %d operand%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", operands.size()));
+            throw structuralException(def.name(), "requires %d operand%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", operands.size()));
         }
         return operands;
     }
@@ -56,7 +58,7 @@ public final class StructuralPreconditions {
     public static List<Value> requireOperands(ExternalizedOp def, int expCount1, int expCount2) {
         int count = def.operands().size();
         if (count != expCount1 && count != expCount2) {
-            throw structuralException(def, "requires %d or %d operands, found %d".formatted(expCount1, expCount2, count));
+            throw structuralException(def.name(), "requires %d or %d operands, found %d".formatted(expCount1, expCount2, count));
         }
         return def.operands();
     }
@@ -68,7 +70,7 @@ public final class StructuralPreconditions {
     public static List<Body.Builder> requireBodies(ExternalizedOp def, int expCount) {
         List<Body.Builder> bodies = def.bodyDefinitions();
         if (bodies.size() != expCount) {
-            throw structuralException(def, "requires %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
+            throw structuralException(def.name(), "requires %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
         }
         return bodies;
     }
@@ -76,16 +78,7 @@ public final class StructuralPreconditions {
     public static List<Body.Builder> requireMinBodies(ExternalizedOp def, int expCount) {
         List<Body.Builder> bodies = def.bodyDefinitions();
         if (bodies.size() < expCount) {
-            throw structuralException(def, "requires at least %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
-        }
-        return bodies;
-    }
-
-    public static List<Body.Builder> requireBodies(ExternalizedOp def, int expCount1, int expCount2) {
-        List<Body.Builder> bodies = def.bodyDefinitions();
-        int count = bodies.size();
-        if (count != expCount1 && count != expCount2) {
-            throw structuralException(def, "requires %d or %d bodies, found %d".formatted(expCount1, expCount2, count));
+            throw structuralException(def.name(), "requires at least %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
         }
         return bodies;
     }
@@ -94,7 +87,7 @@ public final class StructuralPreconditions {
         List<Body.Builder> bodies = def.bodyDefinitions();
         int count = bodies.size();
         if (count < 2 || count % 2 == 1) {
-            throw structuralException(def, "requires one or more body pairs, found %d".formatted(count));
+            throw structuralException(def.name(), "requires one or more body pairs, found %d".formatted(count));
         }
         return bodies;
     }
@@ -106,15 +99,7 @@ public final class StructuralPreconditions {
     public static List<Block.Reference> requireSuccessors(ExternalizedOp def, int expCount) {
         List<Block.Reference> succ = def.successors();
         if (succ.size() != expCount) {
-            throw structuralException(def, "requires %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", succ.size()));
-        }
-        return succ;
-    }
-
-    public static List<Block.Reference> requireMinSuccessors(ExternalizedOp def, int expCount) {
-        List<Block.Reference> succ = def.successors();
-        if (succ.size() < expCount) {
-            throw structuralException(def, "requires at least %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", succ.size()));
+            throw structuralException(def.name(), "requires %d successor%s, found %d".formatted(expCount, expCount == 1 ? "" : "s", succ.size()));
         }
         return succ;
     }
@@ -135,7 +120,7 @@ public final class StructuralPreconditions {
         if (def.attributes().containsKey(attributeName)) {
             return def.attributes().get(attributeName);
         }
-        throw structuralException(def, "requires attribute %s".formatted(attributeName));
+        throw structuralException(def.name(), "requires attribute %s".formatted(attributeName));
     }
 
     public static boolean optionalBooleanAttribute(ExternalizedOp def, String attributeName) {
@@ -151,8 +136,19 @@ public final class StructuralPreconditions {
         throw unsupportedAttributeValueException(def, attributeName, attr);
     }
 
-    public static IllegalStateException structuralException(ExternalizedOp def, String msg) {
-        return new IllegalStateException("Operation " + def.name() + " " + msg);
+    public static Body.Builder requireVoidBodySignature(String opName, Body.Builder bodyC) {
+        return requireBodySignature(opName, bodyC, CoreType.FUNCTION_TYPE_VOID);
+    }
+
+    public static Body.Builder requireBodySignature(String opName, Body.Builder bodyC, FunctionType signature) {
+        if (!bodyC.bodySignature().equals(signature)) {
+            throw structuralException(opName, "requires body signature %s, found %s".formatted(signature, bodyC.bodySignature()));
+        }
+        return bodyC;
+    }
+
+    public static IllegalStateException structuralException(String opName, String msg) {
+        return new IllegalStateException("Operation " + opName + " " + msg);
     }
 
     public static UnsupportedOperationException unsupportedAttributeValueException(ExternalizedOp def, String attributeName, Object value) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/StructuralPreconditions.java
@@ -77,10 +77,9 @@ public final class StructuralPreconditions {
         return bodies;
     }
 
-    public static List<Body.Builder> requireMinBodies(ExternalizedOp def, int expCount) {
-        List<Body.Builder> bodies = def.bodyDefinitions();
+    public static List<Body.Builder> requireMinBodies(String opName, List<Body.Builder> bodies, int expCount) {
         if (bodies.size() < expCount) {
-            throw structuralException(def.name(), "requires at least %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
+            throw structuralException(opName, "requires at least %d bod%s, found %d".formatted(expCount, expCount == 1 ? "y" : "ies", bodies.size()));
         }
         return bodies;
     }


### PR DESCRIPTION
Consolidates the remaining structural checks in the operation construction paths.
Additional structural checks may be added in a follow-up PR.
Consolidates the construction parameters of `ConditionalExpressionOp`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1076/head:pull/1076` \
`$ git checkout pull/1076`

Update a local copy of the PR: \
`$ git checkout pull/1076` \
`$ git pull https://git.openjdk.org/babylon.git pull/1076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1076`

View PR using the GUI difftool: \
`$ git pr show -t 1076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1076.diff">https://git.openjdk.org/babylon/pull/1076.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1076#issuecomment-4867198194)
</details>
