### PR TITLE
Separate Op into an interface and abstract class

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxOp.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/ir/OnnxOp.java
@@ -25,15 +25,12 @@
 
 package oracle.code.onnx.ir;
 
-import jdk.incubator.code.CodeContext;
-import jdk.incubator.code.Op;
-import jdk.incubator.code.CodeType;
-import jdk.incubator.code.Value;
+import jdk.incubator.code.*;
 import jdk.incubator.code.extern.ExternalizedOp;
 
 import java.util.*;
 
-public abstract class OnnxOp extends Op {
+public abstract class OnnxOp extends AbstractOp {
 
     public interface OnnxAttribute {
         String name();

--- a/cr-examples/samples/src/main/java/oracle/code/samples/DialectFMAOp.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/DialectFMAOp.java
@@ -24,6 +24,7 @@
  */
 package oracle.code.samples;
 
+import jdk.incubator.code.AbstractOp;
 import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeTransformer;
 import jdk.incubator.code.Reflect;
@@ -69,7 +70,7 @@ public class DialectFMAOp {
     }
 
     // Custom Node inherits from Op
-    private static class FMA extends Op {
+    private static class FMA extends AbstractOp {
         private static final String NAME = "fma";
 
         private final CodeType codeType;
@@ -79,7 +80,7 @@ public class DialectFMAOp {
             this.codeType = codeType;
         }
 
-        FMA(Op that, CodeContext cc) {
+        FMA(FMA that, CodeContext cc) {
             super(that, cc);
             this.codeType = that.resultType();
         }

--- a/cr-examples/samples/src/main/java/oracle/code/samples/DialectWithInvoke.java
+++ b/cr-examples/samples/src/main/java/oracle/code/samples/DialectWithInvoke.java
@@ -24,6 +24,7 @@
  */
 package oracle.code.samples;
 
+import jdk.incubator.code.AbstractOp;
 import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeTransformer;
 import jdk.incubator.code.Reflect;
@@ -66,7 +67,7 @@ public class DialectWithInvoke {
     }
 
     // Custom/Dialect Nodes extends from Op
-    public static class FMAIntrinsicOp extends Op { // externalized
+    public static class FMAIntrinsicOp extends AbstractOp { // externalized
 
         private final CodeType typeDescriptor;
 
@@ -75,7 +76,7 @@ public class DialectWithInvoke {
             this.typeDescriptor = typeDescriptor;
         }
 
-        FMAIntrinsicOp(Op that, CodeContext cc) {
+        FMAIntrinsicOp(FMAIntrinsicOp that, CodeContext cc) {
             super(that, cc);
             this.typeDescriptor = that.resultType();
         }

--- a/cr-examples/spirv/src/main/java/intel/code/spirv/SpirvOp.java
+++ b/cr-examples/spirv/src/main/java/intel/code/spirv/SpirvOp.java
@@ -27,13 +27,13 @@ package intel.code.spirv;
 
 import java.util.List;
 import java.util.Map;
-import jdk.incubator.code.Op;
+import jdk.incubator.code.AbstractOp;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeType;
 import jdk.incubator.code.dialect.java.JavaType;
 
-public abstract class SpirvOp extends Op {
+public abstract class SpirvOp extends AbstractOp {
     private final String opName;
     private final CodeType type;
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/ArithMathOps.java
@@ -35,7 +35,7 @@ import java.util.Map;
 
 public class ArithMathOps {
 
-    static abstract class ArithMathOp extends Op {
+    static abstract class ArithMathOp extends AbstractOp {
         final String opName;
         final CodeType resultType;
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
@@ -39,7 +39,7 @@ import java.util.function.Consumer;
 public class SCFOps {
 
     @OpFactoryHelper.OpDeclaration(ForOp.NAME)
-    public static final class ForOp extends Op implements Op.Loop {
+    public static final class ForOp extends AbstractOp implements Op.Loop {
 
         public static class Builder {
             final Body.Builder ancestorBody;
@@ -114,7 +114,7 @@ public class SCFOps {
     }
 
     @OpFactoryHelper.OpDeclaration(YieldOp.NAME)
-    public static class YieldOp extends Op implements Op.Terminating {
+    public static class YieldOp extends AbstractOp implements Op.Terminating {
         public static final String NAME = "scf.yield";
 
         public YieldOp(ExternalizedOp def) {

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonOps.java
@@ -39,7 +39,7 @@ import java.util.function.Consumer;
 
 public class TritonOps {
 
-    static abstract class TritonOp extends Op {
+    static abstract class TritonOp extends AbstractOp {
         final CodeType resultType;
 
         public TritonOp(ExternalizedOp def) {

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTestOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTestOps.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class TritonTestOps {
 
     @OpFactoryHelper.OpDeclaration(ConsumeOp.NAME)
-    public static class ConsumeOp extends Op {
+    public static class ConsumeOp extends AbstractOp {
         public static final String NAME = "tt.consume";
 
         public ConsumeOp(ExternalizedOp def) {

--- a/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXPtrOp.java
+++ b/hat/backends/ffi/cuda/src/main/java/hat/backend/ffi/PTXPtrOp.java
@@ -24,16 +24,16 @@
  */
 package hat.backend.ffi;
 
+import jdk.incubator.code.AbstractOp;
 import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeTransformer;
-import jdk.incubator.code.Op;
 import jdk.incubator.code.CodeType;
 import jdk.incubator.code.Value;
 import optkl.ifacemapper.BoundSchema;
 
 import java.util.List;
 
-public class PTXPtrOp extends Op {
+public class PTXPtrOp extends AbstractOp {
     public String fieldName;
     public static final String NAME = "ptxPtr";
     final CodeType resultType;

--- a/hat/core/src/main/java/hat/dialect/HATOp.java
+++ b/hat/core/src/main/java/hat/dialect/HATOp.java
@@ -24,17 +24,17 @@
  */
 package hat.dialect;
 
+import jdk.incubator.code.AbstractOp;
 import jdk.incubator.code.CodeContext;
-import jdk.incubator.code.Op;
 import jdk.incubator.code.Value;
 
 import java.util.List;
 
-public abstract sealed class HATOp extends Op permits HATBarrierOp, HATPtrOp, HATThreadOp {
+public abstract sealed class HATOp extends AbstractOp permits HATBarrierOp, HATPtrOp, HATThreadOp {
     protected HATOp(List<Value> operands) {
         super(operands);
     }
-    protected HATOp(Op that, CodeContext cc) {
+    protected HATOp(HATOp that, CodeContext cc) {
         super(that, cc);
     }
 }

--- a/hat/examples/experiments/src/main/java/experiments/AddArbitraryBlock.java
+++ b/hat/examples/experiments/src/main/java/experiments/AddArbitraryBlock.java
@@ -28,6 +28,7 @@ package experiments;
 
 import hat.ComputeContext;
 import hat.buffer.S32Array;
+import jdk.incubator.code.Op;
 import jdk.incubator.code.Reflect;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
 import jdk.incubator.code.dialect.core.CoreOp;
@@ -55,7 +56,7 @@ public class AddArbitraryBlock {
     static void main() throws Throwable {
         var hackMeMethodRef= MethodRef.method(AddArbitraryBlock.class, "hackMe", void.class, ComputeContext.class, S32Array.class);
         var lookup = MethodHandles.lookup();
-        var hackMeFuncOp = CoreOp.FuncOp.ofMethod(hackMeMethodRef.resolveToMethod(lookup)).get();
+        var hackMeFuncOp = Op.ofMethod(hackMeMethodRef.resolveToMethod(lookup)).get();
         MethodRef Println = MethodRef.method(IO.class, "println", void.class, Object.class);
         VarTable varTable = new VarTable(hackMeFuncOp.funcName());
         Trxfmr.of(lookup,hackMeFuncOp)

--- a/hat/examples/experiments/src/main/java/experiments/CreateFuncOp.java
+++ b/hat/examples/experiments/src/main/java/experiments/CreateFuncOp.java
@@ -26,6 +26,7 @@
 package experiments;
 
 
+import jdk.incubator.code.AbstractOp;
 import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeTransformer;
 import jdk.incubator.code.Op;
@@ -80,12 +81,12 @@ import static optkl.OpHelper.Invoke.invoke;
  */
 public class CreateFuncOp {
 
-    public abstract static class Inject extends Op {
+    public abstract static class Inject extends AbstractOp {
         public Inject(List<Value> operands) {
             super(operands);
         }
 
-        protected Inject(Op that, CodeContext cc) {
+        protected Inject(Inject that, CodeContext cc) {
             super(that, cc);
         }
     }

--- a/hat/examples/experiments/src/main/java/experiments/JavaPMe.java
+++ b/hat/examples/experiments/src/main/java/experiments/JavaPMe.java
@@ -25,9 +25,9 @@
 
 package experiments;
 
+import jdk.incubator.code.Op;
 import jdk.incubator.code.Reflect;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
-import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.java.MethodRef;
 
 import java.lang.classfile.ClassFile;
@@ -37,7 +37,7 @@ public class JavaPMe {
     @Reflect
     public static void main(String[] args) throws ReflectiveOperationException {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
-        CoreOp.FuncOp.ofMethod(
+        Op.ofMethod(
                 MethodRef.method(JavaPMe.class, "main", void.class, String[].class)
                         .resolveToMethod(lookup)).ifPresent(mainFuncOp -> {
             System.out.print(mainFuncOp.toText());

--- a/hat/examples/experiments/src/main/java/experiments/PrefixSum.java
+++ b/hat/examples/experiments/src/main/java/experiments/PrefixSum.java
@@ -35,7 +35,7 @@ import hat.annotations.TypeDef;
 import hat.backend.Backend;
 import hat.device.DeviceSchema;
 import hat.device.NonMappableIface;
-import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.Op;
 import jdk.incubator.code.dialect.java.MethodRef;
 import optkl.VarTable;
 import optkl.codebuilders.JavaCodeBuilder;
@@ -373,7 +373,7 @@ public class PrefixSum {
     static void main() throws ReflectiveOperationException {
         Accelerator accelerator = new Accelerator(MethodHandles.lookup(), Backend.FIRST);
         var methodRef= MethodRef.method(PrefixSum.class, "compute", void.class, ComputeContext.class,S32Array.class);
-        var funcOp = CoreOp.FuncOp.ofMethod(methodRef.resolveToMethod(MethodHandles.lookup())).get();
+        var funcOp = Op.ofMethod(methodRef.resolveToMethod(MethodHandles.lookup())).get();
 
         VarTable varTable = new VarTable(funcOp.funcName());
         Backend.injectBufferTracking(accelerator.config(),accelerator.lookup(), funcOp, varTable);

--- a/hat/optkl/src/main/java/optkl/OpHelper.java
+++ b/hat/optkl/src/main/java/optkl/OpHelper.java
@@ -107,7 +107,7 @@ public sealed interface OpHelper<T extends Op> extends LookupCarrier
     }
 
     static CoreOp.FuncOp methodModelOrNull(Method method) {
-        return CoreOp.FuncOp.ofMethod(method).orElse(null);
+        return Op.ofMethod(method).orElse(null);
     }
 
     static CoreOp.FuncOp methodModelOrThrow(Method method) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/AbstractOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/AbstractOp.java
@@ -121,13 +121,13 @@ public non-sealed abstract class AbstractOp implements Op {
     /**
      * Constructs an operation with operands mapped from, and location copied from, the given operation.
      * <p>
-     * The constructed operation's operands are the values computed, in order, by mapping the given operation's operands
-     * using the given code context. The new operation's location is the given operation's location, if any.
+     * The constructed operation's operands are the values mapped, in order, from the given operation's operands using
+     * the given code context. The new operation's location is the given operation's location, if any.
      *
      * @param that the operation
      * @param cc   the code context
      * @throws IllegalArgumentException if an operation's operand has no context mapping
-     * @throws IllegalArgumentException if an operand's declaring block is built.
+     * @throws IllegalArgumentException if a mapped value's declaring block is built.
      */
     protected AbstractOp(AbstractOp that, CodeContext cc) {
         this(cc.getValues(that.operands));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/AbstractOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/AbstractOp.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.incubator.code;
+
+import com.sun.tools.javac.api.JavacScope;
+import com.sun.tools.javac.api.JavacTrees;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.comp.Attr;
+import com.sun.tools.javac.model.JavacElements;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
+import jdk.incubator.code.dialect.core.CoreType;
+import jdk.incubator.code.dialect.core.FunctionType;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.MethodRef;
+import jdk.incubator.code.extern.OpWriter;
+import jdk.incubator.code.internal.ReflectMethods;
+import jdk.internal.access.SharedSecrets;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.*;
+import java.util.function.BiFunction;
+
+/**
+ * The abstract implementation of an operation. All concrete operations extend this class.
+ *
+ * <h2>Operation implementation requirements</h2>
+ * <p>
+ * A concrete operation class must satisfy the following requirements:
+ * <ul>
+ * <li>
+ * implement {@link #resultType()} to return the result type of operation instances;
+ * <li>
+ * implement {@link #transform(CodeContext, CodeTransformer)} to return a newly constructed, unplaced copy whose
+ * concrete class is the concrete operation class;
+ * <li>
+ * call an appropriate {@code AbstractOp} superclass constructor from each concrete operation constructor. Constructors
+ * for new operations pass the operation's operands to {@link #AbstractOp(List)}. Constructors for transformed copies
+ * can pass the input operation and code context to {@link #AbstractOp(AbstractOp, CodeContext)};
+ * <li>
+ * override {@link #bodies()} if instances may have bodies. If the operation class implements {@link Op.Nested}, then
+ * {@code bodies()} must return one or more bodies;
+ * <li>
+ * override {@link #successors()} if instances may have successors. If the operation class implements
+ * {@link Op.BlockTerminating}, then {@code successors()} must return one or more successors;
+ * <li>
+ * copy mutable constructor arguments that define successors, bodies, and operation-specific state, ensuring they are
+ * all fixed when construction completes; and
+ * <li>
+ * return unmodifiable views or immutable values from accessors that expose successors, bodies, and operation-specific
+ * state.
+ * </ul>
+ * <p>
+ * A concrete operation class may additionally:
+ * <ul>
+ * <li>
+ * override {@link #externalizeOpName()} and {@link #externalize()} to define an external form;
+ * <li>
+ * implement {@link Op.Lowerable} to define a lowering; and
+ * <li>
+ * provide operation-specific accessors for operation-specific state.
+ * </ul>
+ */
+public non-sealed abstract class AbstractOp implements Op {
+
+    // Set when op is placed in a block or as a root operation, otherwise null when unplaced
+    // @@@ stable value?
+    Result result;
+
+    // null if not specified
+    // @@@ stable value?
+    Location location;
+
+    final List<Value> operands;
+
+    /**
+     * Constructs an operation with operands mapped from, and location copied from, the given operation.
+     * <p>
+     * The constructed operation's operands are the values computed, in order, by mapping the given operation's operands
+     * using the given code context. The new operation's location is the given operation's location, if any.
+     *
+     * @param that the given operation
+     * @param cc   the code context
+     */
+    protected AbstractOp(AbstractOp that, CodeContext cc) {
+        List<Value> outputOperands = cc.getValues(that.operands);
+        // Values should be guaranteed to connect to blocks being built since
+        // the context only allows such mappings, assert for clarity
+        assert outputOperands.stream().noneMatch(Value::isBuilt);
+        this.operands = List.copyOf(outputOperands);
+        this.location = that.location;
+    }
+
+    /**
+     * Constructs an operation with a list of operands.
+     *
+     * @param operands the list of operands, a copy of the list is performed if required.
+     * @throws IllegalArgumentException if an operand's declaring block is built.
+     */
+    protected AbstractOp(List<? extends Value> operands) {
+        for (Value operand : operands) {
+            if (operand.isBuilt()) {
+                throw new IllegalArgumentException("Operand's declaring block is built: " + operand);
+            }
+        }
+        this.operands = List.copyOf(operands);
+    }
+
+    @Override
+    public final void setLocation(Location l) {
+        // @@@ Fail if location != null?
+        if (isRoot() || (result != null && result.block.isBuilt())) {
+            throw new IllegalStateException("Built operation");
+        }
+
+        location = l;
+    }
+
+    @Override
+    public final Location location() {
+        return location;
+    }
+
+    @Override
+    public final Block parent() {
+        if (isRoot() || result == null) {
+            return null;
+        }
+
+        if (!result.block.isBuilt()) {
+            throw new IllegalStateException("Parent block is unobservable");
+        }
+
+        return result.block;
+    }
+
+    @Override
+    public final List<Body> children() {
+        return bodies();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @implSpec this implementation returns an unmodifiable empty list.
+     */
+    @Override
+    public List<Body> bodies() {
+        return List.of();
+    }
+
+    @Override
+    public final Result result() {
+        return result == Result.ROOT_RESULT ? null : result;
+    }
+
+    @Override
+    public final List<Value> operands() {
+        return operands;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @implSpec this implementation returns an unmodifiable empty list.
+     */
+    @Override
+    public List<Block.Reference> successors() {
+        return List.of();
+    }
+
+    @Override
+    public final FunctionType opSignature() {
+        List<CodeType> operandTypes = operands.stream().map(Value::type).toList();
+        return CoreType.functionType(resultType(), operandTypes);
+    }
+
+    @Override
+    public final List<Value> capturedValues() {
+        Set<Value> cvs = new LinkedHashSet<>();
+
+        Deque<Body> bodyStack = new ArrayDeque<>();
+        for (Body childBody : bodies()) {
+            Body.capturedValues(cvs, bodyStack, childBody);
+        }
+        return new ArrayList<>(cvs);
+    }
+
+    @Override
+    public final void buildAsRoot() {
+        if (result == Result.ROOT_RESULT) {
+            return;
+        }
+        if (!bodies().stream().allMatch(Body::isIsolated)) {
+            throw new IllegalStateException("One of the operation bodies is not isolated");
+        }
+        if (!operands().isEmpty()) {
+            throw new IllegalStateException("Operation has operands");
+        }
+        if (!successors().isEmpty()) {
+            throw new IllegalStateException("Operation has successors");
+        }
+        if (result != null) {
+            throw new IllegalStateException("Operation is placed in a block");
+        }
+        result = Result.ROOT_RESULT;
+    }
+
+    @Override
+    public final boolean isRoot() {
+        return result == Result.ROOT_RESULT;
+    }
+
+    @Override
+    public final boolean isPlacedInBlock() {
+        return !isRoot() && result != null;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @implSpec this implementation returns the result of the expression {@code this.getClass().getName()}.
+     */
+    @Override
+    public String externalizeOpName() {
+        return this.getClass().getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @implSpec this implementation returns an unmodifiable empty map.
+     */
+    @Override
+    public Map<String, Object> externalize() {
+        return Map.of();
+    }
+
+    @Override
+    public final String toText() {
+        return OpWriter.toText(this);
+    }
+}

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/AbstractOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/AbstractOp.java
@@ -104,24 +104,6 @@ public non-sealed abstract class AbstractOp implements Op {
     final List<Value> operands;
 
     /**
-     * Constructs an operation with operands mapped from, and location copied from, the given operation.
-     * <p>
-     * The constructed operation's operands are the values computed, in order, by mapping the given operation's operands
-     * using the given code context. The new operation's location is the given operation's location, if any.
-     *
-     * @param that the given operation
-     * @param cc   the code context
-     */
-    protected AbstractOp(AbstractOp that, CodeContext cc) {
-        List<Value> outputOperands = cc.getValues(that.operands);
-        // Values should be guaranteed to connect to blocks being built since
-        // the context only allows such mappings, assert for clarity
-        assert outputOperands.stream().noneMatch(Value::isBuilt);
-        this.operands = List.copyOf(outputOperands);
-        this.location = that.location;
-    }
-
-    /**
      * Constructs an operation with a list of operands.
      *
      * @param operands the list of operands, a copy of the list is performed if required.
@@ -134,6 +116,22 @@ public non-sealed abstract class AbstractOp implements Op {
             }
         }
         this.operands = List.copyOf(operands);
+    }
+
+    /**
+     * Constructs an operation with operands mapped from, and location copied from, the given operation.
+     * <p>
+     * The constructed operation's operands are the values computed, in order, by mapping the given operation's operands
+     * using the given code context. The new operation's location is the given operation's location, if any.
+     *
+     * @param that the operation
+     * @param cc   the code context
+     * @throws IllegalArgumentException if an operation's operand has no context mapping
+     * @throws IllegalArgumentException if an operand's declaring block is built.
+     */
+    protected AbstractOp(AbstractOp that, CodeContext cc) {
+        this(cc.getValues(that.operands));
+        this.location = that.location;
     }
 
     @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -768,7 +768,7 @@ public final class Block implements CodeElement<Block, Op> {
             Op outputOp = op.isPlacedInBlock() || op.isRoot()
                     ? op.transform(cc, ct)
                     : op;
-            assert outputOp.result == null;
+            assert ((AbstractOp) outputOp).result == null;
 
             Op.Result outputResult = insertOp(outputOp);
 
@@ -874,7 +874,7 @@ public final class Block implements CodeElement<Block, Op> {
             }
         }
 
-        op.result = opr;
+        ((AbstractOp) op).result = opr;
     }
 
     // Determine if the parent body of value's block is the same as or an ancestor of this block

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -663,7 +663,7 @@ public final class Body implements CodeElement<Body, Block> {
                         throw new IllegalStateException("Descendant body builder is not built");
                     }
 
-                    Op.Result grandchild = greatgrandchild.target().parentOp.result;
+                    Op.Result grandchild = greatgrandchild.target().parentOp.result();
                     if (grandchild == null) {
                         throw new IllegalStateException("Parent operation of descendant body is unplaced");
                     }
@@ -771,7 +771,7 @@ public final class Body implements CodeElement<Body, Block> {
                 b.elements().forEach(ce -> {
                     switch (ce) {
                         case Op op -> {
-                            Op.Result use = op.result;
+                            Op.Result use = op.result();
                             for (Value v : op.operands()) {
                                 v.uses.remove(use);
                             }
@@ -796,7 +796,7 @@ public final class Body implements CodeElement<Body, Block> {
                 b.elements().forEach(ce -> {
                     switch (ce) {
                         case Op op -> {
-                            Op.Result use = op.result;
+                            Op.Result use = op.result();
                             if (!use.uses.isEmpty()) {
                                 throw new IllegalStateException("Use of an operation result is not dominated by the result");
                             }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -60,9 +60,9 @@ import java.util.function.BiFunction;
  *
  * <h2>Operation construction</h2>
  * <p>
- * Constructing an operation creates an <i>unplaced</i> operation. An unplaced operation is not yet part of a code
- * model. The operation's operands, successors, bodies, and operation-specific state are fixed when construction
- * completes.
+ * An operation is constructed by creating an concrete instance of {@link AbstractOp}. Construction creates an
+ * <i>unplaced</i> operation. An unplaced operation is not yet part of a code model. The operation's operands,
+ * successors, bodies, and operation-specific state are fixed when construction completes.
  * <p>
  * An operation can only be constructed with operands whose declaring block is being built. Otherwise, construction
  * fails with an exception.
@@ -94,43 +94,6 @@ import java.util.function.BiFunction;
  * An unplaced operation, or an operation placed in a block whose parent body builder has not
  * <a href="Body.Builder.html#body-building-finishing">finished</a>, is not thread-safe.
  *
- * <h2>Operation implementation requirements</h2>
- * <p>
- * A concrete operation class must satisfy the following requirements:
- * <ul>
- * <li>
- * implement {@link #resultType()} to return the result type of operation instances;
- * <li>
- * implement {@link #transform(CodeContext, CodeTransformer)} to return a newly constructed, unplaced copy whose
- * concrete class is the concrete operation class;
- * <li>
- * call an appropriate {@code Op} superclass constructor from each concrete operation constructor. Constructors
- * for new operations pass the operation's operands to {@link #Op(List)}. Constructors for transformed copies can
- * pass the input operation and code context to {@link #Op(Op, CodeContext)};
- * <li>
- * override {@link #bodies()} if instances may have bodies. If the operation class implements {@link Op.Nested}, then
- * {@code bodies()} must return one or more bodies;
- * <li>
- * override {@link #successors()} if instances may have successors. If the operation class implements
- * {@link Op.BlockTerminating}, then {@code successors()} must return one or more successors;
- * <li>
- * copy mutable constructor arguments that define successors, bodies, and operation-specific state, ensuring
- * they are all fixed when construction completes; and
- * <li>
- * return unmodifiable views or immutable values from accessors that expose successors, bodies, and operation-specific
- * state.
- * </ul>
- * <p>
- * A concrete operation class may additionally:
- * <ul>
- * <li>
- * override {@link #externalizeOpName()} and {@link #externalize()} to define an external form;
- * <li>
- * implement {@link Op.Lowerable} to define a lowering; and
- * <li>
- * provide operation-specific accessors for operation-specific state.
- * </ul>
- *
  * @apiNote
  * An operation might model the {@link JavaOp.AddOp addition} of two integers, or a method
  * {@link JavaOp.InvokeOp invocation} expression. Alternatively an operation may model something more complex like
@@ -138,7 +101,7 @@ import java.util.function.BiFunction;
  * expressions, or {@link JavaOp.TryOp try} statements. In such cases an operation will contain one or more bodies
  * modeling the nested structure.
  */
-public non-sealed abstract class Op implements CodeElement<Op, Body> {
+public sealed interface Op extends CodeElement<Op, Body> permits AbstractOp {
 
     /**
      * An operation characteristic indicating the operation is pure and has no side effects.
@@ -206,15 +169,11 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
 
         /**
          * Computes values captured by this invokable operation's body.
-         * @implSpec
-         * The default implementation returns an empty unmodifiable list.
          *
          * @return the captured values.
          * @see Body#capturedValues()
          */
-        default List<Value> capturedValues() {
-            return List.of();
-        }
+        List<Value> capturedValues();
     }
 
     /**
@@ -334,7 +293,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         /**
          * If assigned to an operation's result field, indicates the operation is a root operation.
          */
-        private static final Result ROOT_RESULT = new Result();
+        static final Result ROOT_RESULT = new Result();
 
         final Op op;
 
@@ -398,33 +357,6 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
         }
     }
 
-    // Set when op is placed in a block or as a root operation, otherwise null when unplaced
-    // @@@ stable value?
-    Result result;
-
-    // null if not specified
-    // @@@ stable value?
-    Location location;
-
-    final List<Value> operands;
-
-    /**
-     * Constructs an operation with operands mapped from, and location copied from, the given operation.
-     * <p>
-     * The constructed operation's operands are the values computed, in order, by mapping the given operation's operands
-     * using the given code context. The new operation's location is the given operation's location, if any.
-     *
-     * @param that the given operation
-     * @param cc   the code context
-     */
-    protected Op(Op that, CodeContext cc) {
-        List<Value> outputOperands = cc.getValues(that.operands);
-        // Values should be guaranteed to connect to blocks being built since
-        // the context only allows such mappings, assert for clarity
-        assert outputOperands.stream().noneMatch(Value::isBuilt);
-        this.operands = List.copyOf(outputOperands);
-        this.location = that.location;
-    }
 
     /**
      * Transforms this operation, copying the operation and transforming any of its bodies.
@@ -448,22 +380,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @return the transformed operation
      * @see CodeTransformer#COPYING_TRANSFORMER
      */
-    public abstract Op transform(CodeContext cc, CodeTransformer ct);
-
-    /**
-     * Constructs an operation with a list of operands.
-     *
-     * @param operands the list of operands, a copy of the list is performed if required.
-     * @throws IllegalArgumentException if an operand's declaring block is built.
-     */
-    protected Op(List<? extends Value> operands) {
-        for (Value operand : operands) {
-            if (operand.isBuilt()) {
-                throw new IllegalArgumentException("Operand's declaring block is built: " + operand);
-            }
-        }
-        this.operands = List.copyOf(operands);
-    }
+    public Op transform(CodeContext cc, CodeTransformer ct);
 
     /**
      * Sets the originating source location of this operation.
@@ -471,21 +388,12 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @param l the location, the {@link Location#NO_LOCATION} value indicates the location is not specified.
      * @throws IllegalStateException if this operation is a root operation, or is placed in a built block.
      */
-    public final void setLocation(Location l) {
-        // @@@ Fail if location != null?
-        if (isRoot() || (result != null && result.block.isBuilt())) {
-            throw new IllegalStateException("Built operation");
-        }
-
-        location = l;
-    }
+    public void setLocation(Location l);
 
     /**
      * {@return the originating source location of this operation, otherwise {@code null} if not specified}
      */
-    public final Location location() {
-        return location;
-    }
+    public Location location();
 
     /**
      * Returns this operation's parent block, or {@code null} if this operation is unplaced or a root operation.
@@ -498,60 +406,34 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @see Value#declaringBlock()
      */
     @Override
-    public final Block parent() {
-        if (isRoot() || result == null) {
-            return null;
-        }
-
-        if (!result.block.isBuilt()) {
-            throw new IllegalStateException("Parent block is unobservable");
-        }
-
-        return result.block;
-    }
-
-    @Override
-    public final List<Body> children() {
-        return bodies();
-    }
+    public Block parent();
 
     /**
      * {@return the operation's bodies, as an unmodifiable list}
-     * @implSpec this implementation returns an unmodifiable empty list.
      * @see #children()
      */
-    public List<Body> bodies() {
-        return List.of();
-    }
+    public List<Body> bodies();
 
     /**
      * {@return the operation's result type}
      */
-    public abstract CodeType resultType();
-
+    public CodeType resultType();
 
     /**
      * {@return the operation's result, or {@code null} if this operation is unplaced or a
      * root operation.}
      */
-    public final Result result() {
-        return result == Result.ROOT_RESULT ? null : result;
-    }
+    public Result result();
 
     /**
      * {@return the operation's operands, as an unmodifiable list}
      */
-    public final List<Value> operands() {
-        return operands;
-    }
+    public List<Value> operands();
 
     /**
      * {@return the operation's successors, as an unmodifiable list}
-     * @implSpec this implementation returns an unmodifiable empty list.
      */
-    public List<Block.Reference> successors() {
-        return List.of();
-    }
+    public List<Block.Reference> successors();
 
     /**
      * Returns the operation's signature, represented as a function type.
@@ -561,10 +443,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      *
      * @return the operation's signature
      */
-    public final FunctionType opSignature() {
-        List<CodeType> operandTypes = operands.stream().map(Value::type).toList();
-        return CoreType.functionType(resultType(), operandTypes);
-    }
+    public FunctionType opSignature();
 
     /**
      * Computes values captured by this operation. A captured value is a value that is used but not declared by any
@@ -576,15 +455,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @return the list of captured values, modifiable
      * @see Body#capturedValues()
      */
-    public final List<Value> capturedValues() {
-        Set<Value> cvs = new LinkedHashSet<>();
-
-        Deque<Body> bodyStack = new ArrayDeque<>();
-        for (Body childBody : bodies()) {
-            Body.capturedValues(cvs, bodyStack, childBody);
-        }
-        return new ArrayList<>(cvs);
-    }
+    public List<Value> capturedValues();
 
     /**
      * Builds this operation, placing it as the root operation of a code model. After this operation is placed as a root
@@ -597,65 +468,38 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * @see #isRoot()
      * @see Body#isIsolated
      */
-    public final void buildAsRoot() {
-        if (result == Result.ROOT_RESULT) {
-            return;
-        }
-        if (!bodies().stream().allMatch(Body::isIsolated)) {
-            throw new IllegalStateException("One of the operation bodies is not isolated");
-        }
-        if (!operands().isEmpty()) {
-            throw new IllegalStateException("Operation has operands");
-        }
-        if (!successors().isEmpty()) {
-            throw new IllegalStateException("Operation has successors");
-        }
-        if (result != null) {
-            throw new IllegalStateException("Operation is placed in a block");
-        }
-        result = Result.ROOT_RESULT;
-    }
+    public void buildAsRoot();
 
     /**
      * {@return {@code true} if this operation is a root operation.}
      * @see #buildAsRoot()
      * @see #isPlacedInBlock()
      */
-    public final boolean isRoot() {
-        return result == Result.ROOT_RESULT;
-    }
+    public boolean isRoot();
 
     /**
      * {@return {@code true} if this operation is placed in a block.}
      * @see #buildAsRoot()
      * @see #isRoot()
      */
-    public final boolean isPlacedInBlock() {
-        return !isRoot() && result != null;
-    }
+    public boolean isPlacedInBlock();
 
     /**
      * Externalizes this operation's name as a string.
-     * @implSpec this implementation returns the result of the expression {@code this.getClass().getName()}.
      *
      * @return the operation name
      */
-    public String externalizeOpName() {
-        return this.getClass().getName();
-    }
+    public String externalizeOpName();
 
     /**
      * Externalizes this operation's specific state as a map of attributes.
      *
      * <p>A null attribute value is represented by the constant
      * value {@link jdk.incubator.code.extern.ExternalizedOp#NULL_ATTRIBUTE_VALUE}.
-     * @implSpec this implementation returns an unmodifiable empty map.
      *
      * @return the operation's externalized state, as an unmodifiable map
      */
-    public Map<String, Object> externalize() {
-        return Map.of();
-    }
+    public Map<String, Object> externalize();
 
     /**
      * Returns the code model text for this operation.
@@ -667,9 +511,7 @@ public non-sealed abstract class Op implements CodeElement<Op, Body> {
      * and comprehension.
      * @see OpWriter#toText(Op, OpWriter.Option...)
      */
-    public final String toText() {
-        return OpWriter.toText(this);
-    }
+    public String toText();
 
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/ConstantLabelSwitchOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/ConstantLabelSwitchOp.java
@@ -26,12 +26,8 @@ package jdk.incubator.code.bytecode.impl;
 
 import java.util.List;
 import java.util.Map;
-import jdk.incubator.code.Block;
-import jdk.incubator.code.CodeContext;
-import jdk.incubator.code.CodeTransformer;
-import jdk.incubator.code.Op;
-import jdk.incubator.code.CodeType;
-import jdk.incubator.code.Value;
+
+import jdk.incubator.code.*;
 import jdk.incubator.code.dialect.java.JavaType;
 
 /**
@@ -44,7 +40,7 @@ import jdk.incubator.code.dialect.java.JavaType;
  * Default is a successor with corresponds null label value.
  * The selected successor refers to the next block to branch to.
  */
-public final class ConstantLabelSwitchOp extends Op implements Op.BlockTerminating {
+public final class ConstantLabelSwitchOp extends AbstractOp implements Op.BlockTerminating {
 
     final List<Integer> labels;
     final List<Block.Reference> targets;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/DynamicFuncCallOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/DynamicFuncCallOp.java
@@ -30,13 +30,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import jdk.incubator.code.AbstractOp;
 import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeTransformer;
 import jdk.incubator.code.CodeType;
-import jdk.incubator.code.Op;
 import jdk.incubator.code.Value;
 
-public final class DynamicFuncCallOp extends Op {
+public final class DynamicFuncCallOp extends AbstractOp {
     private final CodeType resultType;
     private final String funcName;
     private final DirectMethodHandleDesc bootstrapMethod;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/CoreOp.java
@@ -49,9 +49,9 @@ import static jdk.incubator.code.internal.StructuralPreconditions.*;
  * variables, tuples, constants, and control flow. Core operations may appear on their own or together with
  * operations expressed in other dialects.
  */
-public sealed abstract class CoreOp extends Op {
+public sealed abstract class CoreOp extends AbstractOp {
 
-    CoreOp(Op that, CodeContext cc) {
+    CoreOp(AbstractOp that, CodeContext cc) {
         super(that, cc);
     }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -71,9 +71,9 @@ import static jdk.incubator.code.internal.StructuralPreconditions.*;
  * This transformation preserves programming meaning. The resulting lowered code model also represents the same Java
  * program.
  */
-public sealed abstract class JavaOp extends Op {
+public sealed abstract class JavaOp extends AbstractOp {
 
-    JavaOp(Op that, CodeContext cc) {
+    JavaOp(AbstractOp that, CodeContext cc) {
         super(that, cc);
     }
 

--- a/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
@@ -21,8 +21,9 @@
  * questions.
  */
 
-import jdk.incubator.code.Reflect;
 import jdk.incubator.code.CodeTransformer;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Reflect;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.extern.OpWriter;
 import org.junit.jupiter.api.Assertions;
@@ -589,6 +590,6 @@ public class TestSwitchExpressionOp {
                 .filter(m -> m.getName().equals(methodName))
                 .findFirst();
 
-        return CoreOp.ofMethod(om.get()).get();
+        return Op.ofMethod(om.get()).get();
     }
 }

--- a/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
@@ -21,8 +21,9 @@
  * questions.
  */
 
-import jdk.incubator.code.Reflect;
 import jdk.incubator.code.CodeTransformer;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Reflect;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.extern.OpWriter;
 import org.junit.jupiter.api.Assertions;
@@ -704,6 +705,6 @@ public class TestSwitchStatementOp {
                 .filter(m -> m.getName().equals(methodName))
                 .findFirst();
 
-        return CoreOp.ofMethod(om.get()).get();
+        return Op.ofMethod(om.get()).get();
     }
 }

--- a/test/jdk/jdk/incubator/code/anf/AnfDialect.java
+++ b/test/jdk/jdk/incubator/code/anf/AnfDialect.java
@@ -36,7 +36,7 @@ public final class AnfDialect {
     private AnfDialect() {
     }
 
-    public static final class AnfLetOp extends Op implements Op.Terminating, Op.Nested {
+    public static final class AnfLetOp extends AbstractOp implements Op.Terminating, Op.Nested {
         public static final String NAME = "anf.let";
 
         public static class Builder {
@@ -93,7 +93,7 @@ public final class AnfDialect {
     }
 
 
-    public static final class AnfLetRecOp extends Op implements Op.Terminating, Op.Nested {
+    public static final class AnfLetRecOp extends AbstractOp implements Op.Terminating, Op.Nested {
         public static final String NAME = "anf.letrec";
 
         public static class Builder {
@@ -159,7 +159,7 @@ public final class AnfDialect {
         }
     }
 
-    public static final class AnfIfOp extends Op implements Op.Terminating, Op.Nested {
+    public static final class AnfIfOp extends AbstractOp implements Op.Terminating, Op.Nested {
         public static final String NAME = "anf.if";
 
         public static class ThenBuilder {
@@ -250,7 +250,7 @@ public final class AnfDialect {
         }
     }
 
-    public static final class AnfFuncOp extends Op implements Op.Nested {
+    public static final class AnfFuncOp extends AbstractOp implements Op.Nested {
 
         public static class Builder {
             final Body.Builder ancestorBody;
@@ -340,7 +340,7 @@ public final class AnfDialect {
         }
     }
 
-    public static final class AnfApply extends Op implements Op.Terminating {
+    public static final class AnfApply extends AbstractOp implements Op.Terminating {
         public static final String NAME = "anf.apply";
 
         public AnfApply(ExternalizedOp def) {
@@ -375,7 +375,7 @@ public final class AnfDialect {
         }
     }
 
-    public static final class AnfApplyStub extends Op implements Op.Terminating {
+    public static final class AnfApplyStub extends AbstractOp implements Op.Terminating {
         public static final String NAME = "anf.apply.stub";
         public static final String ATTRIBUTE_RESULT_TYPE = ".resultType";
         public static final String ATTRIBUTE_CALLSITE_NAME = ".callsiteName";

--- a/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/SlotOp.java
@@ -32,7 +32,7 @@ import jdk.incubator.code.internal.OpDeclaration;
 import java.util.List;
 import java.util.Map;
 
-sealed abstract class SlotOp extends Op {
+sealed abstract class SlotOp extends AbstractOp {
     public static final String ATTRIBUTE_SLOT = "slot";
 
     public static SlotLoadOp load(int slot, TypeKind tk) {

--- a/test/jdk/jdk/incubator/code/writer/TestAttributeSerialization.java
+++ b/test/jdk/jdk/incubator/code/writer/TestAttributeSerialization.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 public class TestAttributeSerialization {
 
-    static class TestOp extends Op {
+    static class TestOp extends AbstractOp {
         final Object attributeValue;
 
         TestOp(ExternalizedOp opdef) {


### PR DESCRIPTION
Change `Op` to be a sealed interface with abstract methods and introduce a non-sealed `AbstractOp` class implementing `Op`. All concrete implementations of `Op` extend from `AbstractOp`.

This clearly separates out users of operations, the majority, from implementors of operations, the minority.

Follow on PRs:

- Change `Op.Terminating` to be sealed and extend from `Op` with a non-sealed abstract class `AbstractOp.Terminating` extending `AbstractOp` and implementing `Op.Terminating`. 
  - `AbstractOp.Terminating` holds a list of zero or more successors, like `AbstractOp` holds a list of zero or more operands.
  - Extending classes pass successors to the super constructor for both unplaced and copying constructors. This will require `Op.successors` be moved to `Op.Terminating.successors`.
  - Alternatively `AbstractOp` and `AbstractOp.Terminating` might instead extend from a common internal super class, allowing `AbstractOp.successors` to be final and return an empty list. Retaining `Op.successors` even though only instances of `Op.Terminating` may have zero or more of them reduces the disruption to existing code. 
  - Further splitting might distinguish between block terminating and body terminating operations.
- Check that operands and the blocks and arguments of successors passed to the abstract class constructors are not built. We are currently not consistent here, and likely do not have full test coverage. 

  

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1094/head:pull/1094` \
`$ git checkout pull/1094`

Update a local copy of the PR: \
`$ git checkout pull/1094` \
`$ git pull https://git.openjdk.org/babylon.git pull/1094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1094`

View PR using the GUI difftool: \
`$ git pr show -t 1094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1094.diff">https://git.openjdk.org/babylon/pull/1094.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1094#issuecomment-4939190516)
</details>
