### PR TITLE
Update specification for compiler warnings

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Reflect.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Reflect.java
@@ -98,8 +98,8 @@ import java.lang.reflect.Method;
  * }
  * </li>
  * </ol>
- * If a method or lambda expression (or method reference) is declared reflectable then the compiler generates an error
- * message if it contains program elements that cannot be modeled (and therefore a code model cannot be produced).
+ * If a method or lambda expression (or method reference) is declared reflectable but cannot be modeled, then the
+ * compiler generates a warning message, and access returns an empty optional value.
  * <p>
  * The annotation is ignored if it appears in any other valid syntactic location.
  * <p>

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -219,7 +219,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 CoreOp.FuncOp funcOp;
                 try {
                     funcOp = bodyScanner.scanMethod();
-                } catch (Exception e) {
+                } catch (UnsupportedASTException e) {
                     log.warning(tree, Warnings.ReflectableMethodUnsupported(currentClassSym.enclClass(), e.toString()));
                     super.visitMethodDef(tree);
                     return;
@@ -315,7 +315,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             CoreOp.FuncOp funcOp;
             try {
                 funcOp = bodyScanner.scanLambda();
-            } catch (Exception e) {
+            } catch (UnsupportedASTException e) {
                 log.warning(tree, Warnings.ReflectableLambdaUnsupported(currentClassSym.enclClass(), e.toString()));
                 super.visitLambda(tree);
                 return;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -220,7 +220,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 try {
                     funcOp = bodyScanner.scanMethod();
                 } catch (Exception e) {
-                    // log as warning for debugging purposes when reflectAll enabled
                     log.warning(tree, Warnings.ReflectableMethodUnsupported(currentClassSym.enclClass(), e.toString()));
                     super.visitMethodDef(tree);
                     return;


### PR DESCRIPTION
The compiler now generates a warning for a reflectable method/lambda that cannot be modeled. The specification of `@Reflect` is modified accordingly

Also, in `ReflectMethods`, catch `UnsupportedASTException` rather than the `Exception`, thus ensuring we don't swallow translation bugs and present them as compiler warnings. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [d6462d27](https://git.openjdk.org/babylon/pull/1088/files/d6462d27638ea7dbe2d7b978478a277ccf8bf726)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1088/head:pull/1088` \
`$ git checkout pull/1088`

Update a local copy of the PR: \
`$ git checkout pull/1088` \
`$ git pull https://git.openjdk.org/babylon.git pull/1088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1088`

View PR using the GUI difftool: \
`$ git pr show -t 1088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1088.diff">https://git.openjdk.org/babylon/pull/1088.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1088#issuecomment-4898050213)
</details>
