### PR TITLE
[hat] Codegen HAT_WRS for expressing the warp size

### DIFF
--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
@@ -262,9 +262,9 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
                 .when(useS16Types(), _ -> hashDefine("BFLOAT16", _ -> keyword("__nv_bfloat16")))
                 .when(useS16Types(), _ -> typedefSingleValueStruct("F16", "half"))
                 .when(useS16Types(), _ -> typedefSingleValueStruct("BF16", "BFLOAT16"))
-                .when(useTensors(), _ -> includeSys("mma.h")) // only enable if tensor views are used
 
                 // Tensor Macros
+                .when(useTensors(), _ -> includeSys("mma.h"))
                 .when(useTensors(), _ -> defineFragmentCreate(MACRO_FRAMGMENT_CREATE))
                 .when(useTensors(), _ -> defineMacroTensorFill(MACRO_FRAGMENT_FILL))
                 .when(useTensors(), _ -> defineMacroTensorMMA(MACRO_FRAGMENT_MMA))

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/CudaHATKernelBuilder.java
@@ -196,7 +196,7 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
 
     @Override
     protected CudaHATKernelBuilder hatWarpSize() {
-        return intConst(CUDA_WARP_SIZE);
+        return id("HAT_WRS");
     }
 
     @Override
@@ -227,6 +227,7 @@ public class CudaHATKernelBuilder extends C99HATKernelBuilder<CudaHATKernelBuild
                 .hashDefine("HAT_BSX", _ -> gridDimX())
                 .hashDefine("HAT_BSY", _ -> gridDimY())
                 .hashDefine("HAT_BSZ", _ -> gridDimZ())
+                .hashDefine("HAT_WRS", _ -> paren( _ -> intValue(CUDA_WARP_SIZE)))
 
                 // Barrier
                 .when(useBarrier(), _ -> hashDefine("HAT_BARRIER", _ -> keyword("__syncthreads").ocparen()))

--- a/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
+++ b/hat/backends/ffi/opencl/src/main/java/hat/backend/ffi/OpenCLHATKernelBuilder.java
@@ -169,6 +169,7 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
                 .when(useThreadConstruct("bsx"), _-> hashDefine("HAT_BSX", _ -> paren(_ -> id(NUM_GROUPS).paren(_ -> intConstZero()))))
                 .when(useThreadConstruct("bsy"), _-> hashDefine("HAT_BSY", _ -> paren(_ -> id(NUM_GROUPS).paren(_ -> intConstOne()))))
                 .when(useThreadConstruct("bsz"), _-> hashDefine("HAT_BSZ", _ -> paren(_ -> id(NUM_GROUPS).paren(_ -> intConstTwo()))))
+                .when(useThreadConstruct("wrs"), _-> hashDefine("HAT_WRS", _ -> paren(_ -> intValue(OPENCL_WARP_SIZE))))
 
                 // Math Functions
                 .when(useS16Types(), _->maxMacro("MAX_HAT"))
@@ -672,7 +673,7 @@ public class OpenCLHATKernelBuilder extends C99HATKernelBuilder<OpenCLHATKernelB
 
     @Override
     protected OpenCLHATKernelBuilder hatWarpSize() {
-        return intConst(OPENCL_WARP_SIZE);
+        return id("HAT_WRS");
     }
 
     private OpenCLHATKernelBuilder generateHatTensorCreate(List<Integer> shape, Object klass, String varTensorName, Value v, int ordering) {


### PR DESCRIPTION
Codegen HAT_WRS for expressing the warp size

### How to test?

```bash
java @.test-suite ffi-opencl 
java @.test-suite ffi-cuda
```

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1077/head:pull/1077` \
`$ git checkout pull/1077`

Update a local copy of the PR: \
`$ git checkout pull/1077` \
`$ git pull https://git.openjdk.org/babylon.git pull/1077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1077`

View PR using the GUI difftool: \
`$ git pr show -t 1077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1077.diff">https://git.openjdk.org/babylon/pull/1077.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1077#issuecomment-4844632649)
</details>
