### PR TITLE
8388392: Illegal try/finally exception table

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/ExceptionTableCompactor.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/ExceptionTableCompactor.java
@@ -55,15 +55,11 @@ public final class ExceptionTableCompactor implements CodeTransform {
                 last = ec;
             }
         } else {
+            if (last != null) {
+                cob.with(last);
+                last = null;
+            }
             cob.with(coe);
-        }
-    }
-
-    @Override
-    public void atEnd(CodeBuilder cob) {
-        if (last != null) {
-            cob.with(last);
-            last = null;
         }
     }
 }

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -552,6 +552,18 @@ public class TestBytecode {
     }
 
     @Reflect
+    static boolean finallyPassingThrough(boolean flag) {
+        try {
+            if (flag) {
+                return flag;
+            }
+        } finally {
+            flag = !flag;
+        }
+        return flag;
+    }
+
+    @Reflect
     static long doubleUseOfOperand(int x) {
         long piece = x;
         return piece * piece;


### PR DESCRIPTION
`ExceptionTableCompactor` delayed the final transformed `ExceptionCatch` pseudo-instruction, causing the chained `BranchCompactor` to receive it out of order and miss important branch-barrier information.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8388392](https://bugs.openjdk.org/browse/JDK-8388392): Illegal try/finally exception table (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1115/head:pull/1115` \
`$ git checkout pull/1115`

Update a local copy of the PR: \
`$ git checkout pull/1115` \
`$ git pull https://git.openjdk.org/babylon.git pull/1115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1115`

View PR using the GUI difftool: \
`$ git pr show -t 1115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1115.diff">https://git.openjdk.org/babylon/pull/1115.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1115#issuecomment-5088477064)
</details>
