### PR TITLE
[hat] Add warning to remove the I/O annotations for non annotated kernel annotated methods

### DIFF
--- a/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
+++ b/hat/backends/ffi/shared/src/main/java/hat/backend/ffi/C99FFIBackend.java
@@ -60,7 +60,8 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class C99FFIBackend extends FFIBackend implements BufferTracker {
-    public C99FFIBackend(Arena arena, MethodHandles.Lookup lookup, String libName, Config config) {
+
+    protected C99FFIBackend(Arena arena, MethodHandles.Lookup lookup, String libName, Config config) {
         super(arena, lookup, libName, config);
     }
 

--- a/hat/core/src/main/java/hat/buffer/ArgArray.java
+++ b/hat/core/src/main/java/hat/buffer/ArgArray.java
@@ -209,7 +209,6 @@ public interface ArgArray extends Buffer {
 
     int argc();
 
-
     Arg arg(long idx);
 
     int schemaLen();
@@ -217,7 +216,6 @@ public interface ArgArray extends Buffer {
     byte schemaBytes(long idx);
 
     void schemaBytes(long idx, byte b);
-
 
     Schema<ArgArray> schema = Schema.of(ArgArray.class, s -> s
             .arrayLen("argc")
@@ -236,7 +234,6 @@ public interface ArgArray extends Buffer {
             .arrayLen("schemaLen")
             .array("schemaBytes")
     );
-
 
     static ArgArray create(ArenaAndLookupCarrier cc, KernelCallGraph kernelCallGraph, Object... args) {
         String[] schemas = new String[args.length];
@@ -273,13 +270,24 @@ public interface ArgArray extends Buffer {
         return argArray;
     }
 
+    private static void checkAnnotationArg(KernelCallGraph kernelCallGraph, AccessType accessType, Annotation annotation, int argIndex) {
+        if (accessType != AccessType.NA && !isKernelAnnotationPresent(kernelCallGraph)) {
+            // print warning to remove the I/O annotation from the arg parameter
+            IO.println("[WARNING]: Annotation " + annotation + " can be removed from the input parameter " + argIndex);
+        }
+    }
+
+    private static boolean isKernelAnnotationPresent(KernelCallGraph kernelCallGraph) {
+        return kernelCallGraph.callDag.entryPoint.method().getAnnotation(Kernel.class) != null;
+    }
+
     static void update(ArgArray argArray, KernelCallGraph kernelCallGraph, Object... args) {
         Annotation[][] parameterAnnotations = kernelCallGraph.callDag.entryPoint.method().getParameterAnnotations();
         var bufferAccessList = kernelCallGraph.bufferAccessList;
-        for (int i = 0; i < args.length; i++) {
-            Object argObject = args[i];
-            Arg arg = argArray.arg(i); // this should be invariant, but if we are called from create it will be 0 for all
-            arg.idx(i);
+        for (int argIndex = 0; argIndex < args.length; argIndex++) {
+            Object argObject = args[argIndex];
+            Arg arg = argArray.arg(argIndex); // this should be invariant, but if we are called from create it will be 0 for all
+            arg.idx(argIndex);
             switch (argObject) {
                 case Boolean z1 -> arg.z1(z1);
                 case Byte s8 -> arg.s8(s8);
@@ -290,10 +298,11 @@ public interface ArgArray extends Buffer {
                 case Long s64 -> arg.s64(s64);
                 case Double f64 -> arg.f64(f64);
                 case Buffer buffer -> {
-                    Annotation[] annotations = parameterAnnotations[i];
+                    Annotation[] annotations = parameterAnnotations[argIndex];
                     AccessType accessType = AccessType.NA;
                     for (Annotation annotation : annotations) {
                         accessType = AccessType.of(annotation);
+                        checkAnnotationArg(kernelCallGraph, accessType, annotation, argIndex);
                     }
                     MemorySegment segment = getMemorySegment(buffer);
                     arg.variant((byte) '&');
@@ -302,12 +311,12 @@ public interface ArgArray extends Buffer {
                     buf.address(segment);
                     buf.bytes(segment.byteSize());
 
-                    if (kernelCallGraph.callDag.entryPoint.method().getAnnotation(Kernel.class) != null) {
+                    if (isKernelAnnotationPresent(kernelCallGraph)) {
                         // If the annotation is present, then we keep the accessor defined for each parameter
                         buf.access(accessType.value);
                     } else {
                         // otherwise, we rely on the buffer-tagger to set the accessor
-                        buf.access(bufferAccessList.get(i).value);
+                        buf.access(bufferAccessList.get(argIndex).value);
                     }
                 }
                 default -> throw new IllegalStateException("Unexpected value: " + argObject);


### PR DESCRIPTION
Since we are deprecating the Input/Output annotations in favour of the buffer accessor list, this PR 
adds a warning to remove the I/O annotations for non annotated kernel annotated methods.



---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1112/head:pull/1112` \
`$ git checkout pull/1112`

Update a local copy of the PR: \
`$ git checkout pull/1112` \
`$ git pull https://git.openjdk.org/babylon.git pull/1112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1112`

View PR using the GUI difftool: \
`$ git pr show -t 1112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1112.diff">https://git.openjdk.org/babylon/pull/1112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1112#issuecomment-5058960402)
</details>
