### PR TITLE
Fix uses of renamed class in TestInCaseConstantSwitch

### DIFF
--- a/test/jdk/jdk/incubator/code/bytecode/TestIsCaseConstantSwitch.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestIsCaseConstantSwitch.java
@@ -22,7 +22,7 @@
  */
 
 import jdk.incubator.code.*;
-import jdk.incubator.code.bytecode.impl.LoweringTransform;
+import jdk.incubator.code.bytecode.impl.LoweringTransformer;
 import jdk.incubator.code.dialect.core.CoreOp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -188,7 +188,7 @@ public class TestIsCaseConstantSwitch {
                 .filter(o -> o instanceof SwitchExpressionOp)
                 .map(o -> ((SwitchExpressionOp) o)).toList();
         for (SwitchExpressionOp swExprOp : swExprOps) {
-            boolean actual = LoweringTransform.isCaseConstantSwitchWithIntegralSelector(swExprOp, MethodHandles.lookup()).isPresent();
+            boolean actual = LoweringTransformer.isCaseConstantSwitchWithIntegralSelector(swExprOp, MethodHandles.lookup()).isPresent();
             Assertions.assertEquals(
                     expected,
                     actual,
@@ -206,7 +206,7 @@ public class TestIsCaseConstantSwitch {
         var funcOp = Op.ofMethod(this.getClass().getDeclaredMethod("caseConstantSwitchExpressions")).get();
         System.out.println(funcOp.toText());
         var swOp = (JavaSwitchOp) funcOp.body().entryBlock().ops().stream().filter(op -> op instanceof JavaSwitchOp).findFirst().get();
-        Optional<LoweringTransform.LabelsAndTargets> opt = LoweringTransform.isCaseConstantSwitchWithIntegralSelector(swOp, MethodHandles.lookup());
+        Optional<LoweringTransformer.LabelsAndTargets> opt = LoweringTransformer.isCaseConstantSwitchWithIntegralSelector(swOp, MethodHandles.lookup());
         Assertions.assertTrue(opt.isPresent());
         List<Integer> actualLabels = opt.get().labels();
         System.out.println(actualLabels);


### PR DESCRIPTION
This test started to fail after lowering transform was renamed in 98da9e5d295ba9c8bee3d6410201b69e9f926097

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1107/head:pull/1107` \
`$ git checkout pull/1107`

Update a local copy of the PR: \
`$ git checkout pull/1107` \
`$ git pull https://git.openjdk.org/babylon.git pull/1107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1107`

View PR using the GUI difftool: \
`$ git pr show -t 1107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1107.diff">https://git.openjdk.org/babylon/pull/1107.diff</a>

</details>
