### PR TITLE
BytecodeGenerator fix to handle definitive assignment models + test

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -343,11 +343,9 @@ public final class BytecodeGenerator {
     private static boolean canDefer(VarOp op) {
         if (op.isUninitialized()) {
             // Uninitialized var with single store dominating to all its uses can be deferred
-            var storeUses = op.result().uses().stream().filter(u -> u.op() instanceof VarAccessOp.VarStoreOp).toList();
-            if (storeUses.size() == 1) {
-                return op.result().uses().stream().allMatch(u -> u.isDominatedBy(storeUses.getFirst()));
-            }
-            return false;
+            var uses = op.result().uses();
+            var storeUses = uses.stream().filter(u -> u.op() instanceof VarAccessOp.VarStoreOp).toList();
+            return storeUses.size() == 1 && uses.stream().allMatch(u -> u.isDominatedBy(storeUses.getFirst()));
         } else {
             // Initialized var used only for loads or var with a single-use entry block parameter operand can be deferred
             return op.result().uses().stream().allMatch(u -> u.op() instanceof VarAccessOp.VarLoadOp)

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -340,11 +340,21 @@ public final class BytecodeGenerator {
         return !op.resultType().equals(JavaType.J_L_CLASS);
     }
 
-    // Single-use var or var with a single-use entry block parameter operand can be deferred
     private static boolean canDefer(VarOp op) {
-        return op.isUninitialized()
-            || !moreThanOneUse(op.result())
-            || op.initOperand() instanceof Block.Parameter bp && bp.declaringBlock().isEntryBlock() && !moreThanOneUse(bp);
+        if (op.isUninitialized()) {
+            // Uninitialized var with single store dominating to all its uses can be deferred
+            var storeUses = op.result().uses().stream().filter(u -> u.op() instanceof VarAccessOp.VarStoreOp).toList();
+            if (storeUses.size() == 1) {
+                return op.result().uses().stream().allMatch(u -> u.isDominatedBy(storeUses.getFirst()));
+            }
+            return false;
+        } else {
+            // Initialized var used only for loads or var with a single-use entry block parameter operand can be deferred
+            return op.result().uses().stream().allMatch(u -> u.op() instanceof VarAccessOp.VarLoadOp)
+                    || op.initOperand() instanceof Block.Parameter bp
+                        && bp.declaringBlock().isEntryBlock()
+                        && !moreThanOneUse(bp);
+        }
     }
 
     // Var load can be deferred when not used as immediate operand
@@ -506,7 +516,17 @@ public final class BytecodeGenerator {
                         }
                     }
                     case VarOp op when op.isUninitialized() -> {
-                        // Do nothing
+                        if (!canDefer(op)) {
+                            switch (toTypeKind(op.resultType()).asLoadable()) {
+                                case INT -> cob.iconst_0();
+                                case LONG -> cob.lconst_0();
+                                case FLOAT -> cob.fconst_0();
+                                case DOUBLE -> cob.dconst_0();
+                                case REFERENCE -> cob.aconst_null();
+                                default -> throw new IllegalArgumentException("Bad variable type: " + toTypeKind(op.resultType()));
+                            }
+                            storeIfUsed(op.result());
+                        }
                     }
                     case VarOp op -> {
                         //     %1 : Var<int> = var %0 @"i";

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -298,6 +298,15 @@ public class TestBytecode {
         return i;
     }
 
+    @Reflect
+    static int definitiveAssignment(int i) {
+        int assigned;
+        if (i > 0 && (assigned = i) > 1) {
+            return assigned;
+        }
+        return -1;
+    }
+
     public record A(String s) {}
 
     @Reflect


### PR DESCRIPTION
The definitive-assignment model conflicted with `BytecodeGenerator` optimistic assumption that code generation for all uninitialized variables could be deferred, producing invalid bytecode.

This patch does not perform definitive-assignment analysis. Instead, it initializes problematic variables with default values to satisfy stackmap verification for the generated bytecode.

Additionally, it extends deferral of initialized variables from single-use variables to all variables used only by load operations.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1116/head:pull/1116` \
`$ git checkout pull/1116`

Update a local copy of the PR: \
`$ git checkout pull/1116` \
`$ git pull https://git.openjdk.org/babylon.git pull/1116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1116`

View PR using the GUI difftool: \
`$ git pr show -t 1116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1116.diff">https://git.openjdk.org/babylon/pull/1116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1116#issuecomment-5118866002)
</details>
