### PR TITLE
Turn unsupported error into warnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4362,18 +4362,6 @@ compiler.err.enclosing.class.type.non.denotable=\
 ########################################
 
 # 0: symbol
-compiler.err.reflectable.method.inner.class=\
-    unsupported reflectable method in inner class {0}
-
-# 0: symbol
-compiler.err.reflectable.lambda.inner.class=\
-    unsupported reflectable lambda in inner class {0}
-
-# 0: symbol
-compiler.err.reflectable.mref.inner.class=\
-    unsupported reflectable method reference in inner class {0}
-
-# 0: symbol
 compiler.warn.reflectable.method.inner.class=\
     unsupported reflectable method in inner class {0}
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -207,11 +207,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         if (isReflectable) {
             if (isInsideInnerOrLocalClass()) {
                 // Reflectable methods in local classes are not supported
-                if (reflectAll) {
-                    log.warning(tree, Warnings.ReflectableMethodInnerClass(currentClassSym.enclClass()));
-                } else {
-                    log.error(tree, Errors.ReflectableMethodInnerClass(currentClassSym.enclClass()));
-                }
+                log.warning(tree, Warnings.ReflectableMethodInnerClass(currentClassSym.enclClass()));
                 super.visitMethodDef(tree);
                 return;
             } else {
@@ -221,13 +217,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 try {
                     funcOp = bodyScanner.scanMethod();
                 } catch (Exception e) {
-                    if (reflectAll) {
-                        // log as warning for debugging purposses when reflectAll enabled
-                        log.warning(tree, Warnings.ReflectableMethodUnsupported(currentClassSym.enclClass(), e.toString()));
-                        super.visitMethodDef(tree);
-                        return;
-                    }
-                    throw e;
+                    // log as warning for debugging purposes when reflectAll enabled
+                    log.warning(tree, Warnings.ReflectableMethodUnsupported(currentClassSym.enclClass(), e.toString()));
+                    super.visitMethodDef(tree);
+                    return;
                 }
                 if (dumpIR) {
                     // dump the method IR if requested
@@ -310,11 +303,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         if (isReflectable) {
             if (isInsideInnerOrLocalClass()) {
                 // Reflectable lambdas in local classes are not supported
-                if (reflectAll) {
-                    log.warning(tree, Warnings.ReflectableLambdaInnerClass(currentClassSym.enclClass()));
-                } else {
-                    log.error(tree, Errors.ReflectableLambdaInnerClass(currentClassSym.enclClass()));
-                }
+                log.warning(tree, Warnings.ReflectableLambdaInnerClass(currentClassSym.enclClass()));
                 super.visitLambda(tree);
                 return;
             }
@@ -325,12 +314,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
             try {
                 funcOp = bodyScanner.scanLambda();
             } catch (Exception e) {
-                if (reflectAll) {
-                    log.warning(tree, Warnings.ReflectableLambdaUnsupported(currentClassSym.enclClass(), e.toString()));
-                    super.visitLambda(tree);
-                    return;
-                }
-                throw e;
+                log.warning(tree, Warnings.ReflectableLambdaUnsupported(currentClassSym.enclClass(), e.toString()));
+                super.visitLambda(tree);
+                return;
             }
             if (dumpIR) {
                 // dump the method IR if requested
@@ -362,11 +348,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         if (isReflectable(tree)) {
             if (isInsideInnerOrLocalClass()) {
                 // Reflectable method references in local classes are not supported
-                if (reflectAll) {
-                    log.warning(tree, Warnings.ReflectableMrefInnerClass(currentClassSym.enclClass()));
-                } else {
-                    log.error(tree, Errors.ReflectableMrefInnerClass(currentClassSym.enclClass()));
-                }
+                log.warning(tree, Warnings.ReflectableMrefInnerClass(currentClassSym.enclClass()));
                 super.visitReference(tree);
                 return;
             }

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -232,6 +232,3 @@ compiler.warn.reflectable.lambda.inner.class
 compiler.warn.reflectable.mref.inner.class
 compiler.warn.reflectable.method.unsupported
 compiler.warn.reflectable.lambda.unsupported
-compiler.err.reflectable.lambda.inner.class
-compiler.err.reflectable.method.inner.class
-compiler.err.reflectable.mref.inner.class

--- a/test/langtools/tools/javac/reflect/LocalClassTest.java
+++ b/test/langtools/tools/javac/reflect/LocalClassTest.java
@@ -39,149 +39,149 @@ public class LocalClassTest {
     final static String CONST_STRING = "Hello!";
     String nonConstString = "Hello!";
 
-//    @Reflect
-//    @IR("""
-//            func @"testLocalNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-//                %1 : java.type:"LocalClassTest::$1Foo" = new %0 @java.ref:"LocalClassTest::$1Foo::(LocalClassTest)";
-//                invoke %1 @java.ref:"LocalClassTest::$1Foo::m():void";
-//                return;
-//            };
-//            """)
-//    void testLocalNoCapture() {
-//        class Foo {
-//            void m() { }
-//        }
-//        new Foo().m();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testAnonNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-//                %1 : java.type:"LocalClassTest::$1" = new %0 @java.ref:"LocalClassTest::$1::(LocalClassTest)";
-//                invoke %1 @java.ref:"LocalClassTest::$1::m():void";
-//                return;
-//            };
-//            """)
-//    void testAnonNoCapture() {
-//        new Object() {
-//            void m() { }
-//        }.m();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testLocalCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-//                %3 : java.type:"java.lang.String" = var.load %2;
-//                %4 : java.type:"LocalClassTest::$2Foo" = new %0 %3 @java.ref:"LocalClassTest::$2Foo::(LocalClassTest, java.lang.String)";
-//                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2Foo::m():java.lang.String";
-//                return %5;
-//            };
-//            """)
-//    String testLocalCaptureParam(String s) {
-//        class Foo {
-//            String m() { return s; }
-//        }
-//        return new Foo().m();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testAnonCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-//                %3 : java.type:"java.lang.String" = var.load %2;
-//                %4 : java.type:"LocalClassTest::$2" = new %0 %3 @java.ref:"LocalClassTest::$2::(LocalClassTest, java.lang.String)";
-//                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2::m():java.lang.String";
-//                return %5;
-//            };
-//            """)
-//    String testAnonCaptureParam(String s) {
-//        return new Object() {
-//            String m() { return s; }
-//        }.m();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testLocalCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-//                %3 : java.type:"java.lang.String" = constant @"Hello!";
-//                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
-//                %5 : java.type:"java.lang.String" = var.load %2;
-//                %6 : java.type:"LocalClassTest::$3Foo" = new %0 %5 @java.ref:"LocalClassTest::$3Foo::(LocalClassTest, java.lang.String)";
-//                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3Foo::m():java.lang.String";
-//                return %7;
-//            };
-//            """)
-//    String testLocalCaptureParamAndField(String s) {
-//        final String localConst = "Hello!";
-//        class Foo {
-//            String m() { return localConst + s + nonConstString + CONST_STRING; }
-//        }
-//        return new Foo().m();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testAnonCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
-//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-//                %3 : java.type:"java.lang.String" = constant @"Hello!";
-//                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
-//                %5 : java.type:"java.lang.String" = var.load %2;
-//                %6 : java.type:"LocalClassTest::$3" = new %0 %5 @java.ref:"LocalClassTest::$3::(LocalClassTest, java.lang.String)";
-//                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3::m():java.lang.String";
-//                return %7;
-//            };
-//            """)
-//    String testAnonCaptureParamAndField(String s) {
-//        final String localConst = "Hello!";
-//        return new Object() {
-//            String m() { return localConst + s + nonConstString + CONST_STRING; }
-//        }.m();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testLocalDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
-//                %3 : Var<java.type:"int"> = var %1 @"s";
-//                %4 : Var<java.type:"int"> = var %2 @"i";
-//                %5 : java.type:"int" = var.load %3;
-//                %6 : java.type:"int" = var.load %4;
-//                %7 : java.type:"LocalClassTest::$1Bar" = new %0 %5 %6 @java.ref:"LocalClassTest::$1Bar::(LocalClassTest, int, int)";
-//                return;
-//            };
-//            """)
-//    void testLocalDependency(int s, int i) {
-//        class Foo {
-//            int i() { return i; }
-//        }
-//        class Bar {
-//            int s() { return s; }
-//            Foo foo() { return new Foo(); }
-//        }
-//        new Bar();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testAnonDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
-//                %3 : Var<java.type:"int"> = var %1 @"s";
-//                %4 : Var<java.type:"int"> = var %2 @"i";
-//                %5 : java.type:"int" = var.load %3;
-//                %6 : java.type:"int" = var.load %4;
-//                %7 : java.type:"LocalClassTest::$4" = new %0 %5 %6 @java.ref:"LocalClassTest::$4::(LocalClassTest, int, int)";
-//                return;
-//            };
-//            """)
-//    void testAnonDependency(int s, int i) {
-//        class Foo {
-//            int i() { return i; }
-//        }
-//        new Object() {
-//            int s() { return s; }
-//            Foo foo() { return new Foo(); }
-//        };
-//    }
+    @Reflect
+    @IR("""
+            func @"testLocalNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+                %1 : java.type:"LocalClassTest::$1Foo" = new %0 @java.ref:"LocalClassTest::$1Foo::(LocalClassTest)";
+                invoke %1 @java.ref:"LocalClassTest::$1Foo::m():void";
+                return;
+            };
+            """)
+    void testLocalNoCapture() {
+        class Foo {
+            void m() { }
+        }
+        new Foo().m();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testAnonNoCapture" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+                %1 : java.type:"LocalClassTest::$1" = new %0 @java.ref:"LocalClassTest::$1::(LocalClassTest)";
+                invoke %1 @java.ref:"LocalClassTest::$1::m():void";
+                return;
+            };
+            """)
+    void testAnonNoCapture() {
+        new Object() {
+            void m() { }
+        }.m();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testLocalCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = var.load %2;
+                %4 : java.type:"LocalClassTest::$2Foo" = new %0 %3 @java.ref:"LocalClassTest::$2Foo::(LocalClassTest, java.lang.String)";
+                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2Foo::m():java.lang.String";
+                return %5;
+            };
+            """)
+    String testLocalCaptureParam(String s) {
+        class Foo {
+            String m() { return s; }
+        }
+        return new Foo().m();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testAnonCaptureParam" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = var.load %2;
+                %4 : java.type:"LocalClassTest::$2" = new %0 %3 @java.ref:"LocalClassTest::$2::(LocalClassTest, java.lang.String)";
+                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"LocalClassTest::$2::m():java.lang.String";
+                return %5;
+            };
+            """)
+    String testAnonCaptureParam(String s) {
+        return new Object() {
+            String m() { return s; }
+        }.m();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testLocalCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = constant @"Hello!";
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
+                %5 : java.type:"java.lang.String" = var.load %2;
+                %6 : java.type:"LocalClassTest::$3Foo" = new %0 %5 @java.ref:"LocalClassTest::$3Foo::(LocalClassTest, java.lang.String)";
+                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3Foo::m():java.lang.String";
+                return %7;
+            };
+            """)
+    String testLocalCaptureParamAndField(String s) {
+        final String localConst = "Hello!";
+        class Foo {
+            String m() { return localConst + s + nonConstString + CONST_STRING; }
+        }
+        return new Foo().m();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testAnonCaptureParamAndField" (%0 : java.type:"LocalClassTest", %1 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.lang.String" = constant @"Hello!";
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"localConst";
+                %5 : java.type:"java.lang.String" = var.load %2;
+                %6 : java.type:"LocalClassTest::$3" = new %0 %5 @java.ref:"LocalClassTest::$3::(LocalClassTest, java.lang.String)";
+                %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"LocalClassTest::$3::m():java.lang.String";
+                return %7;
+            };
+            """)
+    String testAnonCaptureParamAndField(String s) {
+        final String localConst = "Hello!";
+        return new Object() {
+            String m() { return localConst + s + nonConstString + CONST_STRING; }
+        }.m();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testLocalDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"s";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"LocalClassTest::$1Bar" = new %0 %5 %6 @java.ref:"LocalClassTest::$1Bar::(LocalClassTest, int, int)";
+                return;
+            };
+            """)
+    void testLocalDependency(int s, int i) {
+        class Foo {
+            int i() { return i; }
+        }
+        class Bar {
+            int s() { return s; }
+            Foo foo() { return new Foo(); }
+        }
+        new Bar();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testAnonDependency" (%0 : java.type:"LocalClassTest", %1 : java.type:"int", %2 : java.type:"int")java.type:"void" -> {
+                %3 : Var<java.type:"int"> = var %1 @"s";
+                %4 : Var<java.type:"int"> = var %2 @"i";
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = var.load %4;
+                %7 : java.type:"LocalClassTest::$4" = new %0 %5 %6 @java.ref:"LocalClassTest::$4::(LocalClassTest, int, int)";
+                return;
+            };
+            """)
+    void testAnonDependency(int s, int i) {
+        class Foo {
+            int i() { return i; }
+        }
+        new Object() {
+            int s() { return s; }
+            Foo foo() { return new Foo(); }
+        };
+    }
 
     class Inner { }
 
@@ -251,61 +251,61 @@ public class LocalClassTest {
         };
     }
 
-//    @Reflect
-//    @IR("""
-//            func @"testLocalInMethodWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-//                %1 : java.type:"java.lang.String" = constant @"Foo";
-//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-//                %3 : java.type:"java.util.function.Supplier<LocalClassTest::$3L>" = lambda @lambda.isReflectable=true ()java.type:"LocalClassTest::$3L" -> {
-//                    %4 : java.type:"java.lang.String" = var.load %2;
-//                    %5 : java.type:"LocalClassTest::$3L" = new %0 %4 @java.ref:"LocalClassTest::$3L::(LocalClassTest, java.lang.String)";
-//                    return %5;
-//                };
-//                %6 : Var<java.type:"java.util.function.Supplier<LocalClassTest::$3L>"> = var %3 @"aNew";
-//                return;
-//            };
-//            """)
-//    void testLocalInMethodWithCaptures() {
-//        String s = "Foo";
-//        class L {
-//            String s() {
-//                return s;
-//            }
-//        }
-//        Supplier<L> aNew = (@Reflect Supplier<L>) () -> new L();
-//    }
-//
-//    @Reflect
-//    @IR("""
-//            func @"testLocalInLambdaWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
-//                %1 : java.type:"java.lang.String" = constant @"Foo";
-//                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
-//                %3 : java.type:"java.util.function.Supplier<java.lang.Object>" = lambda @lambda.isReflectable=true ()java.type:"java.lang.Object" -> {
-//                    %4 : java.type:"java.lang.String" = var.load %2;
-//                    %5 : java.type:"LocalClassTest::$4L" = new %0 %4 @java.ref:"LocalClassTest::$4L::(LocalClassTest, java.lang.String)";
-//                    return %5;
-//                };
-//                %6 : Var<java.type:"java.util.function.Supplier<java.lang.Object>"> = var %3 @"aNew";
-//                return;
-//            };
-//            """)
-//    void testLocalInLambdaWithCaptures() {
-//        String s = "Foo";
-//        Supplier<Object> aNew = (@Reflect Supplier<Object>) () -> {
-//            class L {
-//                String s() {
-//                    return s;
-//                }
-//            }
-//            return new L();
-//        };
-//    }
+    @Reflect
+    @IR("""
+            func @"testLocalInMethodWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @"Foo";
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.util.function.Supplier<LocalClassTest::$3L>" = lambda @lambda.isReflectable=true ()java.type:"LocalClassTest::$3L" -> {
+                    %4 : java.type:"java.lang.String" = var.load %2;
+                    %5 : java.type:"LocalClassTest::$3L" = new %0 %4 @java.ref:"LocalClassTest::$3L::(LocalClassTest, java.lang.String)";
+                    return %5;
+                };
+                %6 : Var<java.type:"java.util.function.Supplier<LocalClassTest::$3L>"> = var %3 @"aNew";
+                return;
+            };
+            """)
+    void testLocalInMethodWithCaptures() {
+        String s = "Foo";
+        class L {
+            String s() {
+                return s;
+            }
+        }
+        Supplier<L> aNew = (@Reflect Supplier<L>) () -> new L();
+    }
+
+    @Reflect
+    @IR("""
+            func @"testLocalInLambdaWithCaptures" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
+                %1 : java.type:"java.lang.String" = constant @"Foo";
+                %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                %3 : java.type:"java.util.function.Supplier<java.lang.Object>" = lambda @lambda.isReflectable=true ()java.type:"java.lang.Object" -> {
+                    %4 : java.type:"java.lang.String" = var.load %2;
+                    %5 : java.type:"LocalClassTest::$4L" = new %0 %4 @java.ref:"LocalClassTest::$4L::(LocalClassTest, java.lang.String)";
+                    return %5;
+                };
+                %6 : Var<java.type:"java.util.function.Supplier<java.lang.Object>"> = var %3 @"aNew";
+                return;
+            };
+            """)
+    void testLocalInLambdaWithCaptures() {
+        String s = "Foo";
+        Supplier<Object> aNew = (@Reflect Supplier<Object>) () -> {
+            class L {
+                String s() {
+                    return s;
+                }
+            }
+            return new L();
+        };
+    }
 
     @Reflect
     @IR("""
             func @"testAnonInLambda" (%0 : java.type:"LocalClassTest")java.type:"void" -> {
                 %1 : java.type:"java.util.function.Supplier<java.lang.Object>" = lambda @lambda.isReflectable=true ()java.type:"java.lang.Object" -> {
-                    %2 : java.type:"LocalClassTest::$1" = new %0 @java.ref:"LocalClassTest::$1::(LocalClassTest)";
+                    %2 : java.type:"LocalClassTest::$5" = new %0 @java.ref:"LocalClassTest::$5::(LocalClassTest)";
                     return %2;
                 };
                 %3 : Var<java.type:"java.util.function.Supplier<java.lang.Object>"> = var %1 @"so";

--- a/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
+++ b/test/langtools/tools/javac/reflect/TestNoCodeReflectionInInnerClasses.out
@@ -1,10 +1,12 @@
-TestNoCodeReflectionInInnerClasses.java:35:21: compiler.err.reflectable.method.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:38:46: compiler.err.reflectable.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:42:46: compiler.err.reflectable.mref.inner.class: TestNoCodeReflectionInInnerClasses.Inner
-TestNoCodeReflectionInInnerClasses.java:49:25: compiler.err.reflectable.method.inner.class: Local
-TestNoCodeReflectionInInnerClasses.java:52:50: compiler.err.reflectable.lambda.inner.class: Local
-TestNoCodeReflectionInInnerClasses.java:56:50: compiler.err.reflectable.mref.inner.class: Local
-TestNoCodeReflectionInInnerClasses.java:64:25: compiler.err.reflectable.method.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
-TestNoCodeReflectionInInnerClasses.java:67:50: compiler.err.reflectable.lambda.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
-TestNoCodeReflectionInInnerClasses.java:71:50: compiler.err.reflectable.mref.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
-9 errors
+TestNoCodeReflectionInInnerClasses.java:35:21: compiler.warn.reflectable.method.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:38:46: compiler.warn.reflectable.lambda.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:42:46: compiler.warn.reflectable.mref.inner.class: TestNoCodeReflectionInInnerClasses.Inner
+TestNoCodeReflectionInInnerClasses.java:49:25: compiler.warn.reflectable.method.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:52:50: compiler.warn.reflectable.lambda.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:56:50: compiler.warn.reflectable.mref.inner.class: Local
+TestNoCodeReflectionInInnerClasses.java:64:25: compiler.warn.reflectable.method.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+TestNoCodeReflectionInInnerClasses.java:67:50: compiler.warn.reflectable.lambda.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+TestNoCodeReflectionInInnerClasses.java:71:50: compiler.warn.reflectable.mref.inner.class: compiler.misc.anonymous.class: TestNoCodeReflectionInInnerClasses$1
+- compiler.err.warnings.and.werror
+1 error
+9 warnings

--- a/test/langtools/tools/javac/reflect/TestUnsupported.java
+++ b/test/langtools/tools/javac/reflect/TestUnsupported.java
@@ -1,0 +1,17 @@
+/*
+ * @test /nodynamiccopyright/
+ * @modules jdk.incubator.code
+ * @summary Test that unsupported langauge features don't crash javac
+ * @compile/fail/ref=TestUnsupported.out -Werror -Xlint:-incubating -XDrawDiagnostics TestUnsupported.java
+ */
+import jdk.incubator.code.Reflect;
+
+public class TestUnsupported {
+    @Reflect
+    boolean m(Object o) {
+        return switch (o) {
+            case String _, Integer _ -> true;
+            default -> false;
+        };
+    }
+}

--- a/test/langtools/tools/javac/reflect/TestUnsupported.out
+++ b/test/langtools/tools/javac/reflect/TestUnsupported.out
@@ -1,0 +1,4 @@
+TestUnsupported.java:11:13: compiler.warn.reflectable.method.unsupported: TestUnsupported, jdk.incubator.code.internal.ReflectMethods$UnsupportedASTException:case String _, Integer _ -> yield true;
+- compiler.err.warnings.and.werror
+1 error
+1 warning


### PR DESCRIPTION
ReflectMethods currently issues hard errors whenever it finds things that are unsupported.
Even worse, if the unsupported feature is associated with an AST node not supported by BodyScanner, javac just fails with exception.

When the `reflectAll` option is enabled, errors are turned into warnings, and crashes are replaced with nice warnings too.

This patch makes the `reflectAll` behavior the norm and removes the hard errors.

The main rationale behind preferring warnings to errors is that `@Reflect` has a transitive behavior -- which means sometimes the annotation causing a program element to be reflectable might be far from the element itself. In such cases, issuing errors seems too strong. After all unsupported features just make a method non-reflectable, and a warning is good enough of a signal that something happened.

Some possible follow ups:
* improve the diagnostic that is generated for when BodyScanner bails out. For now we print the AST that led to the failure -- but perhaps printing a message associated with the _feature_ that is unsupported might be better
* decide whether warnings should also emitted for constructors, and things inside constructors (as constructors are not currently reflectable)
* decide whether these warnings should be in a dedicated Lint category

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1084/head:pull/1084` \
`$ git checkout pull/1084`

Update a local copy of the PR: \
`$ git checkout pull/1084` \
`$ git pull https://git.openjdk.org/babylon.git pull/1084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1084`

View PR using the GUI difftool: \
`$ git pr show -t 1084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1084.diff">https://git.openjdk.org/babylon/pull/1084.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1084#issuecomment-4868943975)
</details>
