### PR TITLE
Inliner bug

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
@@ -146,7 +146,11 @@ public final class Inliner {
 
 
         Block.Builder builder = returnBlocks.get(invokableOp.body());
-        return builder != null ? builder : _this;
+        if (builder != null) {
+            return builder.withContextAndTransformer(_this.context(), _this.transformer());
+        } else {
+            return _this;
+        }
     }
 
     private static Op getNearestInvokeableAncestorOp(Op op) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/Inliner.java
@@ -82,7 +82,7 @@ public final class Inliner {
      * non-trivial and outside the scope of this method. In such cases the invokable operation can be transformed
      * with a lowering transformation after which it can then be inlined.
      *
-     * @param _this the block builder
+     * @param inBlock the block builder
      * @param invokableOp the invokable operation
      * @param args the arguments to map, in order, from a prefix of the invokable operation's parameters
      * @param inlineConsumer the consumer applied to process the return from the invokable operation.
@@ -92,11 +92,11 @@ public final class Inliner {
      * @param <O> The invokable type
      */
     public static <O extends Op & Op.Invokable>
-    Block.Builder inline(Block.Builder _this, O invokableOp, List<? extends Value> args,
+    Block.Builder inline(Block.Builder inBlock, O invokableOp, List<? extends Value> args,
                          BiConsumer<Block.Builder, Value> inlineConsumer) {
         Map<Body, Block.Builder> returnBlocks = new HashMap<>();
         // Create new context, ensuring inlining is isolated
-        _this.transformBody(invokableOp.body(), args, CodeContext.create(), (block, op) -> {
+        inBlock.transformBody(invokableOp.body(), args, CodeContext.create(), (block, op) -> {
             // If the return operation is associated with the invokable operation
             if (op instanceof CoreOp.ReturnOp rop && getNearestInvokeableAncestorOp(op) == invokableOp) {
                 // Compute the return block
@@ -147,9 +147,9 @@ public final class Inliner {
 
         Block.Builder builder = returnBlocks.get(invokableOp.body());
         if (builder != null) {
-            return builder.withContextAndTransformer(_this.context(), _this.transformer());
+            return builder.withContextAndTransformer(inBlock.context(), inBlock.transformer());
         } else {
-            return _this;
+            return inBlock;
         }
     }
 

--- a/test/jdk/jdk/incubator/code/TestInline.java
+++ b/test/jdk/jdk/incubator/code/TestInline.java
@@ -216,4 +216,26 @@ public class TestInline {
         Assertions.assertEquals(42, a[0]);
     }
 
+    @Reflect
+    static void n() {
+    }
+    @Reflect
+    static int m(int i) {
+        n();
+        return i; // this make sure context needs to be set properly after inlining, for the transformation to work
+    }
+
+    @Test
+    void testInlineInTransformation() throws NoSuchMethodException {
+        FuncOp m = Op.ofMethod(this.getClass().getDeclaredMethod("m", int.class)).get();
+        FuncOp n = Op.ofMethod(this.getClass().getDeclaredMethod("n")).get();
+        m.transform((b, o) -> {
+            if (o instanceof JavaOp.InvokeOp iop && iop.invokeReference().name().equals("n")) {
+                return Inliner.inline(b, n, List.of(), (b2, o2) -> {});
+            }
+            b.add(o);
+            return b;
+        });
+    }
+
 }

--- a/test/jdk/jdk/incubator/code/TestTryOpWithExceptionRegion.java
+++ b/test/jdk/jdk/incubator/code/TestTryOpWithExceptionRegion.java
@@ -46,6 +46,7 @@ public class TestTryOpWithExceptionRegion {
         }
     }
 
+    BiConsumer<Block.Builder, Value> IGNORE_RETURN = (rb, rv) -> {};
     @Test
     void testTryOpEnclosingExceptionRegion() throws NoSuchMethodException {
         // lower n + inline it in m
@@ -54,9 +55,7 @@ public class TestTryOpWithExceptionRegion {
         CoreOp.FuncOp m = Op.ofMethod(this.getClass().getDeclaredMethod("m", IntConsumer.class)).get();
         CoreOp.FuncOp m2 = m.transform((b, o) -> {
             if (o instanceof JavaOp.InvokeOp iop && iop.invokeReference().name().equals("n")) {
-                var bb = Inliner.inline(b, ln, b.context().getValues(m.parameters()), (b2, v2) -> {
-                });
-                return bb.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER);
+                return Inliner.inline(b, ln, b.context().getValues(m.parameters()), IGNORE_RETURN);
             } else {
                 b.add(o);
                 return b;
@@ -85,8 +84,7 @@ public class TestTryOpWithExceptionRegion {
         CoreOp.FuncOp n = Op.ofMethod(this.getClass().getDeclaredMethod("n", IntConsumer.class)).get();
         CoreOp.FuncOp lm2 = lm.transform((b, o) -> {
             if (o instanceof JavaOp.InvokeOp iop && iop.invokeReference().name().equals("n")) {
-                var bb = Inliner.inline(b, n, b.context().getValues(lm.parameters()), (b2, v2) -> {});
-                return bb.withContextAndTransformer(b.context(), CodeTransformer.COPYING_TRANSFORMER);
+                return Inliner.inline(b, n, b.context().getValues(lm.parameters()), IGNORE_RETURN);
             } else {
                 b.add(o);
                 return b;

--- a/test/jdk/jdk/incubator/code/TestTryOpWithExceptionRegion.java
+++ b/test/jdk/jdk/incubator/code/TestTryOpWithExceptionRegion.java
@@ -1,6 +1,8 @@
+import jdk.incubator.code.Block;
 import jdk.incubator.code.CodeTransformer;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.Reflect;
+import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.Inliner;
 import jdk.incubator.code.dialect.java.JavaOp;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 


### PR DESCRIPTION
The block builder returned by the `Inliner` has `CodeContext` of what's inside the invokable. Now before we return, we revert back to the context of  the passed block builder.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1080/head:pull/1080` \
`$ git checkout pull/1080`

Update a local copy of the PR: \
`$ git checkout pull/1080` \
`$ git pull https://git.openjdk.org/babylon.git pull/1080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1080`

View PR using the GUI difftool: \
`$ git pr show -t 1080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1080.diff">https://git.openjdk.org/babylon/pull/1080.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1080#issuecomment-4866848100)
</details>
