### PR TITLE
Golden file for inner class reflectable test is wrong

### DIFF
--- a/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
+++ b/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
@@ -1,10 +1,10 @@
-TestNoCodeReflectionInInnerClasses.java:12:21: compiler.err.reflectable.method.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:15:46: compiler.err.reflectable.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:19:46: compiler.err.reflectable.mref.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:26:25: compiler.err.reflectable.method.inner.class: Local
-TestNoCodeReflectionInInnerClasses.java:29:50: compiler.err.reflectable.lambda.inner.class: Local
-TestNoCodeReflectionInInnerClasses.java:33:50: compiler.err.reflectable.mref.inner.class: Local
-TestNoCodeReflectionInInnerClasses.java:41:25: compiler.err.reflectable.method.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
-TestNoCodeReflectionInInnerClasses.java:44:50: compiler.err.reflectable.lambda.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
-TestNoCodeReflectionInInnerClasses.java:48:50: compiler.err.reflectable.mref.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+TestNoCodeReflectionInInnerClasses.java:35:21: compiler.err.reflectable.method.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:38:46: compiler.err.reflectable.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:42:46: compiler.err.reflectable.mref.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:49:25: compiler.err.reflectable.method.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:52:50: compiler.err.reflectable.lambda.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:56:50: compiler.err.reflectable.mref.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:64:25: compiler.err.reflectable.method.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+TestNoCodeReflectionInInnerClasses.java:67:50: compiler.err.reflectable.lambda.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+TestNoCodeReflectionInInnerClasses.java:71:50: compiler.err.reflectable.mref.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
 9 errors


### PR DESCRIPTION
The golden file for TestNoCodeReflectionInInnerClasses, which was updated in https://git.openjdk.org/babylon/pull/1079 does not contain the latest babylon changes.

This simple change fixes that, and makes all test green again.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1081/head:pull/1081` \
`$ git checkout pull/1081`

Update a local copy of the PR: \
`$ git checkout pull/1081` \
`$ git pull https://git.openjdk.org/babylon.git pull/1081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1081`

View PR using the GUI difftool: \
`$ git pr show -t 1081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1081.diff">https://git.openjdk.org/babylon/pull/1081.diff</a>

</details>
