### PR TITLE
Fix normalization of lowered pattern matching

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
@@ -74,6 +74,8 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
     @Override
     public Block.Builder acceptOp(Block.Builder b, Op op) {
         switch (op) {
+            // Handle constant dispatch before generic merge.
+            // Boolean constants used only as dispatch arguments are dropped and generic merge cannot handle them.
             case CoreOp.BranchOp bop when isPureConditionalDispatchingBlock(bop.branch().targetBlock())
                     && bop.branch().arguments().getFirst() instanceof Op.Result or
                     && or.op() instanceof CoreOp.ConstantOp cop -> {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
@@ -74,12 +74,6 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
     @Override
     public Block.Builder acceptOp(Block.Builder b, Op op) {
         switch (op) {
-            case CoreOp.BranchOp bop when bop.branch().targetBlock().predecessors().size() == 1 -> {
-                // Merge the successor's target block with this block, and so on
-                // The terminal branch operation is replaced with the operations in the
-                // successor's target block
-                mergeBlock(b, bop);
-            }
             case CoreOp.BranchOp bop when isPureConditionalDispatchingBlock(bop.branch().targetBlock())
                     && bop.branch().arguments().getFirst() instanceof Op.Result or
                     && or.op() instanceof CoreOp.ConstantOp cop -> {
@@ -99,6 +93,12 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
                         .allMatch(r -> r.arguments().getFirst() instanceof Op.Result orr && orr.op() instanceof CoreOp.ConstantOp)) {
                     mergedBlocks.add(bop.branch().targetBlock());
                 }
+            }
+            case CoreOp.BranchOp bop when bop.branch().targetBlock().predecessors().size() == 1 -> {
+                // Merge the successor's target block with this block, and so on
+                // The terminal branch operation is replaced with the operations in the
+                // successor's target block
+                mergeBlock(b, bop);
             }
             case CoreOp.ConstantOp cop when cop.resultType().equals(JavaType.BOOLEAN)
                 && cop.result().uses().stream().allMatch(cr -> cr.op() instanceof CoreOp.BranchOp bop

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -544,6 +544,14 @@ public class TestBytecode {
         return Arrays.asList(a, s).toString();
     }
 
+    @Reflect
+    static int patternMatchSameType(String s) {
+        if (s instanceof String ss) {
+            return ss.length();
+        }
+        return -1;
+    }
+
     record TestData(Method testMethod) {
         @Override
         public String toString() {


### PR DESCRIPTION
Constant branch dispatch blocks must be simplified before generic block merging.
Related test that manifests the problem is attached.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1093/head:pull/1093` \
`$ git checkout pull/1093`

Update a local copy of the PR: \
`$ git checkout pull/1093` \
`$ git pull https://git.openjdk.org/babylon.git pull/1093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1093`

View PR using the GUI difftool: \
`$ git pr show -t 1093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1093.diff">https://git.openjdk.org/babylon/pull/1093.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1093#issuecomment-4925641813)
</details>
