### PR TITLE
Drop ReflectMethods unsupported AST machinery.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4373,16 +4373,6 @@ compiler.warn.reflectable.lambda.inner.class=\
 compiler.warn.reflectable.mref.inner.class=\
     unsupported reflectable method reference in inner class {0}
 
-# 0: symbol, 1: string
-compiler.warn.reflectable.method.unsupported=\
-    unsupported reflectable method in class {0}\n\
-    {1}
-
-# 0: symbol, 1: string
-compiler.warn.reflectable.lambda.unsupported=\
-    unsupported reflectable lambda in class {0}\n\
-    {1}
-
 compiler.misc.feature.reflect.methods=\
     code reflection
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -216,14 +216,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             } else {
                 // if the method is annotated, scan it
                 BodyScanner bodyScanner = new BodyScanner(tree);
-                CoreOp.FuncOp funcOp;
-                try {
-                    funcOp = bodyScanner.scanMethod();
-                } catch (UnsupportedASTException e) {
-                    log.warning(tree, Warnings.ReflectableMethodUnsupported(currentClassSym.enclClass(), e.toString()));
-                    super.visitMethodDef(tree);
-                    return;
-                }
+                CoreOp.FuncOp funcOp = bodyScanner.scanMethod();
                 if (dumpIR) {
                     // dump the method IR if requested
                     log.note(Notes.ReflectableMethodIrDump(tree.sym.enclClass(), tree.sym, funcOp.toText()));
@@ -312,14 +305,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             // quoted lambda - scan it
             BodyScanner bodyScanner = new BodyScanner(tree);
-            CoreOp.FuncOp funcOp;
-            try {
-                funcOp = bodyScanner.scanLambda();
-            } catch (UnsupportedASTException e) {
-                log.warning(tree, Warnings.ReflectableLambdaUnsupported(currentClassSym.enclClass(), e.toString()));
-                super.visitLambda(tree);
-                return;
-            }
+            CoreOp.FuncOp funcOp = bodyScanner.scanLambda();
             if (dumpIR) {
                 // dump the method IR if requested
                 log.note(Notes.ReflectableLambdaIrDump(funcOp.toText()));
@@ -1197,7 +1183,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     break;
                 }
                 default:
-                    unsupported(meth);
+                    throw unreachable();
             }
         }
 
@@ -2491,10 +2477,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
             computeCapturesIfNeeded(tree);
         }
 
-        UnsupportedASTException unsupported(JCTree tree) {
-            return new UnsupportedASTException(tree);
-        }
-
         AssertionError unreachable() {
             return new AssertionError("Should not reach here!");
         }
@@ -2539,24 +2521,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 case DOUBLE -> CoreOp.constant(typeToCodeType(t), 1d);
                 default -> throw new UnsupportedOperationException(t.toString());
             };
-        }
-    }
-
-    /**
-     * An exception thrown when an unsupported AST node is found when building a method IR.
-     */
-    static class UnsupportedASTException extends RuntimeException {
-
-        private static final long serialVersionUID = 0;
-        transient final JCTree tree;
-
-        public UnsupportedASTException(JCTree tree) {
-            this.tree = tree;
-        }
-
-        @Override
-        public String toString() {
-            return super.toString() + ":" + tree;
         }
     }
 

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -230,5 +230,3 @@ compiler.note.reflectable.mref.ir.dump
 compiler.warn.reflectable.method.inner.class
 compiler.warn.reflectable.lambda.inner.class
 compiler.warn.reflectable.mref.inner.class
-compiler.warn.reflectable.method.unsupported
-compiler.warn.reflectable.lambda.unsupported


### PR DESCRIPTION
After git.openjdk.org/babylon/pull/1091 ReflectMethod's BodyScanner support all well-formed AST shaped.
(I had a minor doubt re. primitive patterns but they seem supported and we even have tests for that).

As such, this PR removes the unsupported AST machinery. Moving forward, BodyScanner should strive to support any new feature that is added, and maybe throwing ad-hoc exceptions in the interim.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1092/head:pull/1092` \
`$ git checkout pull/1092`

Update a local copy of the PR: \
`$ git checkout pull/1092` \
`$ git pull https://git.openjdk.org/babylon.git pull/1092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1092`

View PR using the GUI difftool: \
`$ git pr show -t 1092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1092.diff">https://git.openjdk.org/babylon/pull/1092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1092#issuecomment-4925145086)
</details>
