### PR TITLE
Of.Element doc update

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -778,7 +778,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Returns the code model of a executable element.
+     * Returns the code model of an executable element.
      * <p>
      * Repeated invocations of this method will return distinct instances of the code model.
      *

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -778,15 +778,13 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     }
 
     /**
-     * Returns the code model of provided executable element (if any).
+     * Returns the code model of a executable element.
      * <p>
-     * If the executable element has a code model then it will be an instance of
-     * {@code java.lang.reflect.code.op.CoreOps.FuncOp}.
-     * Note: due to circular dependencies we cannot refer to the type explicitly.
+     * Repeated invocations of this method will return different instances of the code model.
      *
      * @param processingEnvironment the annotation processing environment
      * @param e the executable element.
-     * @return the code model of the provided executable element (if any).
+     * @return the code model, or an empty optional if the executable element is not reflectable.
      */
     public static Optional<FuncOp> ofElement(ProcessingEnvironment processingEnvironment, ExecutableElement e) {
         if (e.getModifiers().contains(Modifier.ABSTRACT) ||

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -780,7 +780,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
     /**
      * Returns the code model of a executable element.
      * <p>
-     * Repeated invocations of this method will return different instances of the code model.
+     * Repeated invocations of this method will return distinct instances of the code model.
      *
      * @param processingEnvironment the annotation processing environment
      * @param e the executable element.


### PR DESCRIPTION
Fix documentation of `Op.Element`, the circular dependency is no longer an issue, and align with documentation of other access methods.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1090/head:pull/1090` \
`$ git checkout pull/1090`

Update a local copy of the PR: \
`$ git checkout pull/1090` \
`$ git pull https://git.openjdk.org/babylon.git pull/1090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1090`

View PR using the GUI difftool: \
`$ git pr show -t 1090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1090.diff">https://git.openjdk.org/babylon/pull/1090.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1090#issuecomment-4909122628)
</details>
