### PR TITLE
Separate unreachable from unsupported code paths in BodyScanner

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -860,7 +860,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     Symbol sym = assign.sym;
                     switch (sym.getKind()) {
-                        case LOCAL_VARIABLE, PARAMETER -> {
+                        case LOCAL_VARIABLE, PARAMETER, EXCEPTION_PARAMETER -> {
                             Value varOp = varOpValue(sym);
                             append(CoreOp.varStore(varOp, result));
                         }
@@ -872,10 +872,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                                 append(JavaOp.fieldStore(fd, thisValue(), result));
                             }
                         }
-                        default -> {
-                            // @@@ Cannot reach here?
-                            throw unsupported(tree);
-                        }
+                        default -> throw unreachable();
                     }
                     break;
                 }
@@ -909,7 +906,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     break;
                 }
                 default:
-                    throw unsupported(tree);
+                    throw unreachable();
             }
         }
 
@@ -952,7 +949,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     case USR_ASG -> append(JavaOp.lshr(lhs, rhs));
 
 
-                    default -> throw unsupported(tree);
+                    default -> throw unreachable();
                 };
                 return result = convert(assignOpResult, tree.type);
             };
@@ -969,7 +966,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     Symbol sym = assign.sym;
                     switch (sym.getKind()) {
-                        case LOCAL_VARIABLE, PARAMETER -> {
+                        case LOCAL_VARIABLE, PARAMETER -> { // exception parameters not valid here!
                             Value varOp = varOpValue(sym);
 
                             Op.Result lhsOpValue = append(CoreOp.varLoad(varOp));
@@ -997,10 +994,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                                 append(JavaOp.fieldStore(fr, thisValue(), r));
                             }
                         }
-                        default -> {
-                            // @@@ Cannot reach here?
-                            throw unsupported(lhs);
-                        }
+                        default -> throw unreachable();
                     }
                 }
                 case SELECT -> {
@@ -1039,7 +1033,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     append(JavaOp.arrayStoreOp(array, index, r));
                 }
-                default -> throw unsupported(lhs);
+                default -> throw unreachable();
             }
         }
 
@@ -1072,13 +1066,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         }
                     }
                 }
-                case PACKAGE, INTERFACE, CLASS, RECORD, ENUM -> {
+                case PACKAGE, INTERFACE, CLASS, ANNOTATION_TYPE, RECORD, ENUM -> {
                     result = null;
                 }
-                default -> {
-                    // @@@ Cannot reach here?
-                    throw unsupported(tree);
-                }
+                default -> throw unreachable();
             }
         }
 
@@ -1112,8 +1103,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 if (tree.sym.equals(syms.lengthVar)) {
                     result = append(JavaOp.arrayLength(receiver));
                 } else {
-                    // Should not reach here
-                    throw unsupported(tree);
+                    throw unreachable();
                 }
             } else {
                 Symbol sym = tree.sym;
@@ -1132,13 +1122,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                             }
                         }
                     }
-                    case PACKAGE, INTERFACE, CLASS, RECORD, ENUM -> {
+                    case PACKAGE, INTERFACE, CLASS, ANNOTATION_TYPE, RECORD, ENUM -> {
                         result = null;
                     }
-                    default -> {
-                        // @@@ Cannot reach here?
-                        throw unsupported(tree);
-                    }
+                    default -> throw unreachable();
                 }
             }
         }
@@ -1304,7 +1291,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             } else if (pattern instanceof JCTree.JCRecordPattern p) {
                 patternType = JavaOp.Pattern.recordType(typeToCodeType(p.record.type));
             } else {
-                throw unsupported(pattern);
+                throw unreachable(); // toplevel patterns are type test/record
             }
 
             // Push pattern body
@@ -1413,9 +1400,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 scan(tree.def);
             }
 
-            // @@@ Support local classes in pre-construction contexts
-            // this cannot happen, as constructors cannot be reflectable
             if (tree.type.tsym.isDirectlyOrIndirectlyLocal() && (tree.type.tsym.flags() & NOOUTERTHIS) != 0) {
+                // local class creation in pre-construction context is not supported
                 throw unsupported(tree);
             }
 
@@ -1778,7 +1764,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 // Pop label
                 popBody();
             } else {
-                throw unsupported(tree);
+                throw unreachable();
             }
 
             return body;
@@ -2318,22 +2304,14 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         Value one = convert(append(numericOneValue(unboxedType)), unboxedType);
                         Value unboxedLhs = unboxIfNeeded(lhs);
 
-                        Value unboxedLhsPlusOne = switch (tree.getTag()) {
-                            // Arithmetic operations
-                            case POSTINC, PREINC -> append(JavaOp.add(unboxedLhs, one));
-                            case POSTDEC, PREDEC -> append(JavaOp.sub(unboxedLhs, one));
-
-                            default -> throw unsupported(tree);
-                        };
+                        Value unboxedLhsPlusOne = (tag == Tag.PREINC || tag ==  Tag.POSTINC) ?
+                            append(JavaOp.add(unboxedLhs, one)) :
+                            append(JavaOp.sub(unboxedLhs, one));
                         Value lhsPlusOne = convert(unboxedLhsPlusOne, tree.type);
 
                         // Assign expression result
-                        result =  switch (tree.getTag()) {
-                            case POSTINC, POSTDEC -> lhs;
-                            case PREINC, PREDEC -> lhsPlusOne;
-
-                            default -> throw unsupported(tree);
-                        };
+                        result = (tag == Tag.POSTINC || tag == Tag.POSTDEC) ?
+                                lhs : lhsPlusOne;
                         return lhsPlusOne;
                     };
 
@@ -2355,7 +2333,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     // Result is value of the operand
                     result = toValue(tree.arg, tree.type);
                 }
-                default -> throw unsupported(tree);
+                default -> throw unreachable(); // NULLCHK not possible
             }
         }
 
@@ -2434,7 +2412,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     case SR -> append(JavaOp.ashr(lhs, rhs));
                     case USR -> append(JavaOp.lshr(lhs, rhs));
 
-                    default -> throw unsupported(tree);
+                    default -> throw unreachable();
                 };
             }
         }
@@ -2489,6 +2467,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         UnsupportedASTException unsupported(JCTree tree) {
             return new UnsupportedASTException(tree);
+        }
+
+        AssertionError unreachable() {
+            throw new AssertionError("Should not reach here!");
         }
 
         CoreOp.FuncOp scanMethod(JCBlock body) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2470,7 +2470,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
 
         AssertionError unreachable() {
-            throw new AssertionError("Should not reach here!");
+            return new AssertionError("Should not reach here!");
         }
 
         CoreOp.FuncOp scanMethod(JCBlock body) {

--- a/test/langtools/tools/javac/reflect/ConstantsTest.java
+++ b/test/langtools/tools/javac/reflect/ConstantsTest.java
@@ -276,4 +276,24 @@ public class ConstantsTest {
     void test18() {
         Class<?> s = boolean[][][].class;
     }
+
+    @interface A { }
+    static class B {
+        @interface C { }
+    }
+
+    @IR("""
+            func @"test19" (%0 : java.type:"ConstantsTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.Class" = constant @java.type:"ConstantsTest$A";
+                %2 : Var<java.type:"java.lang.Class<?>"> = var %1 @"a";
+                %3 : java.type:"java.lang.Class" = constant @java.type:"ConstantsTest$B$C";
+                %4 : Var<java.type:"java.lang.Class<?>"> = var %3 @"c";
+                return;
+            };
+            """)
+    @Reflect
+    void test19() {
+        Class<?> a = A.class;
+        Class<?> c = B.C.class;
+    }
 }

--- a/test/langtools/tools/javac/reflect/TryTest.java
+++ b/test/langtools/tools/javac/reflect/TryTest.java
@@ -283,4 +283,28 @@ public class TryTest {
         }
      }
 
+    @Reflect
+    @IR("""
+            func @"test7" (%0 : java.type:"TryTest")java.type:"void" -> {
+                java.try
+                    ()java.type:"void" -> {
+                        %1 : java.type:"java.lang.Exception" = new @java.ref:"java.lang.Exception::()";
+                        throw %1;
+                    }
+                    (%2 : java.type:"java.lang.Exception")java.type:"void" -> {
+                        %3 : Var<java.type:"java.lang.Exception"> = var %2 @"exception";
+                        %4 : java.type:"java.lang.Exception" = constant @null;
+                        var.store %3 %4;
+                        yield;
+                    };
+                return;
+            };
+            """)
+    void test7() {
+        try {
+            throw new Exception();
+        } catch (Exception exception) {
+            exception = null;
+        }
+    }
 }


### PR DESCRIPTION
BodyScanner can throw exception when an AST is not supported:

```
throw unsupported(tree)
```

These exception typically are propagated outwards and cause either a warning to be displayed (explaining the reflectable method is not supported) when `reflectAll` is active, or they just crash the compiler (this is a problem for another day :-) ).

Unfortunately BodyScanner uses this idiom both when a piece of code is unreachable (e.g. because the switch is morally exhaustive but javac doesn't know) and for real program elements that code reflection doesn't support.

After an in-depth analysis, it turns out that there's only two program elements we don't support:

* invocation of a local class constructor in an early construction context
* case labels with multiple constants/patterns

In these cases I left `throw unsupported`. In all the other cases I defined another method called `unreachable` (which creates an assertion error), and called that one instead.

When going through the various use cases I spotted two inconsistencies/missing cases:

* visitAssign was missing a case for EXCEPTION_PARAMETER, so assignments to exception parameters were rejected
* visitIdent and visitSelect missed ANNOTATION_TYPE as a possible selector type - this meant that A.class or B.A.class didn't work if A was an annotation

I've fixed these and added tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1083/head:pull/1083` \
`$ git checkout pull/1083`

Update a local copy of the PR: \
`$ git checkout pull/1083` \
`$ git pull https://git.openjdk.org/babylon.git pull/1083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1083`

View PR using the GUI difftool: \
`$ git pr show -t 1083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1083.diff">https://git.openjdk.org/babylon/pull/1083.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1083#issuecomment-4868075277)
</details>
