### PR TITLE
Implement multi-catch support in TryOp + unreflect fixes

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -35,6 +35,7 @@ import jdk.incubator.code.bytecode.impl.DynamicFuncCallOp;
 import jdk.incubator.code.bytecode.impl.LoweringTransformer;
 import jdk.incubator.code.dialect.core.CoreOp.*;
 import jdk.incubator.code.dialect.core.FunctionType;
+import jdk.incubator.code.dialect.core.TupleType;
 import jdk.incubator.code.dialect.core.VarType;
 import jdk.incubator.code.dialect.java.*;
 
@@ -172,7 +173,7 @@ public final class BytecodeGenerator {
     private final CodeBuilder cob;
     private final Label[] blockLabels;
     private final Block[][] blocksCatchMap;
-    private final BitSet allCatchBlocks;
+    private final CodeType[] catchBlockTypes;
     private final Label[] tryStartLabels;
     private final Map<Value, Slot> slots;
     private final Map<Block.Parameter, Value> singlePredecessorsValues;
@@ -196,7 +197,7 @@ public final class BytecodeGenerator {
         this.cob = cob;
         this.blockLabels = new Label[blocks.size()];
         this.blocksCatchMap = new Block[blocks.size()][];
-        this.allCatchBlocks = new BitSet();
+        this.catchBlockTypes = new CodeType[blocks.size()];
         this.tryStartLabels = new Label[blocks.size()];
         this.slots = new IdentityHashMap<>();
         this.singlePredecessorsValues = new IdentityHashMap<>();
@@ -481,7 +482,7 @@ public final class BytecodeGenerator {
             exceptionRegionsChange(catchBlocks);
 
             // If b is a catch block then the exception argument will be represented on the stack
-            if (allCatchBlocks.get(b.index())) {
+            if (catchBlockTypes[b.index()] != null) {
                 // Retain block argument for exception table generation
                 push(b.parameters().getFirst());
             }
@@ -963,10 +964,12 @@ public final class BytecodeGenerator {
                 }
                 case ExceptionRegionEnter op -> {
                     List<Block.Reference> enteringCatchBlocks = op.catchReferences();
+                    List<CodeType> enteringCatchTypes = op.catchTypes();
                     Block[] activeCatchBlocks = Arrays.copyOf(recentCatchBlocks, recentCatchBlocks.length + enteringCatchBlocks.size());
                     int i = recentCatchBlocks.length;
+                    int catchIndex = 0;
                     for (Block.Reference catchRef : enteringCatchBlocks) {
-                        allCatchBlocks.set(catchRef.targetBlock().index());
+                        catchBlockTypes[catchRef.targetBlock().index()] = enteringCatchTypes.get(catchIndex++);
                         activeCatchBlocks[i++] = catchRef.targetBlock();
                         setCatchStack(catchRef, recentCatchBlocks);
                     }
@@ -1022,12 +1025,17 @@ public final class BytecodeGenerator {
             // Exit catch blocks missing in the newCatchBlocks
             while (i >=0 && (i >= newCatchBlocks.length || recentCatchBlocks[i] != newCatchBlocks[i])) {
                 Block catchBlock = recentCatchBlocks[i--];
-                List<Block.Parameter> params = catchBlock.parameters();
-                if (!params.isEmpty()) {
-                    JavaType jt = (JavaType) params.get(0).type();
-                    cob.exceptionCatch(tryStartLabels[catchBlock.index()], currentLabel, getLabel(catchBlock.index()), jt.toNominalDescriptor());
-                } else {
-                    cob.exceptionCatchAll(tryStartLabels[catchBlock.index()], currentLabel, getLabel(catchBlock.index()));
+                CodeType catchType = catchBlockTypes[catchBlock.index()];
+                Label tryStart = tryStartLabels[catchBlock.index()];
+                Label handler = getLabel(catchBlock.index());
+                switch (catchType) {
+                    case TupleType tt ->
+                        tt.componentTypes().forEach(type ->
+                                cob.exceptionCatch(tryStart, currentLabel, handler, ((JavaType) type).toNominalDescriptor()));
+                    case ClassType ct ->
+                        cob.exceptionCatch(tryStart, currentLabel, handler, ct.toNominalDescriptor());
+                    default ->
+                        cob.exceptionCatchAll(tryStart, currentLabel, handler);
                 }
                 tryStartLabels[catchBlock.index()] = null;
             }
@@ -1236,7 +1244,7 @@ public final class BytecodeGenerator {
     private void assignBlockArguments(Block.Reference ref) {
         Block target = ref.targetBlock();
         List<Value> sargs = ref.arguments();
-        if (allCatchBlocks.get(target.index())) {
+        if (catchBlockTypes[target.index()] != null) {
             // Jumping to an exception handler, exception parameter is expected on stack
             Value value = sargs.getFirst();
             if (oprOnStack == value) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -1034,8 +1034,10 @@ public final class BytecodeGenerator {
                                 cob.exceptionCatch(tryStart, currentLabel, handler, ((JavaType) type).toNominalDescriptor()));
                     case ClassType ct ->
                         cob.exceptionCatch(tryStart, currentLabel, handler, ct.toNominalDescriptor());
-                    default ->
+                    case PrimitiveType pt when pt.equals(JavaType.VOID) ->
                         cob.exceptionCatchAll(tryStart, currentLabel, handler);
+                    default ->
+                        throw new IllegalArgumentException("Bad catch type: " + catchType);
                 }
                 tryStartLabels[catchBlock.index()] = null;
             }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -800,7 +800,7 @@ public final class BytecodeGenerator {
                                                       mDesc.insertParameterTypes(0, specialCaller));
                         }
                         ClassDesc ret = toClassDesc(op.resultType());
-                        if (ret.isClassOrInterface() && !ret.equals(mDesc.returnType())) {
+                        if (!ret.isPrimitive() && !ret.equals(mDesc.returnType())) {
                             // Explicit cast if method return type differs
                             cob.checkcast(ret);
                         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -42,6 +42,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.IntStream;
 
 import static jdk.incubator.code.Op.Lowerable.loweringTransformer;
 import static jdk.incubator.code.dialect.core.CoreOp.*;
@@ -4853,29 +4854,42 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             final Body.Builder connectedAncestorBody;
             final List<Body.Builder> resources;
             final Body.Builder body;
-            final List<Body.Builder> catchers;
+            final List<CodeType> catchTypes;
+            final List<Body.Builder> handlers;
 
             CatchBuilder(Body.Builder connectedAncestorBody, List<Body.Builder> resources, Body.Builder body) {
                 this.connectedAncestorBody = connectedAncestorBody;
                 this.resources = resources;
                 this.body = body;
-                this.catchers = new ArrayList<>();
+                this.catchTypes = new ArrayList<>();
+                this.handlers = new ArrayList<>();
             }
 
-            // @@@ multi-catch
             /**
              * Adds a catch body for handling exceptions of a specific type.
              *
-             * @param exceptionType the type of exception handled
+             * @param handlerExceptionType the type of exception handled
              * @param c a consumer that populates the catch body
              * @return this builder
              */
-            public CatchBuilder catch_(CodeType exceptionType, Consumer<Block.Builder> c) {
-                Body.Builder _catch = Body.Builder.of(connectedAncestorBody,
-                        CoreType.functionType(VOID, exceptionType));
-                c.accept(_catch.entryBlock());
-                catchers.add(_catch);
+            public CatchBuilder catch_(CodeType handlerExceptionType, Consumer<Block.Builder> c) {
+                return catch_(handlerExceptionType, handlerExceptionType, c);
+            }
 
+            /**
+             * Adds a catch body for handling exceptions of a specific catch type and a handler type.
+             *
+             * @param catchType the type of exception(s) caught, use {@link TupleType} for a multi-catch
+             * @param handlerExceptionType the type of exception handled by the catch body
+             * @param c a consumer that populates the catch body
+             * @return this builder
+             */
+            public CatchBuilder catch_(CodeType catchType, CodeType handlerExceptionType, Consumer<Block.Builder> c) {
+                Body.Builder _catch = Body.Builder.of(connectedAncestorBody,
+                        CoreType.functionType(VOID, handlerExceptionType));
+                c.accept(_catch.entryBlock());
+                handlers.add(_catch);
+                catchTypes.add(catchType);
                 return this;
             }
 
@@ -4889,7 +4903,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 Body.Builder _finally = Body.Builder.of(connectedAncestorBody, CoreType.FUNCTION_TYPE_VOID);
                 c.accept(_finally.entryBlock());
 
-                return new TryOp(resources, body, catchers, _finally);
+                return new TryOp(resources, body, catchTypes, handlers, _finally);
             }
 
             /**
@@ -4898,17 +4912,19 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
              * @return the completed try operation
              */
             public TryOp noFinalizer() {
-                return new TryOp(resources, body, catchers, null);
+                return new TryOp(resources, body, catchTypes, handlers, null);
             }
         }
 
         static final String NAME = "java.try";
+        static final String ATTRIBUTE_CATCH_TYPES = NAME + ".catchTypes";
         static final MethodRef AUTO_CLOSEABLE_CLOSE_METHOD = MethodRef.method(AutoCloseable.class, "close", void.class);
         static final MethodRef THROWABLE_ADD_SUPPRESSED_METHOD = MethodRef.method(Throwable.class, "addSuppressed", void.class, Throwable.class);
 
         final List<Body> resourcesBodies;
         final Body body;
-        final List<Body> catchBodies;
+        final List<CodeType> explicitCatchTypes;
+        final List<Body> handlers;
         final Body finallyBody;
 
         TryOp(ExternalizedOp def) {
@@ -4932,11 +4948,13 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             } else {
                 finalizer = null;
             }
-            List<Body.Builder> catchers = bodies.subList(
+            List<CodeType> catchTypes = optionalAttribute(def, ATTRIBUTE_CATCH_TYPES, true, TupleType.class)
+                    .map(TupleType::componentTypes).orElse(null);
+            List<Body.Builder> handlers = bodies.subList(
                     bodyIndex + 1,
                     bodies.size() - (finalizer == null ? 0 : 1));
 
-            this(resources, body, catchers, finalizer);
+            this(resources, body, catchTypes, handlers, finalizer);
         }
 
         TryOp(TryOp that, CodeContext cc, CodeTransformer ct) {
@@ -4946,7 +4964,8 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     .map(b -> b.transform(cc, ct).build(this))
                     .toList();
             this.body = that.body.transform(cc, ct).build(this);
-            this.catchBodies = that.catchBodies.stream()
+            this.explicitCatchTypes = that.explicitCatchTypes;
+            this.handlers = that.handlers.stream()
                     .map(b -> b.transform(cc, ct).build(this))
                     .toList();
             if (that.finallyBody != null) {
@@ -4963,7 +4982,8 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
         TryOp(List<Body.Builder> resourcesC,
               Body.Builder bodyC,
-              List<Body.Builder> catchersC,
+              List<CodeType> catchTypes,
+              List<Body.Builder> handlersC,
               Body.Builder finalizerC) {
             super(List.of());
 
@@ -4977,7 +4997,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             }
             this.resourcesBodies = resourcesC.stream().map(r -> r.build(this)).toList();
             this.body = requireBodySignature(NAME + " try", bodyC, CoreType.functionType(VOID, resourceTypes)).build(this);
-            this.catchBodies = catchersC.stream().map(c -> requireVoidReturnType(NAME + " catch", c, 1).build(this)).toList();
+            this.explicitCatchTypes = catchTypes == null ? null : List.copyOf(catchTypes);
+            this.handlers = handlersC.stream().map(c -> requireVoidReturnType(NAME + " catch", c, 1).build(this)).toList();
+            if (explicitCatchTypes != null && explicitCatchTypes.size() != handlers.size()) {
+                throw structuralException(NAME, "catch types %s require %d catch bodies, found %d".formatted(explicitCatchTypes, explicitCatchTypes.size(), handlers.size()));
+            }
             if (finalizerC != null) {
                 this.finallyBody = requireVoidBodySignature(NAME + " finalizer", finalizerC).build(this);
             } else {
@@ -4986,11 +5010,21 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         }
 
         @Override
+        public Map<String, Object> externalize() {
+            return explicitCatchTypes == null
+                    // avoid storing explicit catch types if they all match the handlers
+                    || IntStream.range(0, explicitCatchTypes.size()).allMatch(i ->
+                            explicitCatchTypes.get(i).equals(handlers.get(i).entryBlock().parameterTypes().getFirst()))
+                    ? Map.of()
+                    : Map.of("", CoreType.tupleType(explicitCatchTypes));
+        }
+
+        @Override
         public List<Body> bodies() {
             ArrayList<Body> bodies = new ArrayList<>();
             bodies.addAll(resourcesBodies);
             bodies.add(body);
-            bodies.addAll(catchBodies);
+            bodies.addAll(handlers);
             if (finallyBody != null) {
                 bodies.add(finallyBody);
             }
@@ -5012,10 +5046,19 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         }
 
         /**
+         * {@return the catch types}
+         */
+        public List<CodeType> catchTypes() {
+            return explicitCatchTypes == null
+                    ? handlers.stream().map(h -> h.entryBlock().parameterTypes().getFirst()).toList()
+                    : explicitCatchTypes;
+        }
+
+        /**
          * {@return the catch bodies}
          */
         public List<Body> catchBodies() {
-            return catchBodies;
+            return handlers;
         }
 
         /**
@@ -5036,7 +5079,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             // There is no recursion here, each time it is structurally different TryOp.
             if (!resourcesBodies.isEmpty()) {
                 b.transformBody(resourcesBodies.size() == 1
-                        && catchBodies.isEmpty()
+                        && handlers.isEmpty()
                         && finallyBody == null
                                 ? lowerBasicTryWithResources()
                                 : normalizeTryWithResources(),
@@ -5053,7 +5096,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             }
 
             // Simple case with no catch and finally bodies
-            if (catchBodies.isEmpty() && finallyBody == null) {
+            if (handlers.isEmpty() && finallyBody == null) {
                 b.transformBody(body, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.add(branch(exit.reference()));
@@ -5134,9 +5177,9 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             }
 
             // Inline the catch bodies
-            for (int i = 0; i < this.catchBodies.size(); i++) {
+            for (int i = 0; i < this.handlers.size(); i++) {
                 Block.Builder catcher = catchers.get(i);
-                Body catcherBody = this.catchBodies.get(i);
+                Body catcherBody = this.handlers.get(i);
                 // Create the throwable argument
                 Block.Parameter t = catcher.parameter(catcherBody.bodySignature().parameterTypes().get(0));
 
@@ -5307,14 +5350,14 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     block.context().mapValues(capturedValues(), entryBlock.parameters());
                     return normalizeExtendedTryWithResources(block.parentBody(), block.context(), new ArrayList<>());
                 };
-                if (catchBodies.isEmpty() && finallyBody == null) {
+                if (handlers.isEmpty() && finallyBody == null) {
                     entryBlock.add(normalizedTry.apply(entryBlock));
                 } else {
                     CatchBuilder catchBuilder = try_(entryBlock.parentBody(), tryB -> {
                         tryB.add(normalizedTry.apply(tryB));
                         tryB.add(core_yield());
                     });
-                    for (Body catcher : catchBodies) {
+                    for (Body catcher : handlers) {
                         catchBuilder.catch_(catcher.bodySignature().parameterTypes().getFirst(), catchB ->
                                 catchB.transformBody(catcher, catchB.parameters(), entryBlock.context(), CodeTransformer.COPYING_TRANSFORMER));
                     }
@@ -7287,7 +7330,25 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                              Body.Builder body,
                              List<Body.Builder> catchBodies,
                              Body.Builder finallyBody) {
-        return new TryOp(resourceBodies, body, catchBodies, finallyBody);
+        return try_(resourceBodies, body, null, catchBodies, finallyBody);
+    }
+
+    /**
+     * Creates a try or try-with-resources operation.
+     *
+     * @param resourceBodies the resources body builders
+     * @param body           the try body builder
+     * @param catchTypes     the explicit catch types, may be {@code null}
+     * @param catchBodies    the catch body builders
+     * @param finallyBody    the finalizer body builder, may be {@code null}
+     * @return the try or try-with-resources operation
+     */
+    public static TryOp try_(List<Body.Builder> resourceBodies,
+                             Body.Builder body,
+                             List<CodeType> catchTypes,
+                             List<Body.Builder> catchBodies,
+                             Body.Builder finallyBody) {
+        return new TryOp(resourceBodies, body, catchTypes, catchBodies, finallyBody);
     }
 
     //

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -1561,6 +1561,9 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
     public static final class ExceptionRegionEnter extends AbstractOp.Terminating
             implements JavaOp {
         static final String NAME = "exception.region.enter";
+        static final String ATTRIBUTE_CATCH_TYPES = NAME + ".catchTypes";
+
+        final List<CodeType> explicitCatchTypes;
 
         // First successor is the non-exceptional successor whose target indicates
         // the first block in the exception region.
@@ -1568,11 +1571,14 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         // each of which have one block argument whose type is an exception type.
 
         ExceptionRegionEnter(ExternalizedOp def) {
-            this(def.successors());
+            this(optionalAttribute(def, ATTRIBUTE_CATCH_TYPES, true, TupleType.class)
+                            .map(TupleType::componentTypes).orElse(null),
+                 def.successors());
         }
 
         ExceptionRegionEnter(ExceptionRegionEnter that, CodeContext cc) {
             super(that, cc);
+            this.explicitCatchTypes = that.explicitCatchTypes;
         }
 
         @Override
@@ -1580,11 +1586,24 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             return new ExceptionRegionEnter(this, cc);
         }
 
-        ExceptionRegionEnter(List<Block.Reference> references) {
+        ExceptionRegionEnter(List<CodeType> catchTypes, List<Block.Reference> references) {
             if (references.size() < 2) {
                 throw structuralException(NAME, "requires at least 2 successors, found %d".formatted(references.size()));
             }
+            if (catchTypes != null && catchTypes.size() != references.size() - 1) {
+                throw structuralException(NAME, "catch types %s require %d catch references, found %d"
+                        .formatted(catchTypes, catchTypes.size(), references.size() - 1));
+            }
             super(List.of(), references);
+            this.explicitCatchTypes = catchTypes == null ? null : List.copyOf(catchTypes);
+        }
+
+        @Override
+        public Map<String, Object> externalize() {
+            // avoid storing explicit catch types if they all match the handlers
+            return explicitCatchTypes == null || explicitCatchTypes.equals(catchTypes())
+                    ? Map.of()
+                    : Map.of("", CoreType.tupleType(explicitCatchTypes));
         }
 
         /**
@@ -1599,6 +1618,15 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
          */
         public List<Block.Reference> catchReferences() {
             return successors().subList(1, successors().size());
+        }
+
+        /**
+         * {@return the catch types}
+         */
+        public List<CodeType> catchTypes() {
+            return explicitCatchTypes == null
+                    ? catchReferences().stream().map(r -> r.targetBlock().parameterTypes().getFirst()).toList()
+                    : explicitCatchTypes;
         }
 
         @Override
@@ -5011,10 +5039,8 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
         @Override
         public Map<String, Object> externalize() {
-            return explicitCatchTypes == null
-                    // avoid storing explicit catch types if they all match the handlers
-                    || IntStream.range(0, explicitCatchTypes.size()).allMatch(i ->
-                            explicitCatchTypes.get(i).equals(handlers.get(i).entryBlock().parameterTypes().getFirst()))
+            // avoid storing explicit catch types if they all match the handlers
+            return explicitCatchTypes == null || explicitCatchTypes.equals(catchTypes())
                     ? Map.of()
                     : Map.of("", CoreType.tupleType(explicitCatchTypes));
         }
@@ -5115,6 +5141,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             List<Block.Builder> catchers = catchBodies().stream()
                     .map(catcher -> b.block())
                     .toList();
+            List<CodeType> catchTypes = catchTypes();
             Block.Builder catcherFinally;
             if (finallyBody == null) {
                 catcherFinally = null;
@@ -5122,13 +5149,16 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 catcherFinally = b.block();
                 catchers = new ArrayList<>(catchers);
                 catchers.add(catcherFinally);
+                catchTypes = new ArrayList<>(catchTypes());
+                catchTypes.add(VOID);
             }
 
             // Enter the try exception region
             List<Block.Reference> exitHandlers = catchers.stream()
                     .map(Block.Builder::reference)
                     .toList();
-            Op.Result enter = b.add(exceptionRegionEnter(tryRegionEnter.reference(), exitHandlers.reversed()));
+            Op.Result enter = b.add(exceptionRegionEnter(
+                    catchTypes.reversed(), tryRegionEnter.reference(), exitHandlers.reversed()));
 
             BiFunction<Block.Builder, Op, Block.Builder> tryExitTransformer;
             if (finallyBody != null) {
@@ -5357,9 +5387,13 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                         tryB.add(normalizedTry.apply(tryB));
                         tryB.add(core_yield());
                     });
-                    for (Body catcher : handlers) {
-                        catchBuilder.catch_(catcher.bodySignature().parameterTypes().getFirst(), catchB ->
-                                catchB.transformBody(catcher, catchB.parameters(), entryBlock.context(), CodeTransformer.COPYING_TRANSFORMER));
+                    List<CodeType> catchTypes = catchTypes();
+                    for (int i = 0; i < handlers.size(); i++) {
+                        Body catcher = handlers.get(i);
+                        catchBuilder.catch_(
+                                catchTypes.get(i),
+                                catcher.bodySignature().parameterTypes().getFirst(),
+                                catchB -> catchB.transformBody(catcher, catchB.parameters(), entryBlock.context(), CodeTransformer.COPYING_TRANSFORMER));
                     }
                     entryBlock.add(finallyBody == null
                             ? catchBuilder.noFinalizer()
@@ -6230,7 +6264,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @return the exception region enter operation
      */
     public static ExceptionRegionEnter exceptionRegionEnter(Block.Reference start, Block.Reference... catchers) {
-        return exceptionRegionEnter(start, List.of(catchers));
+        return exceptionRegionEnter(null, start, List.of(catchers));
     }
 
     /**
@@ -6241,10 +6275,24 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @return the exception region enter operation
      */
     public static ExceptionRegionEnter exceptionRegionEnter(Block.Reference start, List<Block.Reference> catchers) {
+        return exceptionRegionEnter(null, start, catchers);
+    }
+
+    /**
+     * Creates an exception region enter operation
+     *
+     * @param catchTypes the explicit catch types, may be {@code null}
+     * @param start      the reference to the block that enters the exception region
+     * @param catchers   the references to blocks handling exceptions thrown by blocks within the exception region
+     * @return the exception region enter operation
+     */
+    public static ExceptionRegionEnter exceptionRegionEnter(List<CodeType> catchTypes,
+                                                            Block.Reference start,
+                                                            List<Block.Reference> catchers) {
         List<Block.Reference> s = new ArrayList<>();
         s.add(start);
         s.addAll(catchers);
-        return new ExceptionRegionEnter(s);
+        return new ExceptionRegionEnter(catchTypes, s);
     }
 
     /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -1601,7 +1601,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         @Override
         public Map<String, Object> externalize() {
             // avoid storing explicit catch types if they all match the handlers
-            return explicitCatchTypes == null || explicitCatchTypes.equals(catchTypes())
+            return explicitCatchTypes == null || explicitCatchTypes.equals(implicitCatchTypes())
                     ? Map.of()
                     : Map.of("", CoreType.tupleType(explicitCatchTypes));
         }
@@ -1624,9 +1624,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
          * {@return the catch types}
          */
         public List<CodeType> catchTypes() {
-            return explicitCatchTypes == null
-                    ? catchReferences().stream().map(r -> r.targetBlock().parameterTypes().getFirst()).toList()
-                    : explicitCatchTypes;
+            return explicitCatchTypes == null ? implicitCatchTypes() : explicitCatchTypes;
+        }
+
+        private List<CodeType> implicitCatchTypes() {
+            return catchReferences().stream().map(r -> r.targetBlock().parameterTypes().getFirst()).toList();
         }
 
         @Override
@@ -5040,7 +5042,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         @Override
         public Map<String, Object> externalize() {
             // avoid storing explicit catch types if they all match the handlers
-            return explicitCatchTypes == null || explicitCatchTypes.equals(catchTypes())
+            return explicitCatchTypes == null || explicitCatchTypes.equals(implicitCatchTypes())
                     ? Map.of()
                     : Map.of("", CoreType.tupleType(explicitCatchTypes));
         }
@@ -5075,9 +5077,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
          * {@return the catch types}
          */
         public List<CodeType> catchTypes() {
-            return explicitCatchTypes == null
-                    ? handlers.stream().map(h -> h.entryBlock().parameterTypes().getFirst()).toList()
-                    : explicitCatchTypes;
+            return explicitCatchTypes == null ? implicitCatchTypes() : explicitCatchTypes;
+        }
+
+        private List<CodeType> implicitCatchTypes() {
+            return handlers.stream().map(h -> h.entryBlock().parameterTypes().getFirst()).toList();
         }
 
         /**

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5509,8 +5509,9 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             CodeType resourceType = resourcesBodies.getFirst().bodySignature().returnType();
             return syntheticBody(entryBlock -> {
                 Block.Builder afterAcquire = entryBlock.block(resourceType);
-                entryBlock.transformBody(resourcesBodies.getFirst(), List.of(), (block, op) -> {
-                    if (op instanceof CoreOp.YieldOp yop) {
+                Body resourceBody = resourcesBodies.getFirst();
+                entryBlock.transformBody(resourceBody, List.of(), (block, op) -> {
+                    if (op instanceof CoreOp.YieldOp yop && op.ancestorBody() == resourceBody) {
                         block.add(branch(afterAcquire.reference(block.context().getValue(yop.yieldValue()))));
                     } else {
                         return resolveStatementTarget(block, op);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -2463,6 +2463,36 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      */
     public sealed static abstract class StatementTargetOp extends AbstractOp.Terminating
             implements JavaOp, Op.Lowerable, JavaStatement {
+
+        @OpDeclaration("java.resolvedControlTransfer")
+        private static final class ResolvedStatementTarget extends StatementTargetOp {
+            private final Op target;
+            private final boolean continues;
+
+            ResolvedStatementTarget(StatementTargetOp source, Op target) {
+                super((Value) null);
+                this.target = target;
+                this.continues = source instanceof ContinueOp
+                        || source instanceof ResolvedStatementTarget resolved && resolved.continues;
+                setLocation(source.location());
+            }
+
+            @Override
+            public ResolvedStatementTarget transform(CodeContext cc, CodeTransformer ct) {
+                return new ResolvedStatementTarget(this, this.target);
+            }
+
+            @Override
+            Op target() {
+                return target;
+            }
+
+            @Override
+            public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
+                return lower(b, continues ? BranchTarget::continueBlock : BranchTarget::breakBlock);
+            }
+        }
+
         StatementTargetOp(StatementTargetOp that, CodeContext cc) {
             super(that, cc);
         }
@@ -2913,8 +2943,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         }
 
         boolean ifExitFromSynchronized(StatementTargetOp lop) {
-            Op target = lop.target();
-            return target == this || target.isAncestorOf(this);
+            return lop instanceof StatementTargetOp.ResolvedStatementTarget || lop.target() == this || lop.target().isAncestorOf(this);
         }
 
         @Override
@@ -5144,12 +5173,13 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             // try-catch-finally -> lower-level try form.
             // There is no recursion here, each time it is structurally different TryOp.
             if (!resourcesBodies.isEmpty()) {
-                b.transformBody(resourcesBodies.size() == 1
+                NormalizedBody normalized = resourcesBodies.size() == 1
                         && handlers.isEmpty()
                         && finallyBody == null
                                 ? lowerBasicTryWithResources()
-                                : normalizeTryWithResources(),
-                        b.context().getValues(capturedValues()),
+                                : normalizeTryWithResources();
+                b.transformBody(normalized.body(),
+                        b.context().getValues(normalized.captures()),
                         loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
                         block.add(branch(exit.reference()));
@@ -5414,11 +5444,12 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// @jls 14.20.3 try-with-resources
         /// @jls 14.20.3.1 Basic try-with-resources
         /// @jls 14.20.3.2 Extended try-with-resources
-        Body normalizeTryWithResources() {
+        NormalizedBody normalizeTryWithResources() {
             return syntheticBody(entryBlock -> {
                 Function<Block.Builder, TryOp> normalizedTry = block -> {
-                    block.context().mapValues(capturedValues(), entryBlock.parameters());
-                    return normalizeExtendedTryWithResources(block.parentBody(), block.context(), new ArrayList<>());
+                    block.context().mapValues(normalizationCaptures(), entryBlock.parameters());
+                    return normalizeExtendedTryWithResources(
+                            block.parentBody(), block.context(), new ArrayList<>());
                 };
                 if (handlers.isEmpty() && finallyBody == null) {
                     entryBlock.add(normalizedTry.apply(entryBlock));
@@ -5433,12 +5464,14 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                         catchBuilder.catch_(
                                 catchTypes.get(i),
                                 catcher.bodySignature().parameterTypes().getFirst(),
-                                catchB -> catchB.transformBody(catcher, catchB.parameters(), entryBlock.context(), CodeTransformer.COPYING_TRANSFORMER));
+                                catchB -> catchB.transformBody(
+                                        catcher, catchB.parameters(), entryBlock.context(), this::resolveStatementTarget));
                     }
                     entryBlock.add(finallyBody == null
                             ? catchBuilder.noFinalizer()
                             : catchBuilder.finally_(finB ->
-                                    finB.transformBody(finallyBody, List.of(), entryBlock.context(), CodeTransformer.COPYING_TRANSFORMER)));
+                                    finB.transformBody(
+                                            finallyBody, List.of(), entryBlock.context(), this::resolveStatementTarget)));
                 }
                 entryBlock.add(core_yield());
             });
@@ -5471,7 +5504,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// ```
         ///
         /// @jls 14.20.3.1 Basic try-with-resources
-        Body lowerBasicTryWithResources() {
+        NormalizedBody lowerBasicTryWithResources() {
             assert resourcesBodies.size() == 1;
             CodeType resourceType = resourcesBodies.getFirst().bodySignature().returnType();
             return syntheticBody(entryBlock -> {
@@ -5480,7 +5513,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     if (op instanceof CoreOp.YieldOp yop) {
                         block.add(branch(afterAcquire.reference(block.context().getValue(yop.yieldValue()))));
                     } else {
-                        block.add(op);
+                        return resolveStatementTarget(block, op);
                     }
                     return block;
                 });
@@ -5488,7 +5521,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 Value primaryExceptionVar = afterAcquire.add(var(afterAcquire.add(constant(type(Throwable.class), null))));
                 // @@@ following builder code may be refactored into a reflected template method transformation
                 afterAcquire.add(try_(entryBlock.parentBody(), tryEntry -> {
-                    tryEntry.transformBody(body, List.of(resource), afterAcquire.context(), CodeTransformer.COPYING_TRANSFORMER);
+                    tryEntry.transformBody(body, List.of(resource), afterAcquire.context(), this::resolveStatementTarget);
                 }).catch_(type(Throwable.class), catchB -> {
                     Block.Parameter thrown = catchB.parameters().getFirst();
                     catchB.add(varStore(primaryExceptionVar, thrown));
@@ -5531,7 +5564,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         TryOp normalizeExtendedTryWithResources(Body.Builder ancestorBody, CodeContext cc, List<Value> resourceValues) {
             Body resource = resourcesBodies.get(resourceValues.size());
             Body.Builder resourceBody = Body.Builder.of(ancestorBody, CoreType.functionType(resource.yieldType()), cc);
-            resourceBody.entryBlock().transformBody(resource, resourceValues, cc, CodeTransformer.COPYING_TRANSFORMER);
+            resourceBody.entryBlock().transformBody(resource, resourceValues, cc, this::resolveStatementTarget);
             Body.Builder basicBody = Body.Builder.of(ancestorBody, CoreType.functionType(VOID, List.of(resource.yieldType())), cc);
             Block.Builder bodyB = basicBody.entryBlock();
             resourceValues.add(bodyB.parameters().getFirst());
@@ -5539,23 +5572,43 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 bodyB.add(normalizeExtendedTryWithResources(basicBody, cc, resourceValues));
                 bodyB.add(core_yield());
             } else {
-                bodyB.transformBody(body, resourceValues, cc, CodeTransformer.COPYING_TRANSFORMER);
+                bodyB.transformBody(body, resourceValues, cc, this::resolveStatementTarget);
             }
             return try_(List.of(resourceBody), basicBody, List.of(), null);
         }
 
-        Body syntheticBody(Consumer<Block.Builder> c) {
-            List<Value> captures = capturedValues();
+        private record NormalizedBody(Body body, List<Value> captures) {
+        }
+
+        NormalizedBody syntheticBody(Consumer<Block.Builder> action) {
+            List<Value> captures = normalizationCaptures();
             Body.Builder syntheticBody = Body.Builder.of(null, CoreType.functionType(VOID, captures.stream().map(Value::type).toList()));
             Block.Builder entryBlock = syntheticBody.entryBlock();
             entryBlock.context().mapValues(captures, entryBlock.parameters());
-            c.accept(entryBlock);
-            return syntheticBody.build(unreachable());
+            action.accept(entryBlock);
+            return new NormalizedBody(syntheticBody.build(unreachable()), captures);
+        }
+
+        private Block.Builder resolveStatementTarget(Block.Builder block, Op op) {
+            block.add(switch (op) {
+                case StatementTargetOp.ResolvedStatementTarget _ -> op;
+                case StatementTargetOp st when st.target() == this || st.target().isAncestorOf(this) ->
+                        new StatementTargetOp.ResolvedStatementTarget(st, st.target());
+                default -> op;
+            });
+            return block;
+        }
+
+        private List<Value> normalizationCaptures() {
+            return capturedValues().stream()
+                    .filter(value -> !(value instanceof Result result
+                            && result.op().ancestorOp() instanceof LabeledOp labeled
+                            && labeled.labelIdentifier() == result))
+                    .toList();
         }
 
         boolean ifExitFromTry(StatementTargetOp lop) {
-            Op target = lop.target();
-            return target == this || target.isAncestorOf(this);
+            return lop instanceof StatementTargetOp.ResolvedStatementTarget || lop.target() == this || lop.target().isAncestorOf(this);
         }
 
         Block.Builder inlineFinalizer(Block.Builder block1, Value enter, BiFunction<Block.Builder, Op, Block.Builder> inherited) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2274,8 +2274,15 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // Pop block
             popBody();
 
+            List<CodeType> catchTypes = new ArrayList<>();
             List<Body.Builder> catchers = new ArrayList<>();
             for (JCTree.JCCatch catcher : tree.catchers) {
+
+                catchTypes.add(TreeInfo.isMultiCatch(catcher)
+                        ? CoreType.tupleType(((JCTree.JCTypeUnion) catcher.param.vartype).alternatives.stream()
+                                .map(a -> typeToCodeType(a.type)).toList())
+                        : typeToCodeType(catcher.param.vartype.type));
+
                 // Push body
                 pushBody(catcher.body, CoreType.functionType(JavaType.VOID, typeToCodeType(catcher.param.type)));
                 Op.Result exVariable = append(CoreOp.var(
@@ -2305,7 +2312,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 finalizer = null;
             }
 
-            result = append(JavaOp.try_(resources, body, catchers, finalizer));
+            result = append(JavaOp.try_(resources, body, catchTypes, catchers, finalizer));
         }
 
         @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -261,6 +261,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
             if (!ops.isEmpty()) {
                 tree.defs = tree.defs.prependList(opMethodDecls.toList());
                 tree = new JCReflectMethodsClassDecl(tree, ops);
+                Env<AttrContext> classEnv = typeEnvs.get(tree.sym);
+                classEnv.tree = tree;
+                classEnv.enclClass = tree;
                 currentClassSym.members().enter(codeModelsClassSym);
             }
         } finally {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -261,6 +261,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             if (!ops.isEmpty()) {
                 tree.defs = tree.defs.prependList(opMethodDecls.toList());
                 tree = new JCReflectMethodsClassDecl(tree, ops);
+                // store the tree for later phases
                 Env<AttrContext> classEnv = typeEnvs.get(tree.sym);
                 classEnv.tree = tree;
                 classEnv.enclClass = tree;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2544,9 +2544,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
     }
 
     boolean isReflectable(JCMethodDecl tree) {
-        return reflectAll || codeReflectionEnabled ||
+        return codeReflectionEnabled ||
                 (tree.body != null &&
-                tree.sym.attribute(crSyms.codeReflectionType.tsym) != null);
+                (reflectAll || tree.sym.attribute(crSyms.codeReflectionType.tsym) != null));
     }
 
     boolean isReflectable(JCFunctionalExpression expr) {

--- a/test/jdk/jdk/incubator/code/TestTryNested.java
+++ b/test/jdk/jdk/incubator/code/TestTryNested.java
@@ -433,6 +433,42 @@ public class TestTryNested {
     }
 
 
+    @Reflect
+    public static int multiCatch(int mode) {
+        try {
+            try {
+                if (mode == 0) {
+                    throw new IllegalArgumentException();
+                }
+                if (mode == 1) {
+                    throw new IllegalStateException();
+                }
+                if (mode == 2) {
+                    throw new ArithmeticException();
+                }
+                return 0;
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                return 10;
+            }
+        } catch (RuntimeException e) {
+            return 20;
+        }
+    }
+
+    @Test
+    public void testMultiCatch() {
+        CoreOp.FuncOp f = getFuncOp("multiCatch");
+        CoreOp.FuncOp lf = f.transform(CodeTransformer.LOWERING_TRANSFORMER);
+
+        for (CoreOp.FuncOp op : List.of(f, lf)) {
+            for (int mode = 0; mode < 4; mode++) {
+                Assertions.assertEquals(
+                        multiCatch(mode),
+                        Interpreter.invoke(MethodHandles.lookup(), op, mode));
+            }
+        }
+    }
+
     static CoreOp.FuncOp getFuncOp(String name) {
         Optional<Method> om = Stream.of(TestTryNested.class.getDeclaredMethods())
                 .filter(m -> m.getName().equals(name))

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -284,6 +284,20 @@ public class TestBytecode {
         return i;
     }
 
+    @Reflect
+    static int tryWithResourceFinallyInLoopWithBreakAndContinue(int i) {
+        for (int j = -5; j < 5; j++) {
+            try (var _ = Stream.empty()) {
+                if (i == j) continue;
+                i++;
+            } finally {
+                if (i == -j) break;
+                i = i + j;
+            }
+        }
+        return i;
+    }
+
     public record A(String s) {}
 
     @Reflect

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -285,9 +285,9 @@ public class TestBytecode {
     }
 
     @Reflect
-    static int tryWithResourceFinallyInLoopWithBreakAndContinue(int i) {
+    static int tryWithConditionalResourceFinallyInLoopWithBreakAndContinue(int i) {
         for (int j = -5; j < 5; j++) {
-            try (var _ = Stream.empty()) {
+            try (var _ = i % 2 == 1 ? Stream.empty(): Stream.empty()) {
                 if (i == j) continue;
                 i++;
             } finally {

--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -108,6 +108,7 @@ public final class BytecodeLift {
     private final Deque<ClassDesc> newStack;
     // Bytecode index for each exception table handler
     private final List<Integer> handlerBcis;
+    private final List<CodeType> catchTypes;
     // Converts classfile labels to bytecode indexes
     private final ToIntFunction<Label> label2Bci;
     // Current entered region result stack
@@ -133,11 +134,13 @@ public final class BytecodeLift {
                         smfi -> label2Bci.applyAsInt(smfi.target()),
                         smfi -> entryBlock.block(toBlockParams(smfi.stack()))))).orElseGet(Map::of);
         this.handlerBcis = new ArrayList<>();
+        this.catchTypes = new ArrayList<>();
         record RegionKey(int start, int end) {}
         Map<RegionKey, List<Integer>> grouped = new LinkedHashMap<>();
         for (ExceptionCatch ec : codeModel.exceptionHandlers()) {
             int handler = handlerBcis.size();
             handlerBcis.add(label2Bci.applyAsInt(ec.handler()));
+            catchTypes.add(ec.catchType().map(ct -> JavaType.type(ct.asSymbol())).orElse(JavaType.VOID));
             grouped.computeIfAbsent(new RegionKey(label2Bci.applyAsInt(ec.tryStart()), label2Bci.applyAsInt(ec.tryEnd())), _ -> new ArrayList<>())
                     .add(handler);
         }
@@ -177,8 +180,9 @@ public final class BytecodeLift {
 
     // Cache key for a handler reached from a concrete region stack
     record CatchTargetKey(int handler, List<Op.Result> enteredRegions) {}
-    // Find where the active region stack changes in bytecode
 
+    // Handlers block references with related catch types
+    record CatchEntries(List<CodeType> types, List<Block.Reference> references) {}
 
     private List<CodeType> toBlockParams(List<StackMapFrameInfo.VerificationTypeInfo> vtis) {
         ArrayList<CodeType> params = new ArrayList<>(vtis.size());
@@ -900,7 +904,8 @@ public final class BytecodeLift {
                 Block.Builder nextBlock = last ? targetBlock : newBlock(targetBlock.parameters());
                 Block.Reference nextReference = nextBlock.reference(currentBlock.parameters());
                 ExceptionRegion entered = targetEreStack.get(i);
-                Op.Result enter = currentBlock.add(JavaOp.exceptionRegionEnter(nextReference, catchReferences(ereStack, entered)));
+                CatchEntries catches = catchReferences(ereStack, entered);
+                Op.Result enter = currentBlock.add(JavaOp.exceptionRegionEnter(catches.types(), nextReference, catches.references()));
                 enteredRegionMap.put(enter, entered);
                 ereStack.add(enter);
                 currentBlock = nextBlock;
@@ -953,7 +958,8 @@ public final class BytecodeLift {
                 block.add(JavaOp.exceptionRegionExit(ereStack.removeLast(), nextReference));
             } else {
                 ExceptionRegion entered = targetEreStack.get(common + t - exits);
-                Op.Result enter = block.add(JavaOp.exceptionRegionEnter(nextReference, catchReferences(ereStack, entered)));
+                CatchEntries catches = catchReferences(ereStack, entered);
+                Op.Result enter = block.add(JavaOp.exceptionRegionEnter(catches.types(), nextReference, catches.references()));
                 enteredRegionMap.put(enter, entered);
                 ereStack.add(enter);
             }
@@ -964,20 +970,37 @@ public final class BytecodeLift {
     }
 
     // Build catch targets for one enter op
-    private List<Block.Reference> catchReferences(List<Op.Result> initialEreStack, ExceptionRegion enteredRegion) {
-        List<Block.Reference> catchReferences = new ArrayList<>();
-        List<Op.Result> enteredRegions = List.copyOf(initialEreStack);
-        for (int handler : enteredRegion.handlers().reversed()) {
+    private CatchEntries catchReferences(List<Op.Result> initialEreStack, ExceptionRegion enteredRegion) {
+        record Group(int firstHandler, int handlerBci, List<CodeType> catchTypes) {}
+
+        List<Group> groups = new ArrayList<>();
+        for (int handler : enteredRegion.handlers()) {
             int handlerBci = handlerBcis.get(handler);
-            CatchTargetKey key = new CatchTargetKey(handler, enteredRegions);
+            CodeType catchType = catchTypes.get(handler);
+            Group last = groups.isEmpty() ? null : groups.getLast();
+            if (last != null && last.handlerBci() == handlerBci) {
+                last.catchTypes().add(catchType);
+            } else {
+                groups.add(new Group(handler, handlerBci, new ArrayList<>(List.of(catchType))));
+            }
+        }
+
+        List<Block.Reference> references = new ArrayList<>();
+        List<CodeType> types = new ArrayList<>();
+        List<Op.Result> enteredRegions = List.copyOf(initialEreStack);
+        for (Group group : groups.reversed()) {
+            CatchTargetKey key = new CatchTargetKey(group.firstHandler(), enteredRegions);
             Block.Builder target = exceptionHandlerBlocks.get(key);
             if (target == null) { // Avoid ConcurrentModificationException
-                target = transitionBlockForTarget(enteredRegions, handlerBci);
+                target = transitionBlockForTarget(enteredRegions, group.handlerBci());
                 exceptionHandlerBlocks.put(key, target);
             }
-            catchReferences.add(target.reference());
+            references.add(target.reference());
+            types.add(group.catchTypes().size() == 1
+                    ? group.catchTypes().getFirst()
+                    : CoreType.tupleType(group.catchTypes()));
         }
-        return catchReferences;
+        return new CatchEntries(types, references);
     }
 
     Block.Reference successorWithStack(Block.Builder next) {

--- a/test/jdk/jdk/incubator/code/bytecode/lift/TestBytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/TestBytecodeLift.java
@@ -565,6 +565,24 @@ public class TestBytecodeLift {
         }
     }
 
+    @Reflect
+    static int multiCatch(int mode) {
+        try {
+            try {
+                return switch (mode) {
+                    case 1 -> throw new IllegalArgumentException();
+                    case 2 -> throw new IllegalStateException();
+                    case 4 -> throw new ArithmeticException();
+                    default -> 0;
+                };
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                return 10;
+            }
+        } catch (RuntimeException e) {
+            return 20;
+        }
+    }
+
     record TestData(Method testMethod) {
         @Override
         public String toString() {

--- a/test/jdk/jdk/incubator/code/lib/JavaHighInterpreter.java
+++ b/test/jdk/jdk/incubator/code/lib/JavaHighInterpreter.java
@@ -42,17 +42,17 @@ public class JavaHighInterpreter extends JavaLowInterpreter {
     }
 
     static class JavaHighEnv extends JavaLowInterpreter.JavaEnv {
-        private JavaHighEnv(Map<Value, Object> bindings, MethodHandles.Lookup l, Deque<List<Block>> catchBlocks) {
-            super(bindings, l, catchBlocks);
+        private JavaHighEnv(Map<Value, Object> bindings, MethodHandles.Lookup l, Deque<List<CatchHandler>> catchHandlers) {
+            super(bindings, l, catchHandlers);
         }
 
         @Override
         protected Env newEnv(Map<Value, Object> m) {
-            return new JavaHighEnv(m, l, catchBlocks);
+            return new JavaHighEnv(m, l, catchHandlers);
         }
 
         @Override
-        protected JavaEnv newEnv(Deque<List<Block>> catchBlocks) {
+        protected JavaEnv newEnv(Deque<List<CatchHandler>> catchBlocks) {
             return new JavaHighEnv(bindings, l, catchBlocks);
         }
 
@@ -270,20 +270,18 @@ public class JavaHighInterpreter extends JavaLowInterpreter {
     }
 
     private static Body findCatchBody(MethodHandles.Lookup l, JavaOp.TryOp tryOp, Throwable t) {
-        Body cb = null;
-        for (Body catchBody : tryOp.catchBodies()) {
-            Class<?> c;
+        for (int i = 0; i < tryOp.catchBodies().size(); i++) {
+            Body catchBody = tryOp.catchBodies().get(i);
+            CatchHandler handler = new CatchHandler(tryOp.catchTypes().get(i), catchBody.entryBlock());
             try {
-                c = resolveToClass(l, catchBody.entryBlock().parameters().getFirst().type());
+                if (handler.matches(l, t)) {
+                    return catchBody;
+                }
             } catch (ReflectiveOperationException ex) {
                 throw new InterpreterException(ex);
             }
-            if (c.isInstance(t)) {
-                cb = catchBody;
-                break;
-            }
         }
-        return cb;
+        return null;
     }
 
     static OpEffect processVoidEffect(TerminatingOpEffect eff, Body body, Env e) {

--- a/test/jdk/jdk/incubator/code/lib/JavaLowInterpreter.java
+++ b/test/jdk/jdk/incubator/code/lib/JavaLowInterpreter.java
@@ -25,6 +25,7 @@ import jdk.incubator.code.*;
 import jdk.incubator.code.dialect.core.CoreOp;
 import jdk.incubator.code.dialect.core.CoreType;
 import jdk.incubator.code.dialect.core.FunctionType;
+import jdk.incubator.code.dialect.core.TupleType;
 import jdk.incubator.code.dialect.core.VarType;
 import jdk.incubator.code.dialect.java.*;
 import jdk.incubator.code.extern.ExternalizedOp;
@@ -36,6 +37,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
@@ -44,23 +46,57 @@ public class JavaLowInterpreter extends Interpreter {
     public JavaLowInterpreter() {
     }
 
+    record CatchHandler(CodeType catchType, Block block) {
+
+        static List<CatchHandler> of(JavaOp.ExceptionRegionEnter op) {
+            List<Block.Reference> references = op.catchReferences();
+            List<CodeType> types = op.catchTypes();
+            return IntStream.range(0, references.size())
+                    .mapToObj(i -> new CatchHandler(types.get(i), references.get(i).targetBlock()))
+                    .toList().reversed();
+        }
+
+        boolean matches(MethodHandles.Lookup l, Throwable t) throws ReflectiveOperationException {
+            return matches(l, catchType, t);
+        }
+
+        private static boolean matches(MethodHandles.Lookup l, CodeType catchType, Throwable t)
+                throws ReflectiveOperationException {
+            return switch (catchType) {
+                case TupleType tt -> {
+                    boolean matched = false;
+                    for (CodeType componentType : tt.componentTypes()) {
+                        if (matches(l, componentType, t)) {
+                            matched = true;
+                            break;
+                        }
+                    }
+                    yield matched;
+                }
+                case ClassType ct -> resolveToClass(l, ct).isInstance(t);
+                case PrimitiveType pt when pt.equals(JavaType.VOID) -> true;
+                default -> throw new InterpreterException("Unexpected catch type: " + catchType);
+            };
+        }
+    }
+
     static class JavaEnv implements Env {
         final Map<Value, Object> bindings;
         final MethodHandles.Lookup l;
-        final Deque<List<Block>> catchBlocks;
+        final Deque<List<CatchHandler>> catchHandlers;
 
-        protected JavaEnv(Map<Value, Object> bindings, MethodHandles.Lookup l, Deque<List<Block>> catchBlocks) {
+        protected JavaEnv(Map<Value, Object> bindings, MethodHandles.Lookup l, Deque<List<CatchHandler>> catchHandlers) {
             this.bindings = bindings;
             this.l = l;
-            this.catchBlocks = catchBlocks;
+            this.catchHandlers = catchHandlers;
         }
 
         protected Env newEnv(Map<Value, Object> m) {
-            return new JavaEnv(m, l, catchBlocks);
+            return new JavaEnv(m, l, catchHandlers);
         }
 
-        protected JavaEnv newEnv(Deque<List<Block>> catchBlocks) {
-            return new JavaEnv(bindings, l, catchBlocks);
+        protected JavaEnv newEnv(Deque<List<CatchHandler>> catchHandlers) {
+            return new JavaEnv(bindings, l, catchHandlers);
         }
 
         Map<Value, Object> newBindings() {
@@ -102,16 +138,15 @@ public class JavaLowInterpreter extends Interpreter {
             return bindings.get(symbolicValue);
         }
 
-        public JavaEnv registerCatchBlocks(List<Block> catchBlocks) {
-            var stack = new ArrayDeque<>(this.catchBlocks);
-            stack.addFirst(catchBlocks);
+        public JavaEnv registerCatchHandlers(List<CatchHandler> handlers) {
+            var stack = new ArrayDeque<>(catchHandlers);
+            stack.addFirst(handlers);
             return newEnv(stack);
         }
 
-        public JavaEnv removeCatchBlocks(List<Block> catchBlocks) {
-            var stack = new ArrayDeque<>(this.catchBlocks);
-            List<Block> l = stack.removeFirst();
-            if (!l.equals(catchBlocks)) {
+        public JavaEnv removeCatchHandlers(List<CatchHandler> handlers) {
+            var stack = new ArrayDeque<>(catchHandlers);
+            if (!stack.removeFirst().equals(handlers)) {
                 throw new InternalError();
             }
             return newEnv(stack);
@@ -131,24 +166,23 @@ public class JavaLowInterpreter extends Interpreter {
         // @@@ review this area and improve the code
         private Optional<SuccessorEffect> findCatchBlock(Block executedBlock, Throwable t) {
             Block cb = null;
-            int blockListToRemove = 0;
+            int handlerListsToRemove = 0;
             l:
-            for (List<Block> blocks : catchBlocks) {
-                blockListToRemove++;
-                for (Block block : blocks) {
+            for (List<CatchHandler> handlers : catchHandlers) {
+                handlerListsToRemove++;
+                for (CatchHandler handler : handlers) {
+                    Block block = handler.block();
                     // make sure we are searching for catch block within the same body
                     if (block.parent() != executedBlock.parent()) {
                         break l;
                     }
-                    Class<?> c;
                     try {
-                        c = resolveToClass(l, block.parameters().getFirst().type());
+                        if (handler.matches(l, t)) {
+                            cb = block;
+                            break l;
+                        }
                     } catch (ReflectiveOperationException ex) {
                         throw new InterpreterException(ex);
-                    }
-                    if (c.isInstance(t)) {
-                        cb = block;
-                        break l;
                     }
                 }
             }
@@ -157,13 +191,12 @@ public class JavaLowInterpreter extends Interpreter {
                 return Optional.empty();
             }
 
-            var cbs = new ArrayDeque<>(catchBlocks);
-            while (blockListToRemove > 0) {
-                cbs.removeFirst();
-                blockListToRemove--;
+            var rhs = new ArrayDeque<>(catchHandlers);
+            while (handlerListsToRemove-- > 0) {
+                rhs.removeFirst();
             }
 
-            return Optional.of(new SuccessorEffect(cb, List.of(t), new JavaEnv(bindings, l, cbs)));
+            return Optional.of(new SuccessorEffect(cb, List.of(t), new JavaEnv(bindings, l, rhs)));
         }
 
         private JavaEnv removeAllCatchBlocks() {
@@ -537,14 +570,14 @@ public class JavaLowInterpreter extends Interpreter {
             }
             case JavaOp.ExceptionRegionEnter o -> {
                 JavaEnv je = (JavaEnv) e;
-                List<Block> catchBlocks = o.catchReferences().stream().map(Block.Reference::targetBlock).toList();
-                je = je.registerCatchBlocks(catchBlocks.reversed()); // store catch block from specific to general
+                List<CatchHandler> handlers = CatchHandler.of(o);
+                je = je.registerCatchHandlers(handlers);
                 yield new SuccessorEffect(o.startReference().targetBlock(), je.valuesOf(o.startReference().arguments()), je);
             }
             case JavaOp.ExceptionRegionExit o -> {
                 JavaEnv je = (JavaEnv) e;
-                List<Block> catchBlocks = o.enterOp().catchReferences().stream().map(Block.Reference::targetBlock).toList();
-                je = je.removeCatchBlocks(catchBlocks.reversed());
+                List<CatchHandler> handlers = CatchHandler.of(o.enterOp());
+                je = je.removeCatchHandlers(handlers);
                 yield new SuccessorEffect(o.endReference().targetBlock(), je.valuesOf(o.endReference().arguments()), je);
             }
             default -> throw new UnsupportedOperationException(op.toString());

--- a/test/langtools/tools/javac/reflect/BridgeTest.java
+++ b/test/langtools/tools/javac/reflect/BridgeTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ import java.lang.reflect.Method;
+ import java.util.Arrays;
+ import jdk.incubator.code.Reflect;
+
+/*
+ * @test
+ * @summary Verify reflected bridge generation
+ * @modules jdk.incubator.code
+ * @run main BridgeTest
+ */
+public class BridgeTest {
+
+    interface Value<T> {
+        T value();
+    }
+
+    static final class StringValue implements Value<String> {
+        @Override
+        @Reflect
+        public String value() {
+            return "string value";
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        var val = new StringValue().value();
+        if (!"string value".equals(val)) {
+            throw new AssertionError("Unexpected bridge invocation result: " + val);
+        }
+        Method bridge = Arrays.stream(StringValue.class.getDeclaredMethods())
+                              .filter(Method::isBridge)
+                              .findFirst()
+                              .orElseThrow();
+        if (bridge.getReturnType() != Object.class) {
+            throw new AssertionError("Unexpected bridge return type: " + bridge.getReturnType());
+        }
+    }
+}

--- a/test/langtools/tools/javac/reflect/BridgeTest.java
+++ b/test/langtools/tools/javac/reflect/BridgeTest.java
@@ -29,7 +29,10 @@
  * @test
  * @summary Verify reflected bridge generation
  * @modules jdk.incubator.code
+ * @build BridgeTest
+ * @build CodeReflectionTester
  * @run main BridgeTest
+ * @run main CodeReflectionTester BridgeTest$StringValue
  */
 public class BridgeTest {
 
@@ -40,6 +43,12 @@ public class BridgeTest {
     static final class StringValue implements Value<String> {
         @Override
         @Reflect
+        @IR("""
+            func @"value" (%0 : java.type:"BridgeTest$StringValue")java.type:"java.lang.String" -> {
+                %1 : java.type:"java.lang.String" = constant @"string value";
+                return %1;
+            };
+            """)
         public String value() {
             return "string value";
         }

--- a/test/langtools/tools/javac/reflect/CodeReflectionTester.java
+++ b/test/langtools/tools/javac/reflect/CodeReflectionTester.java
@@ -52,7 +52,7 @@ public class CodeReflectionTester {
 
     public static void check(Class<?> clazz) throws ReflectiveOperationException {
         for (Method m : clazz.getDeclaredMethods()) {
-            check(m);
+            if (!m.isBridge()) check(m);
         }
         for (Field f : clazz.getDeclaredFields()) {
             check(f);

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -207,7 +207,7 @@ public class DenotableTypesTest {
     @Reflect
     @IR("""
             func @"test10" ()java.type:"void" -> {
-                java.try
+                java.try @Tuple<Tuple<java.type:"DenotableTypesTest$XA", java.type:"DenotableTypesTest$XB">>
                     ()java.type:"void" -> {
                         invoke @java.ref:"DenotableTypesTest::g():void";
                         yield;


### PR DESCRIPTION
Missing multi-catch support in TryOp is one of the last blockers.
This PR extends TryOp and ExceptionRegionEnter with optional explicit catch types. A multi-catch is represented by an explicit TupleType catch type.

Additionally it fixes break and continue targets resolution in `TryOp` multi-stage lowering, BytecodeGenerator missing checkcast for array, and `ReflectMethods` with `-XDreflectAll` option to skip abstract interface methods.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1114/head:pull/1114` \
`$ git checkout pull/1114`

Update a local copy of the PR: \
`$ git checkout pull/1114` \
`$ git pull https://git.openjdk.org/babylon.git pull/1114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1114`

View PR using the GUI difftool: \
`$ git pr show -t 1114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1114.diff">https://git.openjdk.org/babylon/pull/1114.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1114#issuecomment-5071316236)
</details>
