### PR TITLE
NPE when scanning body of anon class inside a reflectable lambda

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -203,7 +203,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
     @Override
     public void visitMethodDef(JCMethodDecl tree) {
-        boolean isReflectable = isReflectable(tree);
+        boolean isReflectable = !tree.sym.isConstructor() && isReflectable(tree);
         if (isReflectable) {
             if (isInsideInnerOrLocalClass()) {
                 // Reflectable methods in local classes are not supported
@@ -624,6 +624,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             @Override
             public void visitNewClass(JCNewClass tree) {
+                super.visitNewClass(tree); // this might scan an anon class def, so we need to do that first
                 if (tree.type.tsym.isDirectlyOrIndirectlyLocal()) {
                     for (Symbol c : localCaptures.get(tree.type.tsym)) {
                         addFreeVar((VarSymbol) c);
@@ -632,7 +633,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 if (tree.encl == null && tree.type.tsym.hasOuterInstance()) {
                     capturesThis = true;
                 }
-                super.visitNewClass(tree);
             }
 
             @Override

--- a/test/langtools/tools/javac/reflect/LocalClassTest.java
+++ b/test/langtools/tools/javac/reflect/LocalClassTest.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @ignore Reflection on the contents of local classes is not supported.
  * @summary Smoke test for code reflection with local class creation expressions.
  * @modules jdk.incubator.code
  * @build LocalClassTest
@@ -40,149 +39,149 @@ public class LocalClassTest {
     final static String CONST_STRING = "Hello!";
     String nonConstString = "Hello!";
 
-    @Reflect
-    @IR("""
-            func @"testLocalNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-                %1 : java.type:"LocalClassTest::$1Foo" = new %0 @java.ref:"LocalClassTest::$1Foo::(LocalClassTest)";
-                invoke %1 @java.ref:"LocalClassTest::$1Foo::m():void";
-                return;
-            };
-            """)
-    void testLocalNoCapture() {
-        class Foo {
-            void m() { }
-        }
-        new Foo().m();
-    }
-
-    @Reflect
-    @IR("""
-            func @"testAnonNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-                %1 : java.type:"LocalClassTest::$1" = new %0 @java.ref:"LocalClassTest::$1::(LocalClassTest)";
-                invoke %1 @java.ref:"LocalClassTest::$1::m():void";
-                return;
-            };
-            """)
-    void testAnonNoCapture() {
-        new Object() {
-            void m() { }
-        }.m();
-    }
-
-    @Reflect
-    @IR("""
-            func @"testLocalCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-                %3 : java.type:"java.lang.String" = var.load %2;
-                %4 : java.type:"LocalClassTest::$2Foo" = new %0 %3 @java.ref:"LocalClassTest::$2Foo::(LocalClassTest, java.lang.String)";
-                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2Foo::m():java.lang.String";
-                return %5;
-            };
-            """)
-    String testLocalCaptureParam(String s) {
-        class Foo {
-            String m() { return s; }
-        }
-        return new Foo().m();
-    }
-
-    @Reflect
-    @IR("""
-            func @"testAnonCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-                %3 : java.type:"java.lang.String" = var.load %2;
-                %4 : java.type:"LocalClassTest::$2" = new %0 %3 @java.ref:"LocalClassTest::$2::(LocalClassTest, java.lang.String)";
-                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2::m():java.lang.String";
-                return %5;
-            };
-            """)
-    String testAnonCaptureParam(String s) {
-        return new Object() {
-            String m() { return s; }
-        }.m();
-    }
-
-    @Reflect
-    @IR("""
-            func @"testLocalCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-                %3 : java.type:"java.lang.String" = constant @"Hello!";
-                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
-                %5 : java.type:"java.lang.String" = var.load %2;
-                %6 : java.type:"LocalClassTest::$3Foo" = new %0 %5 @java.ref:"LocalClassTest::$3Foo::(LocalClassTest, java.lang.String)";
-                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3Foo::m():java.lang.String";
-                return %7;
-            };
-            """)
-    String testLocalCaptureParamAndField(String s) {
-        final String localConst = "Hello!";
-        class Foo {
-            String m() { return localConst + s + nonConstString + CONST_STRING; }
-        }
-        return new Foo().m();
-    }
-
-    @Reflect
-    @IR("""
-            func @"testAnonCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-                %3 : java.type:"java.lang.String" = constant @"Hello!";
-                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
-                %5 : java.type:"java.lang.String" = var.load %2;
-                %6 : java.type:"LocalClassTest::$3" = new %0 %5 @java.ref:"LocalClassTest::$3::(LocalClassTest, java.lang.String)";
-                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3::m():java.lang.String";
-                return %7;
-            };
-            """)
-    String testAnonCaptureParamAndField(String s) {
-        final String localConst = "Hello!";
-        return new Object() {
-            String m() { return localConst + s + nonConstString + CONST_STRING; }
-        }.m();
-    }
-
-    @Reflect
-    @IR("""
-            func @"testLocalDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
-                %3 : Var<java.type:"int"> = var %1 @"s";
-                %4 : Var<java.type:"int"> = var %2 @"i";
-                %5 : java.type:"int" = var.load %3;
-                %6 : java.type:"int" = var.load %4;
-                %7 : java.type:"LocalClassTest::$1Bar" = new %0 %5 %6 @java.ref:"LocalClassTest::$1Bar::(LocalClassTest, int, int)";
-                return;
-            };
-            """)
-    void testLocalDependency(int s, int i) {
-        class Foo {
-            int i() { return i; }
-        }
-        class Bar {
-            int s() { return s; }
-            Foo foo() { return new Foo(); }
-        }
-        new Bar();
-    }
-
-    @Reflect
-    @IR("""
-            func @"testAnonDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
-                %3 : Var<java.type:"int"> = var %1 @"s";
-                %4 : Var<java.type:"int"> = var %2 @"i";
-                %5 : java.type:"int" = var.load %3;
-                %6 : java.type:"int" = var.load %4;
-                %7 : java.type:"LocalClassTest::$4" = new %0 %5 %6 @java.ref:"LocalClassTest::$4::(LocalClassTest, int, int)";
-                return;
-            };
-            """)
-    void testAnonDependency(int s, int i) {
-        class Foo {
-            int i() { return i; }
-        }
-        new Object() {
-            int s() { return s; }
-            Foo foo() { return new Foo(); }
-        };
-    }
+//    @Reflect
+//    @IR("""
+//            func @"testLocalNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+//                %1 : java.type:"LocalClassTest::$1Foo" = new %0 @java.ref:"LocalClassTest::$1Foo::(LocalClassTest)";
+//                invoke %1 @java.ref:"LocalClassTest::$1Foo::m():void";
+//                return;
+//            };
+//            """)
+//    void testLocalNoCapture() {
+//        class Foo {
+//            void m() { }
+//        }
+//        new Foo().m();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testAnonNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+//                %1 : java.type:"LocalClassTest::$1" = new %0 @java.ref:"LocalClassTest::$1::(LocalClassTest)";
+//                invoke %1 @java.ref:"LocalClassTest::$1::m():void";
+//                return;
+//            };
+//            """)
+//    void testAnonNoCapture() {
+//        new Object() {
+//            void m() { }
+//        }.m();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testLocalCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+//                %3 : java.type:"java.lang.String" = var.load %2;
+//                %4 : java.type:"LocalClassTest::$2Foo" = new %0 %3 @java.ref:"LocalClassTest::$2Foo::(LocalClassTest, java.lang.String)";
+//                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2Foo::m():java.lang.String";
+//                return %5;
+//            };
+//            """)
+//    String testLocalCaptureParam(String s) {
+//        class Foo {
+//            String m() { return s; }
+//        }
+//        return new Foo().m();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testAnonCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+//                %3 : java.type:"java.lang.String" = var.load %2;
+//                %4 : java.type:"LocalClassTest::$2" = new %0 %3 @java.ref:"LocalClassTest::$2::(LocalClassTest, java.lang.String)";
+//                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2::m():java.lang.String";
+//                return %5;
+//            };
+//            """)
+//    String testAnonCaptureParam(String s) {
+//        return new Object() {
+//            String m() { return s; }
+//        }.m();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testLocalCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+//                %3 : java.type:"java.lang.String" = constant @"Hello!";
+//                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
+//                %5 : java.type:"java.lang.String" = var.load %2;
+//                %6 : java.type:"LocalClassTest::$3Foo" = new %0 %5 @java.ref:"LocalClassTest::$3Foo::(LocalClassTest, java.lang.String)";
+//                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3Foo::m():java.lang.String";
+//                return %7;
+//            };
+//            """)
+//    String testLocalCaptureParamAndField(String s) {
+//        final String localConst = "Hello!";
+//        class Foo {
+//            String m() { return localConst + s + nonConstString + CONST_STRING; }
+//        }
+//        return new Foo().m();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testAnonCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+//                %3 : java.type:"java.lang.String" = constant @"Hello!";
+//                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
+//                %5 : java.type:"java.lang.String" = var.load %2;
+//                %6 : java.type:"LocalClassTest::$3" = new %0 %5 @java.ref:"LocalClassTest::$3::(LocalClassTest, java.lang.String)";
+//                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3::m():java.lang.String";
+//                return %7;
+//            };
+//            """)
+//    String testAnonCaptureParamAndField(String s) {
+//        final String localConst = "Hello!";
+//        return new Object() {
+//            String m() { return localConst + s + nonConstString + CONST_STRING; }
+//        }.m();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testLocalDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
+//                %3 : Var<java.type:"int"> = var %1 @"s";
+//                %4 : Var<java.type:"int"> = var %2 @"i";
+//                %5 : java.type:"int" = var.load %3;
+//                %6 : java.type:"int" = var.load %4;
+//                %7 : java.type:"LocalClassTest::$1Bar" = new %0 %5 %6 @java.ref:"LocalClassTest::$1Bar::(LocalClassTest, int, int)";
+//                return;
+//            };
+//            """)
+//    void testLocalDependency(int s, int i) {
+//        class Foo {
+//            int i() { return i; }
+//        }
+//        class Bar {
+//            int s() { return s; }
+//            Foo foo() { return new Foo(); }
+//        }
+//        new Bar();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testAnonDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
+//                %3 : Var<java.type:"int"> = var %1 @"s";
+//                %4 : Var<java.type:"int"> = var %2 @"i";
+//                %5 : java.type:"int" = var.load %3;
+//                %6 : java.type:"int" = var.load %4;
+//                %7 : java.type:"LocalClassTest::$4" = new %0 %5 %6 @java.ref:"LocalClassTest::$4::(LocalClassTest, int, int)";
+//                return;
+//            };
+//            """)
+//    void testAnonDependency(int s, int i) {
+//        class Foo {
+//            int i() { return i; }
+//        }
+//        new Object() {
+//            int s() { return s; }
+//            Foo foo() { return new Foo(); }
+//        };
+//    }
 
     class Inner { }
 
@@ -252,53 +251,68 @@ public class LocalClassTest {
         };
     }
 
-    @Reflect
-    @IR("""
-            func @"testLocalInMethodWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-                %1 : java.type:"java.lang.String" = constant @"Foo";
-                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-                %3 : java.type:"java.util.function.Supplier<LocalClassTest::$3L>" = lambda @lambda.isReflectable=true ()java.type:"LocalClassTest::$3L" -> {
-                    %4 : java.type:"java.lang.String" = var.load %2;
-                    %5 : java.type:"LocalClassTest::$3L" = new %0 %4 @java.ref:"LocalClassTest::$3L::(LocalClassTest, java.lang.String)";
-                    return %5;
-                };
-                %6 : Var<java.type:"java.util.function.Supplier<LocalClassTest::$3L>"> = var %3 @"aNew";
-                return;
-            };
-            """)
-    void testLocalInMethodWithCaptures() {
-        String s = "Foo";
-        class L {
-            String s() {
-                return s;
-            }
-        }
-        Supplier<L> aNew = (@Reflect Supplier<L>) () -> new L();
-    }
+//    @Reflect
+//    @IR("""
+//            func @"testLocalInMethodWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+//                %1 : java.type:"java.lang.String" = constant @"Foo";
+//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+//                %3 : java.type:"java.util.function.Supplier<LocalClassTest::$3L>" = lambda @lambda.isReflectable=true ()java.type:"LocalClassTest::$3L" -> {
+//                    %4 : java.type:"java.lang.String" = var.load %2;
+//                    %5 : java.type:"LocalClassTest::$3L" = new %0 %4 @java.ref:"LocalClassTest::$3L::(LocalClassTest, java.lang.String)";
+//                    return %5;
+//                };
+//                %6 : Var<java.type:"java.util.function.Supplier<LocalClassTest::$3L>"> = var %3 @"aNew";
+//                return;
+//            };
+//            """)
+//    void testLocalInMethodWithCaptures() {
+//        String s = "Foo";
+//        class L {
+//            String s() {
+//                return s;
+//            }
+//        }
+//        Supplier<L> aNew = (@Reflect Supplier<L>) () -> new L();
+//    }
+//
+//    @Reflect
+//    @IR("""
+//            func @"testLocalInLambdaWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+//                %1 : java.type:"java.lang.String" = constant @"Foo";
+//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+//                %3 : java.type:"java.util.function.Supplier<java.lang.Object>" = lambda @lambda.isReflectable=true ()java.type:"java.lang.Object" -> {
+//                    %4 : java.type:"java.lang.String" = var.load %2;
+//                    %5 : java.type:"LocalClassTest::$4L" = new %0 %4 @java.ref:"LocalClassTest::$4L::(LocalClassTest, java.lang.String)";
+//                    return %5;
+//                };
+//                %6 : Var<java.type:"java.util.function.Supplier<java.lang.Object>"> = var %3 @"aNew";
+//                return;
+//            };
+//            """)
+//    void testLocalInLambdaWithCaptures() {
+//        String s = "Foo";
+//        Supplier<Object> aNew = (@Reflect Supplier<Object>) () -> {
+//            class L {
+//                String s() {
+//                    return s;
+//                }
+//            }
+//            return new L();
+//        };
+//    }
 
     @Reflect
     @IR("""
-            func @"testLocalInLambdaWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-                %1 : java.type:"java.lang.String" = constant @"Foo";
-                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-                %3 : java.type:"java.util.function.Supplier<java.lang.Object>" = lambda @lambda.isReflectable=true ()java.type:"java.lang.Object" -> {
-                    %4 : java.type:"java.lang.String" = var.load %2;
-                    %5 : java.type:"LocalClassTest::$4L" = new %0 %4 @java.ref:"LocalClassTest::$4L::(LocalClassTest, java.lang.String)";
-                    return %5;
+            func @"testAnonInLambda" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+                %1 : java.type:"java.util.function.Supplier<java.lang.Object>" = lambda @lambda.isReflectable=true ()java.type:"java.lang.Object" -> {
+                    %2 : java.type:"LocalClassTest::$1" = new %0 @java.ref:"LocalClassTest::$1::(LocalClassTest)";
+                    return %2;
                 };
-                %6 : Var<java.type:"java.util.function.Supplier<java.lang.Object>"> = var %3 @"aNew";
+                %3 : Var<java.type:"java.util.function.Supplier<java.lang.Object>"> = var %1 @"so";
                 return;
             };
             """)
-    void testLocalInLambdaWithCaptures() {
-        String s = "Foo";
-        Supplier<Object> aNew = (@Reflect Supplier<Object>) () -> {
-            class L {
-                String s() {
-                    return s;
-                }
-            }
-            return new L();
-        };
+    void testAnonInLambda() {
+        Supplier<Object> so = () -> new Object() { };
     }
 }

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -24,6 +24,7 @@
 import jdk.incubator.code.Reflect;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.function.Supplier;
 
 /*
  * @test

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -24,7 +24,6 @@
 import jdk.incubator.code.Reflect;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.function.Supplier;
 
 /*
  * @test


### PR DESCRIPTION
I discovered a NPE when compiling code like this:

```
    void m1() {
        Supplier<Object> so = (@Reflect Supplier<Object>) () -> new Object() {};
    }
```

The NPE occurred because of a quirk in ReflectableLambdaCaptureScanner -- this scanner is meant to recursively compute the captures of any class declaration it encounters.
But its `visitNewClass` method was assuming the local class being created was already examined -- which was not the case (as the call to `super::visitNewClass` only occurred as last statement).

The fix is to simply move the call to `super::visitNewClass` at the beginning of the method.

I also noticed that javac was issuing spurious errors for constructors of anon and local classes (e.g. javac treated them as "reflectable methods"). This behavior was due to the fact that, inside `ReflectMethod::visitMethodDef` we don't exclude constructors explicitly from the reflectable test (and constructors are never reflectable, at least for now -- also as documented in `@Reflect` javadoc).

I fixed this spurious error as well, by adding an explicit check to avoid treating constructors as reflectable program elements.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1082/head:pull/1082` \
`$ git checkout pull/1082`

Update a local copy of the PR: \
`$ git checkout pull/1082` \
`$ git pull https://git.openjdk.org/babylon.git pull/1082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1082`

View PR using the GUI difftool: \
`$ git pr show -t 1082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1082.diff">https://git.openjdk.org/babylon/pull/1082.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1082#issuecomment-4868038358)
</details>
