### PR TITLE
8388390: Inner constructor generation uses the wrong synthetic outer receiver type

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1403,7 +1403,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     outerInstance = toValue(tree.encl);
                 }
                 args.add(outerInstance);
-                argtypes.add(outerInstance.type());
+                JavaType outerType = typeToCodeType(tree.constructor.innermostAccessibleEnclosingClass().erasure(types));
+                argtypes.add(outerType);
             }
             if (tree.type.tsym.isDirectlyOrIndirectlyLocal()) {
                 for (Symbol c : localCaptures.get(tree.type.tsym)) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1406,6 +1406,11 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 JavaType outerType = typeToCodeType(tree.constructor.innermostAccessibleEnclosingClass().erasure(types));
                 argtypes.add(outerType);
             }
+
+            MethodRef methodRef = symbolToMethodRef(tree.constructor);
+            argtypes.addAll(methodRef.signature().parameterTypes());
+            args.addAll(scanMethodArguments(tree.args, tree.constructorType, tree.varargsElement));
+
             if (tree.type.tsym.isDirectlyOrIndirectlyLocal()) {
                 for (Symbol c : localCaptures.get(tree.type.tsym)) {
                     args.add(loadVar(c));
@@ -1418,14 +1423,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // We need to manually construct the constructor reference,
             // as the signature of the constructor symbol is not augmented
             // with enclosing this and captured params.
-            MethodRef methodRef = symbolToMethodRef(tree.constructor);
-            argtypes.addAll(methodRef.signature().parameterTypes());
             FunctionType constructorSignature = CoreType.functionType(
                     symbolToErasedDesc(tree.constructor.owner),
                     argtypes);
             MethodRef constructorRef = MethodRef.constructor(constructorSignature);
-
-            args.addAll(scanMethodArguments(tree.args, tree.constructorType, tree.varargsElement));
 
             result = append(JavaOp.new_(tree.varargsElement != null, typeToCodeType(type), constructorRef, args));
         }

--- a/test/jdk/jdk/incubator/code/TestInvokeInnerCtor.java
+++ b/test/jdk/jdk/incubator/code/TestInvokeInnerCtor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.code
+ * @library lib
+ * @run junit TestInvokeInnerCtor
+ * @run main Unreflect TestInvokeInnerCtor
+ * @run junit TestInvokeInnerCtor
+ */
+
+import jdk.incubator.code.Reflect;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.dialect.core.CoreOp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class TestInvokeInnerCtor {
+
+    static class Base {
+        class Inner {
+            private String s;
+
+            Inner(String s) {
+                this.s = s;
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                if (obj instanceof Inner in) {
+                    return Objects.equals(this.s, in.s);
+                }
+                return false;
+            }
+        }
+    }
+
+    static class Sub extends Base {
+        @Reflect
+        Inner make(String s) {
+            return new Inner(s);
+        }
+    }
+
+    @Test
+    public void test() {
+        CoreOp.FuncOp f = getFuncOp(Sub.class, "make");
+        System.out.println(f.toText());
+        Assertions.assertEquals(new Sub().make("Test"), Interpreter.invoke(MethodHandles.lookup(), f, new Sub(), "Test"));
+    }
+
+    static CoreOp.FuncOp getFuncOp(Class<?> c, String name) {
+        Optional<Method> om = Stream.of(c.getDeclaredMethods())
+                .filter(m -> m.getName().equals(name))
+                .findFirst();
+        Method m = om.get();
+        return Op.ofMethod(m).get();
+    }
+}

--- a/test/jdk/jdk/incubator/code/TestInvokeInnerCtor.java
+++ b/test/jdk/jdk/incubator/code/TestInvokeInnerCtor.java
@@ -67,6 +67,15 @@ public class TestInvokeInnerCtor {
         Inner make(String s) {
             return new Inner(s);
         }
+
+        @Reflect
+        String localCaptureParam(String s) {
+            class Foo {
+                Foo(int i) {}
+                String m() { return s; }
+            }
+            return new Foo(10).m();
+        }
     }
 
     @Test
@@ -74,6 +83,13 @@ public class TestInvokeInnerCtor {
         CoreOp.FuncOp f = getFuncOp(Sub.class, "make");
         System.out.println(f.toText());
         Assertions.assertEquals(new Sub().make("Test"), Interpreter.invoke(MethodHandles.lookup(), f, new Sub(), "Test"));
+    }
+
+    @Test
+    public void testLocalCaptureParam() {
+        CoreOp.FuncOp f = getFuncOp(Sub.class, "localCaptureParam");
+        System.out.println(f.toText());
+        Assertions.assertEquals(new Sub().localCaptureParam("Test"), Interpreter.invoke(MethodHandles.lookup(), f, new Sub(), "Test"));
     }
 
     static CoreOp.FuncOp getFuncOp(Class<?> c, String name) {

--- a/test/langtools/tools/javac/reflect/NewTest.java
+++ b/test/langtools/tools/javac/reflect/NewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,7 +192,7 @@ public class NewTest {
                   %5 : java.type:"java.util.List<java.lang.String>" = var.load %3;
                   %6 : java.type:"NewTest::BG<java.lang.String>" = new %0 %5 @java.ref:"NewTest::BG::(NewTest, java.util.List)";
                   %7 : java.type:"java.util.List<java.lang.Number>" = var.load %4;
-                  %8 : java.type:"NewTest::BG<java.lang.String>::CG<java.lang.Number>" = new %6 %7 @java.ref:"NewTest::BG::CG::(NewTest::BG<java.lang.String>, java.util.List)";
+                  %8 : java.type:"NewTest::BG<java.lang.String>::CG<java.lang.Number>" = new %6 %7 @java.ref:"NewTest::BG::CG::(NewTest::BG, java.util.List)";
                   %9 : Var<java.type:"NewTest::BG<java.lang.String>::CG<java.lang.Number>"> = var %8 @"numberCG";
                   return;
               };


### PR DESCRIPTION
Consider the following code snippet:
```
class Base {
    class Inner {
        Inner(String s) {}
    }
}

class Sub extends Base {
    @Reflect
    Inner make(String s) {
        return new Inner(s);
    }
}
```

When attempting to interpret the generated code model for `make`, the following exception is thrown:
```
java.lang.NoSuchMethodException: no such constructor: TestInvokeInnerCtor$Base$Inner.<init>(Sub,String)void/newInvokeSpecial
	at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:909)
	at java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:990)
	at java.base/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:3599)
	at java.base/java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:2680)
	at jdk.incubator.code/jdk.incubator.code.dialect.java.impl.MethodRefImpl.resolveToConstructorHandle(MethodRefImpl.java:110)
	at jdk.incubator.code/jdk.incubator.code.dialect.java.impl.MethodRefImpl.resolveToHandle(MethodRefImpl.java:87)
	at JavaLowInterpreter.resolveToConstructorHandle(JavaLowInterpreter.java:657)
	at JavaLowInterpreter.executeOp(JavaLowInterpreter.java:463)
	at JavaHighInterpreter.executeOp(JavaHighInterpreter.java:78)
	at Interpreter.executeBlock(Interpreter.java:64)
	at Interpreter.executeBody(Interpreter.java:46)
	at JavaLowInterpreter.interpret_(JavaLowInterpreter.java:189)
	at JavaLowInterpreter.interpret(JavaLowInterpreter.java:177)
	at Interpreter.invoke(Interpreter.java:114)
	at Interpreter.invoke(Interpreter.java:110)
```

The problem arises when a reflected method in a subclass instantiates a non-static inner class declared by a superclass. The generated constructor reference uses the subclass type for the synthetic enclosing-instance parameter. However, the constructor’s JVM signature requires the erased type of the inner class’s declaring enclosing class.

The proposal her is to update constructor-reference generation to derive this parameter from `innermostAccessibleEnclosingClass()` and erase it before forming the `MethodRef` signature, consistent with javac’s behavior in `Lower`.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8388390](https://bugs.openjdk.org/browse/JDK-8388390): Inner constructor generation uses the wrong synthetic outer receiver type (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**) ⚠️ Review applies to [8276e5bd](https://git.openjdk.org/babylon/pull/1106/files/8276e5bd4f0e2c10ac7bb86a0e8324b94eecc96f)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1106/head:pull/1106` \
`$ git checkout pull/1106`

Update a local copy of the PR: \
`$ git checkout pull/1106` \
`$ git pull https://git.openjdk.org/babylon.git pull/1106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1106`

View PR using the GUI difftool: \
`$ git pr show -t 1106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1106.diff">https://git.openjdk.org/babylon/pull/1106.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1106#issuecomment-5019909138)
</details>
