### PR TITLE
Array index should have int type as target

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -874,7 +874,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     JCArrayAccess assign = (JCArrayAccess) lhs;
 
                     Value array = toValue(assign.indexed);
-                    Value index = toValue(assign.index);
+                    Value index = toValue(assign.index, syms.intType);
 
                     // Scan the rhs, the assign expression result is its input
                     result = toValue(tree.rhs, target);
@@ -1005,7 +1005,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     JCArrayAccess assign = (JCArrayAccess) lhs;
 
                     Value array = toValue(assign.indexed);
-                    Value index = toValue(assign.index);
+                    Value index = toValue(assign.index, syms.intType);
 
                     Op.Result lhsOpValue = append(JavaOp.arrayLoadOp(array, index));
                     // Scan the rhs
@@ -1116,7 +1116,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             Value array = toValue(tree.indexed);
 
-            Value index = toValue(tree.index, codeTypeToType(JavaType.INT));
+            Value index = toValue(tree.index, syms.intType);
 
             result = append(JavaOp.arrayLoadOp(array, index));
         }

--- a/test/langtools/tools/javac/reflect/BoxingConversionTest.java
+++ b/test/langtools/tools/javac/reflect/BoxingConversionTest.java
@@ -861,4 +861,56 @@ public class BoxingConversionTest {
         }
         return j;
     }
+
+    @Reflect
+    @IR("""
+            func @"boxedIndexArrayRead" (%0 : java.type:"int[]", %1 : java.type:"java.lang.Integer")java.type:"int" -> {
+                %2 : Var<java.type:"int[]"> = var %0 @"arr";
+                %3 : Var<java.type:"java.lang.Integer"> = var %1 @"index";
+                %4 : java.type:"int[]" = var.load %2;
+                %5 : java.type:"java.lang.Integer" = var.load %3;
+                %6 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::intValue():int";
+                %7 : java.type:"int" = array.load %4 %6;
+                return %7;
+            };
+            """)
+    public static int boxedIndexArrayRead(int[] arr, Integer index) {
+        return arr[index];
+    }
+
+    @Reflect
+    @IR("""
+            func @"boxedIndexArrayWrite" (%0 : java.type:"int[]", %1 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %0 @"arr";
+                %3 : Var<java.type:"java.lang.Integer"> = var %1 @"index";
+                %4 : java.type:"int[]" = var.load %2;
+                %5 : java.type:"java.lang.Integer" = var.load %3;
+                %6 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::intValue():int";
+                %7 : java.type:"int" = constant @1;
+                array.store %4 %6 %7;
+                return;
+            };
+            """)
+    static void boxedIndexArrayWrite(int[] arr, Integer index) {
+        arr[index] = 1;
+    }
+
+    @Reflect
+    @IR("""
+            func @"boxedIndexArrayWriteCompound" (%0 : java.type:"int[]", %1 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %0 @"arr";
+                %3 : Var<java.type:"java.lang.Integer"> = var %1 @"index";
+                %4 : java.type:"int[]" = var.load %2;
+                %5 : java.type:"java.lang.Integer" = var.load %3;
+                %6 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::intValue():int";
+                %7 : java.type:"int" = array.load %4 %6;
+                %8 : java.type:"int" = constant @1;
+                %9 : java.type:"int" = add %7 %8;
+                array.store %4 %6 %9;
+                return;
+            };
+            """)
+    static void boxedIndexArrayWriteCompound(int[] arr, Integer index) {
+        arr[index] += 1;
+    }
 }

--- a/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
+++ b/test/langtools/tools/javac/reflect/ImplicitConversionTest.java
@@ -605,4 +605,56 @@ public class ImplicitConversionTest {
         }
         return j;
     }
+
+    @Reflect
+    @IR("""
+            func @"byteIndexArrayRead" (%0 : java.type:"int[]", %1 : java.type:"byte")java.type:"int" -> {
+                %2 : Var<java.type:"int[]"> = var %0 @"arr";
+                %3 : Var<java.type:"byte"> = var %1 @"index";
+                %4 : java.type:"int[]" = var.load %2;
+                %5 : java.type:"byte" = var.load %3;
+                %6 : java.type:"int" = conv %5;
+                %7 : java.type:"int" = array.load %4 %6;
+                return %7;
+            };
+            """)
+    public static int byteIndexArrayRead(int[] arr, byte index) {
+        return arr[index];
+    }
+
+    @Reflect
+    @IR("""
+            func @"byteIndexArrayWrite" (%0 : java.type:"int[]", %1 : java.type:"byte")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %0 @"arr";
+                %3 : Var<java.type:"byte"> = var %1 @"index";
+                %4 : java.type:"int[]" = var.load %2;
+                %5 : java.type:"byte" = var.load %3;
+                %6 : java.type:"int" = conv %5;
+                %7 : java.type:"int" = constant @1;
+                array.store %4 %6 %7;
+                return;
+            };
+            """)
+    static void byteIndexArrayWrite(int[] arr, byte index) {
+        arr[index] = 1;
+    }
+
+    @Reflect
+    @IR("""
+            func @"byteIndexArrayWriteCompound" (%0 : java.type:"int[]", %1 : java.type:"byte")java.type:"void" -> {
+                %2 : Var<java.type:"int[]"> = var %0 @"arr";
+                %3 : Var<java.type:"byte"> = var %1 @"index";
+                %4 : java.type:"int[]" = var.load %2;
+                %5 : java.type:"byte" = var.load %3;
+                %6 : java.type:"int" = conv %5;
+                %7 : java.type:"int" = array.load %4 %6;
+                %8 : java.type:"int" = constant @1;
+                %9 : java.type:"int" = add %7 %8;
+                array.store %4 %6 %9;
+                return;
+            };
+            """)
+    static void byteIndexArrayWriteCompound(int[] arr, byte index) {
+        arr[index] += 1;
+    }
 }


### PR DESCRIPTION
When producing code model for array access expression, the index expression has (in some cases) `Type.noType` as target. This leads to missing unboxing/implicit conversions.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1110/head:pull/1110` \
`$ git checkout pull/1110`

Update a local copy of the PR: \
`$ git checkout pull/1110` \
`$ git pull https://git.openjdk.org/babylon.git pull/1110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1110`

View PR using the GUI difftool: \
`$ git pr show -t 1110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1110.diff">https://git.openjdk.org/babylon/pull/1110.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1110#issuecomment-5047769484)
</details>
