### PR TITLE
Add support for `case null, default`

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -27,6 +27,7 @@ package jdk.incubator.code.dialect.java;
 
 import java.lang.constant.ClassDesc;
 import jdk.incubator.code.*;
+import jdk.incubator.code.dialect.java.JavaOp.JavaSwitchOp.SwitchNullHandling;
 import jdk.incubator.code.extern.DialectFactory;
 import jdk.incubator.code.dialect.core.*;
 import jdk.incubator.code.extern.ExternalizedOp;
@@ -45,7 +46,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import static jdk.incubator.code.Op.Lowerable.*;
 import static jdk.incubator.code.dialect.core.CoreOp.*;
@@ -3440,6 +3440,28 @@ public sealed abstract class JavaOp extends Op {
             permits SwitchStatementOp, SwitchExpressionOp {
 
         final List<Body> bodies;
+        final boolean handleNulls;
+
+        enum SwitchNullHandling {
+            ALLOW_NULL,
+            REJECT_NULL,
+            INFER;
+
+            static SwitchNullHandling of(ExternalizedOp def) {
+                return of(optionalBooleanAttribute(def, ATTRIBUTE_SWITCH_HANDLE_NULLS));
+
+            }
+
+            static SwitchNullHandling of(boolean handleNulls) {
+                return handleNulls ?
+                        ALLOW_NULL : REJECT_NULL;
+            }
+        }
+
+        /**
+         * The externalized attribute key for a switch that handles nulls.
+         */
+        static final String ATTRIBUTE_SWITCH_HANDLE_NULLS = "switch.handle.nulls";
 
         JavaSwitchOp(JavaSwitchOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
@@ -3447,9 +3469,10 @@ public sealed abstract class JavaOp extends Op {
             // Copy body
             this.bodies = that.bodies.stream()
                     .map(b -> b.transform(cc, ct).build(this)).toList();
+            this.handleNulls = that.handleNulls;
         }
 
-        JavaSwitchOp(Value target, List<Body.Builder> bodyCs) {
+        JavaSwitchOp(Value target, SwitchNullHandling nullHandling, List<Body.Builder> bodyCs) {
             super(List.of(target));
 
             // Each case is modeled as a contiguous pair of bodies
@@ -3457,6 +3480,11 @@ public sealed abstract class JavaOp extends Op {
             // The labels body has a parameter whose type is target operand's type and returns a boolean value
             // The action body has no parameters and returns void
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
+            this.handleNulls = switch (nullHandling) {
+                case ALLOW_NULL -> true;
+                case REJECT_NULL -> false;
+                case INFER -> inferNullCase();
+            };
         }
 
         @Override
@@ -3465,12 +3493,19 @@ public sealed abstract class JavaOp extends Op {
         }
 
         @Override
+        public Map<String, Object> externalize() {
+            return handleNulls ?
+                    Map.of(ATTRIBUTE_SWITCH_HANDLE_NULLS, true) :
+                    Map.of();
+        }
+
+        @Override
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Value selectorExpression = b.context().getValue(operands().get(0));
 
             // @@@ we can add this during model generation
             // if no case null, add one that throws NPE
-            if (!(selectorExpression.type() instanceof PrimitiveType) && !haveNullCase()) {
+            if (!(selectorExpression.type() instanceof PrimitiveType) && !handleNulls) {
                 Block.Builder throwBlock = b.block();
                 throwBlock.add(throw_(
                         throwBlock.add(new_(MethodRef.constructor(NullPointerException.class)))
@@ -3590,7 +3625,14 @@ public sealed abstract class JavaOp extends Op {
             return exit;
         }
 
-        boolean haveNullCase() {
+        /**
+         * {@return {@code true} if this switch operation handles nulls}
+         */
+        public boolean handleNulls() {
+            return handleNulls;
+        }
+
+        private boolean inferNullCase() {
             /*
             case null is modeled like this:
             (%4 : T)boolean -> {
@@ -3634,7 +3676,7 @@ public sealed abstract class JavaOp extends Op {
         final CodeType resultType;
 
         SwitchExpressionOp(ExternalizedOp def) {
-            this(def.resultType(), requireSingleOperand(def), def.bodyDefinitions());
+            this(def.resultType(), requireSingleOperand(def), SwitchNullHandling.of(def), def.bodyDefinitions());
         }
 
         SwitchExpressionOp(SwitchExpressionOp that, CodeContext cc, CodeTransformer ct) {
@@ -3648,8 +3690,8 @@ public sealed abstract class JavaOp extends Op {
             return new SwitchExpressionOp(this, cc, ct);
         }
 
-        SwitchExpressionOp(CodeType resultType, Value target, List<Body.Builder> bodyCs) {
-            super(target, requireBodyPairs(NAME, bodyCs));
+        SwitchExpressionOp(CodeType resultType, Value target, SwitchNullHandling nullHandling, List<Body.Builder> bodyCs) {
+            super(target, nullHandling, requireBodyPairs(NAME, bodyCs));
             this.resultType = resultType == null ? bodies.get(1).yieldType() : resultType;
         }
 
@@ -3674,7 +3716,7 @@ public sealed abstract class JavaOp extends Op {
         static final String NAME = "java.switch.statement";
 
         SwitchStatementOp(ExternalizedOp def) {
-            this(requireSingleOperand(def), def.bodyDefinitions());
+            this(requireSingleOperand(def), SwitchNullHandling.of(def), def.bodyDefinitions());
         }
 
         SwitchStatementOp(SwitchStatementOp that, CodeContext cc, CodeTransformer ct) {
@@ -3686,8 +3728,8 @@ public sealed abstract class JavaOp extends Op {
             return new SwitchStatementOp(this, cc, ct);
         }
 
-        SwitchStatementOp(Value target, List<Body.Builder> bodyCs) {
-            super(target, requireBodyPairs(NAME, bodyCs));
+        SwitchStatementOp(Value target, SwitchNullHandling nullHandling, List<Body.Builder> bodyCs) {
+            super(target, nullHandling, requireBodyPairs(NAME, bodyCs));
         }
 
         @Override
@@ -7104,18 +7146,31 @@ public sealed abstract class JavaOp extends Op {
     /**
      * Creates a switch expression operation.
      * <p>
-     * The result type of the operation will be derived from the yield type of the second body
+     * Case bodies are provided as pairs of bodies, where the first body of each pair is the predicate body and the
+     * second is the corresponding action body. The result type of the operation will be derived from the yield type of
+     * the first action body.
+     * <p>
+     * The returned switch expression operation handles nulls if this factory can determine that at least one of the
+     * predicate bodies accepts null selector values. For more explicit selection of null-handling policy, please
+     * use {@link #switchExpression(CodeType, Value, boolean, List)}.</p>
      *
      * @param target the switch target value
      * @param bodies the body builders for the predicate and action bodies
      * @return the switch expression operation
      */
     public static SwitchExpressionOp switchExpression(Value target, List<Body.Builder> bodies) {
-        return new SwitchExpressionOp(null, target, bodies);
+        return new SwitchExpressionOp(null, target, SwitchNullHandling.INFER, bodies);
     }
 
     /**
      * Creates a switch expression operation.
+     * <p>
+     * Case bodies are provided as pairs of bodies, where the first body of each pair is the predicate body and the
+     * second is the corresponding action body.
+     * <p>
+     * The returned switch expression operation handles nulls if this factory can determine that at least one of the
+     * predicate bodies accepts null selector values. For more explicit selection of null-handling policy, please
+     * use {@link #switchExpression(CodeType, Value, boolean, List)}.</p>
      *
      * @param resultType the result type of the expression
      * @param target     the switch target value
@@ -7125,7 +7180,44 @@ public sealed abstract class JavaOp extends Op {
     public static SwitchExpressionOp switchExpression(CodeType resultType, Value target,
                                                       List<Body.Builder> bodies) {
         Objects.requireNonNull(resultType);
-        return new SwitchExpressionOp(resultType, target, bodies);
+        return new SwitchExpressionOp(resultType, target, SwitchNullHandling.INFER, bodies);
+    }
+
+    /**
+     * Creates a switch expression operation.
+     * <p>
+     * Case bodies are provided as pairs of bodies, where the first body of each pair is the predicate body and the
+     * second is the corresponding action body.
+     *
+     * @param resultType  the result type of the expression
+     * @param target      the switch target value
+     * @param handleNulls whether the switch expression handles nulls
+     * @param bodies      the body builders for the predicate and action bodies
+     * @return the switch expression operation
+     */
+    public static SwitchExpressionOp switchExpression(CodeType resultType, Value target,
+                                                      boolean handleNulls,
+                                                      List<Body.Builder> bodies) {
+        Objects.requireNonNull(resultType);
+        return new SwitchExpressionOp(resultType, target, SwitchNullHandling.of(handleNulls), bodies);
+    }
+
+    /**
+     * Creates a switch statement operation.
+     * <p>
+     * Case bodies are provided as pairs of bodies, where the first body of each pair is the predicate body and the
+     * second is the corresponding action body.
+     * <p>
+     * The returned switch statement operation handles nulls if this factory can determine that at least one of the
+     * predicate bodies accepts null selector values. For more explicit selection of null-handling policy, please
+     * use {@link #switchStatement(Value, boolean, List)}.</p>
+     *
+     * @param target the switch target value
+     * @param bodies the body builders for the predicate and action bodies
+     * @return the switch statement operation
+     */
+    public static SwitchStatementOp switchStatement(Value target, List<Body.Builder> bodies) {
+        return new SwitchStatementOp(target, SwitchNullHandling.INFER, bodies);
     }
 
     /**
@@ -7135,11 +7227,12 @@ public sealed abstract class JavaOp extends Op {
      * second is the corresponding action body.
      *
      * @param target the switch target value
+     * @param handleNulls whether the switch statement handles nulls
      * @param bodies the body builders for the predicate and action bodies
      * @return the switch statement operation
      */
-    public static SwitchStatementOp switchStatement(Value target, List<Body.Builder> bodies) {
-        return new SwitchStatementOp(target, bodies);
+    public static SwitchStatementOp switchStatement(Value target, boolean handleNulls, List<Body.Builder> bodies) {
+        return new SwitchStatementOp(target, SwitchNullHandling.of(handleNulls), bodies);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1607,10 +1607,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
             Type switchType = adaptBottom(tree.type);
             FunctionType caseBodyType = CoreType.functionType(typeToCodeType(switchType));
 
-            List<Body.Builder> bodies = visitSwitchStatAndExpr(tree, tree.selector, target, tree.cases, caseBodyType,
+            SwitchBodyInfo bodyInfo = visitSwitchStatAndExpr(tree, tree.selector, target, tree.cases, caseBodyType,
                     !tree.hasUnconditionalPattern);
 
-            result = append(JavaOp.switchExpression(caseBodyType.returnType(), target, bodies));
+            result = append(JavaOp.switchExpression(caseBodyType.returnType(), target, bodyInfo.handlesNull, bodyInfo.bodies));
         }
 
         @Override
@@ -1619,28 +1619,32 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             FunctionType actionType = CoreType.FUNCTION_TYPE_VOID;
 
-            List<Body.Builder> bodies = visitSwitchStatAndExpr(tree, tree.selector, target, tree.cases, actionType,
+            SwitchBodyInfo bodyInfo = visitSwitchStatAndExpr(tree, tree.selector, target, tree.cases, actionType,
                     tree.patternSwitch && !tree.hasUnconditionalPattern);
 
-            result = append(JavaOp.switchStatement(target, bodies));
+            result = append(JavaOp.switchStatement(target, bodyInfo.handlesNull, bodyInfo.bodies));
         }
 
-        private List<Body.Builder> visitSwitchStatAndExpr(JCTree tree, JCExpression selector, Value target,
+        record SwitchBodyInfo(boolean handlesNull, List<Body.Builder> bodies) { }
+
+        private SwitchBodyInfo visitSwitchStatAndExpr(JCTree tree, JCExpression selector, Value target,
                                                           List<JCTree.JCCase> cases, FunctionType caseBodyType,
                                                           boolean isDefaultCaseNeeded) {
             List<Body.Builder> bodies = new ArrayList<>();
             boolean hasDefaultCase = false;
+            boolean handlesNull = false;
 
             for (JCTree.JCCase c : cases) {
-                if (isNull(c.labels.head) && c.labels.tail.head instanceof JCDefaultCaseLabel) {
-                    // case null, default unsupported
-                    throw unsupported(c);
+                if (handlesNull(c)) {
+                    handlesNull = true;
+                }
+                if (isDefault(c)) {
+                    hasDefaultCase = true;
                 }
                 Body.Builder caseLabel = visitCaseLabel(tree, target, c);
                 Body.Builder caseBody = visitCaseBody(tree, c, caseBodyType, cases.getLast() == c);
                 bodies.add(caseLabel);
                 bodies.add(caseBody);
-                hasDefaultCase |= c.labels.head instanceof JCDefaultCaseLabel;
             }
 
             if (!hasDefaultCase && isDefaultCaseNeeded) {
@@ -1659,12 +1663,16 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 popBody();
             }
 
-            return bodies;
+            return new SwitchBodyInfo(handlesNull, bodies);
         }
 
-        boolean isNull(JCCaseLabel label) {
-            return label instanceof JCConstantCaseLabel constantCaseLabel &&
-                    TreeInfo.isNull(constantCaseLabel.expr);
+        boolean handlesNull(JCTree.JCCase caseTree) {
+            return caseTree.labels.stream().anyMatch(l -> l instanceof JCConstantCaseLabel constLabel &&
+                    TreeInfo.isNull(constLabel.expr));
+        }
+
+        boolean isDefault(JCTree.JCCase caseTree) {
+            return caseTree.labels.stream().anyMatch(l -> l instanceof JCDefaultCaseLabel);
         }
 
         private Value processConstantLabel(Value target, JCTree.JCConstantCaseLabel label) {
@@ -1692,7 +1700,16 @@ public class ReflectMethods extends TreeTranslatorPrev {
             FunctionType caseLabelType = CoreType.functionType(JavaType.BOOLEAN, target.type());
 
             JCTree.JCCaseLabel headCl = c.labels.head;
-            if (headCl instanceof JCTree.JCPatternCaseLabel pcl) {
+            if (isDefault(c)) {
+                // @@@ Do we need to model the default label body?
+                pushBody(headCl, CoreType.functionType(JavaType.BOOLEAN));
+
+                append(CoreOp.core_yield(append(CoreOp.constant(JavaType.BOOLEAN, true))));
+                body = stack.body;
+
+                // Pop label
+                popBody();
+            } else if (headCl instanceof JCTree.JCPatternCaseLabel pcl) {
                 boolean isMultiLabel = c.labels.size() > 1;
 
                 pushBody(pcl, caseLabelType);
@@ -1773,15 +1790,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 body = stack.body;
 
                 // Pop labels
-                popBody();
-            } else if (headCl instanceof JCTree.JCDefaultCaseLabel) {
-                // @@@ Do we need to model the default label body?
-                pushBody(headCl, CoreType.functionType(JavaType.BOOLEAN));
-
-                append(CoreOp.core_yield(append(CoreOp.constant(JavaType.BOOLEAN, true))));
-                body = stack.body;
-
-                // Pop label
                 popBody();
             } else {
                 throw unreachable();

--- a/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
@@ -286,9 +286,16 @@ public class TestSwitchExpressionOp {
         };
     }
 
-    // @Reflect
-    // compiler code doesn't support case null, default
-    // @@@ support such as case and test the switch expression lowering for this case
+    @Test
+    void testCaseConstantNullAndDefault() {
+        CoreOp.FuncOp lmodel = lower("caseConstantNullAndDefault");
+        String[] args = { "abc", "hello", null };
+        for (String arg : args) {
+            Assertions.assertEquals(caseConstantNullAndDefault(arg), Interpreter.invoke(MethodHandles.lookup(), lmodel, arg));
+        }
+    }
+
+    @Reflect
     private static String caseConstantNullAndDefault(String s) {
         return switch (s) {
             case "abc" -> "alphabet";

--- a/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
@@ -238,6 +238,25 @@ public class TestSwitchStatementOp {
     }
 
     @Test
+    void testCaseConstantNullAndDefault() {
+        CoreOp.FuncOp lmodel = lower("caseConstantNullAndDefault");
+        String[] args = { "abc", "hello", null };
+        for (String arg : args) {
+            Assertions.assertEquals(caseConstantNullAndDefault(arg), Interpreter.invoke(MethodHandles.lookup(), lmodel, arg));
+        }
+    }
+
+    @Reflect
+    private static String caseConstantNullAndDefault(String s) {
+        String res = null;
+        switch (s) {
+            case "abc" -> res = "alphabet";
+            case null, default -> res = "null or default";
+        };
+        return res;
+    }
+
+    @Test
     void testCaseConstantEnum() {
         CoreOp.FuncOp lmodel = lower("caseConstantEnum");
         for (Day day : Day.values()) {

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest2.java
@@ -509,7 +509,7 @@ public class SwitchExpressionTest2 {
             func @"caseConstantNullLabel" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
                 %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
                 %2 : java.type:"java.lang.String" = var.load %1;
-                %3 : java.type:"java.lang.String" = java.switch.expression %2
+                %3 : java.type:"java.lang.String" = java.switch.expression %2 @switch.handle.nulls=true
                     (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
                         %5 : java.type:"java.lang.Object" = constant @null;
                         %6 : java.type:"boolean" = invoke %4 %5 @java.ref:"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
@@ -538,9 +538,32 @@ public class SwitchExpressionTest2 {
         };
     }
 
-    // @Reflect
-    // compiler code doesn't support case null, default
-    // @@@ support such as case and test the switch expression lowering for this case
+    @IR("""
+            func @"caseConstantNullAndDefault" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = var.load %1;
+                %3 : java.type:"java.lang.String" = java.switch.expression %2 @switch.handle.nulls=true
+                    (%4 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %5 : java.type:"java.lang.String" = constant @"abc";
+                        %6 : java.type:"boolean" = invoke %4 %5 @java.ref:"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %6;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %7 : java.type:"java.lang.String" = constant @"alphabet";
+                        yield %7;
+                    }
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"boolean" = constant @true;
+                        yield %8;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"java.lang.String" = constant @"null or default";
+                        yield %9;
+                    };
+                return %3;
+            };
+            """)
+    @Reflect
     private static String caseConstantNullAndDefault(String s) {
         return switch (s) {
             case "abc" -> "alphabet";

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -394,7 +394,7 @@ public class SwitchStatementTest {
                 %2 : java.type:"java.lang.String" = constant @"";
                 %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
                 %4 : java.type:"java.lang.String" = var.load %1;
-                java.switch.statement %4
+                java.switch.statement %4 @switch.handle.nulls=true
                     (%5 : java.type:"java.lang.String")java.type:"boolean" -> {
                         %6 : java.type:"java.lang.Object" = constant @null;
                         %7 : java.type:"boolean" = invoke %5 %6 @java.ref:"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
@@ -432,8 +432,41 @@ public class SwitchStatementTest {
         return r;
     }
 
-//    @Reflect
-//    @@@ not supported
+    @IR("""
+            func @"caseConstantNullAndDefault" (%0 : java.type:"java.lang.String")java.type:"java.lang.String" -> {
+                %1 : Var<java.type:"java.lang.String"> = var %0 @"s";
+                %2 : java.type:"java.lang.String" = constant @"";
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
+                %4 : java.type:"java.lang.String" = var.load %1;
+                java.switch.statement %4 @switch.handle.nulls=true
+                    (%5 : java.type:"java.lang.String")java.type:"boolean" -> {
+                        %6 : java.type:"java.lang.String" = constant @"abc";
+                        %7 : java.type:"boolean" = invoke %5 %6 @java.ref:"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                        yield %7;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %3;
+                        %9 : java.type:"java.lang.String" = constant @"alphabet";
+                        %10 : java.type:"java.lang.String" = concat %8 %9;
+                        var.store %3 %10;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %11 : java.type:"boolean" = constant @true;
+                        yield %11;
+                    }
+                    ()java.type:"void" -> {
+                        %12 : java.type:"java.lang.String" = var.load %3;
+                        %13 : java.type:"java.lang.String" = constant @"null or default";
+                        %14 : java.type:"java.lang.String" = concat %12 %13;
+                        var.store %3 %14;
+                        yield;
+                    };
+                %15 : java.type:"java.lang.String" = var.load %3;
+                return %15;
+            };
+            """)
+    @Reflect
     private static String caseConstantNullAndDefault(String s) {
         String r = "";
         switch (s) {
@@ -1031,7 +1064,7 @@ public class SwitchStatementTest {
                 %2 : java.type:"java.lang.String" = constant @"";
                 %3 : Var<java.type:"java.lang.String"> = var %2 @"r";
                 %4 : java.type:"SwitchStatementTest$E" = var.load %1;
-                java.switch.statement %4
+                java.switch.statement %4 @switch.handle.nulls=true
                     (%5 : java.type:"SwitchStatementTest$E")java.type:"boolean" -> {
                         %6 : java.type:"SwitchStatementTest$E" = field.load @java.ref:"SwitchStatementTest$E::A:SwitchStatementTest$E";
                         %7 : java.type:"boolean" = eq %5 %6;

--- a/test/langtools/tools/javac/reflect/TestUnsupported.java
+++ b/test/langtools/tools/javac/reflect/TestUnsupported.java
@@ -1,6 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @modules jdk.incubator.code
+ * @ignore there's no more unsupported AST features
  * @summary Test that unsupported langauge features don't crash javac
  * @compile/fail/ref=TestUnsupported.out -Werror -Xlint:-incubating -XDrawDiagnostics TestUnsupported.java
  */


### PR DESCRIPTION
Current support for switch expressions and statements include support for `case null` as a standalone case label.

However, javac rejects null-accepting case labels when combined with default labels, as in `case null, default`.

The reason for this is that `JavaSwitchOp` infers whether nulls should be handled or not by the switch based on whether one of the switch predicate bodies seems to accept nulls.
However, when the null case is conflated with the default case, the corresponding predicate is just a predicate that always returns true, and inference fails.

We could maybe generate a special predicate, like `value != null || true` and double down on the inference path. But that seems brittle.

Instead I've decided to capture whether a switch handles nulls or not as a separate attribute of the switch op. The current inference behavior is retained, but just as an ease-of-use move: clients that don't want to specify whether the switch accepts nulls or not can rely on the code model API to try and figure that out.
But for more complex cases, like `case default, null`, or cases where the null predicate is different from the one accepted by the inference scheme, clients now have the option to specify null handling explictly.

To reduce verbosity, the new attribute is only externalize if set to true -- this matches how we deal with invocation optional attributes like `isVarargs`.

I've added several tests (and re-enabled tests that have been disabled) to make sure this works as expected.

One final note is that I left the support for "unsupported AST errors" in place (and related test as well, which is now ignored). I wanted to separate this change from the associated discussion of whether we wanted to keep that machinery alive (for future uses). If preferred, I can go ahead and remove test and exception handling inside `ReflectMethods` as part of this PR.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1091/head:pull/1091` \
`$ git checkout pull/1091`

Update a local copy of the PR: \
`$ git checkout pull/1091` \
`$ git pull https://git.openjdk.org/babylon.git pull/1091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1091`

View PR using the GUI difftool: \
`$ git pr show -t 1091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1091.diff">https://git.openjdk.org/babylon/pull/1091.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1091#issuecomment-4916260466)
</details>
