### PR TITLE
Several boolean-returning code paths in BodyScanner lack target type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -3376,7 +3376,7 @@ public class Attr extends JCTree.Visitor {
                         }
                         bound = types.removeWildcards(bound);
                         components.add(bound);
-                    }
+                    }`
                     currentTarget = types.makeIntersectionType(components.toList());
                     currentTarget.tsym.flags_field |= INTERFACE;
                     lambdaType = types.findDescriptorType(currentTarget);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1557,8 +1557,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 // Push if condition
                 pushBody(cond,
                         CoreType.functionType(JavaType.BOOLEAN));
-                Value last = toValue(cond);
-                last = convert(last, codeTypeToType(JavaType.BOOLEAN));
+                Value last = toValue(cond, syms.booleanType);
                 // Yield the boolean result of the condition
                 append(CoreOp.core_yield(last));
                 bodies.add(stack.body);
@@ -1739,7 +1738,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     }
 
                     pushBody(c.guard, CoreType.functionType(JavaType.BOOLEAN));
-                    append(CoreOp.core_yield(toValue(c.guard)));
+                    append(CoreOp.core_yield(toValue(c.guard, syms.booleanType)));
                     clBodies.add(stack.body);
                     popBody();
 
@@ -1859,9 +1858,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             // Push while condition
             pushBody(cond, CoreType.functionType(JavaType.BOOLEAN));
-            Value last = toValue(cond);
-            // Yield the boolean result of the condition
-            last = convert(last, codeTypeToType(JavaType.BOOLEAN));
+            Value last = toValue(cond, syms.booleanType);
             append(CoreOp.core_yield(last));
             Body.Builder condition = stack.body;
 
@@ -1897,8 +1894,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             // Push while condition
             pushBody(cond, CoreType.functionType(JavaType.BOOLEAN));
-            Value last = toValue(cond);
-            last = convert(last, codeTypeToType(JavaType.BOOLEAN));
+            Value last = toValue(cond, syms.booleanType);
             // Yield the boolean result of the condition
             append(CoreOp.core_yield(last));
             Body.Builder condition = stack.body;
@@ -2026,7 +2022,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             if (tree.cond != null) {
                 vds.mapVarsToBlockArguments();
 
-                Value last = toValue(tree.cond);
+                Value last = toValue(tree.cond, syms.booleanType);
                 // Yield the boolean result of the condition
                 append(CoreOp.core_yield(last));
             } else {
@@ -2075,7 +2071,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // Push condition
             pushBody(cond,
                     CoreType.functionType(JavaType.BOOLEAN));
-            Value condVal = toValue(cond);
+            Value condVal = toValue(cond, syms.booleanType);
             // Yield the boolean result of the condition
             append(CoreOp.core_yield(condVal));
             Body.Builder predicateBody = stack.body;
@@ -2140,7 +2136,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // Push condition
             pushBody(cond,
                     CoreType.functionType(JavaType.BOOLEAN));
-            Value condVal = toValue(cond);
+            Value condVal = toValue(cond, syms.booleanType);
 
             // Yield the boolean result of the condition
             append(CoreOp.core_yield(condVal));
@@ -2372,7 +2368,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                 // Push lhs
                 pushBody(tree.lhs, CoreType.functionType(JavaType.BOOLEAN));
-                Value lhs = toValue(tree.lhs);
+                Value lhs = toValue(tree.lhs, syms.booleanType);
                 // Yield the boolean result of the condition
                 append(CoreOp.core_yield(lhs));
                 Body.Builder bodyLhs = stack.body;
@@ -2382,7 +2378,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                 // Push rhs
                 pushBody(tree.rhs, CoreType.functionType(JavaType.BOOLEAN));
-                Value rhs = toValue(tree.rhs);
+                Value rhs = toValue(tree.rhs, syms.booleanType);
                 // Yield the boolean result of the condition
                 append(CoreOp.core_yield(rhs));
                 Body.Builder bodyRhs = stack.body;
@@ -2405,11 +2401,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 result = append(JavaOp.concat(lhs, rhs));
             }
             else {
-                Type opType = tree.operator.type.getParameterTypes().getFirst();
-                // @@@ potentially handle shift input conversion like other binary ops
-                boolean isShift = tag == Tag.SL || tag == Tag.SR || tag == Tag.USR;
-                Value lhs = toValue(tree.lhs, opType);
-                Value rhs = toValue(tree.rhs, isShift ? tree.operator.type.getParameterTypes().getLast() : opType);
+                Type lhsType = tree.operator.type.getParameterTypes().head;
+                Type rhsType = tree.operator.type.getParameterTypes().tail.head;
+                Value lhs = toValue(tree.lhs, lhsType);
+                Value rhs = toValue(tree.rhs, rhsType);
 
                 result = switch (tag) {
                     // Arithmetic operations

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1859,6 +1859,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // Push while condition
             pushBody(cond, CoreType.functionType(JavaType.BOOLEAN));
             Value last = toValue(cond, syms.booleanType);
+            // Yield the boolean result of the condition
             append(CoreOp.core_yield(last));
             Body.Builder condition = stack.body;
 

--- a/test/langtools/tools/javac/reflect/AssertTest.java
+++ b/test/langtools/tools/javac/reflect/AssertTest.java
@@ -71,4 +71,20 @@ public class AssertTest {
     public static void assertTest2(int i) {
         assert (i == 1);
     }
+
+    @Reflect
+    @IR("""
+            func @"assertTest3" (%0 : java.type:"java.lang.Boolean")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Boolean"> = var %0 @"b";
+                assert ()java.type:"boolean" -> {
+                    %2 : java.type:"java.lang.Boolean" = var.load %1;
+                    %3 : java.type:"boolean" = invoke %2 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                    yield %3;
+                };
+                return;
+            };
+            """)
+    public static void assertTest3(Boolean b) {
+        assert (b);
+    }
 }

--- a/test/langtools/tools/javac/reflect/BinopTest.java
+++ b/test/langtools/tools/javac/reflect/BinopTest.java
@@ -321,4 +321,122 @@ public class BinopTest {
 
         a >>= 1L;
     }
+
+    @Reflect
+    @IR("""
+            func @"test10" (%0 : java.type:"BinopTest", %1 : java.type:"boolean", %2 : java.type:"java.lang.Boolean")java.type:"void" -> {
+                %3 : Var<java.type:"boolean"> = var %1 @"b";
+                %4 : Var<java.type:"java.lang.Boolean"> = var %2 @"B";
+                %5 : java.type:"boolean" = java.cor
+                    ()java.type:"boolean" -> {
+                        %6 : java.type:"boolean" = var.load %3;
+                        yield %6;
+                    }
+                    ()java.type:"boolean" -> {
+                        %7 : java.type:"java.lang.Boolean" = var.load %4;
+                        %8 : java.type:"boolean" = invoke %7 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %8;
+                    };
+                %9 : Var<java.type:"boolean"> = var %5 @"or1";
+                %10 : java.type:"boolean" = java.cor
+                    ()java.type:"boolean" -> {
+                        %11 : java.type:"java.lang.Boolean" = var.load %4;
+                        %12 : java.type:"boolean" = invoke %11 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %12;
+                    }
+                    ()java.type:"boolean" -> {
+                        %13 : java.type:"boolean" = var.load %3;
+                        yield %13;
+                    };
+                %14 : Var<java.type:"boolean"> = var %10 @"or2";
+                %15 : java.type:"boolean" = java.cor
+                    ()java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = var.load %3;
+                        yield %16;
+                    }
+                    ()java.type:"boolean" -> {
+                        %17 : java.type:"boolean" = var.load %3;
+                        yield %17;
+                    };
+                %18 : Var<java.type:"boolean"> = var %15 @"or3";
+                %19 : java.type:"boolean" = java.cor
+                    ()java.type:"boolean" -> {
+                        %20 : java.type:"java.lang.Boolean" = var.load %4;
+                        %21 : java.type:"boolean" = invoke %20 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %21;
+                    }
+                    ()java.type:"boolean" -> {
+                        %22 : java.type:"java.lang.Boolean" = var.load %4;
+                        %23 : java.type:"boolean" = invoke %22 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %23;
+                    };
+                %24 : Var<java.type:"boolean"> = var %19 @"or4";
+                %25 : java.type:"boolean" = java.cand
+                    ()java.type:"boolean" -> {
+                        %26 : java.type:"boolean" = var.load %3;
+                        yield %26;
+                    }
+                    ()java.type:"boolean" -> {
+                        %27 : java.type:"java.lang.Boolean" = var.load %4;
+                        %28 : java.type:"boolean" = invoke %27 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %28;
+                    };
+                %29 : Var<java.type:"boolean"> = var %25 @"and1";
+                %30 : java.type:"boolean" = java.cand
+                    ()java.type:"boolean" -> {
+                        %31 : java.type:"java.lang.Boolean" = var.load %4;
+                        %32 : java.type:"boolean" = invoke %31 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %32;
+                    }
+                    ()java.type:"boolean" -> {
+                        %33 : java.type:"boolean" = var.load %3;
+                        yield %33;
+                    };
+                %34 : Var<java.type:"boolean"> = var %30 @"and2";
+                %35 : java.type:"boolean" = java.cand
+                    ()java.type:"boolean" -> {
+                        %36 : java.type:"boolean" = var.load %3;
+                        yield %36;
+                    }
+                    ()java.type:"boolean" -> {
+                        %37 : java.type:"boolean" = var.load %3;
+                        yield %37;
+                    };
+                %38 : Var<java.type:"boolean"> = var %35 @"and3";
+                %39 : java.type:"boolean" = java.cand
+                    ()java.type:"boolean" -> {
+                        %40 : java.type:"java.lang.Boolean" = var.load %4;
+                        %41 : java.type:"boolean" = invoke %40 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %41;
+                    }
+                    ()java.type:"boolean" -> {
+                        %42 : java.type:"java.lang.Boolean" = var.load %4;
+                        %43 : java.type:"boolean" = invoke %42 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %43;
+                    };
+                %44 : Var<java.type:"boolean"> = var %39 @"and4";
+                %45 : java.type:"boolean" = var.load %3;
+                %46 : java.type:"boolean" = not %45;
+                %47 : Var<java.type:"boolean"> = var %46 @"not1";
+                %48 : java.type:"java.lang.Boolean" = var.load %4;
+                %49 : java.type:"boolean" = invoke %48 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                %50 : java.type:"boolean" = not %49;
+                %51 : Var<java.type:"boolean"> = var %50 @"not2";
+                return;
+            };
+            """)
+    void test10(boolean b, Boolean B) {
+        var or1 = b || B;
+        var or2 = B || b;
+        var or3 = b || b;
+        var or4 = B || B;
+
+        var and1 = b && B;
+        var and2 = B && b;
+        var and3 = b && b;
+        var and4 = B && B;
+
+        var not1 = !b;
+        var not2 = !B;
+    }
 }

--- a/test/langtools/tools/javac/reflect/ConditionalAndOrTest.java
+++ b/test/langtools/tools/javac/reflect/ConditionalAndOrTest.java
@@ -118,4 +118,31 @@ public class ConditionalAndOrTest {
     void test3(int i) {
         boolean b = i > 1 && i < 10 || i == 100;
     }
+
+    @Reflect
+    @IR("""
+            func @"test4" (%0 : java.type:"ConditionalAndOrTest", %1 : java.type:"java.lang.Boolean", %2 : java.type:"int", %3 : java.type:"int")java.type:"int" -> {
+                %4 : Var<java.type:"java.lang.Boolean"> = var %1 @"c";
+                %5 : Var<java.type:"int"> = var %2 @"i1";
+                %6 : Var<java.type:"int"> = var %3 @"i2";
+                %7 : java.type:"int" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %8 : java.type:"java.lang.Boolean" = var.load %4;
+                        %9 : java.type:"boolean" = invoke %8 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                        yield %9;
+                    }
+                    ()java.type:"int" -> {
+                        %10 : java.type:"int" = var.load %5;
+                        yield %10;
+                    }
+                    ()java.type:"int" -> {
+                        %11 : java.type:"int" = var.load %6;
+                        yield %11;
+                    };
+                return %7;
+            };
+            """)
+    int test4(Boolean c, int i1, int i2) {
+        return c ? i1 : i2;
+    }
 }

--- a/test/langtools/tools/javac/reflect/ForLoopTest.java
+++ b/test/langtools/tools/javac/reflect/ForLoopTest.java
@@ -598,4 +598,29 @@ public class ForLoopTest {
         }
     }
 
+    @Reflect
+    @IR("""
+        func @"test13" (%0 : java.type:"ForLoopTest", %1 : java.type:"java.lang.Boolean")java.type:"void" -> {
+            %2 : Var<java.type:"java.lang.Boolean"> = var %1 @"b";
+            java.for
+                ()java.type:"void" -> {
+                    yield;
+                }
+                ()java.type:"boolean" -> {
+                    %3 : java.type:"java.lang.Boolean" = var.load %2;
+                    %4 : java.type:"boolean" = invoke %3 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                    yield %4;
+                }
+                ()java.type:"void" -> {
+                    yield;
+                }
+                ()java.type:"void" -> {
+                    java.continue;
+                };
+            return;
+        };
+        """)
+    void test13(Boolean b) {
+        for (; b ;) { }
+    }
 }

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
@@ -510,4 +510,56 @@ public class SwitchExpressionTest {
             }
         };
     }
+
+    @IR("""
+            func @"caseBoxedGuard" (%0 : java.type:"java.lang.Object", %1 : java.type:"java.lang.Boolean")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %3 : Var<java.type:"java.lang.Boolean"> = var %1 @"B";
+                %4 : java.type:"java.lang.Object" = var.load %2;
+                %5 : java.type:"java.lang.Object" = constant @null;
+                %6 : Var<java.type:"java.lang.Object"> = var %5;
+                %7 : java.type:"java.lang.String" = java.switch.expression %4
+                    (%8 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %10 : java.type:"boolean" = pattern.match %8
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Object>" -> {
+                                        %11 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Object>" = pattern.type;
+                                        yield %11;
+                                    }
+                                    (%12 : java.type:"java.lang.Object")java.type:"void" -> {
+                                        var.store %6 %12;
+                                        yield;
+                                    };
+                                yield %10;
+                            }
+                            ()java.type:"boolean" -> {
+                                %13 : java.type:"java.lang.Boolean" = var.load %3;
+                                %14 : java.type:"boolean" = invoke %13 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                                yield %14;
+                            };
+                        yield %9;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %15 : java.type:"java.lang.String" = constant @"match";
+                        yield %15;
+                    }
+                    ()java.type:"boolean" -> {
+                        %16 : java.type:"boolean" = constant @true;
+                        yield %16;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %17 : java.type:"java.lang.String" = constant @"no match";
+                        yield %17;
+                    };
+                return %7;
+            };
+            """)
+    @Reflect
+    private static String caseBoxedGuard(Object o, Boolean B) {
+        return switch (o) {
+            case Object _ when B -> "match";
+            default -> "no match";
+        };
+    }
 }

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -2573,4 +2573,66 @@ public class SwitchStatementTest {
         return r;
     }
 
+    @IR("""
+            func @"caseBoxedGuard" (%0 : java.type:"java.lang.Object", %1 : java.type:"java.lang.Boolean")java.type:"java.lang.String" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %3 : Var<java.type:"java.lang.Boolean"> = var %1 @"B";
+                %4 : java.type:"java.lang.String" = constant @"";
+                %5 : Var<java.type:"java.lang.String"> = var %4 @"r";
+                %6 : java.type:"java.lang.Object" = var.load %2;
+                %7 : java.type:"java.lang.Object" = constant @null;
+                %8 : Var<java.type:"java.lang.Object"> = var %7;
+                java.switch.statement %6
+                    (%9 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                        %10 : java.type:"boolean" = java.cand
+                            ()java.type:"boolean" -> {
+                                %11 : java.type:"boolean" = pattern.match %9
+                                    ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Object>" -> {
+                                        %12 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.Object>" = pattern.type;
+                                        yield %12;
+                                    }
+                                    (%13 : java.type:"java.lang.Object")java.type:"void" -> {
+                                        var.store %8 %13;
+                                        yield;
+                                    };
+                                yield %11;
+                            }
+                            ()java.type:"boolean" -> {
+                                %14 : java.type:"java.lang.Boolean" = var.load %3;
+                                %15 : java.type:"boolean" = invoke %14 @java.ref:"java.lang.Boolean::booleanValue():boolean";
+                                yield %15;
+                            };
+                        yield %10;
+                    }
+                    ()java.type:"void" -> {
+                        %16 : java.type:"java.lang.String" = var.load %5;
+                        %17 : java.type:"java.lang.String" = constant @"match";
+                        %18 : java.type:"java.lang.String" = concat %16 %17;
+                        var.store %5 %18;
+                        yield;
+                    }
+                    ()java.type:"boolean" -> {
+                        %19 : java.type:"boolean" = constant @true;
+                        yield %19;
+                    }
+                    ()java.type:"void" -> {
+                        %20 : java.type:"java.lang.String" = var.load %5;
+                        %21 : java.type:"java.lang.String" = constant @"no match";
+                        %22 : java.type:"java.lang.String" = concat %20 %21;
+                        var.store %5 %22;
+                        yield;
+                    };
+                %23 : java.type:"java.lang.String" = var.load %5;
+                return %23;
+            };
+            """)
+    @Reflect
+    private static String caseBoxedGuard(Object o, Boolean B) {
+        String r = "";
+        switch (o) {
+            case Object _ when B -> r += "match";
+            default -> r += "no match";
+        }
+        return r;
+    }
 }


### PR DESCRIPTION
When reviewing the code for binary operators, I realized that the operands of `||` and && were missing the `boolean` target type argument. This means missing unboxing operations.
Zooming out (I looked for all places where we constructed a boolean-returning body) I realized we had several gaps like this:
* for loop condition
* assert condition
* ternary condition
* switch expression/statement guards

I've fixed all of the above gaps, and added corresponding regression tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [09ce5c33](https://git.openjdk.org/babylon/pull/1097/files/09ce5c33bae15117e99208d4498919a193605bd0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1097/head:pull/1097` \
`$ git checkout pull/1097`

Update a local copy of the PR: \
`$ git checkout pull/1097` \
`$ git pull https://git.openjdk.org/babylon.git pull/1097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1097`

View PR using the GUI difftool: \
`$ git pr show -t 1097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1097.diff">https://git.openjdk.org/babylon/pull/1097.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1097#issuecomment-4959474980)
</details>
