### PR TITLE
Add null checks to methods of Block.Builder and Body.Builder.

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -570,6 +570,8 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the block builder with the given code context and code transformer
          */
         public Block.Builder withContextAndTransformer(CodeContext cc, CodeTransformer ct) {
+            Objects.requireNonNull(cc);
+            Objects.requireNonNull(ct);
             check();
             return this.cc == cc && this.ct == ct
                     ? this
@@ -599,6 +601,10 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the new block builder
          */
         public Block.Builder block(List<CodeType> params) {
+            Objects.requireNonNull(params);
+            if (params.stream().anyMatch(Objects::isNull)) {
+                throw new NullPointerException();
+            }
             check();
             return parentBody.block(params, cc, ct);
         }
@@ -620,6 +626,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the appended block parameter
          */
         public Parameter parameter(CodeType p) {
+            Objects.requireNonNull(p);
             check();
             return appendBlockParameter(p);
         }
@@ -649,6 +656,8 @@ public final class Block implements CodeElement<Block, Op> {
          * @throws IllegalArgumentException if any argument's declaring block is built.
          */
         public Reference reference(List<? extends Value> args) {
+            Objects.requireNonNull(args);
+            args.forEach(Objects::requireNonNull);
             check();
 
             if (isEntryBlock()) {
@@ -680,6 +689,10 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public void transformBody(Body body, List<? extends Value> entryValues,
                                   CodeTransformer ct) {
+            Objects.requireNonNull(body);
+            Objects.requireNonNull(entryValues);
+            entryValues.forEach(Objects::requireNonNull);
+            Objects.requireNonNull(ct);
             check();
 
             transformBody(body, entryValues, CodeContext.create(cc), ct);
@@ -715,6 +728,11 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public void transformBody(Body body, List<? extends Value> entryValues,
                                   CodeContext cc, CodeTransformer ct) {
+            Objects.requireNonNull(body);
+            Objects.requireNonNull(entryValues);
+            entryValues.forEach(Objects::requireNonNull);
+            Objects.requireNonNull(cc);
+            Objects.requireNonNull(ct);
             check();
 
             ct.acceptBody(withContextAndTransformer(cc, ct), body, entryValues);
@@ -762,6 +780,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @see Op#transform(CodeContext, CodeTransformer)
          */
         public Op.Result add(Op op) {
+            Objects.requireNonNull(op);
             check();
 
             // Perform transform-on-append for a placed operation

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -570,9 +570,9 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the block builder with the given code context and code transformer
          */
         public Block.Builder withContextAndTransformer(CodeContext cc, CodeTransformer ct) {
+            check();
             Objects.requireNonNull(cc);
             Objects.requireNonNull(ct);
-            check();
             return this.cc == cc && this.ct == ct
                     ? this
                     : this.target().new Builder(parentBody(), cc, ct);
@@ -588,6 +588,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the new block builder
          */
         public Block.Builder block(CodeType... params) {
+            check();
             return block(List.of(params));
         }
 
@@ -601,11 +602,11 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the new block builder
          */
         public Block.Builder block(List<CodeType> params) {
+            check();
             Objects.requireNonNull(params);
             if (params.stream().anyMatch(Objects::isNull)) {
                 throw new NullPointerException();
             }
-            check();
             return parentBody.block(params, cc, ct);
         }
 
@@ -626,8 +627,8 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the appended block parameter
          */
         public Parameter parameter(CodeType p) {
-            Objects.requireNonNull(p);
             check();
+            Objects.requireNonNull(p);
             return appendBlockParameter(p);
         }
 
@@ -642,6 +643,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @throws IllegalArgumentException if any argument's declaring block is built.
          */
         public Reference reference(Value... args) {
+            check();
             return reference(List.of(args));
         }
 
@@ -656,9 +658,9 @@ public final class Block implements CodeElement<Block, Op> {
          * @throws IllegalArgumentException if any argument's declaring block is built.
          */
         public Reference reference(List<? extends Value> args) {
+            check();
             Objects.requireNonNull(args);
             args.forEach(Objects::requireNonNull);
-            check();
 
             if (isEntryBlock()) {
                 throw new IllegalStateException("Entry block cannot be referenced and targeted as a successor");
@@ -689,12 +691,6 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public void transformBody(Body body, List<? extends Value> entryValues,
                                   CodeTransformer ct) {
-            Objects.requireNonNull(body);
-            Objects.requireNonNull(entryValues);
-            entryValues.forEach(Objects::requireNonNull);
-            Objects.requireNonNull(ct);
-            check();
-
             transformBody(body, entryValues, CodeContext.create(cc), ct);
         }
 
@@ -728,12 +724,12 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public void transformBody(Body body, List<? extends Value> entryValues,
                                   CodeContext cc, CodeTransformer ct) {
+            check();
             Objects.requireNonNull(body);
             Objects.requireNonNull(entryValues);
             entryValues.forEach(Objects::requireNonNull);
             Objects.requireNonNull(cc);
             Objects.requireNonNull(ct);
-            check();
 
             ct.acceptBody(withContextAndTransformer(cc, ct), body, entryValues);
         }
@@ -780,8 +776,8 @@ public final class Block implements CodeElement<Block, Op> {
          * @see Op#transform(CodeContext, CodeTransformer)
          */
         public Op.Result add(Op op) {
-            Objects.requireNonNull(op);
             check();
+            Objects.requireNonNull(op);
 
             // Perform transform-on-append for a placed operation
             Op outputOp = op.isPlacedInBlock() || op.isRoot()

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -47,6 +47,8 @@ public final class Block implements CodeElement<Block, Op> {
      */
     public static final class Parameter extends Value {
         Parameter(Block block, CodeType type) {
+            Objects.requireNonNull(type);
+
             super(block, type);
         }
 
@@ -500,6 +502,9 @@ public final class Block implements CodeElement<Block, Op> {
         final CodeTransformer ct;
 
         Builder(Body.Builder parentBody, CodeContext cc, CodeTransformer ct) {
+            Objects.requireNonNull(cc);
+            Objects.requireNonNull(ct);
+
             this.parentBody = parentBody;
             this.cc = cc;
             this.ct = ct;
@@ -571,8 +576,6 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public Block.Builder withContextAndTransformer(CodeContext cc, CodeTransformer ct) {
             check();
-            Objects.requireNonNull(cc);
-            Objects.requireNonNull(ct);
             return this.cc == cc && this.ct == ct
                     ? this
                     : this.target().new Builder(parentBody(), cc, ct);
@@ -588,7 +591,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @return the new block builder
          */
         public Block.Builder block(CodeType... params) {
-            check();
+            check(); // needs to be here to make sure finished building check precede null check
             return block(List.of(params));
         }
 
@@ -603,10 +606,6 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public Block.Builder block(List<CodeType> params) {
             check();
-            Objects.requireNonNull(params);
-            if (params.stream().anyMatch(Objects::isNull)) {
-                throw new NullPointerException();
-            }
             return parentBody.block(params, cc, ct);
         }
 
@@ -628,7 +627,6 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public Parameter parameter(CodeType p) {
             check();
-            Objects.requireNonNull(p);
             return appendBlockParameter(p);
         }
 
@@ -643,7 +641,7 @@ public final class Block implements CodeElement<Block, Op> {
          * @throws IllegalArgumentException if any argument's declaring block is built.
          */
         public Reference reference(Value... args) {
-            check();
+            check(); // needs to be here to make sure finished building check precede null check
             return reference(List.of(args));
         }
 
@@ -659,8 +657,6 @@ public final class Block implements CodeElement<Block, Op> {
          */
         public Reference reference(List<? extends Value> args) {
             check();
-            Objects.requireNonNull(args);
-            args.forEach(Objects::requireNonNull);
 
             if (isEntryBlock()) {
                 throw new IllegalStateException("Entry block cannot be referenced and targeted as a successor");
@@ -725,11 +721,6 @@ public final class Block implements CodeElement<Block, Op> {
         public void transformBody(Body body, List<? extends Value> entryValues,
                                   CodeContext cc, CodeTransformer ct) {
             check();
-            Objects.requireNonNull(body);
-            Objects.requireNonNull(entryValues);
-            entryValues.forEach(Objects::requireNonNull);
-            Objects.requireNonNull(cc);
-            Objects.requireNonNull(ct);
 
             ct.acceptBody(withContextAndTransformer(cc, ct), body, entryValues);
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -592,6 +592,10 @@ public final class Body implements CodeElement<Body, Block> {
 
         Builder(Builder connectedAncestorBody, FunctionType bodySignature,
                 CodeContext cc, CodeTransformer ct) {
+            Objects.requireNonNull(bodySignature);
+            Objects.requireNonNull(cc);
+            Objects.requireNonNull(ct);
+
             // Structural check
             // The connected ancestor body should not be built before this body is built
             if (connectedAncestorBody != null) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -651,11 +651,10 @@ public final class Body implements CodeElement<Body, Block> {
          * not {@link Value#isDominatedBy(Value) dominate} a use of that value
          */
         public Body build(Op op) {
-            Objects.requireNonNull(op);
-
             // Structural check
             // This body builder should not be finished
             check();
+            Objects.requireNonNull(op);
             finished = true;
 
             // Structural check

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -592,9 +592,6 @@ public final class Body implements CodeElement<Body, Block> {
 
         Builder(Builder connectedAncestorBody, FunctionType bodySignature,
                 CodeContext cc, CodeTransformer ct) {
-            Objects.requireNonNull(bodySignature);
-            Objects.requireNonNull(cc);
-            Objects.requireNonNull(ct);
 
             // Structural check
             // The connected ancestor body should not be built before this body is built
@@ -912,7 +909,6 @@ public final class Body implements CodeElement<Body, Block> {
 
         // Build new block in body
         Block.Builder block(List<CodeType> params, CodeContext cc, CodeTransformer ct) {
-            check();
             Block block = Body.this.createBlock(params);
 
             return block.new Builder(this, cc, ct);

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -434,9 +434,13 @@ public class TestBuild {
         entryBlockBuilder.add(branch(blockBuilder.reference()));
 
         for (int j = 0; j < 2; j++) {
+            Class<?> expectedExceptionClass;
             if (j == 1) {
                 // test with built body and block
                 func("f", bodyBuilder);
+                expectedExceptionClass = IllegalStateException.class;
+            } else {
+                expectedExceptionClass = NullPointerException.class;
             }
             for (Object r : List.of(bodyBuilder, blockBuilder)) {
                 for (Method m : r.getClass().getDeclaredMethods()) {
@@ -454,7 +458,7 @@ public class TestBuild {
                         }
                         var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class,
                                 () -> m.invoke(r, args));
-                        Assertions.assertInstanceOf(NullPointerException.class, wrapperException.getCause());
+                        Assertions.assertInstanceOf(expectedExceptionClass, wrapperException.getCause());
                     }
                 }
             }

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -403,30 +403,7 @@ public class TestBuild {
     }
 
     @Test
-    void testBuilderInoperableAfterBuildFinishes() {
-        var bodyBuilder = Body.Builder.of(null, FUNCTION_TYPE_VOID);
-        var entryBlockBuilder = bodyBuilder.entryBlock();
-        var blockBuilder = entryBlockBuilder.block();
-        blockBuilder.add(return_());
-        entryBlockBuilder.add(branch(blockBuilder.reference()));
-
-        var fop = func("f", bodyBuilder);
-
-        for (Object r : List.of(bodyBuilder, blockBuilder)) {
-            for (Method m : r.getClass().getDeclaredMethods()) {
-                if (m.accessFlags().contains(AccessFlag.STATIC) || !m.accessFlags().contains(AccessFlag.PUBLIC)) {
-                    continue;
-                }
-                List<Object> args = generateArgs(m);
-                var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class,
-                        () -> m.invoke(r, args.toArray()));
-                Assertions.assertInstanceOf(IllegalStateException.class, wrapperException.getCause());
-            }
-        }
-    }
-
-    @Test
-    void testNullChecks() {
+    void testBuildersChecks() {
         var bodyBuilder = Body.Builder.of(null, FUNCTION_TYPE_VOID);
         var entryBlockBuilder = bodyBuilder.entryBlock();
         var blockBuilder = entryBlockBuilder.block();
@@ -450,15 +427,14 @@ public class TestBuild {
                     if (m.getName().equals("equals")) {
                         continue;
                     }
-                    int pn = m.getParameterTypes().length;
-                    for (int i = 0; i < pn; i++) {
-                        Object[] args = new Object[pn];
-                        if (pn > 1) {
-                            args[i] = generateArg(m.getParameterTypes()[i]);
-                        }
+                    Object[] args = generateArgs(m);
+                    for (int i = 0; i < args.length; i++) {
+                        Object currArg = args[i];
+                        args[i] = null;
                         var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class,
                                 () -> m.invoke(r, args));
                         Assertions.assertInstanceOf(expectedExceptionClass, wrapperException.getCause());
+                        args[i] = currArg;
                     }
                 }
             }
@@ -483,19 +459,18 @@ public class TestBuild {
             arg = func("", FUNCTION_TYPE_VOID).body(b -> b.add(return_())).body();
         } else if (parameterType == Op.class) {
             arg = func("", FUNCTION_TYPE_VOID).body(b -> b.add(return_()));
-        } else if (parameterType == Object.class) {
-            arg = null;
         } else {
             throw new AssertionError("Unhandled parameter type " + parameterType);
         }
         return arg;
     }
 
-    static List<Object> generateArgs(Method m) {
-        List<Object> args = new ArrayList<>();
-        for (Class<?> parameterType : m.getParameterTypes()) {
-            Object arg = generateArg(parameterType);
-            args.add(arg);
+    static Object[] generateArgs(Method m) {
+        Object[] args = new Object[m.getParameterTypes().length];
+        Class<?>[] parameterTypes = m.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            Class<?> parameterType = parameterTypes[i];
+            args[i] = generateArg(parameterType);
         }
         return args;
     }

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -417,36 +417,82 @@ public class TestBuild {
                 if (m.accessFlags().contains(AccessFlag.STATIC) || !m.accessFlags().contains(AccessFlag.PUBLIC)) {
                     continue;
                 }
-                List<Object> args = new ArrayList<>();
-                for (Class<?> parameterType : m.getParameterTypes()) {
-                    Object arg;
-                    if (parameterType == Value[].class) {
-                        arg = new Value[]{};
-                    } else if (parameterType == CodeType[].class) {
-                        arg = new CodeType[]{};
-                    } else if (parameterType == CodeType.class) {
-                        arg = INT;
-                    } else if (parameterType == List.class) {
-                        arg = List.of();
-                    } else if (parameterType == CodeContext.class) {
-                        arg = CodeContext.create();
-                    } else if (parameterType == CodeTransformer.class) {
-                        arg = CodeTransformer.COPYING_TRANSFORMER;
-                    } else if (parameterType == Body.class) {
-                        arg = fop.body();
-                    } else if (parameterType == Op.class) {
-                        arg = fop;
-                    } else if (parameterType == Object.class) {
-                        arg = null;
-                    } else {
-                        throw new AssertionError("Unhandled parameter type " + parameterType + ", in the method " + m);
-                    }
-                    args.add(arg);
-                }
+                List<Object> args = generateArgs(m);
                 var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class,
                         () -> m.invoke(r, args.toArray()));
                 Assertions.assertInstanceOf(IllegalStateException.class, wrapperException.getCause());
             }
         }
+    }
+
+    @Test
+    void testNullChecks() {
+        var bodyBuilder = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+        var entryBlockBuilder = bodyBuilder.entryBlock();
+        var blockBuilder = entryBlockBuilder.block();
+        blockBuilder.add(return_());
+        entryBlockBuilder.add(branch(blockBuilder.reference()));
+
+        for (int j = 0; j < 2; j++) {
+            if (j == 1) {
+                // test with built body and block
+                func("f", bodyBuilder);
+            }
+            for (Object r : List.of(bodyBuilder, blockBuilder)) {
+                for (Method m : r.getClass().getDeclaredMethods()) {
+                    if (m.accessFlags().contains(AccessFlag.STATIC) || !m.accessFlags().contains(AccessFlag.PUBLIC)) {
+                        continue;
+                    }
+                    if (m.getName().equals("equals")) {
+                        continue;
+                    }
+                    int pn = m.getParameterTypes().length;
+                    for (int i = 0; i < pn; i++) {
+                        Object[] args = new Object[pn];
+                        if (pn > 1) {
+                            args[i] = generateArg(m.getParameterTypes()[i]);
+                        }
+                        var wrapperException = Assertions.assertThrowsExactly(InvocationTargetException.class,
+                                () -> m.invoke(r, args));
+                        Assertions.assertInstanceOf(NullPointerException.class, wrapperException.getCause());
+                    }
+                }
+            }
+        }
+    }
+
+    static Object generateArg(Class<?> parameterType) {
+        Object arg;
+        if (parameterType == Value[].class) {
+            arg = new Value[]{};
+        } else if (parameterType == CodeType[].class) {
+            arg = new CodeType[]{};
+        } else if (parameterType == CodeType.class) {
+            arg = INT;
+        } else if (parameterType == List.class) {
+            arg = List.of();
+        } else if (parameterType == CodeContext.class) {
+            arg = CodeContext.create();
+        } else if (parameterType == CodeTransformer.class) {
+            arg = CodeTransformer.COPYING_TRANSFORMER;
+        } else if (parameterType == Body.class) {
+            arg = func("", FUNCTION_TYPE_VOID).body(b -> b.add(return_())).body();
+        } else if (parameterType == Op.class) {
+            arg = func("", FUNCTION_TYPE_VOID).body(b -> b.add(return_()));
+        } else if (parameterType == Object.class) {
+            arg = null;
+        } else {
+            throw new AssertionError("Unhandled parameter type " + parameterType);
+        }
+        return arg;
+    }
+
+    static List<Object> generateArgs(Method m) {
+        List<Object> args = new ArrayList<>();
+        for (Class<?> parameterType : m.getParameterTypes()) {
+            Object arg = generateArg(parameterType);
+            args.add(arg);
+        }
+        return args;
     }
 }

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -410,14 +410,10 @@ public class TestBuild {
         blockBuilder.add(return_());
         entryBlockBuilder.add(branch(blockBuilder.reference()));
 
-        for (int j = 0; j < 2; j++) {
-            Class<?> expectedExceptionClass;
-            if (j == 1) {
+        for (Class<?> expectedExceptionClass : List.of(NullPointerException.class, IllegalStateException.class)) {
+            if (expectedExceptionClass == IllegalStateException.class) {
                 // test with built body and block
                 func("f", bodyBuilder);
-                expectedExceptionClass = IllegalStateException.class;
-            } else {
-                expectedExceptionClass = NullPointerException.class;
             }
             for (Object r : List.of(bodyBuilder, blockBuilder)) {
                 for (Method m : r.getClass().getDeclaredMethods()) {


### PR DESCRIPTION
Add null checks to methods of `Block.Builder` and `Body.Builder`. The finished building checks take precedence over null checks.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [8deb37bb](https://git.openjdk.org/babylon/pull/1104/files/8deb37bbddaac10ae440c77d20db9b67d3b371f3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1104/head:pull/1104` \
`$ git checkout pull/1104`

Update a local copy of the PR: \
`$ git checkout pull/1104` \
`$ git pull https://git.openjdk.org/babylon.git pull/1104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1104`

View PR using the GUI difftool: \
`$ git pr show -t 1104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1104.diff">https://git.openjdk.org/babylon/pull/1104.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1104#issuecomment-4997088529)
</details>
