### PR TITLE
Reflectable method references in local classes should be rejected

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -196,11 +196,16 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
     }
 
+    boolean isInsideInnerOrLocalClass() {
+        return currentClassSym.type.getEnclosingType().hasTag(CLASS) ||
+                currentClassSym.isDirectlyOrIndirectlyLocal();
+    }
+
     @Override
     public void visitMethodDef(JCMethodDecl tree) {
         boolean isReflectable = isReflectable(tree);
         if (isReflectable) {
-            if (currentClassSym.type.getEnclosingType().hasTag(CLASS) || currentClassSym.isDirectlyOrIndirectlyLocal()) {
+            if (isInsideInnerOrLocalClass()) {
                 // Reflectable methods in local classes are not supported
                 if (reflectAll) {
                     log.warning(tree, Warnings.ReflectableMethodInnerClass(currentClassSym.enclClass()));
@@ -303,7 +308,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
     public void visitLambda(JCLambda tree) {
         boolean isReflectable = isReflectable(tree);
         if (isReflectable) {
-            if (currentClassSym.type.getEnclosingType().hasTag(CLASS) || currentClassSym.isDirectlyOrIndirectlyLocal()) {
+            if (isInsideInnerOrLocalClass()) {
                 // Reflectable lambdas in local classes are not supported
                 if (reflectAll) {
                     log.warning(tree, Warnings.ReflectableLambdaInnerClass(currentClassSym.enclClass()));
@@ -355,7 +360,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         JCLambda lambdaTree = memberReferenceToLambda.lambda();
 
         if (isReflectable(tree)) {
-            if (currentClassSym.type.getEnclosingType().hasTag(CLASS)) {
+            if (isInsideInnerOrLocalClass()) {
                 // Reflectable method references in local classes are not supported
                 if (reflectAll) {
                     log.warning(tree, Warnings.ReflectableMrefInnerClass(currentClassSym.enclClass()));

--- a/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.java
+++ b/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.java
@@ -42,4 +42,34 @@ class TestNoCodeReflectionInInnerClasses {
             Runnable q = (@Reflect Runnable) this::test2;
         }
     }
+
+    void local() {
+        class Local {
+            @Reflect
+            public void test1() { }
+
+            void test2() {
+                Runnable q = (@Reflect Runnable) () -> { };
+            }
+
+            void test3() {
+                Runnable q = (@Reflect Runnable) this::test2;
+            }
+        }
+    }
+
+    void anon() {
+        new Object() {
+            @Reflect
+            public void test1() { }
+
+            void test2() {
+                Runnable q = (@Reflect Runnable) () -> { };
+            }
+
+            void test3() {
+                Runnable q = (@Reflect Runnable) this::test2;
+            }
+        };
+    }
 }

--- a/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
+++ b/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
@@ -1,4 +1,10 @@
-TestNoCodeReflectionInInnerClasses.java:35:21: compiler.err.reflectable.method.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:38:46: compiler.err.reflectable.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:42:46: compiler.err.reflectable.mref.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-3 errors
+TestNoCodeReflectionInInnerClasses.java:12:21: compiler.err.reflectable.method.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:15:46: compiler.err.reflectable.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:19:46: compiler.err.reflectable.mref.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:26:25: compiler.err.reflectable.method.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:29:50: compiler.err.reflectable.lambda.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:33:50: compiler.err.reflectable.mref.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:41:25: compiler.err.reflectable.method.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+TestNoCodeReflectionInInnerClasses.java:44:50: compiler.err.reflectable.lambda.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+TestNoCodeReflectionInInnerClasses.java:48:50: compiler.err.reflectable.mref.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+9 errors


### PR DESCRIPTION
An internal review round has revealed an asymmetry in reflectable method references. While reflectable lambdas and methods are rejected when inside a local class, reflectable method references aren't.

This was not deliberate. Rather, the issue stems from a missing call to `isDirectlyOrIndirectlyLocal`, which was added in https://github.com/openjdk/babylon/pull/822 (for methods) and in https://github.com/openjdk/babylon/pull/846 (for lambdas) -- but failed to handle all cases.

I've beefed up the negative test `TestNoCodeReflectionInInnerClasses` to test that both reflectable method, lambdas and method references are rejected inside inner classes, local classes and anon classes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1079/head:pull/1079` \
`$ git checkout pull/1079`

Update a local copy of the PR: \
`$ git checkout pull/1079` \
`$ git pull https://git.openjdk.org/babylon.git pull/1079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1079`

View PR using the GUI difftool: \
`$ git pr show -t 1079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1079.diff">https://git.openjdk.org/babylon/pull/1079.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1079#issuecomment-4854270162)
</details>
