### PR TITLE
Lambda ops bytecode generation refactored

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -170,22 +170,21 @@ public final class BytecodeGenerator {
                                                                           SequencedMap<String, ? extends O> ops) {
         byte[] classBytes = ClassFile.of().build(clName, clb -> {
             List<LambdaOp> lambdaSink = new ArrayList<>();
-            BitSet reflectableLambda = new BitSet();
             CodeTransformer lowering = LoweringTransform.getInstance(lookup);
             for (var e : ops.sequencedEntrySet()) {
                 Op transformed = ConstantExpressionTransformer.transform(lookup, e.getValue());
                 transformed = transformed.transform(CodeContext.create(), RemoveUnusedConstantTransformer.INSTANCE);
                 O lowered = NormalizeBlocksTransformer.transform(
                         (O)transformed.transform(CodeContext.create(), lowering));
-                generateMethod(lookup, clName, e.getKey(), lowered, clb, ops, lambdaSink, reflectableLambda);
+                generateMethod(lookup, clName, e.getKey(), lowered, clb, ops, lambdaSink);
             }
             var modelsToBuild = new LinkedHashMap<String, FuncOp>();
             for (int i = 0; i < lambdaSink.size(); i++) {
                 LambdaOp lop = lambdaSink.get(i);
-                if (reflectableLambda.get(i)) {
+                if (lop.isReflectable()) {
                     modelsToBuild.put("op$lambda$" + i, Quoted.embedOp(lop));
                 }
-                generateMethod(lookup, clName, "lambda$" + i, lop, clb, ops, lambdaSink, reflectableLambda);
+                generateMethod(lookup, clName, "lambda$" + i, lop, clb, ops, lambdaSink);
             }
             if (!modelsToBuild.isEmpty()) {
                 var module = OpBuilder.createBuilderFunctions(
@@ -196,7 +195,7 @@ public final class BytecodeGenerator {
                 for (var e : module.functionTable().sequencedEntrySet()) {
                     var lowered = NormalizeBlocksTransformer.transform(
                             e.getValue().transform(CodeContext.create(), lowering));
-                    generateMethod(lookup, clName, e.getKey(), lowered, clb, module.functionTable(), null, null);
+                    generateMethod(lookup, clName, e.getKey(), lowered, clb, module.functionTable(), null);
                 }
             }
         });
@@ -211,15 +210,14 @@ public final class BytecodeGenerator {
                                                                      O iop,
                                                                      ClassBuilder clb,
                                                                      SequencedMap<String, ? extends O> functionTable,
-                                                                     List<LambdaOp> lambdaSink,
-                                                                     BitSet reflectableLambda) {
+                                                                     List<LambdaOp> lambdaSink) {
         List<Value> capturedValues = iop instanceof LambdaOp lop ? lop.capturedValues() : List.of();
         MethodTypeDesc mtd = MethodRef.toNominalDescriptor(
                 iop.invokableSignature()).insertParameterTypes(0, capturedValues.stream()
                         .map(Value::type).map(BytecodeGenerator::toClassDesc).toArray(ClassDesc[]::new));
         clb.withMethodBody(methodName, mtd, ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC,
                 cob -> new BytecodeGenerator(lookup, className, capturedValues, TypeKind.from(mtd.returnType()),
-                                             iop.body().blocks(), cob, functionTable, lambdaSink, reflectableLambda).generate());
+                                             iop.body().blocks(), cob, functionTable, lambdaSink).generate());
     }
 
     private record Slot(int slot, TypeKind typeKind) {}
@@ -238,7 +236,6 @@ public final class BytecodeGenerator {
     private final Map<Block.Parameter, Value> singlePredecessorsValues;
     private final Map<String, ? extends Invokable> functionMap;
     private final List<LambdaOp> lambdaSink;
-    private final BitSet reflectableLambda;
     private final Map<Op, Boolean> deferCache;
     private Value oprOnStack;
     private Block[] recentCatchBlocks;
@@ -250,8 +247,7 @@ public final class BytecodeGenerator {
                               List<Block> blocks,
                               CodeBuilder cob,
                               Map<String, ? extends Invokable> functionMap,
-                              List<LambdaOp> lambdaSink,
-                              BitSet reflectableLambda) {
+                              List<LambdaOp> lambdaSink) {
         this.lookup = lookup;
         this.className = className;
         this.capturedValues = capturedValues;
@@ -266,7 +262,6 @@ public final class BytecodeGenerator {
         this.singlePredecessorsValues = new IdentityHashMap<>();
         this.functionMap = functionMap;
         this.lambdaSink = lambdaSink;
-        this.reflectableLambda = reflectableLambda;
         this.deferCache = new IdentityHashMap<>();
     }
 
@@ -950,7 +945,6 @@ public final class BytecodeGenerator {
                             if (op.isReflectable()) {
                                 lambdaMetafactory = DMHD_REFLECTABLE_LAMBDA_METAFACTORY;
                                 intfMethodName = intfMethodName + "=" + "op$lambda$" + lambdaIndex;
-                                reflectableLambda.set(lambdaSink.size());
                             }
                             cob.invokedynamic(DynamicCallSiteDesc.of(
                                     lambdaMetafactory,

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -40,29 +40,22 @@ import java.lang.constant.DynamicCallSiteDesc;
 import java.lang.constant.DynamicConstantDesc;
 import java.lang.constant.MethodHandleDesc;
 import java.lang.constant.MethodTypeDesc;
-import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.StringConcatFactory;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.stream.Stream;
 
 import jdk.incubator.code.*;
-import jdk.incubator.code.dialect.core.NormalizeBlocksTransformer;
 import jdk.incubator.code.bytecode.impl.BytecodeCompactor;
 import jdk.incubator.code.bytecode.impl.ConstantLabelSwitchOp;
-import jdk.incubator.code.bytecode.impl.LoweringTransform;
+import jdk.incubator.code.bytecode.impl.DynamicFuncCallOp;
+import jdk.incubator.code.bytecode.impl.LoweringTransformer;
 import jdk.incubator.code.dialect.core.CoreOp.*;
 import jdk.incubator.code.dialect.java.*;
 import jdk.incubator.code.dialect.core.FunctionType;
 import jdk.incubator.code.dialect.core.VarType;
-import jdk.incubator.code.extern.DialectFactory;
-import jdk.incubator.code.internal.OpBuilder;
-import jdk.incubator.code.internal.RemoveUnusedConstantTransformer;
-import jdk.incubator.code.runtime.ReflectableLambdaMetafactory;
 
 import static java.lang.constant.ConstantDescs.*;
 import static jdk.incubator.code.dialect.java.JavaOp.*;
@@ -72,22 +65,10 @@ import static jdk.incubator.code.dialect.java.JavaOp.*;
  */
 public final class BytecodeGenerator {
 
-    private static final DirectMethodHandleDesc DMHD_LAMBDA_METAFACTORY = ofCallsiteBootstrap(
-            LambdaMetafactory.class.describeConstable().orElseThrow(),
-            "metafactory",
-            CD_CallSite, CD_MethodType, CD_MethodHandle, CD_MethodType);
-
-    private static final DirectMethodHandleDesc DMHD_REFLECTABLE_LAMBDA_METAFACTORY = ofCallsiteBootstrap(
-            ReflectableLambdaMetafactory.class.describeConstable().orElseThrow(),
-            "metafactory",
-            CD_CallSite, CD_MethodType, CD_MethodHandle, CD_MethodType);
-
     private static final DirectMethodHandleDesc DMHD_STRING_CONCAT = ofCallsiteBootstrap(
             StringConcatFactory.class.describeConstable().orElseThrow(),
             "makeConcat",
             CD_CallSite);
-
-    private static final MethodTypeDesc OP_METHOD_DESC = MethodTypeDesc.of(Op.class.describeConstable().get());
 
     /**
      * Transforms the invokable operation to bytecode encapsulated in a method of hidden class and exposed
@@ -164,39 +145,13 @@ public final class BytecodeGenerator {
         return generateClassData(lookup, clsName, new LinkedHashMap<>(Map.of(name, iop)));
     }
 
-    @SuppressWarnings("unchecked")
     private static <O extends Op & Op.Invokable> byte[] generateClassData(MethodHandles.Lookup lookup,
                                                                           ClassDesc clName,
                                                                           SequencedMap<String, ? extends O> ops) {
+        ModuleOp module = LoweringTransformer.transform(lookup, ops);
         byte[] classBytes = ClassFile.of().build(clName, clb -> {
-            List<LambdaOp> lambdaSink = new ArrayList<>();
-            CodeTransformer lowering = LoweringTransform.getInstance(lookup);
-            for (var e : ops.sequencedEntrySet()) {
-                Op transformed = ConstantExpressionTransformer.transform(lookup, e.getValue());
-                transformed = transformed.transform(CodeContext.create(), RemoveUnusedConstantTransformer.INSTANCE);
-                O lowered = NormalizeBlocksTransformer.transform(
-                        (O)transformed.transform(CodeContext.create(), lowering));
-                generateMethod(lookup, clName, e.getKey(), lowered, clb, ops, lambdaSink);
-            }
-            var modelsToBuild = new LinkedHashMap<String, FuncOp>();
-            for (int i = 0; i < lambdaSink.size(); i++) {
-                LambdaOp lop = lambdaSink.get(i);
-                if (lop.isReflectable()) {
-                    modelsToBuild.put("op$lambda$" + i, Quoted.embedOp(lop));
-                }
-                generateMethod(lookup, clName, "lambda$" + i, lop, clb, ops, lambdaSink);
-            }
-            if (!modelsToBuild.isEmpty()) {
-                var module = OpBuilder.createBuilderFunctions(
-                        modelsToBuild,
-                        b -> b.add(JavaOp.fieldLoad(
-                                FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))));
-
-                for (var e : module.functionTable().sequencedEntrySet()) {
-                    var lowered = NormalizeBlocksTransformer.transform(
-                            e.getValue().transform(CodeContext.create(), lowering));
-                    generateMethod(lookup, clName, e.getKey(), lowered, clb, module.functionTable(), null);
-                }
+            for (var e : module.functionTable().sequencedEntrySet()) {
+                generateMethod(lookup, clName, e.getKey(), e.getValue(), clb, module.functionTable());
             }
         });
 
@@ -204,20 +159,16 @@ public final class BytecodeGenerator {
         return BytecodeCompactor.transform(classBytes);
     }
 
-    private static <O extends Op & Op.Invokable> void generateMethod(MethodHandles.Lookup lookup,
-                                                                     ClassDesc className,
-                                                                     String methodName,
-                                                                     O iop,
-                                                                     ClassBuilder clb,
-                                                                     SequencedMap<String, ? extends O> functionTable,
-                                                                     List<LambdaOp> lambdaSink) {
-        List<Value> capturedValues = iop instanceof LambdaOp lop ? lop.capturedValues() : List.of();
-        MethodTypeDesc mtd = MethodRef.toNominalDescriptor(
-                iop.invokableSignature()).insertParameterTypes(0, capturedValues.stream()
-                        .map(Value::type).map(BytecodeGenerator::toClassDesc).toArray(ClassDesc[]::new));
+    private static void generateMethod(MethodHandles.Lookup lookup,
+                                       ClassDesc className,
+                                       String methodName,
+                                       FuncOp fop,
+                                       ClassBuilder clb,
+                                       SequencedMap<String, FuncOp> functionTable) {
+        MethodTypeDesc mtd = MethodRef.toNominalDescriptor(fop.invokableSignature());
         clb.withMethodBody(methodName, mtd, ClassFile.ACC_PUBLIC | ClassFile.ACC_STATIC,
-                cob -> new BytecodeGenerator(lookup, className, capturedValues, TypeKind.from(mtd.returnType()),
-                                             iop.body().blocks(), cob, functionTable, lambdaSink).generate());
+                cob -> new BytecodeGenerator(lookup, className, List.of(), TypeKind.from(mtd.returnType()),
+                                             fop.body().blocks(), cob, functionTable).generate());
     }
 
     private record Slot(int slot, TypeKind typeKind) {}
@@ -235,7 +186,6 @@ public final class BytecodeGenerator {
     private final Map<Value, Slot> slots;
     private final Map<Block.Parameter, Value> singlePredecessorsValues;
     private final Map<String, ? extends Invokable> functionMap;
-    private final List<LambdaOp> lambdaSink;
     private final Map<Op, Boolean> deferCache;
     private Value oprOnStack;
     private Block[] recentCatchBlocks;
@@ -246,8 +196,7 @@ public final class BytecodeGenerator {
                               TypeKind returnType,
                               List<Block> blocks,
                               CodeBuilder cob,
-                              Map<String, ? extends Invokable> functionMap,
-                              List<LambdaOp> lambdaSink) {
+                              Map<String, ? extends Invokable> functionMap) {
         this.lookup = lookup;
         this.className = className;
         this.capturedValues = capturedValues;
@@ -261,7 +210,6 @@ public final class BytecodeGenerator {
         this.slots = new IdentityHashMap<>();
         this.singlePredecessorsValues = new IdentityHashMap<>();
         this.functionMap = functionMap;
-        this.lambdaSink = lambdaSink;
         this.deferCache = new IdentityHashMap<>();
     }
 
@@ -425,9 +373,6 @@ public final class BytecodeGenerator {
             // New object cannot use first operand from stack, new array fall through to the default
             case NewOp op when !(op.constructorReference().signature().returnType() instanceof ArrayType) ->
                 false;
-            // For lambda the effective operands are captured values
-            case LambdaOp op ->
-                !(values = op.capturedValues()).isEmpty() && values.getFirst() == opr;
             // Conditional branch may delegate to its binary test operation
             case ConditionalBranchOp op when getConditionForCondBrOp(op) instanceof CompareOp co ->
                 isFirstOperand(co, opr);
@@ -891,7 +836,7 @@ public final class BytecodeGenerator {
                     }
                     case FieldAccessOp.FieldLoadOp op -> {
                         processOperands(op);
-                FieldRef fd = op.fieldReference();
+                        FieldRef fd = op.fieldReference();
                         if (op.operands().isEmpty()) {
                             cob.getstatic(
                                     ((JavaType) fd.refType()).toNominalDescriptor(),
@@ -907,7 +852,7 @@ public final class BytecodeGenerator {
                     }
                     case FieldAccessOp.FieldStoreOp op -> {
                         processOperands(op);
-                FieldRef fd = op.fieldReference();
+                        FieldRef fd = op.fieldReference();
                         if (op.operands().size() == 1) {
                             cob.putstatic(
                                     ((JavaType) fd.refType()).toNominalDescriptor(),
@@ -930,36 +875,22 @@ public final class BytecodeGenerator {
                         cob.checkcast(((JavaType) op.targetType()).toNominalDescriptor());
                         push(op.result());
                     }
-                    case LambdaOp op -> {
-                        JavaType intfType = (JavaType)op.functionalInterface();
-                        MethodTypeDesc mtd = MethodRef.toNominalDescriptor(op.invokableSignature());
-                        try {
-                            Class<?> intfClass = (Class<?>)intfType.erasure().resolve(lookup);
-                            Method intfMethod = funcIntfMethod(intfClass, mtd);
-                            processOperands(op.capturedValues());
-                            ClassDesc[] captureTypes = op.capturedValues().stream()
-                                    .map(Value::type).map(BytecodeGenerator::toClassDesc).toArray(ClassDesc[]::new);
-                            int lambdaIndex = lambdaSink.size();
-                            DirectMethodHandleDesc lambdaMetafactory = DMHD_LAMBDA_METAFACTORY;
-                            String intfMethodName = intfMethod.getName();
-                            if (op.isReflectable()) {
-                                lambdaMetafactory = DMHD_REFLECTABLE_LAMBDA_METAFACTORY;
-                                intfMethodName = intfMethodName + "=" + "op$lambda$" + lambdaIndex;
-                            }
-                            cob.invokedynamic(DynamicCallSiteDesc.of(
-                                    lambdaMetafactory,
-                                    intfMethodName,
-                                    MethodTypeDesc.of(intfType.toNominalDescriptor(), captureTypes),
-                                    toMTD(intfMethod),
-                                    MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC,
-                                                              className,
-                                                              "lambda$" + lambdaIndex,
-                                                              mtd.insertParameterTypes(0, captureTypes)),
-                                    mtd));
-                            lambdaSink.add(op);
-                        } catch (ReflectiveOperationException e) {
-                            throw new IllegalArgumentException(e);
+                    case DynamicFuncCallOp op -> {
+                        Invokable fop = functionMap.get(op.funcName());
+                        if (fop == null) {
+                            throw new IllegalArgumentException("Could not resolve function: " + op.funcName());
                         }
+                        processOperands(op);
+                        cob.invokedynamic(DynamicCallSiteDesc.of(
+                                op.bootstrapMethod(),
+                                op.invocationName(),
+                                op.invocationType(),
+                                op.interfaceMethodType(),
+                                MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC,
+                                        className,
+                                        op.funcName(),
+                                        MethodRef.toNominalDescriptor(fop.invokableSignature())),
+                                op.dynamicMethodType()));
                         push(op.result());
                     }
                     case ConcatOp op -> {
@@ -1188,47 +1119,6 @@ public final class BytecodeGenerator {
         } else {
             return null;
         }
-    }
-
-    private Method funcIntfMethod(Class<?> intfc, MethodTypeDesc mtd) {
-        Method intfM = null;
-        for (Method m : intfc.getMethods()) {
-            // ensure it's SAM interface
-            String methodName = m.getName();
-            if (Modifier.isAbstract(m.getModifiers())
-                    && (m.getReturnType() != String.class
-                        || m.getParameterCount() != 0
-                        || !methodName.equals("toString"))
-                    && (m.getReturnType() != int.class
-                        || m.getParameterCount() != 0
-                        || !methodName.equals("hashCode"))
-                    && (m.getReturnType() != boolean.class
-                        || m.getParameterCount() != 1
-                        || m.getParameterTypes()[0] != Object.class
-                        || !methodName.equals("equals"))) {
-                if (intfM == null && isAdaptable(m, mtd)) {
-                    intfM = m;
-                } else if (!intfM.getName().equals(methodName)) {
-                    // too many abstract methods
-                    throw new IllegalArgumentException("Not a single-method interface: " + intfc.getName());
-                }
-            }
-        }
-        if (intfM == null) {
-            throw new IllegalArgumentException("No method in: " + intfc.getName() + " matching: " + mtd);
-        }
-        return intfM;
-    }
-
-    private static boolean isAdaptable(Method m, MethodTypeDesc mdesc) {
-        // @@@ filter overrides
-        return true;
-    }
-
-    private static MethodTypeDesc toMTD(Method m) {
-        return MethodTypeDesc.of(
-                m.getReturnType().describeConstable().get(),
-                Stream.of(m.getParameterTypes()).map(t -> t.describeConstable().get()).toList());
     }
 
     private void conditionalBranch(Opcode reverseOpcode, Block.Reference trueBlock, Block.Reference falseBlock) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/DynamicFuncCallOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/DynamicFuncCallOp.java
@@ -26,7 +26,9 @@ package jdk.incubator.code.bytecode.impl;
 
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.MethodTypeDesc;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeTransformer;
@@ -80,6 +82,19 @@ public final class DynamicFuncCallOp extends Op {
     @Override
     public CodeType resultType() {
         return resultType;
+    }
+
+    @Override
+    public Map<String, Object> externalize() {
+        // for debug print
+        LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("func", funcName);
+        attributes.put("bootstrap", bootstrapMethod);
+        attributes.put("invocationName", invocationName);
+        attributes.put("invocationType", invocationType);
+        attributes.put("interfaceMethodType", interfaceMethodType);
+        attributes.put("dynamicMethodType", dynamicMethodType);
+        return attributes;
     }
 
     public String funcName() {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/DynamicFuncCallOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/DynamicFuncCallOp.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.incubator.code.bytecode.impl;
+
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.util.List;
+
+import jdk.incubator.code.CodeContext;
+import jdk.incubator.code.CodeTransformer;
+import jdk.incubator.code.CodeType;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Value;
+
+public final class DynamicFuncCallOp extends Op {
+    private final CodeType resultType;
+    private final String funcName;
+    private final DirectMethodHandleDesc bootstrapMethod;
+    private final String invocationName;
+    private final MethodTypeDesc invocationType;
+    private final MethodTypeDesc interfaceMethodType;
+    private final MethodTypeDesc dynamicMethodType;
+
+    public DynamicFuncCallOp(CodeType resultType,
+                             List<Value> operands,
+                             String funcName,
+                             DirectMethodHandleDesc bootstrapMethod,
+                             String invocationName,
+                             MethodTypeDesc invocationType,
+                             MethodTypeDesc interfaceMethodType,
+                             MethodTypeDesc dynamicMethodType) {
+        super(operands);
+        this.resultType = resultType;
+        this.funcName = funcName;
+        this.bootstrapMethod = bootstrapMethod;
+        this.invocationName = invocationName;
+        this.invocationType = invocationType;
+        this.interfaceMethodType = interfaceMethodType;
+        this.dynamicMethodType = dynamicMethodType;
+    }
+
+    DynamicFuncCallOp(DynamicFuncCallOp that, CodeContext cc) {
+        super(that, cc);
+        this.resultType = that.resultType;
+        this.funcName = that.funcName;
+        this.bootstrapMethod = that.bootstrapMethod;
+        this.invocationName = that.invocationName;
+        this.invocationType = that.invocationType;
+        this.interfaceMethodType = that.interfaceMethodType;
+        this.dynamicMethodType = that.dynamicMethodType;
+    }
+
+    @Override
+    public DynamicFuncCallOp transform(CodeContext cc, CodeTransformer ct) {
+        return new DynamicFuncCallOp(this, cc);
+    }
+
+    @Override
+    public CodeType resultType() {
+        return resultType;
+    }
+
+    public String funcName() {
+        return funcName;
+    }
+
+    public DirectMethodHandleDesc bootstrapMethod() {
+        return bootstrapMethod;
+    }
+
+    public String invocationName() {
+        return invocationName;
+    }
+
+    public MethodTypeDesc invocationType() {
+        return invocationType;
+    }
+
+    public MethodTypeDesc interfaceMethodType() {
+        return interfaceMethodType;
+    }
+
+    public MethodTypeDesc dynamicMethodType() {
+        return dynamicMethodType;
+    }
+}

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LambdaExpansionTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LambdaExpansionTransformer.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.incubator.code.bytecode.impl;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.SequencedMap;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import jdk.incubator.code.Block;
+import jdk.incubator.code.CodeTransformer;
+import jdk.incubator.code.CodeType;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Quoted;
+import jdk.incubator.code.Value;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
+import jdk.incubator.code.dialect.core.CoreType;
+import jdk.incubator.code.dialect.core.FunctionType;
+import jdk.incubator.code.dialect.core.VarType;
+import jdk.incubator.code.dialect.java.FieldRef;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
+import jdk.incubator.code.dialect.java.MethodRef;
+import jdk.incubator.code.extern.DialectFactory;
+import jdk.incubator.code.internal.OpBuilder;
+import jdk.incubator.code.runtime.ReflectableLambdaMetafactory;
+
+import static java.lang.constant.ConstantDescs.*;
+
+/**
+ * Lambda expansion transformer generates a module with lambda operations replaced
+ * by dynamic function calls and with synthetic functions for lambda bodies and
+ * reflectable lambda model builders.
+ */
+final class LambdaExpansionTransformer implements CodeTransformer {
+
+    private static final DirectMethodHandleDesc DMHD_LAMBDA_METAFACTORY = ofCallsiteBootstrap(
+            LambdaMetafactory.class.describeConstable().orElseThrow(),
+            "metafactory",
+            CD_CallSite, CD_MethodType, CD_MethodHandle, CD_MethodType);
+
+    private static final DirectMethodHandleDesc DMHD_REFLECTABLE_LAMBDA_METAFACTORY = ofCallsiteBootstrap(
+            ReflectableLambdaMetafactory.class.describeConstable().orElseThrow(),
+            "metafactory",
+            CD_CallSite, CD_MethodType, CD_MethodHandle, CD_MethodType);
+
+    private final MethodHandles.Lookup lookup;
+    private final Set<String> names;
+    private final List<FuncOp> functions = new ArrayList<>();
+    private final LinkedHashMap<String, FuncOp> modelsToBuild = new LinkedHashMap<>();
+    private int nextLambdaIndex;
+
+    private LambdaExpansionTransformer(MethodHandles.Lookup lookup, Set<String> names) {
+        this.lookup = lookup;
+        this.names = new LinkedHashSet<>(names);
+    }
+
+    static <O extends Op & Op.Invokable> CoreOp.ModuleOp transform(MethodHandles.Lookup lookup,
+                                                                   SequencedMap<String, ? extends O> ops) {
+        return new LambdaExpansionTransformer(lookup, ops.sequencedKeySet()).transform(ops);
+    }
+
+    private <O extends Op & Op.Invokable> CoreOp.ModuleOp transform(SequencedMap<String, ? extends O> ops) {
+        for (var e : ops.sequencedEntrySet()) {
+            functions.add(switch (e.getValue()) {
+                case FuncOp fop -> fop.transform(e.getKey(), this);
+                case JavaOp.LambdaOp lop -> lambdaToFuncOp(e.getKey(), lop).transform(this);
+                default -> throw new IllegalArgumentException("Unsupported invokable operation: " + e.getValue());
+            });
+        }
+        if (!modelsToBuild.isEmpty()) {
+            functions.addAll(OpBuilder.createBuilderFunctions(
+                    modelsToBuild,
+                    b -> b.add(JavaOp.fieldLoad(
+                            FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))))
+                    .functionTable().sequencedValues());
+        }
+        return CoreOp.module(functions);
+    }
+
+    // LambdaMetafactory implementation methods take captures before lambda parameters.
+    private static FuncOp lambdaToFuncOp(String name, JavaOp.LambdaOp lop) {
+        List<Value> captures = lop.capturedValues();
+        FunctionType lambdaType = lop.invokableSignature();
+        ArrayList<CodeType> parameterTypes = new ArrayList<>(captures.size() + lambdaType.parameterTypes().size());
+        for (Value v : captures) {
+            parameterTypes.add(v.type() instanceof VarType vt ? vt.valueType() : v.type());
+        }
+        parameterTypes.addAll(lambdaType.parameterTypes());
+        return CoreOp.func(name, CoreType.functionType(lambdaType.returnType(), parameterTypes)).body(b -> {
+            int i = 0;
+            for (Value cv : captures) {
+                Value v = b.parameters().get(i++);
+                if (cv.type() instanceof VarType) {
+                    v = b.add(CoreOp.var(v));
+                }
+                b.context().mapValue(cv, v);
+            }
+            b.transformBody(lop.body(), b.parameters().subList(i, b.parameters().size()),
+                    CodeTransformer.COPYING_TRANSFORMER);
+        });
+    }
+
+    private static String uniqueName(Set<String> names, String name) {
+        if (names.add(name)) {
+            return name;
+        }
+        for (int i = 0; ; i++) {
+            String n = name + "$" + i;
+            if (names.add(n)) {
+                return n;
+            }
+        }
+    }
+
+    @Override
+    public Block.Builder acceptOp(Block.Builder block, Op op) {
+        if (!(op instanceof JavaOp.LambdaOp lop)) {
+            block.add(op);
+            return block;
+        }
+        JavaType intfType = (JavaType) lop.functionalInterface();
+        MethodTypeDesc mtd = MethodRef.toNominalDescriptor(lop.invokableSignature());
+        try {
+            Class<?> intfClass = (Class<?>) intfType.erasure().resolve(lookup);
+            Method intfMethod = funcIntfMethod(intfClass, mtd);
+            List<Value> captures = lop.capturedValues();
+            int i = nextLambdaIndex++;
+            String implName = uniqueName(names, "lambda$" + i);
+            String intfMethodName = intfMethod.getName();
+            DirectMethodHandleDesc lambdaMetafactory = DMHD_LAMBDA_METAFACTORY;
+            if (lop.isReflectable()) {
+                String modelName = uniqueName(names, "op$lambda$" + i);
+                modelsToBuild.put(modelName, Quoted.embedOp(lop));
+                lambdaMetafactory = DMHD_REFLECTABLE_LAMBDA_METAFACTORY;
+                intfMethodName = intfMethodName + "=" + modelName;
+            }
+            functions.add(lambdaToFuncOp(implName, lop).transform(this));
+
+            ClassDesc[] captureTypes = captures.stream()
+                    .map(Value::type).map(LambdaExpansionTransformer::toClassDesc).toArray(ClassDesc[]::new);
+            Op.Result r = block.add(new DynamicFuncCallOp(
+                    lop.functionalInterface(),
+                    block.context().getValues(captures),
+                    implName,
+                    lambdaMetafactory,
+                    intfMethodName,
+                    MethodTypeDesc.of(intfType.toNominalDescriptor(), captureTypes),
+                    MethodTypeDesc.of(
+                            intfMethod.getReturnType().describeConstable().get(),
+                            Stream.of(intfMethod.getParameterTypes()).map(t -> t.describeConstable().get()).toList()),
+                    mtd));
+            block.context().mapValue(lop.result(), r);
+            return block;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static ClassDesc toClassDesc(CodeType t) {
+        return switch (t) {
+            case VarType vt -> toClassDesc(vt.valueType());
+            case JavaType jt -> jt.toNominalDescriptor();
+            default -> throw new IllegalArgumentException("Bad type: " + t);
+        };
+    }
+
+    private static Method funcIntfMethod(Class<?> intfc, MethodTypeDesc mtd) {
+        Method intfM = null;
+        for (Method m : intfc.getMethods()) {
+            String methodName = m.getName();
+            if (Modifier.isAbstract(m.getModifiers())
+                    && (m.getReturnType() != String.class
+                    || m.getParameterCount() != 0
+                    || !methodName.equals("toString"))
+                    && (m.getReturnType() != int.class
+                    || m.getParameterCount() != 0
+                    || !methodName.equals("hashCode"))
+                    && (m.getReturnType() != boolean.class
+                    || m.getParameterCount() != 1
+                    || m.getParameterTypes()[0] != Object.class
+                    || !methodName.equals("equals"))) {
+                if (intfM == null) {
+                    intfM = m;
+                } else if (!intfM.getName().equals(methodName)) {
+                    throw new IllegalArgumentException("Not a single-method interface: " + intfc.getName());
+                }
+            }
+        }
+        if (intfM == null) {
+            throw new IllegalArgumentException("No method in: " + intfc.getName() + " matching: " + mtd);
+        }
+        return intfM;
+    }
+}

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LoweringTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LoweringTransformer.java
@@ -30,20 +30,26 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SequencedMap;
 import java.util.Set;
 
 import jdk.incubator.code.Block;
 import jdk.incubator.code.Body;
+import jdk.incubator.code.CodeContext;
 import jdk.incubator.code.CodeTransformer;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.Value;
 import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
+import jdk.incubator.code.dialect.core.NormalizeBlocksTransformer;
 import jdk.incubator.code.dialect.java.ClassType;
+import jdk.incubator.code.dialect.java.ConstantExpressionTransformer;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
 import jdk.incubator.code.dialect.java.MethodRef;
 import jdk.incubator.code.dialect.java.PrimitiveType;
 import jdk.incubator.code.internal.BranchTarget;
+import jdk.incubator.code.internal.RemoveUnusedConstantTransformer;
 
 import static jdk.incubator.code.dialect.core.CoreOp.YieldOp;
 import static jdk.incubator.code.dialect.core.CoreOp.branch;
@@ -51,13 +57,16 @@ import static jdk.incubator.code.dialect.java.JavaType.*;
 
 /**
  * Lowering transformer generates models supported by {@code BytecodeGenerator}.
+ * It expands lambda operations into synthetic functions and dynamic function calls,
+ * evaluates constant expressions, removes unused constants, lowers operations, and
+ * normalizes blocks.
  * Constant-labeled switch statements and switch expressions are lowered to
  * {@code ConstantLabelSwitchOp} with evaluated labels.
  * We expect label value to be the second operand to the operation that perform equality check.
  */
-public final class LoweringTransform {
+public final class LoweringTransformer {
 
-    public static CodeTransformer getInstance(MethodHandles.Lookup lookup) {
+    private static CodeTransformer getInstance(MethodHandles.Lookup lookup) {
         return (block, op) -> switch (op) {
             case JavaOp.JavaSwitchOp swOp -> {
                 Optional<LabelsAndTargets> opt = isCaseConstantSwitchWithIntegralSelector(swOp, lookup);
@@ -72,6 +81,20 @@ public final class LoweringTransform {
                 yield block;
             }
         };
+    }
+
+    public static <O extends Op & Op.Invokable> CoreOp.ModuleOp transform(MethodHandles.Lookup lookup,
+                                                                          SequencedMap<String, ? extends O> ops) {
+        CoreOp.ModuleOp module = LambdaExpansionTransformer.transform(lookup, ops);
+        CodeTransformer lowering = getInstance(lookup);
+        List<FuncOp> functions = new ArrayList<>();
+        for (FuncOp fop : module.functionTable().sequencedValues()) {
+            Op transformed = ConstantExpressionTransformer.transform(lookup, fop);
+            transformed = transformed.transform(CodeContext.create(), RemoveUnusedConstantTransformer.INSTANCE);
+            functions.add(NormalizeBlocksTransformer.transform(
+                    (FuncOp) transformed.transform(CodeContext.create(), lowering)));
+        }
+        return CoreOp.module(functions);
     }
 
     private static Block.Builder lowerToConstantLabelSwitchOp(Block.Builder block, CodeTransformer transformer,

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -28,6 +28,7 @@ import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
+import jdk.incubator.code.extern.OpWriter;
 import jdk.internal.classfile.components.ClassPrinter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,7 +49,9 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 import java.util.function.IntUnaryOperator;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -398,6 +401,27 @@ public class TestBytecode {
     @Reflect
     static int nestedLambdasWithCaptures(int i, int j, String s) {
         return consumeLambda(i, a -> consumeLambda(a, b -> a + b + j - s.length()) + s.length());
+    }
+
+    static String lambdaModelText(Object f) {
+        return OpWriter.toText(Op.ofLambda(f).orElseThrow().op(), OpWriter.LocationOption.DROP_LOCATION);
+    }
+
+    @Reflect
+    static String nestedLambdaModels(boolean b) {
+        Supplier<IntSupplier> outer = () -> () -> {
+            if (b) {
+                return 1;
+            }
+            return 2;
+        };
+        return """
+               outer lambda model:
+               %s
+               inner lambda model:
+               %s
+               """.formatted(lambdaModelText(outer),
+                             lambdaModelText(outer.get()));
     }
 
     @Reflect


### PR DESCRIPTION
This proposal moves lambda handling out of `BytecodeGenerator` and into the lowering phase, fixing issues with lowered models for reflectable lambdas.

`LambdaExpansionTransformer` replaces each lambda operation with a proprietary `DynamicFuncCallOp`. The lambda body is emitted as a synthetic function, while a reflectable lambda emits an additional synthetic function that provides the original model.

All bytecode-lowering logic is consolidated in `BytecodeTransformer`, allowing `BytecodeGenerator` to receive a clean, fully lowered model with no nested bodies.

Lambda model:

```
func @"lambdaWithCapture" (%0 : java.type:"int", %1 : java.type:"java.lang.String")java.type:"int" -> {
    %2 : Var<java.type:"int"> = var %0 @"i";
    %3 : Var<java.type:"java.lang.String"> = var %1 @"s";
    %4 : java.type:"int" = var.load %2;
    %5 : java.type:"java.util.function.IntUnaryOperator" = lambda @lambda.isReflectable=true (%6 : java.type:"int")java.type:"int" -> {
        %7 : Var<java.type:"int"> = var %6 @"a";
        %8 : java.type:"int" = var.load %7;
        %9 : java.type:"java.lang.String" = var.load %3;
        %10 : java.type:"int" = invoke %9 @java.ref:"java.lang.String::length():int";
        %11 : java.type:"int" = add %8 %10;
        return %11;
    };
    %12 : java.type:"int" = invoke %4 %5 @java.ref:"TestBytecode::consumeLambda(int, java.util.function.IntUnaryOperator):int";
    return %12;
};
```


Expanded and lowered lambda model:

```
func @"lambdaWithCapture" (%8 : java.type:"int", %9 : java.type:"java.lang.String")java.type:"int" -> {
    %10 : Var<java.type:"int"> = var %8 @"i";
    %11 : Var<java.type:"java.lang.String"> = var %9 @"s";
    %12 : java.type:"int" = var.load %10;
    %13 : java.type:"java.util.function.IntUnaryOperator" = jdk.incubator.code.bytecode.impl.DynamicFuncCallOp %11 @func="lambda$0" @bootstrap="MethodHandleDesc[STATIC/ReflectableLambdaMetafactory::metafactory(MethodHandles$Lookup,String,MethodType,MethodType,MethodHandle,MethodType)CallSite]" @invocationName="applyAsInt=op$lambda$0" @invocationType="MethodTypeDesc[(String)IntUnaryOperator]" @interfaceMethodType="MethodTypeDesc[(int)int]" @dynamicMethodType="MethodTypeDesc[(int)int]";
    %14 : java.type:"int" = invoke %12 %13 @java.ref:"TestBytecode::consumeLambda(int, java.util.function.IntUnaryOperator):int";
    return %14;
};

func @"lambda$0" (%0 : java.type:"java.lang.String", %1 : java.type:"int")java.type:"int" -> {
    %2 : Var<java.type:"java.lang.String"> = var %0;
    %3 : Var<java.type:"int"> = var %1 @"a";
    %4 : java.type:"int" = var.load %3;
    %5 : java.type:"java.lang.String" = var.load %2;
    %6 : java.type:"int" = invoke %5 @java.ref:"java.lang.String::length():int";
    %7 : java.type:"int" = add %4 %6;
    return %7;
};

func @"op$lambda$0" ()java.type:"jdk.incubator.code.Op" -> {

    ... build lambda model ...

};
```


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1095/head:pull/1095` \
`$ git checkout pull/1095`

Update a local copy of the PR: \
`$ git checkout pull/1095` \
`$ git pull https://git.openjdk.org/babylon.git pull/1095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1095`

View PR using the GUI difftool: \
`$ git pr show -t 1095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1095.diff">https://git.openjdk.org/babylon/pull/1095.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1095#issuecomment-4938302840)
</details>
