### PR TITLE
Align Op.ofElement with ReflectMethods::visitMethodDef

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -421,8 +421,14 @@ public class ReflectMethods extends TreeTranslatorPrev {
         try {
             this.make = make;
             currentClassSym = classSym;
-            BodyScanner bodyScanner = new BodyScanner(methodDecl);
-            return bodyScanner.scanMethod(attributedBody);
+            // same checks as in ReflectMethods::visitMethodDef
+            boolean isReflectable = !methodDecl.sym.isConstructor() && isReflectable(methodDecl);
+            if (isReflectable && !isInsideInnerOrLocalClass()) {
+                BodyScanner bodyScanner = new BodyScanner(methodDecl);
+                return bodyScanner.scanMethod(attributedBody);
+            } else {
+                return null;
+            }
         } finally {
             currentClassSym = null;
             this.make = null;

--- a/test/langtools/tools/javac/reflect/TestElementReflection.java
+++ b/test/langtools/tools/javac/reflect/TestElementReflection.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Check presence/absence of code model in annotated elements
+ * @library /tools/javac/lib
+ * @modules java.compiler
+ *          jdk.compiler
+ *          jdk.incubator.code
+ * @enablePreview
+ * @build   JavacTestingAbstractProcessor TestElementReflection
+ * @compile -processor TestElementReflection -proc:only TestElementReflection.java
+ */
+
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Reflect;
+import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
+
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.*;
+
+public class TestElementReflection extends JavacTestingAbstractProcessor {
+
+    @interface HasModel {
+        boolean value();
+    }
+
+    static class Test {
+        @HasModel(false)
+        Test() { } // constructor
+
+        @Reflect
+        @HasModel(true)
+        void member_reflectable() { } // reflectable class member
+
+        @HasModel(false)
+        void member() { } // class member
+
+        class Inner {
+            @Reflect
+            @HasModel(false)
+            void inner_member_reflectable() { } // reflectable inner class member
+
+            @HasModel(false)
+            void inner_member() { } // inner class member
+        }
+
+        static class Nested {
+            @Reflect
+            @HasModel(true)
+            void static_member_reflectable() { } // reflectable nested class member
+
+            @HasModel(false)
+            void static_member() { } // nested class member
+        }
+    }
+
+    public boolean process(Set<? extends TypeElement> annotations,
+                           RoundEnvironment roundEnvironment) {
+        class Scan extends ElementScanner<Void,Void> {
+            @Override
+            public Void visitExecutable(ExecutableElement e, Void p) {
+                HasModel hasModel = e.getAnnotation(HasModel.class);
+                if (hasModel == null) {
+                    return null; // skip
+                }
+                Optional<FuncOp> body = Op.ofElement(processingEnv, e);
+                if (body.isPresent() && !hasModel.value()) {
+                    throw new AssertionError(String.format("Unexpected model found for unsupported element %s",
+                            toExecutableElementString(e)));
+                } else if (body.isEmpty() && hasModel.value()) {
+                    throw new AssertionError(String.format("Model not found for supported element %s",
+                            toExecutableElementString(e)));
+                }
+                return null;
+            }
+        }
+        Scan scan = new Scan();
+        for (Element e : roundEnvironment.getRootElements()) {
+            scan.scan(e);
+        }
+        return true;
+    }
+
+    static String toExecutableElementString(ExecutableElement e) {
+        return e.getEnclosingElement() + "." + e;
+    }
+}


### PR DESCRIPTION
ReflectMethods does not generate a model for methods in the following cases:
* the method is a constructor
* the method is inside an inner/local class

Unfortunately, these checks are missing from `Op::ofElement`, which calls `ReflectMethod::getMethodBody` -- a different entry point that jumps into `BodyScanner` immediately, w/o checks.

The solution is to replicate the same checks we have in `ReflectMethods::visitMethodDef` inside `ReflectMethods::getMethodBody`, so that in situation that no model should be emitted, `Op::ofElement` would return an empty optional.

I've added an annotation processor regression test to check that the behavior is now aligned.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1086/head:pull/1086` \
`$ git checkout pull/1086`

Update a local copy of the PR: \
`$ git checkout pull/1086` \
`$ git pull https://git.openjdk.org/babylon.git pull/1086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1086`

View PR using the GUI difftool: \
`$ git pr show -t 1086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1086.diff">https://git.openjdk.org/babylon/pull/1086.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1086#issuecomment-4875940793)
</details>
