### PR TITLE
[hat] PROFILE_CUDA_KERNEL option merged with PROFILE

### DIFF
--- a/hat/.ffisync
+++ b/hat/.ffisync
@@ -1,1 +1,1 @@
--cp build/hat-core-1.0.jar  hat.FFIConfigCreator
+-cp build/hat-core-1.0.jar:build/hat-optkl-1.0.jar  hat.FFIConfigCreator

--- a/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
+++ b/hat/backends/ffi/cuda/src/main/native/cpp/cuda_backend.cpp
@@ -264,7 +264,7 @@ Backend::CompilationUnit *CudaBackend::compile(const int len, char *source) {
         if (config->trace) {
             std::cout << "compiling from provided  cuda " << std::endl;
         }
-        CudaSource cudaSource(len , source, false, config->profileCudaKernel);
+        CudaSource cudaSource(len , source, false, config->profile);
         return compile(cudaSource);
     }
 }

--- a/hat/backends/ffi/shared/src/main/native/include/config.h
+++ b/hat/backends/ffi/shared/src/main/native/include/config.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2025-2026, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 */
 /*
 You probably should not edit this this file!!!
-It was auto generated 2026-01-08 12:22:32.577 by hat.FFIConfigCreator
+It was auto generated 2026-07-23 16:04:56.597 by hat.FFIConfigCreator
 */
 #pragma once
 
@@ -54,6 +54,7 @@ struct BasicConfig{
     static constexpr int SHOW_COMPILATION_PHASES_BIT      = 1<<0x1c;
     static constexpr int PROFILE_CUDA_KERNEL_BIT          = 1<<0x1d;
     static constexpr int SHOW_COMPUTE_MODEL_JAVA_CODE_BIT = 1<<0x1e;
+    static constexpr int CHECK_SSA_LOWERING_BIT           = 1<<0x1f;
     const static char *bitNames[]; // See below for initialization
     const static char *bitDescriptions[]; // See below for initialization
     int configBits;
@@ -80,6 +81,7 @@ struct BasicConfig{
     bool showCompilationPhases;
     bool profileCudaKernel;
     bool showComputeModelJavaCode;
+    bool checkSsaLowering;
     int platform;
     int device;
     bool alwaysCopy;
@@ -108,6 +110,7 @@ struct BasicConfig{
         showCompilationPhases((configBits & SHOW_COMPILATION_PHASES_BIT)==SHOW_COMPILATION_PHASES_BIT),
         profileCudaKernel((configBits & PROFILE_CUDA_KERNEL_BIT)==PROFILE_CUDA_KERNEL_BIT),
         showComputeModelJavaCode((configBits & SHOW_COMPUTE_MODEL_JAVA_CODE_BIT)==SHOW_COMPUTE_MODEL_JAVA_CODE_BIT),
+        checkSsaLowering((configBits & CHECK_SSA_LOWERING_BIT)==CHECK_SSA_LOWERING_BIT),
         platform(configBits & 0xf),
         alwaysCopy(!minimizeCopies),
         device((configBits & 0xf0) >> 4){
@@ -135,6 +138,7 @@ struct BasicConfig{
                 std::cout << "native showCompilationPhases " << showCompilationPhases << std::endl;
                 std::cout << "native profileCudaKernel " << profileCudaKernel << std::endl;
                 std::cout << "native showComputeModelJavaCode " << showComputeModelJavaCode << std::endl;
+                std::cout << "native checkSsaLowering " << checkSsaLowering << std::endl;
                 std::cout << "native platform " << platform << std::endl;
                 std::cout << "native device " << device << std::endl;
             }
@@ -167,6 +171,7 @@ const char *BasicConfig::bitNames[]={
     "SHOW_COMPILATION_PHASES_BIT",
     "PROFILE_CUDA_KERNEL_BIT",
     "SHOW_COMPUTE_MODEL_JAVA_CODE_BIT",
+    "CHECK_SSA_LOWERING_BIT",
 };
 const char *BasicConfig::bitDescriptions[]={
     "FFI ONLY Try to minimize copies",
@@ -192,5 +197,6 @@ const char *BasicConfig::bitDescriptions[]={
     "Show HAT compilation phases",
     "Add -lineinfo to CUDA kernel compilation for profiling and debugging",
     "Show java code view of compute model",
+    "Verify that code model can be lowered to SSA",
 };
 #endif

--- a/hat/core/src/main/java/hat/Config.java
+++ b/hat/core/src/main/java/hat/Config.java
@@ -29,6 +29,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Config bits shared across Java and Native code.
+ *
+ * <p>
+ * After modifying this file, run the following command to sync the corresponding
+ * config with the native side.
+ * </p>
+ *
+ * <p>
+ * <code>
+ *     java @.ffisync
+ * </code>
+ * </p>
+ */
 public class Config {
 
     public record Bit(int index, int size, String name, String alt, String description) implements Comparable<Bit> {
@@ -67,47 +81,64 @@ public class Config {
 
     public static final Bit PLATFORM =  Bit.of(0,4, "PLATFORM","P", "FFI ONLY platform id (0-15)");
     public static final Bit DEVICE = Bit.nextBit(PLATFORM, 4, "DEVICE","D","FFI ONLY device id (0-15)");
+
     private static final Bit MINIMIZE_COPIES =  Bit.nextBit(DEVICE, "MINIMIZE_COPIES","MC","FFI ONLY Try to minimize copies");
     public boolean minimizeCopies() {
         return MINIMIZE_COPIES.isSet(this);
     }
+
     private static final Bit TRACE = Bit.nextBit(MINIMIZE_COPIES,"TRACE", "T","FFI ONLY trace code");
+
     private static final Bit PROFILE = Bit.nextBit(TRACE, "PROFILE", "P","FFI ONLY Turn on profiling");
+
     private static final Bit SHOW_CODE = Bit.nextBit(PROFILE,"SHOW_CODE","SC","Show generated code (PTX/OpenCL/CUDA)");
     public boolean showCode() {
         return SHOW_CODE.isSet(this);
     }
+
     private static final Bit SHOW_KERNEL_MODEL = Bit.nextBit(SHOW_CODE,"SHOW_KERNEL_MODEL", "SKM","Show (via OpWriter) Kernel Model");
     public boolean showKernelModel() {
         return SHOW_KERNEL_MODEL.isSet(this);
     }
+
     private static final Bit SHOW_COMPUTE_MODEL = Bit.nextBit(SHOW_KERNEL_MODEL,"SHOW_COMPUTE_MODEL", "SCM","Show (via OpWriter) Compute Model");
     public boolean showComputeModel() {
         return SHOW_COMPUTE_MODEL.isSet(this);
     }
+
     private static final Bit SHOW_DEVICE_INFO = Bit.nextBit(SHOW_COMPUTE_MODEL, "SHOW_DEVICE_INFO", "SDI","FFI show platform and device info");
+
     public static final Bit INFO = Bit.nextBit(SHOW_DEVICE_INFO, "INFO", "I","INFO level logging");
+
     public static final Bit WARN = Bit.nextBit(INFO, "WARN", "W","WARN(ing) level logging ");
+
     public static final Bit UNIT = Bit.nextBit(WARN, "UNIT", "U","UNIT test level logging  ");
+
     private static final Bit TRACE_COPIES = Bit.nextBit(UNIT, "TRACE_COPIES", "TC","FFI ONLY trace copies");
+
     private static final Bit TRACE_SKIPPED_COPIES = Bit.nextBit(TRACE_COPIES,"TRACE_SKIPPED_COPIES", "TSC",  "FFI ONLY Trace skipped copies (see MINIMIZE_COPIES) ");
+
     private static final Bit TRACE_ENQUEUES = Bit.nextBit(TRACE_SKIPPED_COPIES,"TRACE_ENQUEUES","TE", "FFI ONLY trace enqueued tasks");
+
     private static final Bit TRACE_CALLS= Bit.nextBit(TRACE_ENQUEUES, "TRACE_CALLS", "TCALLS","FFI ONLY trace calls (enter/leave)");
+
     private static final Bit SHOW_WHY = Bit.nextBit(TRACE_CALLS, "SHOW_WHY", "SW","FFI ONLY show why we decided to copy buffer (H to D)");
+
     private static final Bit SHOW_STATE = Bit.nextBit(SHOW_WHY, "SHOW_STATE", "SS","Show iface buffer state changes");
     public boolean showState(){return SHOW_STATE.isSet(this);}
+
     private static final Bit PTX = Bit.nextBit(SHOW_STATE, "PTX", "PTX","FFI (NVIDIA) ONLY pass PTX rather than C99 CUDA code");
     public boolean ptx(){return PTX.isSet(this);}
+
     private static final Bit INTERPRET = Bit.nextBit(PTX, "INTERPRET", "I","Interpret the code model rather than converting to bytecode");
     public boolean interpret() {
         return INTERPRET.isSet(this);
     }
-    private static final Bit HEADLESS = Bit.nextBit(INTERPRET, "HEADLESS", "H","Don't show UI");
 
+    private static final Bit HEADLESS = Bit.nextBit(INTERPRET, "HEADLESS", "H","Don't show UI");
     public boolean headless() {
         return HEADLESS.isSet(this) || Boolean.getBoolean("headless");
     }
-
     public boolean headless(String arg) {
         return headless() || "--headless".equals(arg);
     }
@@ -116,17 +147,13 @@ public class Config {
     public boolean showLoweredKernelModel() {
         return SHOW_LOWERED_KERNEL_MODEL.isSet(this);
     }
+
     private static final Bit SHOW_COMPILATION_PHASES = Bit.nextBit(SHOW_LOWERED_KERNEL_MODEL, "SHOW_COMPILATION_PHASES","SCP", "Show HAT compilation phases");
     public boolean showCompilationPhases() {
         return SHOW_COMPILATION_PHASES.isSet(this);
     }
-    private static final Bit PROFILE_CUDA_KERNEL = Bit.nextBit(SHOW_COMPILATION_PHASES, "PROFILE_CUDA_KERNEL","PCK", "Add -lineinfo to CUDA kernel compilation for profiling and debugging");
 
-    public boolean profileCUDAKernel() {
-        return PROFILE_CUDA_KERNEL.isSet(this);
-    }
-    private static final Bit SHOW_COMPUTE_MODEL_JAVA_CODE = Bit.nextBit(PROFILE_CUDA_KERNEL, "SHOW_COMPUTE_MODEL_JAVA_CODE","SCMJC", "Show java code view of compute model");
-
+    private static final Bit SHOW_COMPUTE_MODEL_JAVA_CODE = Bit.nextBit(SHOW_COMPILATION_PHASES, "SHOW_COMPUTE_MODEL_JAVA_CODE","SCMJC", "Show java code view of compute model");
     public boolean showComputeModelJavaCode() {
         return SHOW_COMPUTE_MODEL_JAVA_CODE.isSet(this);
     }
@@ -160,7 +187,6 @@ public class Config {
             HEADLESS,
             SHOW_LOWERED_KERNEL_MODEL,
             SHOW_COMPILATION_PHASES,
-            PROFILE_CUDA_KERNEL,
             SHOW_COMPUTE_MODEL_JAVA_CODE,
             CHECK_SSA_LOWERING
     );
@@ -177,7 +203,6 @@ public class Config {
 
     // These must sync with hat/backends/ffi/shared/include/config.h
     // We can create the above config by running main() below...
-
     public static Config fromEnvOrProperty() {
         if (System.getenv("HAT") instanceof String opts) {
             return fromSpec(opts);

--- a/hat/examples/tensors/src/main/java/tensors/Main.java
+++ b/hat/examples/tensors/src/main/java/tensors/Main.java
@@ -37,7 +37,6 @@ import hat.examples.common.ParseArgs.Options;
 import hat.types.F16;
 import hat.types.Tensor;
 import jdk.incubator.code.Reflect;
-import optkl.ifacemapper.MappableIface;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;


### PR DESCRIPTION
`PROFILE_CUDA_KERNEL` options merged with `PROFILE`.

To profile CUDA kernels, use the `HAT=PROFILE` option. 

This PR also fixes the `.ffisync` launch script. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1113/head:pull/1113` \
`$ git checkout pull/1113`

Update a local copy of the PR: \
`$ git checkout pull/1113` \
`$ git pull https://git.openjdk.org/babylon.git pull/1113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1113`

View PR using the GUI difftool: \
`$ git pr show -t 1113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1113.diff">https://git.openjdk.org/babylon/pull/1113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1113#issuecomment-5059699180)
</details>
