### PR TITLE
Better document code reflection's use of LazyConstant

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -155,7 +155,7 @@ module java.base {
     exports jdk.internal.javac to
         java.compiler,
         jdk.compiler,
-        jdk.incubator.code;
+        jdk.incubator.code; // Uses LazyConstant
     exports jdk.internal.access to
         java.desktop,
         java.logging,

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -74,7 +74,7 @@ public final class Body implements CodeElement<Body, Block> {
     // Lazily computed map of a block to its immediate dominator
     // Computed after body is built
     // @@@ when dominance checks are implemented, may be computed and used in build method
-    LazyConstant<Map<Block, Block>> idoms = LazyConstant.of(this::computeImmediateDominators);
+    final LazyConstant<Map<Block, Block>> idoms = LazyConstant.of(this::computeImmediateDominators);
 
     /**
      * Constructs a body, whose connected ancestor body is the given ancestor body.

--- a/src/jdk.incubator.code/share/classes/module-info.java
+++ b/src/jdk.incubator.code/share/classes/module-info.java
@@ -34,7 +34,7 @@ import jdk.internal.javac.ParticipatesInPreview;
 /// {@incubating}
 ///
 /// @moduleGraph
-@ParticipatesInPreview
+@ParticipatesInPreview // Uses LazyConstant
 module jdk.incubator.code {
     requires transitive jdk.compiler;
 


### PR DESCRIPTION
There is this `@ParticipatesInPreview` marker, which is confusing because it really only allows participation in the use of preview APIs for implementation without allowing the use of preview language features. We should indicate which preview API is being used to simplify maintenance.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1099/head:pull/1099` \
`$ git checkout pull/1099`

Update a local copy of the PR: \
`$ git checkout pull/1099` \
`$ git pull https://git.openjdk.org/babylon.git pull/1099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1099`

View PR using the GUI difftool: \
`$ git pr show -t 1099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1099.diff">https://git.openjdk.org/babylon/pull/1099.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1099#issuecomment-4963475710)
</details>
