### PR TITLE
Allow local class creation in early construction context

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1401,11 +1401,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 scan(tree.def);
             }
 
-            if (tree.type.tsym.isDirectlyOrIndirectlyLocal() && (tree.type.tsym.flags() & NOOUTERTHIS) != 0) {
-                // local class creation in pre-construction context is not supported
-                throw unsupported(tree);
-            }
-
             List<CodeType> argtypes = new ArrayList<>();
             Type type = tree.type;
             List<Value> args = new ArrayList<>();

--- a/test/langtools/tools/javac/reflect/LocalClassInEarlyContext.java
+++ b/test/langtools/tools/javac/reflect/LocalClassInEarlyContext.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test for local class creation in early construction context
+ * @modules jdk.incubator.code
+ */
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Reflect;
+import jdk.incubator.code.extern.OpWriter;
+
+public class LocalClassInEarlyContext {
+    static class TestNoCapture {
+        TestNoCapture() {
+            class Foo {
+                void t() { }
+            }
+            check((@Reflect Runnable)() -> new Foo(), EXPECTED);
+            super();
+        }
+
+        static final String EXPECTED =
+                """
+                %0 : java.type:"java.lang.Runnable" = lambda @lambda.isReflectable=true ()java.type:"void" -> {
+                    %1 : java.type:"LocalClassInEarlyContext$TestNoCapture::$1Foo" = new @java.ref:"LocalClassInEarlyContext$TestNoCapture::$1Foo::()";
+                    return;
+                };
+                """;
+    }
+
+    static class TestCapture {
+        TestCapture(int i, String s) {
+            final long L = 42L; // this should NOT be captured
+            class Foo {
+                long t() {
+                    return i + s.length() + L;
+                }
+            }
+            check((@Reflect Runnable)() -> new Foo(), EXPECTED);
+            super();
+        }
+
+        static final String EXPECTED =
+                """
+                %0 : java.type:"java.lang.Runnable" = lambda @lambda.isReflectable=true ()java.type:"void" -> {
+                    %1 : java.type:"int" = var.load %2;
+                    %3 : java.type:"java.lang.String" = var.load %4;
+                    %5 : java.type:"LocalClassInEarlyContext$TestCapture::$1Foo" = new %1 %3 @java.ref:"LocalClassInEarlyContext$TestCapture::$1Foo::(int, java.lang.String)";
+                    return;
+                };
+                """;
+    }
+
+    public static void main(String[] args) {
+        new TestNoCapture();
+        new TestCapture(1, "");
+    }
+
+    static void check(Runnable r, String expected) {
+        expected = expected.trim();
+        var quoted = Op.ofLambda(r).get();
+        var found = OpWriter.toText(quoted.op(), OpWriter.LocationOption.DROP_LOCATION);
+        if (!found.equals(expected)) {
+            throw new AssertionError("Model mismatch. Found:\n" + found + "\nExpected:\n" + expected);
+        }
+    }
+}


### PR DESCRIPTION
Some time ago, I added a restriction to reject local class creation in early context. The reason this restriction was added is that capture of "this" in local classes in early context work differently, in the sense that a local class in such context is allowed to capture an outer this, but not the current this.

Example:

```
class Outer {
    void m() { }
    
    class Inner {
        Inner() {
            class Foo {
                void t() { m(); }
            }
            new Foo();
	    super();
	}
    }
}
```

This is legal, as the local class needs `Outer.this`, not `Inner.this`.
       
But, the babylon compiler features several restriction when it comes to inner classes and constructors:

1. code reflection in constructors is disabled
2. reflectable program elements in inner/local classes are skipped

Now, (1) seems promising (after all, you only are in early construction context if you are... in a constructor). But, you can still have a reflectable lambda in a constructor:

```
class Outer {
    void m() { }
    
    class Inner {
        Inner() {
            class Foo {
                void t() { m(); }
            }
            @Reflect
            Runnable r = () -> new Foo();
	    super();
	}
    }
}
```

Except -- this still fails, beause of (2) -- the reflectable lambda is inside an inner class (Inner).

For these reasons, I don't think it's possible to ever trigger a case where strange outer this capturing would be relevant. For this to happen the local class has to be inside a constructor of an inner class. And, inside that constructor we can't, by definition, have reflectable elements.

The equivalent example w/o inner classes:

```
class Outer {
    Outer() {
        class Foo {
            void t() { }
        }
        @Reflect
        Runnable r = () -> new Foo();
        super();
    }   
}
```

Is still rejected by the current AST check, but in fact there's nothing problematic about this. So this PR re-allows this.

I've added a test to make sure this shape works correctly -- unfortunately I couldn't rely on the `@IR` test harness (as that requires the reflectable element to be inside a reflectable method, which is not the case here), so I have hand-rolled a new test.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1089/head:pull/1089` \
`$ git checkout pull/1089`

Update a local copy of the PR: \
`$ git checkout pull/1089` \
`$ git pull https://git.openjdk.org/babylon.git pull/1089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1089`

View PR using the GUI difftool: \
`$ git pr show -t 1089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1089.diff">https://git.openjdk.org/babylon/pull/1089.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1089#issuecomment-4905963578)
</details>
