### PR TITLE
Add support for multi label pattern case in switch

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -61,7 +61,9 @@ import com.sun.tools.javac.tree.JCTree.JCArrayAccess;
 import com.sun.tools.javac.tree.JCTree.JCAssign;
 import com.sun.tools.javac.tree.JCTree.JCBinary;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCDefaultCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCFunctionalExpression;
@@ -1265,6 +1267,16 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
         }
 
+        Body.Builder scanPatternAsBody(JCTree.JCPattern pattern, Value target) {
+            pushBody(pattern, CoreType.functionType(JavaType.BOOLEAN));
+            Value localTarget = boxIfNeeded(target);
+            Value patVal = scanPattern(pattern, localTarget);
+            append(CoreOp.core_yield(patVal));
+            Body.Builder patternBody = stack.body;
+            popBody();
+            return patternBody;
+        }
+
         Value scanPattern(JCTree.JCPattern pattern, Value target) {
             // Type of pattern
             JavaType patternType;
@@ -1619,11 +1631,15 @@ public class ReflectMethods extends TreeTranslatorPrev {
             boolean hasDefaultCase = false;
 
             for (JCTree.JCCase c : cases) {
+                boolean anyLabelIsDefault = c.labels.stream().anyMatch(l -> l instanceof JCTree.JCDefaultCaseLabel);
+                if (anyLabelIsDefault && !(c.labels.head instanceof JCDefaultCaseLabel)) {
+                    throw unsupported(c);
+                }
                 Body.Builder caseLabel = visitCaseLabel(tree, target, c);
                 Body.Builder caseBody = visitCaseBody(tree, c, caseBodyType, cases.getLast() == c);
                 bodies.add(caseLabel);
                 bodies.add(caseBody);
-                hasDefaultCase = c.labels.head instanceof JCTree.JCDefaultCaseLabel;
+                hasDefaultCase |= anyLabelIsDefault;
             }
 
             if (!hasDefaultCase && isDefaultCaseNeeded) {
@@ -1671,9 +1687,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             JCTree.JCCaseLabel headCl = c.labels.head;
             if (headCl instanceof JCTree.JCPatternCaseLabel pcl) {
-                if (c.labels.size() > 1) {
-                    throw unsupported(c);
-                }
+                boolean isMultiLabel = c.labels.size() > 1;
 
                 pushBody(pcl, caseLabelType);
 
@@ -1682,13 +1696,24 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 if (c.guard != null) {
                     List<Body.Builder> clBodies = new ArrayList<>();
 
-                    pushBody(pcl.pat, CoreType.functionType(JavaType.BOOLEAN));
+                    if (isMultiLabel) {
+                        // push a body for or-ing the patterns
+                        pushBody(pcl, CoreType.functionType(JavaType.BOOLEAN));
+                    }
 
-                    localTarget = boxIfNeeded(localTarget);
-                    Value patVal = scanPattern(pcl.pat, localTarget);
-                    append(CoreOp.core_yield(patVal));
-                    clBodies.add(stack.body);
-                    popBody();
+                    for (JCCaseLabel l : c.labels) {
+                        JCTree.JCPatternCaseLabel pat = (JCTree.JCPatternCaseLabel)l;
+                        clBodies.add(scanPatternAsBody(pat.pat, localTarget));
+                    }
+
+                    if (isMultiLabel) {
+                        // or the pattern bodies and replace clBodies with a single body
+                        Value patternOrResult = append(JavaOp.conditionalOr(clBodies));
+                        append(CoreOp.core_yield(patternOrResult));
+                        clBodies.clear();
+                        clBodies.add(stack.body);
+                        popBody();
+                    }
 
                     pushBody(c.guard, CoreType.functionType(JavaType.BOOLEAN));
                     append(CoreOp.core_yield(toValue(c.guard)));
@@ -1696,6 +1721,14 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     popBody();
 
                     localResult = append(JavaOp.conditionalAnd(clBodies));
+                } else if (isMultiLabel) {
+                    // push a body for or-ing the patterns
+                    List<Body.Builder> clBodies = new ArrayList<>();
+                    for (JCCaseLabel l : c.labels) {
+                        JCTree.JCPatternCaseLabel pat = (JCTree.JCPatternCaseLabel)l;
+                        clBodies.add(scanPatternAsBody(pat.pat, localTarget));
+                    }
+                    localResult = append(JavaOp.conditionalOr(clBodies));
                 } else {
                     localTarget = boxIfNeeded(localTarget);
                     localResult = scanPattern(pcl.pat, localTarget);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -63,6 +63,7 @@ import com.sun.tools.javac.tree.JCTree.JCBinary;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCConstantCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCDefaultCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
@@ -1631,15 +1632,15 @@ public class ReflectMethods extends TreeTranslatorPrev {
             boolean hasDefaultCase = false;
 
             for (JCTree.JCCase c : cases) {
-                boolean anyLabelIsDefault = c.labels.stream().anyMatch(l -> l instanceof JCTree.JCDefaultCaseLabel);
-                if (anyLabelIsDefault && !(c.labels.head instanceof JCDefaultCaseLabel)) {
+                if (isNull(c.labels.head) && c.labels.tail.head instanceof JCDefaultCaseLabel) {
+                    // case null, default unsupported
                     throw unsupported(c);
                 }
                 Body.Builder caseLabel = visitCaseLabel(tree, target, c);
                 Body.Builder caseBody = visitCaseBody(tree, c, caseBodyType, cases.getLast() == c);
                 bodies.add(caseLabel);
                 bodies.add(caseBody);
-                hasDefaultCase |= anyLabelIsDefault;
+                hasDefaultCase |= c.labels.head instanceof JCDefaultCaseLabel;
             }
 
             if (!hasDefaultCase && isDefaultCaseNeeded) {
@@ -1659,6 +1660,11 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
 
             return bodies;
+        }
+
+        boolean isNull(JCCaseLabel label) {
+            return label instanceof JCConstantCaseLabel constantCaseLabel &&
+                    TreeInfo.isNull(constantCaseLabel.expr);
         }
 
         private Value processConstantLabel(Value target, JCTree.JCConstantCaseLabel label) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1728,7 +1728,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     localResult = append(JavaOp.conditionalAnd(clBodies));
                 } else if (isMultiLabel) {
-                    // push a body for or-ing the patterns
                     List<Body.Builder> clBodies = new ArrayList<>();
                     for (JCCaseLabel l : c.labels) {
                         JCTree.JCPatternCaseLabel pat = (JCTree.JCPatternCaseLabel)l;

--- a/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
@@ -123,7 +123,7 @@ public class TestSwitchExpressionOp {
         };
     }
 
-    // @Test
+    @Test
     void testCasePatternMultiLabel() {
         CoreOp.FuncOp lmodel = lower("casePatternMultiLabel");
         Object[] args = {(byte) 1, (short) 2, 'A', 3, 4L, 5f, 6d, true, "str"};
@@ -131,9 +131,8 @@ public class TestSwitchExpressionOp {
             Assertions.assertEquals(casePatternMultiLabel(arg), Interpreter.invoke(MethodHandles.lookup(), lmodel, arg));
         }
     }
-    // @Reflect
-    // code model for such as code is not supported
-    // @@@ support this case and uncomment its test
+
+    @Reflect
     private static String casePatternMultiLabel(Object o) {
         return switch (o) {
             case Integer _, Long _, Character _, Byte _, Short _-> "integral type";

--- a/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
@@ -135,6 +135,44 @@ public class TestSwitchStatementOp {
     }
 
     @Test
+    void testCasePatternMultiLabel() {
+        CoreOp.FuncOp lmodel = lower("casePatternMultiLabel");
+        Object[] args = {(byte) 1, (short) 2, 'A', 3, 4L, 5f, 6d, true, "str"};
+        for (Object arg : args) {
+            Assertions.assertEquals(casePatternMultiLabel(arg), Interpreter.invoke(MethodHandles.lookup(), lmodel, arg));
+        }
+    }
+
+    @Reflect
+    private static String casePatternMultiLabel(Object o) {
+        String s = null;
+        switch (o) {
+            case Integer _, Long _, Character _, Byte _, Short _-> s = "integral type";
+            default -> s = "non integral type";
+        };
+        return s;
+    }
+
+    @Test
+    void testCasePatternGuardedMultiLabel() {
+        CoreOp.FuncOp lmodel = lower("casePatternGuardedMultiLabel");
+        Object[] args = {(byte) -1, (short) 2, 'A', -3, 4L, -5f, 6d, true, "str"};
+        for (Object arg : args) {
+            Assertions.assertEquals(casePatternGuardedMultiLabel(arg), Interpreter.invoke(MethodHandles.lookup(), lmodel, arg));
+        }
+    }
+
+    @Reflect
+    private static String casePatternGuardedMultiLabel(Object o) {
+        String s = null;
+        switch (o) {
+            case Integer _, Long _, Byte _, Short _ when ((Number)o).intValue() > 0 -> s = "integral type";
+            default -> s = "non integral type";
+        };
+        return s;
+    }
+
+    @Test
     void testCaseConstantThrow() {
         CoreOp.FuncOp lmodel = lower("caseConstantThrow");
 

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
@@ -259,6 +259,208 @@ public class SwitchExpressionTest2 {
     }
 
     @IR("""
+            func @"casePatternMultiLabel" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.Integer" = constant @null;
+                %4 : Var<java.type:"java.lang.Integer"> = var %3;
+                %5 : java.type:"java.lang.Long" = constant @null;
+                %6 : Var<java.type:"java.lang.Long"> = var %5;
+                %7 : java.type:"java.lang.Character" = constant @null;
+                %8 : Var<java.type:"java.lang.Character"> = var %7;
+                %9 : java.type:"java.lang.Byte" = constant @null;
+                %10 : Var<java.type:"java.lang.Byte"> = var %9;
+                %11 : java.type:"java.lang.Short" = constant @null;
+                %12 : Var<java.type:"java.lang.Short"> = var %11;
+                %13 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%14 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %15 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %16 : java.type:"boolean" = pattern.match %14
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" -> {
+                                        %17 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" = pattern.type;
+                                        yield %17;
+                                    }
+                                    (%18 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                        var.store %4 %18;
+                                        yield;
+                                    };
+                                yield %16;
+                            }
+                            ()java.type:"boolean" -> {
+                                %19 : java.type:"boolean" = pattern.match %14
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" -> {
+                                        %20 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" = pattern.type;
+                                        yield %20;
+                                    }
+                                    (%21 : java.type:"java.lang.Long")java.type:"void" -> {
+                                        var.store %6 %21;
+                                        yield;
+                                    };
+                                yield %19;
+                            }
+                            ()java.type:"boolean" -> {
+                                %22 : java.type:"boolean" = pattern.match %14
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Character>" -> {
+                                        %23 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Character>" = pattern.type;
+                                        yield %23;
+                                    }
+                                    (%24 : java.type:"java.lang.Character")java.type:"void" -> {
+                                        var.store %8 %24;
+                                        yield;
+                                    };
+                                yield %22;
+                            }
+                            ()java.type:"boolean" -> {
+                                %25 : java.type:"boolean" = pattern.match %14
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" -> {
+                                        %26 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" = pattern.type;
+                                        yield %26;
+                                    }
+                                    (%27 : java.type:"java.lang.Byte")java.type:"void" -> {
+                                        var.store %10 %27;
+                                        yield;
+                                    };
+                                yield %25;
+                            }
+                            ()java.type:"boolean" -> {
+                                %28 : java.type:"boolean" = pattern.match %14
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" -> {
+                                        %29 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" = pattern.type;
+                                        yield %29;
+                                    }
+                                    (%30 : java.type:"java.lang.Short")java.type:"void" -> {
+                                        var.store %12 %30;
+                                        yield;
+                                    };
+                                yield %28;
+                            };
+                        yield %15;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %31 : java.type:"java.lang.String" = constant @"integral type";
+                        yield %31;
+                    }
+                    ()java.type:"boolean" -> {
+                        %32 : java.type:"boolean" = constant @true;
+                        yield %32;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %33 : java.type:"java.lang.String" = constant @"non integral type";
+                        yield %33;
+                    };
+                return %13;
+            };
+            """)
+    @Reflect
+    private static String casePatternMultiLabel(Object o) {
+        return switch (o) {
+            case Integer _, Long _, Character _, Byte _, Short _-> "integral type";
+            default -> "non integral type";
+        };
+    }
+
+    @IR("""
+            func @"casePatternGuardedMultiLabel" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.Integer" = constant @null;
+                %4 : Var<java.type:"java.lang.Integer"> = var %3;
+                %5 : java.type:"java.lang.Long" = constant @null;
+                %6 : Var<java.type:"java.lang.Long"> = var %5;
+                %7 : java.type:"java.lang.Byte" = constant @null;
+                %8 : Var<java.type:"java.lang.Byte"> = var %7;
+                %9 : java.type:"java.lang.Short" = constant @null;
+                %10 : Var<java.type:"java.lang.Short"> = var %9;
+                %11 : java.type:"java.lang.String" = java.switch.expression %2
+                    (%12 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %13 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %14 : java.type:"boolean" = java.cor
+                                    ()java.type:"boolean" -> {
+                                        %15 : java.type:"boolean" = pattern.match %12
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" -> {
+                                                %16 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" = pattern.type;
+                                                yield %16;
+                                            }
+                                            (%17 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                                var.store %4 %17;
+                                                yield;
+                                            };
+                                        yield %15;
+                                    }
+                                    ()java.type:"boolean" -> {
+                                        %18 : java.type:"boolean" = pattern.match %12
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" -> {
+                                                %19 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" = pattern.type;
+                                                yield %19;
+                                            }
+                                            (%20 : java.type:"java.lang.Long")java.type:"void" -> {
+                                                var.store %6 %20;
+                                                yield;
+                                            };
+                                        yield %18;
+                                    }
+                                    ()java.type:"boolean" -> {
+                                        %21 : java.type:"boolean" = pattern.match %12
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" -> {
+                                                %22 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" = pattern.type;
+                                                yield %22;
+                                            }
+                                            (%23 : java.type:"java.lang.Byte")java.type:"void" -> {
+                                                var.store %8 %23;
+                                                yield;
+                                            };
+                                        yield %21;
+                                    }
+                                    ()java.type:"boolean" -> {
+                                        %24 : java.type:"boolean" = pattern.match %12
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" -> {
+                                                %25 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" = pattern.type;
+                                                yield %25;
+                                            }
+                                            (%26 : java.type:"java.lang.Short")java.type:"void" -> {
+                                                var.store %10 %26;
+                                                yield;
+                                            };
+                                        yield %24;
+                                    };
+                                yield %14;
+                            }
+                            ()java.type:"boolean" -> {
+                                %27 : java.type:"java.lang.Object" = var.load %1;
+                                %28 : java.type:"java.lang.Number" = cast %27 @java.type:"java.lang.Number";
+                                %29 : java.type:"int" = invoke %28 @java.ref:"java.lang.Number::intValue():int";
+                                %30 : java.type:"int" = constant @0;
+                                %31 : java.type:"boolean" = gt %29 %30;
+                                yield %31;
+                            };
+                        yield %13;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %32 : java.type:"java.lang.String" = constant @"integral type";
+                        yield %32;
+                    }
+                    ()java.type:"boolean" -> {
+                        %33 : java.type:"boolean" = constant @true;
+                        yield %33;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %34 : java.type:"java.lang.String" = constant @"non integral type";
+                        yield %34;
+                    };
+                return %11;
+            };
+            """)
+    @Reflect
+    private static String casePatternGuardedMultiLabel(Object o) {
+        return switch (o) {
+            case Integer _, Long _, Byte _, Short _ when ((Number)o).intValue() > 0 -> "integral type";
+            default -> "non integral type";
+        };
+    }
+
+    @IR("""
             func @"caseConstantThrow" (%0 : java.type:"java.lang.Integer")java.type:"java.lang.String" -> {
                 %1 : Var<java.type:"java.lang.Integer"> = var %0 @"i";
                 %2 : java.type:"java.lang.Integer" = var.load %1;

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -1531,12 +1531,225 @@ public class SwitchStatementTest {
         return r;
     }
 
-    // @@@ code model for such as code is not supported
-//    @Reflect
+    @IR("""
+            func @"casePatternMultiLabel" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.Integer" = constant @null;
+                %6 : Var<java.type:"java.lang.Integer"> = var %5;
+                %7 : java.type:"java.lang.Long" = constant @null;
+                %8 : Var<java.type:"java.lang.Long"> = var %7;
+                %9 : java.type:"java.lang.Character" = constant @null;
+                %10 : Var<java.type:"java.lang.Character"> = var %9;
+                %11 : java.type:"java.lang.Byte" = constant @null;
+                %12 : Var<java.type:"java.lang.Byte"> = var %11;
+                %13 : java.type:"java.lang.Short" = constant @null;
+                %14 : Var<java.type:"java.lang.Short"> = var %13;
+                java.switch.statement %4
+                    (%15 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = java.cor
+                            ()java.type:"boolean" -> {
+                                %17 : java.type:"boolean" = pattern.match %15
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" -> {
+                                        %18 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" = pattern.type;
+                                        yield %18;
+                                    }
+                                    (%19 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                        var.store %6 %19;
+                                        yield;
+                                    };
+                                yield %17;
+                            }
+                            ()java.type:"boolean" -> {
+                                %20 : java.type:"boolean" = pattern.match %15
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" -> {
+                                        %21 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" = pattern.type;
+                                        yield %21;
+                                    }
+                                    (%22 : java.type:"java.lang.Long")java.type:"void" -> {
+                                        var.store %8 %22;
+                                        yield;
+                                    };
+                                yield %20;
+                            }
+                            ()java.type:"boolean" -> {
+                                %23 : java.type:"boolean" = pattern.match %15
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Character>" -> {
+                                        %24 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Character>" = pattern.type;
+                                        yield %24;
+                                    }
+                                    (%25 : java.type:"java.lang.Character")java.type:"void" -> {
+                                        var.store %10 %25;
+                                        yield;
+                                    };
+                                yield %23;
+                            }
+                            ()java.type:"boolean" -> {
+                                %26 : java.type:"boolean" = pattern.match %15
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" -> {
+                                        %27 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" = pattern.type;
+                                        yield %27;
+                                    }
+                                    (%28 : java.type:"java.lang.Byte")java.type:"void" -> {
+                                        var.store %12 %28;
+                                        yield;
+                                    };
+                                yield %26;
+                            }
+                            ()java.type:"boolean" -> {
+                                %29 : java.type:"boolean" = pattern.match %15
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" -> {
+                                        %30 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" = pattern.type;
+                                        yield %30;
+                                    }
+                                    (%31 : java.type:"java.lang.Short")java.type:"void" -> {
+                                        var.store %14 %31;
+                                        yield;
+                                    };
+                                yield %29;
+                            };
+                        yield %16;
+                    }
+                    ()java.type:"void" -> {
+                        %32 : java.type:"java.lang.String" = var.load %3;
+                        %33 : java.type:"java.lang.String" = constant @"integral type";
+                        %34 : java.type:"java.lang.String" = concat %32 %33;
+                        var.store %3 %34;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %35 : java.type:"boolean" = constant @true;
+                        yield %35;
+                    }
+                    ()java.type:"void" -> {
+                        %36 : java.type:"java.lang.String" = var.load %3;
+                        %37 : java.type:"java.lang.String" = constant @"non integral type";
+                        %38 : java.type:"java.lang.String" = concat %36 %37;
+                        var.store %3 %38;
+                        yield;
+                    };
+                %39 : java.type:"java.lang.String" = var.load %3;
+                return %39;
+            };
+            """)
+    @Reflect
     private static String casePatternMultiLabel(Object o) {
         String r = "";
         switch (o) {
             case Integer _, Long _, Character _, Byte _, Short _-> r += "integral type";
+            default -> r += "non integral type";
+        }
+        return r;
+    }
+
+    @IR("""
+            func @"casePatternGuardedMultiLabel" (%0 : java.type:"java.lang.Object")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.Object" = var.load %1;
+                %5 : java.type:"java.lang.Integer" = constant @null;
+                %6 : Var<java.type:"java.lang.Integer"> = var %5;
+                %7 : java.type:"java.lang.Long" = constant @null;
+                %8 : Var<java.type:"java.lang.Long"> = var %7;
+                %9 : java.type:"java.lang.Byte" = constant @null;
+                %10 : Var<java.type:"java.lang.Byte"> = var %9;
+                %11 : java.type:"java.lang.Short" = constant @null;
+                %12 : Var<java.type:"java.lang.Short"> = var %11;
+                java.switch.statement %4
+                    (%13 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %14 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %15 : java.type:"boolean" = java.cor
+                                    ()java.type:"boolean" -> {
+                                        %16 : java.type:"boolean" = pattern.match %13
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" -> {
+                                                %17 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Integer>" = pattern.type;
+                                                yield %17;
+                                            }
+                                            (%18 : java.type:"java.lang.Integer")java.type:"void" -> {
+                                                var.store %6 %18;
+                                                yield;
+                                            };
+                                        yield %16;
+                                    }
+                                    ()java.type:"boolean" -> {
+                                        %19 : java.type:"boolean" = pattern.match %13
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" -> {
+                                                %20 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Long>" = pattern.type;
+                                                yield %20;
+                                            }
+                                            (%21 : java.type:"java.lang.Long")java.type:"void" -> {
+                                                var.store %8 %21;
+                                                yield;
+                                            };
+                                        yield %19;
+                                    }
+                                    ()java.type:"boolean" -> {
+                                        %22 : java.type:"boolean" = pattern.match %13
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" -> {
+                                                %23 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Byte>" = pattern.type;
+                                                yield %23;
+                                            }
+                                            (%24 : java.type:"java.lang.Byte")java.type:"void" -> {
+                                                var.store %10 %24;
+                                                yield;
+                                            };
+                                        yield %22;
+                                    }
+                                    ()java.type:"boolean" -> {
+                                        %25 : java.type:"boolean" = pattern.match %13
+                                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" -> {
+                                                %26 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Short>" = pattern.type;
+                                                yield %26;
+                                            }
+                                            (%27 : java.type:"java.lang.Short")java.type:"void" -> {
+                                                var.store %12 %27;
+                                                yield;
+                                            };
+                                        yield %25;
+                                    };
+                                yield %15;
+                            }
+                            ()java.type:"boolean" -> {
+                                %28 : java.type:"java.lang.Object" = var.load %1;
+                                %29 : java.type:"java.lang.Number" = cast %28 @java.type:"java.lang.Number";
+                                %30 : java.type:"int" = invoke %29 @java.ref:"java.lang.Number::intValue():int";
+                                %31 : java.type:"int" = constant @0;
+                                %32 : java.type:"boolean" = gt %30 %31;
+                                yield %32;
+                            };
+                        yield %14;
+                    }
+                    ()java.type:"void" -> {
+                        %33 : java.type:"java.lang.String" = var.load %3;
+                        %34 : java.type:"java.lang.String" = constant @"integral type";
+                        %35 : java.type:"java.lang.String" = concat %33 %34;
+                        var.store %3 %35;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %36 : java.type:"boolean" = constant @true;
+                        yield %36;
+                    }
+                    ()java.type:"void" -> {
+                        %37 : java.type:"java.lang.String" = var.load %3;
+                        %38 : java.type:"java.lang.String" = constant @"non integral type";
+                        %39 : java.type:"java.lang.String" = concat %37 %38;
+                        var.store %3 %39;
+                        yield;
+                    };
+                %40 : java.type:"java.lang.String" = var.load %3;
+                return %40;
+            };
+            """)
+    @Reflect
+    private static String casePatternGuardedMultiLabel(Object o) {
+        String r = "";
+        switch (o) {
+            case Integer _, Long _, Byte _, Short _ when ((Number)o).intValue() > 0 -> r += "integral type";
             default -> r += "non integral type";
         }
         return r;

--- a/test/langtools/tools/javac/reflect/TestUnsupported.java
+++ b/test/langtools/tools/javac/reflect/TestUnsupported.java
@@ -10,8 +10,7 @@ public class TestUnsupported {
     @Reflect
     boolean m(Object o) {
         return switch (o) {
-            case String _, Integer _ -> true;
-            default -> false;
+            case null, default -> true;
         };
     }
 }

--- a/test/langtools/tools/javac/reflect/TestUnsupported.out
+++ b/test/langtools/tools/javac/reflect/TestUnsupported.out
@@ -1,4 +1,4 @@
-TestUnsupported.java:11:13: compiler.warn.reflectable.method.unsupported: TestUnsupported, jdk.incubator.code.internal.ReflectMethods$UnsupportedASTException:case String _, Integer _ -> yield true;
+TestUnsupported.java:11:13: compiler.warn.reflectable.method.unsupported: TestUnsupported, jdk.incubator.code.internal.ReflectMethods$UnsupportedASTException:case null, default -> yield true;
 - compiler.err.warnings.and.werror
 1 error
 1 warning


### PR DESCRIPTION
`ReflectMethods` supports already multi label constant cases like:

```
case 1, 2 ->
```

But it doesn't support a similar case where patterns are used:

```
case Foo _, Bar _ ->
```

The crucial observation here is that these patterns can _not_ introduce bindings (the only valid name here is `_`). Because of this language restriction, effectively the pattern bodies are side-effect free -- which means we can just turn them into a boolean returning body, and OR-them together (as we do for the constant case).

Some special care is required for patterns, as we can also have guards. But the essence is the same.

I've updated and uncommented existing tests that were stressing the feature.

I've also tweaked the code in `ReflectMethod` to correctly tag `case null,default` as unsupported -- as such case would currently trigger a class cast exception (fixing that is unfortunately not straightforward, and will be addressed in a separate PR).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Mourad Abbay](https://openjdk.org/census#mabbay) (@mabbay - **Reviewer**) ⚠️ Review applies to [f083210c](https://git.openjdk.org/babylon/pull/1087/files/f083210c6fec633593b742b61ebaedaf89f238f2)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1087/head:pull/1087` \
`$ git checkout pull/1087`

Update a local copy of the PR: \
`$ git checkout pull/1087` \
`$ git pull https://git.openjdk.org/babylon.git pull/1087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1087`

View PR using the GUI difftool: \
`$ git pr show -t 1087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1087.diff">https://git.openjdk.org/babylon/pull/1087.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1087#issuecomment-4878106542)
</details>
