### PR TITLE
Hat move to static thread methods from fields

### DIFF
--- a/hat/backends/java/seq/src/main/java/hat/backend/java/JavaSequentialBackend.java
+++ b/hat/backends/java/seq/src/main/java/hat/backend/java/JavaSequentialBackend.java
@@ -34,7 +34,8 @@ public class JavaSequentialBackend extends JavaBackend {
     @Override
     public void dispatchKernel(KernelCallGraph kernelCallGraph, KernelContext kernelContext, Object... args) {
       //  KernelEntrypoint kernelEntrypoint = kernelCallGraph.entrypoint;
-        for (kernelContext.gix = 0; kernelContext.gix < kernelContext.gsx; kernelContext.gix++) {
+        throw new RuntimeException("We need NDRange");
+       /* for (kernelContext.gix = 0; kernelContext.gix < kernelContext.gsx; kernelContext.gix++) {
             try {
                 args[0] = kernelContext;
                 kernelCallGraph.callDag.entryPoint.method().invoke(null, args);
@@ -42,6 +43,6 @@ public class JavaSequentialBackend extends JavaBackend {
                 throw new RuntimeException(e);
             }
 
-        }
+        }*/
     }
 }

--- a/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
+++ b/hat/backends/jextracted/shared/src/main/java/hat/backend/jextracted/C99JExtractedBackend.java
@@ -69,9 +69,10 @@ public abstract class C99JExtractedBackend extends JExtractedBackend {
         }
 
         public void dispatch(KernelContext kernelContext, Object[] args) {
-            this.kernelContext.gsx(kernelContext.gsx);
-            args[0] = this.kernelContext;
-            ArgArray.update(argArray, kernelCallGraph, args);
+            throw new RuntimeException("We need NDRANGE");
+           // this.kernelContext.gsx(kernelContext.gsx);
+           // args[0] = this.kernelContext;
+          //  ArgArray.update(argArray, kernelCallGraph, args);
             //kernelBridge.ndRange(this.argArray);
         }
     }

--- a/hat/core/src/main/java/hat/ComputeContext.java
+++ b/hat/core/src/main/java/hat/ComputeContext.java
@@ -171,9 +171,8 @@ public class ComputeContext implements ArenaAndLookupCarrier, BufferTracker {
             });
         }
         Object[] args = lambda(lookup(),kernelCallSite.lambdaOp).getQuotedCapturedValues(kernelCallSite.quoted, kernelCallSite.kernelCallGraph.callDag.entryPoint.method());
-        KernelContext kernelContext = accelerator.range(ndRange);
-        args[0] = kernelContext;
-        accelerator.backend.dispatchKernel(kernelCallSite.kernelCallGraph, kernelContext, args);
+        args[0] = accelerator.range(ndRange);
+        accelerator.backend.dispatchKernel(kernelCallSite.kernelCallGraph, (KernelContext) args[0], args);
     }
 
 

--- a/hat/core/src/main/java/hat/KernelContext.java
+++ b/hat/core/src/main/java/hat/KernelContext.java
@@ -24,6 +24,8 @@
  */
 package hat;
 
+import optkl.util.Regex;
+
 /**
  * Created by a dispatch call to a kernel from within a Compute method and 'conceptually' passed to a kernel.
  * <p>
@@ -40,38 +42,38 @@ package hat;
  */
 public class KernelContext {
     // Global accesses
-    public int gix;
-    public int giy;
-    public int giz;
+  //  public int gix;
+   // public int giy;
+   // public int giz;
 
-    public final int gsx;
-    public final int gsy;
-    public final int gsz;
+   // public final int gsx;
+   // public final int gsy;
+   // public final int gsz;
 
     // Local accesses within a group
-    public int lix;
-    public int liy;
-    public int liz;
+   // public int lix;
+   // public int liy;
+   // public int liz;
 
     // Specify sizes for the local group sizes
-    public int lsx;
-    public int lsy;
-    public int lsz;
+   // public int lsx;
+ //   public int lsy;
+ //   public int lsz;
 
     // Specify group/block index
-    public int bix;
-    public int biy;
-    public int biz;
+  //  public int bix;
+  //  public int biy;
+  //  public int biz;
 
     // Specify the number of blocks
-    public int bsx;
-    public int bsy;
-    public int bsz;
+  //  public int bsx;
+  //  public int bsy;
+  //  public int bsz;
 
     // Warp size
-    public int wrs;
+   // public int wrs;
 
-    final int dimensions;
+   // final int dimensions;
 
     public final NDRange ndRange;
 
@@ -81,7 +83,7 @@ public class KernelContext {
         }
 
         this.ndRange = ndRange;
-        switch (ndRange) {
+      /*  switch (ndRange) {
             case NDRange.NDRange1D ndRange1D -> {
                 this.gsx = ((NDRange.M1D)(ndRange1D.global())).x();
                 this.gsy = 1;
@@ -102,14 +104,36 @@ public class KernelContext {
             }
             default -> throw new IllegalArgumentException("Unknown NDRange type: "  + ndRange.getClass());
 
-        }
+        }*/
     }
+
+
+
+    public final static Regex threadAccessRegex = Regex.of("(([GLB][SI][XYZ])|WRS|barrier)");
 
     /**
      * Marker called by kernel code which is mapped to a barrier implementation in the target language.
      */
-    public void barrier() {
+    public static void barrier() {
         // empty method - this is just a marker for the HAT Kernels
     }
-
+    public static int GIX(){return 0;};
+    public static int GIY(){return 0;};
+    public static int GIZ(){return 0;};
+    public static int GSX(){return 0;};
+    public static int GSY(){return 0;};
+    public static int GSZ(){return 0;};
+    public static int BIX(){return 0;};
+    public static int BIY(){return 0;};
+    public static int BIZ(){return 0;};
+    public static int BSX(){return 0;};
+    public static int BSY(){return 0;};
+    public static int BSZ(){return 0;};
+    public static int LIX(){return 0;};
+    public static int LIY(){return 0;};
+    public static int LIZ(){return 0;};
+    public static int LSX(){return 0;};
+    public static int LSY(){return 0;};
+    public static int LSZ(){return 0;};
+    public static int WRS(){return 0;};
 }

--- a/hat/core/src/main/java/hat/backend/BackendAdaptor.java
+++ b/hat/core/src/main/java/hat/backend/BackendAdaptor.java
@@ -56,7 +56,8 @@ public abstract class BackendAdaptor extends Backend {
     @Override
     public void dispatchKernel(KernelCallGraph kernelCallGraph, KernelContext kernelContext, Object... args) {
       //  KernelEntrypoint kernelEntrypoint = kernelCallGraph.entrypoint;
-        for (kernelContext.gix = 0; kernelContext.gix < kernelContext.gsx; kernelContext.gix++) {
+        // We need to use NDRANGE here?
+     /*   for (kernelContext.gix = 0; kernelContext.gix < kernelContext.gsx; kernelContext.gix++) {
             try {
                 args[0] = kernelContext;
                 kernelCallGraph.callDag.entryPoint.method().invoke(null, args);
@@ -65,7 +66,7 @@ public abstract class BackendAdaptor extends Backend {
             } catch (InvocationTargetException e) {
                 throw new RuntimeException(e);
             }
-        }
+        } */
     }
 
 

--- a/hat/core/src/main/java/hat/backend/java/WorkStealer.java
+++ b/hat/core/src/main/java/hat/backend/java/WorkStealer.java
@@ -72,9 +72,10 @@ public class WorkStealer {
                         try {
                             int myChunk;
                             while ((myChunk = taskCount.getAndIncrement()) < (range / chunkSize) + 1) {
-                                for (kernelContext.gix = myChunk * chunkSize; kernelContext.gix < (myChunk + 1) * chunkSize && kernelContext.gix < range; kernelContext.gix++) {
+                                throw new RuntimeException("We need NDRANGE fixed up here ");
+                              /*  for (kernelContext.gix = myChunk * chunkSize; kernelContext.gix < (myChunk + 1) * chunkSize && kernelContext.gix < range; kernelContext.gix++) {
                                     rangeConsumer.accept(kernelContext);
-                                }
+                                } */
                             }
                         } finally {
                             //  System.out.println("Thread #"+Thread.currentThread()+" done");
@@ -107,16 +108,18 @@ public class WorkStealer {
         if (threadCount > 1) {
             rendezvous(setupBarrier);
             this.taskCount.set(0);
-            this.range = kernelContext.gsx;
-            this.rangeConsumer = rangeConsumer;
+            throw new RuntimeException("We need NDRANGE");
+            //this.range = kernelContext.gsx;
+           // this.rangeConsumer = rangeConsumer;
 
-            rendezvous(startBarrier);
+           // rendezvous(startBarrier);
             // This should start all threads
-            rendezvous(doneBarrier);
+            //rendezvous(doneBarrier);
         } else {
-            for (kernelContext.gix = 0; kernelContext.gix < range; kernelContext.gix++) {
-                rangeConsumer.accept(kernelContext);
-            }
+            throw new RuntimeException("We need NDRANGE");
+           // for (kernelContext.gix = 0; kernelContext.gix < range; kernelContext.gix++) {
+             //   rangeConsumer.accept(kernelContext);
+           // }
         }
     }
 

--- a/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
+++ b/hat/core/src/main/java/hat/callgraph/KernelCallGraph.java
@@ -78,8 +78,8 @@ public class KernelCallGraph implements LookupCarrier {
     public final Set<Class<? extends MappableIface>> accessedMappableIfaceClasses;
     public final Set<Class<? extends IfaceValue.vec>> accessedVecClasses;
     public final Set<Class<? extends S16ImplOfF16>> accessedFP16Classes;
-    public final Set<String> accessedKernelContextFields;
-
+  //  public final Set<String> accessedKernelContextFields;
+    public final Set<String> accessedKernelContextMethods;
     private boolean usesBarrier;
     private boolean usesAtomics;
     private final VarTable varTable;
@@ -90,9 +90,14 @@ public class KernelCallGraph implements LookupCarrier {
         this.computeCallGraph = computeCallGraph;
         var inlinedEntryPoint = inlineEntryPoint(kernelFunction);
         this.usesBarrier = OpHelper.Invoke.stream(lookup(), inlinedEntryPoint)
-                .anyMatch(invoke -> invoke.refIs(KernelContext.class) && invoke.named("barrier"));
-        this.accessedKernelContextFields = new HashSet<>(OpHelper.FieldAccess.stream(lookup(), inlinedEntryPoint)
-                .filter(fieldAccess -> fieldAccess.refType(KernelContext.class)).map(OpHelper.FieldAccess::name).toList()
+                .anyMatch(invoke -> invoke instanceof OpHelper.Invoke.Static invokeStatic && invokeStatic.refIs(KernelContext.class) && invokeStatic.named("barrier"));
+        // We should be able to remove these field access checks once we pivot to using direct access to KernelContext static calls.
+    //    this.accessedKernelContextFields = new HashSet<>(OpHelper.FieldAccess.stream(lookup(), inlinedEntryPoint)
+      //          .filter(fieldAccess -> fieldAccess.refType(KernelContext.class)).map(OpHelper.FieldAccess::name).toList()
+       // );
+        this.accessedKernelContextMethods = new HashSet<>(OpHelper.Invoke.stream(lookup(), inlinedEntryPoint)
+                .filter(invoke -> invoke instanceof OpHelper.Invoke.Static)
+                .filter(invokeStatic -> invokeStatic.refIs(KernelContext.class) && invokeStatic.nameMatchesRegex(KernelContext.threadAccessRegex)).map(OpHelper.Invoke::name).toList()
         );
         this.accessedTypes = inlinedEntryPoint.elements()
                 .filter(Op.class::isInstance).map(ce -> ((Op) ce).resultType())
@@ -208,9 +213,9 @@ public class KernelCallGraph implements LookupCarrier {
                     var ssaInline = SSA.transform(inline.transform(CodeTransformer.LOWERING_TRANSFORMER));
                     var exitBlockBuilder = jdk.incubator.code.dialect.core.Inliner.inline(
                             blockbuilder, ssaInline,
-                            blockbuilder.context().getValues(invoke.op().operands()), (_, value) -> {
-                                if (value != null) {
-                                    blockbuilder.context().mapValue(invoke.op().result(), value);
+                            blockbuilder.context().getValues(invoke.op().operands()), (_, v) -> {
+                                if (v != null) {
+                                    blockbuilder.context().mapValue(invoke.op().result(), v);
                                 }
                             });
                     if (!exitBlockBuilder.parameters().isEmpty()) {

--- a/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
+++ b/hat/core/src/main/java/hat/codebuilders/C99HATKernelBuilder.java
@@ -147,7 +147,8 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     }
 
     protected boolean useThreadConstruct(String construct) {
-        return kernelCallGraph.accessedKernelContextFields.contains(construct);
+        return// kernelCallGraph.accessedKernelContextFields.contains(construct)||
+                 kernelCallGraph.accessedKernelContextMethods.contains(construct.toUpperCase());
     }
 
     protected boolean useAtomic() {
@@ -991,7 +992,9 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
     public final T invokeOp(JavaOp.InvokeOp invokeOp) {
         MethodHandles.Lookup lookup = scopedCodeBuilderContext().lookup();
         var invoke = invoke(lookup, invokeOp);
-        if (isVecInvoke(invoke)) { // hacked for vec op calls.
+        if (invoke instanceof Invoke.Static staticInvoke && staticInvoke.refIs(KernelContext.class) && invoke.nameMatchesRegex(KernelContext.threadAccessRegex)){
+            id("HAT_"+invoke.name().toUpperCase()); // toUppercase is for barrier()
+        }else if (isVecInvoke(invoke)) { // hacked for vec op calls.
             handleInvoke(self(), invoke);
         } else if (isVectorOperation(lookup, invokeOp)) {
             handleVectorOperations(invoke);
@@ -1136,7 +1139,7 @@ public abstract class C99HATKernelBuilder<T extends C99HATKernelBuilder<T>> exte
                         List<Boolean> referenceList = invoke.op()
                                 .operands()
                                 .stream()
-                                .map(value -> isArrayReference(scopedCodeBuilderContext.lookup(), value))
+                                .map(v -> isArrayReference(scopedCodeBuilderContext.lookup(), v))
                                 .toList();
                         paren(_ -> {
                             int[] counter = {0};

--- a/hat/core/src/main/java/hat/dialect/HATThreadOp.java
+++ b/hat/core/src/main/java/hat/dialect/HATThreadOp.java
@@ -69,7 +69,7 @@ public abstract sealed class HATThreadOp extends HATOp implements Dim, LoadOrCon
             case "bsx" -> new HATThreadOp.HAT_BS.HAT_BSX();
             case "bsy" -> new HATThreadOp.HAT_BS.HAT_BSY();
             case "bsz" -> new HATThreadOp.HAT_BS.HAT_BSZ();
-            case "wrs" -> new HATThreadOp.HAT_WARP_SIZE();
+            case "WARPSZ" -> new HATThreadOp.HAT_WARP_SIZE();
             default -> throw new IllegalStateException("[ERROR] Illegal/unsupported parallel construct: " + name);
         };
     }

--- a/hat/core/src/main/java/hat/phases/HATBarrierPhase.java
+++ b/hat/core/src/main/java/hat/phases/HATBarrierPhase.java
@@ -24,6 +24,7 @@
  */
 package hat.phases;
 
+import hat.KernelContext;
 import hat.dialect.HATBarrierOp;
 import jdk.incubator.code.CodeElement;
 import jdk.incubator.code.dialect.core.CoreOp;
@@ -41,17 +42,13 @@ import static optkl.OpHelper.Invoke.invoke;
 public record HATBarrierPhase() implements HATPhase {
     @Override
     public CoreOp.FuncOp transform(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp, VarTable varTable) {
-         Set<CodeElement<?,?>> removeMe = new HashSet<>();
          return Trxfmr.of(lookup,funcOp).transform(ce->ce instanceof JavaOp.InvokeOp, c-> {
-                         if (invoke(lookup, c.op()) instanceof OpHelper.Invoke.Virtual  virtual &&
-                                  virtual.isInstanceAccessedViaVarAccess()                  // we are called via var kc such as kc->XX()
-                              && virtual.named(HATBarrierOp.NAME)){
-                             removeMe.add(virtual.instanceVarAccess().op());
+                         if (invoke(lookup, c.op()) instanceof OpHelper.Invoke.Static  staticInvoke &&
+                                  staticInvoke.refIs(KernelContext.class)                 // we are called via var kc such as kc->XX()
+                              && staticInvoke.named(HATBarrierOp.NAME)){
                              c.replace(new HATBarrierOp());
                          }
                     }, varTable)
-                 .remap(removeMe) // replaced varOps with new identities
-                 .remove(removeMe::contains, varTable)
                  .funcOp();
     }
 }

--- a/hat/core/src/main/java/hat/phases/HATTransformer.java
+++ b/hat/core/src/main/java/hat/phases/HATTransformer.java
@@ -34,7 +34,7 @@ public class HATTransformer {
 
     public static final List<HATPhase> KernelPhases = List.of(
             // barriers
-            new HATBarrierPhase(),
+          //  new HATBarrierPhase(),
 
             // array views
             new HATArrayViewPhase(),
@@ -43,10 +43,10 @@ public class HATTransformer {
             new HATMemoryPhase(),
 
             // ID's /thread access
-            new HATThreadsPhase(),
+           // new HATThreadsPhase(),
 
             // Warp size
-            new HATWarpSizePhase(),
+           // new HATWarpSizePhase(),
 
             // MathLib phase
             new HATMathLibPhase(),

--- a/hat/core/src/main/java/hat/phases/HATWarpSizePhase.java
+++ b/hat/core/src/main/java/hat/phases/HATWarpSizePhase.java
@@ -37,21 +37,18 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static optkl.OpHelper.FieldAccess.fieldAccess;
+import static optkl.OpHelper.Invoke.invoke;
 
 public record HATWarpSizePhase() implements HATPhase {
 
     @Override
     public CoreOp.FuncOp transform(MethodHandles.Lookup lookup, CoreOp.FuncOp funcOp, VarTable varTable) {
-        Set<CodeElement<?, ?>> varAccessesToBeRemoved = new HashSet<>();
         return Trxfmr.of(lookup, funcOp)
                 .transform(c -> {
-                    if (fieldAccess(lookup, c.op()) instanceof OpHelper.FieldAccess.Instance fieldAccess
-                            && fieldAccess.refType(KernelContext.class) && fieldAccess.nameMatchesRegex("wrs")) {
-                        varAccessesToBeRemoved.add(fieldAccess.instanceVarAccess().op());
-                        c.replace(HATThreadOp.create(fieldAccess.name()));
+                    if (invoke(lookup, c.op()) instanceof OpHelper.Invoke.Static invokeStatic
+                            && invokeStatic.refIs(KernelContext.class) && invokeStatic.nameMatchesRegex("WRZ")) {
+                        c.replace(HATThreadOp.create(invokeStatic.name()));
                     }}, varTable)
-                .remap(varAccessesToBeRemoved)
-                .remove(varAccessesToBeRemoved::contains, varTable)
                 .funcOp();
     }
 }

--- a/hat/docs/ProgrammingModel/programming-model.md
+++ b/hat/docs/ProgrammingModel/programming-model.md
@@ -91,7 +91,7 @@ Kernel's and any kernel reachable methods will naturally be restricted to subset
       - Technically you can call a kernel entrypoint, but must pass your KernelContext
    * `ifaceMappedSegment` accessor/mutators (see later)
    * Calls on `KernelContext` (backend kernel features)
-     - `KernelContext.barrier()`
+     - `barrier()`
      - `kernelContext.I32.hypot(x,y)`
 #### Kernel Entrypoints
 * Declared `@Reflect static public void`

--- a/hat/examples/blackscholes/src/main/java/blackscholes/Main.java
+++ b/hat/examples/blackscholes/src/main/java/blackscholes/Main.java
@@ -50,18 +50,18 @@ public class Main {
                                           F32Array tArray,
                                           float r,
                                           float v) {
-        if (kc.gix < kc.gsx){
-            float S = sArray.array(kc.gix);
-            float X = xArray.array(kc.gix);
-            float T = tArray.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()){
+            float S = sArray.array(KernelContext.GIX());
+            float X = xArray.array(KernelContext.GIX());
+            float T = tArray.array(KernelContext.GIX());
             float expNegRt = (float) Math.exp(-r * T);
             float d1 = (float) ((Math.log(S / X) + (r + v * v * .5f) * T) / (v * Math.sqrt(T)));
             float d2 = (float) (d1 - v * Math.sqrt(T));
             float cnd1 = CND(d1);
             float cnd2 = CND(d2);
             float value = S * cnd1 - expNegRt * X * cnd2;
-            call.array(kc.gix, value);
-            put.array(kc.gix, expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
+            call.array(KernelContext.GIX(), value);
+            put.array(KernelContext.GIX(), expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
         }
     }
 

--- a/hat/examples/blackscholes/src/main/java/blackscholes/Main.java
+++ b/hat/examples/blackscholes/src/main/java/blackscholes/Main.java
@@ -30,6 +30,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 
@@ -50,18 +51,18 @@ public class Main {
                                           F32Array tArray,
                                           float r,
                                           float v) {
-        if (KernelContext.GIX() < KernelContext.GSX()){
-            float S = sArray.array(KernelContext.GIX());
-            float X = xArray.array(KernelContext.GIX());
-            float T = tArray.array(KernelContext.GIX());
+        if (GIX() < GSX()){
+            float S = sArray.array(GIX());
+            float X = xArray.array(GIX());
+            float T = tArray.array(GIX());
             float expNegRt = (float) Math.exp(-r * T);
             float d1 = (float) ((Math.log(S / X) + (r + v * v * .5f) * T) / (v * Math.sqrt(T)));
             float d2 = (float) (d1 - v * Math.sqrt(T));
             float cnd1 = CND(d1);
             float cnd2 = CND(d2);
             float value = S * cnd1 - expNegRt * X * cnd2;
-            call.array(KernelContext.GIX(), value);
-            put.array(KernelContext.GIX(), expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
+            call.array(GIX(), value);
+            put.array(GIX(), expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
         }
     }
 

--- a/hat/examples/dft/src/main/java/dft/Main.java
+++ b/hat/examples/dft/src/main/java/dft/Main.java
@@ -30,6 +30,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.HATMath;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -102,8 +103,8 @@ public class Main {
     @Reflect
     private static void dftKernel(KernelContext kc, ComplexArray input, ComplexArray output) {
         int size = input.length();
-        int idx = KernelContext.GIX();
-        if (idx < KernelContext.GSX()) {
+        int idx = GIX();
+        if (idx < GSX()) {
             float sumReal = 0.0f;
             float sumImag = 0.0f;
             for (int k = 0; k < size; k++) {
@@ -129,8 +130,8 @@ public class Main {
     @Reflect
     private static void dftPlainKernel(KernelContext kc, F32Array inReal, F32Array inImag, F32Array outReal, F32Array outImag) {
         int size = inReal.length();
-        int idx = KernelContext.GIX();
-        if (idx < KernelContext.GSX()) {
+        int idx = GIX();
+        if (idx < GSX()) {
             float sumReal = 0.0f;
             float sumImag = 0.0f;
             for (int k = 0; k < size; k++) {

--- a/hat/examples/dft/src/main/java/dft/Main.java
+++ b/hat/examples/dft/src/main/java/dft/Main.java
@@ -102,8 +102,8 @@ public class Main {
     @Reflect
     private static void dftKernel(KernelContext kc, ComplexArray input, ComplexArray output) {
         int size = input.length();
-        int idx = kc.gix;
-        if (idx < kc.gsx) {
+        int idx = KernelContext.GIX();
+        if (idx < KernelContext.GSX()) {
             float sumReal = 0.0f;
             float sumImag = 0.0f;
             for (int k = 0; k < size; k++) {
@@ -129,8 +129,8 @@ public class Main {
     @Reflect
     private static void dftPlainKernel(KernelContext kc, F32Array inReal, F32Array inImag, F32Array outReal, F32Array outImag) {
         int size = inReal.length();
-        int idx = kc.gix;
-        if (idx < kc.gsx) {
+        int idx = KernelContext.GIX();
+        if (idx < KernelContext.GSX()) {
             float sumReal = 0.0f;
             float sumImag = 0.0f;
             for (int k = 0; k < size; k++) {

--- a/hat/examples/experiments/src/main/java/experiments/ForTests.java
+++ b/hat/examples/experiments/src/main/java/experiments/ForTests.java
@@ -40,8 +40,8 @@ public class ForTests {
 
         @Reflect
         static void breakAndContinue(KernelContext kc, F32Array a) {
-            long i = kc.gix;
-            long size = kc.gsx;
+            long i = KernelContext.GIX();
+            long size = KernelContext.GSX();
             outer:
             for (long j = 0; j < size; j++) {
                 float sum = 0f;

--- a/hat/examples/experiments/src/main/java/experiments/ForTests.java
+++ b/hat/examples/experiments/src/main/java/experiments/ForTests.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.buffer.F32Array;
 
 import java.lang.invoke.MethodHandles;
@@ -40,8 +41,8 @@ public class ForTests {
 
         @Reflect
         static void breakAndContinue(KernelContext kc, F32Array a) {
-            long i = KernelContext.GIX();
-            long size = KernelContext.GSX();
+            long i = GIX();
+            long size = GSX();
             outer:
             for (long j = 0; j < size; j++) {
                 float sum = 0f;

--- a/hat/examples/experiments/src/main/java/experiments/InjectBufferTracking.java
+++ b/hat/examples/experiments/src/main/java/experiments/InjectBufferTracking.java
@@ -26,6 +26,7 @@ package experiments;
 
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.buffer.S32Array;
 import jdk.incubator.code.Op;
@@ -100,8 +101,8 @@ public class InjectBufferTracking {
 
     @Reflect
     public static void inc(@RO KernelContext kc, @RW S32Array s32Array, int len) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            s32Array.array(KernelContext.GIX(), s32Array.array(KernelContext.GIX()) + 1);
+        if (GIX() < GSX()) {
+            s32Array.array(GIX(), s32Array.array(GIX()) + 1);
         }
     }
 

--- a/hat/examples/experiments/src/main/java/experiments/InjectBufferTracking.java
+++ b/hat/examples/experiments/src/main/java/experiments/InjectBufferTracking.java
@@ -100,8 +100,8 @@ public class InjectBufferTracking {
 
     @Reflect
     public static void inc(@RO KernelContext kc, @RW S32Array s32Array, int len) {
-        if (kc.gix < kc.gsx) {
-            s32Array.array(kc.gix, s32Array.array(kc.gix) + 1);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            s32Array.array(KernelContext.GIX(), s32Array.array(KernelContext.GIX()) + 1);
         }
     }
 

--- a/hat/examples/experiments/src/main/java/experiments/LocalArray.java
+++ b/hat/examples/experiments/src/main/java/experiments/LocalArray.java
@@ -30,6 +30,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.device.DeviceSchema;
 import hat.device.NonMappableIface;
@@ -65,13 +66,13 @@ public class LocalArray {
     }
 
     @Reflect
-    private static void compute(@RO KernelContext kernelContext, @RW F32Array data) {
+    private static void compute(@RO KernelContext unused, @RW F32Array data) {
         SharedMemory mySharedArray = SharedMemory.createLocal();
-        int lix = KernelContext.LIX();
-        int blockId = KernelContext.BIX();
-        int blockSize = KernelContext.LSX();
+        int lix = LIX();
+        int blockId = BIX();
+        int blockSize = LSX();
         mySharedArray.array(lix, lix);
-        KernelContext.barrier();
+        barrier();
         data.array(lix + (long) blockId * blockSize, mySharedArray.array(lix));
     }
 

--- a/hat/examples/experiments/src/main/java/experiments/LocalArray.java
+++ b/hat/examples/experiments/src/main/java/experiments/LocalArray.java
@@ -67,11 +67,11 @@ public class LocalArray {
     @Reflect
     private static void compute(@RO KernelContext kernelContext, @RW F32Array data) {
         SharedMemory mySharedArray = SharedMemory.createLocal();
-        int lix = kernelContext.lix;
-        int blockId = kernelContext.bix;
-        int blockSize = kernelContext.lsx;
+        int lix = KernelContext.LIX();
+        int blockId = KernelContext.BIX();
+        int blockSize = KernelContext.LSX();
         mySharedArray.array(lix, lix);
-        kernelContext.barrier();
+        KernelContext.barrier();
         data.array(lix + (long) blockId * blockSize, mySharedArray.array(lix));
     }
 

--- a/hat/examples/experiments/src/main/java/experiments/LocalIds.java
+++ b/hat/examples/experiments/src/main/java/experiments/LocalIds.java
@@ -49,11 +49,11 @@ public class LocalIds {
     private static boolean PRINT_RESULTS = false;
 
     @Reflect
-    private static void assign(@RO KernelContext context, @RW S32Array arrayA, @RW S32Array arrayB, @RW S32Array arrayC) {
-        int gx = context.gix;
-        int lx = context.lix;
-        int lsx = context.lsx;
-        int bix = context.bix;
+    private static void assign(@RO KernelContext __, @RW S32Array arrayA, @RW S32Array arrayB, @RW S32Array arrayC) {
+        int gx = KernelContext.GIX();
+        int lx = KernelContext.LIX();
+        int lsx = KernelContext.LSX();
+        int bix = KernelContext.BIX();
         arrayA.array(gx, lx);
         arrayB.array(gx, lsx);
         arrayC.array(gx, bix);

--- a/hat/examples/experiments/src/main/java/experiments/LocalIds.java
+++ b/hat/examples/experiments/src/main/java/experiments/LocalIds.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.S32Array;
 import optkl.ifacemapper.MappableIface.RO;
@@ -50,10 +51,10 @@ public class LocalIds {
 
     @Reflect
     private static void assign(@RO KernelContext __, @RW S32Array arrayA, @RW S32Array arrayB, @RW S32Array arrayC) {
-        int gx = KernelContext.GIX();
-        int lx = KernelContext.LIX();
-        int lsx = KernelContext.LSX();
-        int bix = KernelContext.BIX();
+        int gx = GIX();
+        int lx = LIX();
+        int lsx = LSX();
+        int bix = BIX();
         arrayA.array(gx, lx);
         arrayB.array(gx, lsx);
         arrayC.array(gx, bix);

--- a/hat/examples/experiments/src/main/java/experiments/Mesh.java
+++ b/hat/examples/experiments/src/main/java/experiments/Mesh.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 
 import optkl.ifacemapper.BoundSchema;
 import optkl.ifacemapper.MappableIface;
@@ -120,9 +121,9 @@ public class Mesh {
     public static class ComputeApp {
         @Reflect
         public static void initPoints(KernelContext kc, MeshData mesh) {
-            if (KernelContext.GIX() < KernelContext.GSX()) {
-                MeshData.Point3D point = mesh.point(KernelContext.GIX());
-                point.x(KernelContext.GIX());
+            if (GIX() < GSX()) {
+                MeshData.Point3D point = mesh.point(GIX());
+                point.x(GIX());
                 point.y(0);
                 point.z(0);
             }

--- a/hat/examples/experiments/src/main/java/experiments/Mesh.java
+++ b/hat/examples/experiments/src/main/java/experiments/Mesh.java
@@ -120,9 +120,9 @@ public class Mesh {
     public static class ComputeApp {
         @Reflect
         public static void initPoints(KernelContext kc, MeshData mesh) {
-            if (kc.gix < kc.gsx) {
-                MeshData.Point3D point = mesh.point(kc.gix);
-                point.x(kc.gix);
+            if (KernelContext.GIX() < KernelContext.GSX()) {
+                MeshData.Point3D point = mesh.point(KernelContext.GIX());
+                point.x(KernelContext.GIX());
                 point.y(0);
                 point.z(0);
             }

--- a/hat/examples/experiments/src/main/java/experiments/MinBufferTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/MinBufferTest.java
@@ -45,8 +45,8 @@ public class MinBufferTest {
     public static class ComputeApp {
         @Reflect
         public static void inc(@RO KernelContext kc, @RW S32Array s32Array, int len) {
-            if (kc.gix < kc.gsx) {
-                s32Array.array(kc.gix, s32Array.array(kc.gix) + 1);
+            if (KernelContext.GIX() < KernelContext.GSX()) {
+                s32Array.array(KernelContext.GIX(), s32Array.array(KernelContext.GIX()) + 1);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/MinBufferTest.java
+++ b/hat/examples/experiments/src/main/java/experiments/MinBufferTest.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.buffer.S32Array;
 import optkl.ifacemapper.MappableIface.RO;
 import optkl.ifacemapper.MappableIface.RW;
@@ -45,8 +46,8 @@ public class MinBufferTest {
     public static class ComputeApp {
         @Reflect
         public static void inc(@RO KernelContext kc, @RW S32Array s32Array, int len) {
-            if (KernelContext.GIX() < KernelContext.GSX()) {
-                s32Array.array(KernelContext.GIX(), s32Array.array(KernelContext.GIX()) + 1);
+            if (GIX() < GSX()) {
+                s32Array.array(GIX(), s32Array.array(GIX()) + 1);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/NBodyF32x4.java
+++ b/hat/examples/experiments/src/main/java/experiments/NBodyF32x4.java
@@ -27,6 +27,7 @@ package experiments;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import jdk.incubator.code.Reflect;
@@ -100,7 +101,7 @@ public class NBodyF32x4 {
         float accx = 0.0f;
         float accy = 0.0f;
         float accz = 0.0f;
-        Universe.Body body = universe.body(KernelContext.GIX());
+        Universe.Body body = universe.body(GIX());
 
         for (int i = 0; i < universe.length(); i++) {
             Universe.Body otherBody = universe.body(i);
@@ -136,7 +137,7 @@ public class NBodyF32x4 {
         KernelContext kernelContext = new KernelContext(ndrange);
         //We can't do this once we refactor to static KerneContext
         throw new RuntimeException("We need NDRANGE for this");
-       // for (KernelContext.GIX() = 0; KernelContext.GIX() < KernelContext.GSX(); KernelContext.GIX()++) {
+       // for (GIX() = 0; GIX() < GSX(); GIX()++) {
           // nbodyKernel(kernelContext,universe,mass,delT,espSqr);
        // }
     }

--- a/hat/examples/experiments/src/main/java/experiments/NBodyF32x4.java
+++ b/hat/examples/experiments/src/main/java/experiments/NBodyF32x4.java
@@ -100,7 +100,7 @@ public class NBodyF32x4 {
         float accx = 0.0f;
         float accy = 0.0f;
         float accz = 0.0f;
-        Universe.Body body = universe.body(kc.gix);
+        Universe.Body body = universe.body(KernelContext.GIX());
 
         for (int i = 0; i < universe.length(); i++) {
             Universe.Body otherBody = universe.body(i);
@@ -131,11 +131,14 @@ public class NBodyF32x4 {
     }
 
     public static void computeSequential(Universe universe, float mass, float delT, float espSqr) {
+
         var ndrange = NDRange.of1D((int)universe.length());
         KernelContext kernelContext = new KernelContext(ndrange);
-        for (kernelContext.gix = 0; kernelContext.gix < kernelContext.gsx; kernelContext.gix++) {
-           nbodyKernel(kernelContext,universe,mass,delT,espSqr);
-        }
+        //We can't do this once we refactor to static KerneContext
+        throw new RuntimeException("We need NDRANGE for this");
+       // for (KernelContext.GIX() = 0; KernelContext.GIX() < KernelContext.GSX(); KernelContext.GIX()++) {
+          // nbodyKernel(kernelContext,universe,mass,delT,espSqr);
+       // }
     }
 
     @Reflect

--- a/hat/examples/experiments/src/main/java/experiments/PrefixSum.java
+++ b/hat/examples/experiments/src/main/java/experiments/PrefixSum.java
@@ -171,36 +171,36 @@ public class PrefixSum {
         // int[] scratch=scratchBuf.arrayView();
         int[] data = dataBuf.arrayView();
 
-        scratchBuf.array(kc.lix, data[kc.gix]); // scratch[kc.lix]=data[kc.gix];
-        kc.barrier();
+        scratchBuf.array(KernelContext.LIX(), data[KernelContext.GIX()]); // scratch[KernelContext.LIX()]=data[KernelContext.GIX()];
+        KernelContext.barrier();
 
-        for (int step = 2; step <= kc.lsx; step <<= 1) {
-            if (((kc.lix + 1) % step) == 0) {
-                scratchBuf.array(kc.lix, scratchBuf.array(kc.lix) + scratchBuf.array(kc.lix - (step >> 1))); // scratch[kc.lix]+=scratch[kc.lix-(step>>1)];
+        for (int step = 2; step <= KernelContext.LSX(); step <<= 1) {
+            if (((KernelContext.LIX() + 1) % step) == 0) {
+                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + scratchBuf.array(KernelContext.LIX() - (step >> 1))); // scratch[KernelContext.LIX()]+=scratch[KernelContext.LIX()-(step>>1)];
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
         int sum = 0;
-        if ((kc.lix + 1) == kc.lsx) {
-            sum = scratchBuf.array(kc.lix);    // sum = scratch[kc.lix];
-            scratchBuf.array(kc.lix, 0); // scratch[kc.lix]=0;
+        if ((KernelContext.LIX() + 1) == KernelContext.LSX()) {
+            sum = scratchBuf.array(KernelContext.LIX());    // sum = scratch[KernelContext.LIX()];
+            scratchBuf.array(KernelContext.LIX(), 0); // scratch[KernelContext.LIX()]=0;
         }
-        kc.barrier();
-        for (int step = kc.lsx; step > 1; step >>= 1) {
-            if (((kc.lix + 1) % step) == 0) {
-                int prev = scratchBuf.array(kc.lix - (step >> 1));                // int prev = scratch[kc.lix-(step>>1)];
-                scratchBuf.array(kc.lix - (step >> 1), scratchBuf.array(kc.lix)); // scratch[kc.lix-(step>>1)]=scratch[kc.lix];
-                scratchBuf.array(kc.lix, scratchBuf.array(kc.lix) + prev);        //  scratch[kc.lix]+= prev;
+        KernelContext.barrier();
+        for (int step = KernelContext.LSX(); step > 1; step >>= 1) {
+            if (((KernelContext.LIX() + 1) % step) == 0) {
+                int prev = scratchBuf.array(KernelContext.LIX() - (step >> 1));                // int prev = scratch[KernelContext.LIX()-(step>>1)];
+                scratchBuf.array(KernelContext.LIX() - (step >> 1), scratchBuf.array(KernelContext.LIX())); // scratch[KernelContext.LIX()-(step>>1)]=scratch[KernelContext.LIX()];
+                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + prev);        //  scratch[KernelContext.LIX()]+= prev;
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
 
-        if ((kc.lix + 1) == kc.lsx) {
-            data[kc.gix] = sum;
+        if ((KernelContext.LIX() + 1) == KernelContext.LSX()) {
+            data[KernelContext.GIX()] = sum;
         } else {
-            data[kc.gix] = scratchBuf.array(kc.lix + 1);  // data[ kc.gix] = scratch[kc.lix+1];
+            data[KernelContext.GIX()] = scratchBuf.array(KernelContext.LIX() + 1);  // data[ KernelContext.GIX()] = scratch[KernelContext.LIX()+1];
         }
-        kc.barrier();
+        KernelContext.barrier();
 
     }
 
@@ -260,35 +260,35 @@ public class PrefixSum {
         var scratchBuf = SharedS32x256Array.createLocal();
         int[] data = dataBuf.arrayView();  // int[] scratch=scratchBuf.arrayView();
 
-        int gid = (kc.gix * (kc.gsx)) - 1; // 0-> -1?  hence the >0 checks below.
+        int gid = (KernelContext.GIX() * (KernelContext.GSX())) - 1; // 0-> -1?  hence the >0 checks below.
 
-        scratchBuf.array(kc.lix, (gid > 0) ? data[gid] : 0);   // scratch[kc.lix]= (gid>0)?data[gid]:0;
+        scratchBuf.array(KernelContext.LIX(), (gid > 0) ? data[gid] : 0);   // scratch[KernelContext.LIX()]= (gid>0)?data[gid]:0;
         kc.barrier();
-        for (int step = 2; step <= kc.gsx; step <<= 1) {
-            if (((kc.lix + 1) % step) == 0) {
-                scratchBuf.array(kc.lix, scratchBuf.array(kc.lix) + scratchBuf.array(kc.lix - (step >> 1))); // scratch[kc.lix]+=scratch[kc.lix-(step>>1)];
+        for (int step = 2; step <= KernelContext.GSX(); step <<= 1) {
+            if (((KernelContext.LIX() + 1) % step) == 0) {
+                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + scratchBuf.array(KernelContext.LIX() - (step >> 1))); // scratch[KernelContext.LIX()]+=scratch[KernelContext.LIX()-(step>>1)];
             }
             kc.barrier();
         }
         int sum = 0;
-        if ((kc.lix + 1) == kc.gsx) {
-            sum = scratchBuf.array(kc.lix);     // sum = scratch[kc.lix];
-            scratchBuf.array(kc.lix, 0);  // scratch[kc.lix]=0;
+        if ((KernelContext.LIX() + 1) == KernelContext.GSX()) {
+            sum = scratchBuf.array(KernelContext.LIX());     // sum = scratch[KernelContext.LIX()];
+            scratchBuf.array(KernelContext.LIX(), 0);  // scratch[KernelContext.LIX()]=0;
         }
         kc.barrier();
-        for (int step = kc.gsx; step > 1; step >>= 1) {
-            if (((kc.lix + 1) % step) == 0) {
-                int swap = scratchBuf.array(kc.lix - (step >> 1));                // int swap = scratch[kc.lix-(step>>1)];
-                scratchBuf.array(kc.lix - (step >> 1), scratchBuf.array(kc.lix)); // scratch[kc.lix-(step>>1)]=scratch[kc.lix];
-                scratchBuf.array(kc.lix, scratchBuf.array(kc.lix) + swap);        // scratch[kc.lix]+= swap;
+        for (int step = KernelContext.GSX(); step > 1; step >>= 1) {
+            if (((KernelContext.LIX() + 1) % step) == 0) {
+                int swap = scratchBuf.array(KernelContext.LIX() - (step >> 1));                // int swap = scratch[KernelContext.LIX()-(step>>1)];
+                scratchBuf.array(KernelContext.LIX() - (step >> 1), scratchBuf.array(KernelContext.LIX())); // scratch[KernelContext.LIX()-(step>>1)]=scratch[KernelContext.LIX()];
+                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + swap);        // scratch[KernelContext.LIX()]+= swap;
             }
             kc.barrier();
         }
 
-        if ((kc.lix + 1) == kc.gsx) {
+        if ((KernelContext.LIX() + 1) == KernelContext.GSX()) {
             data[gid] = sum;
         } else if (gid > 0) {
-            data[gid] = scratchBuf.array(kc.lix + 1); //  data[ gid] = scratch[kc.lix+1];
+            data[gid] = scratchBuf.array(KernelContext.LIX() + 1); //  data[ gid] = scratch[KernelContext.LIX()+1];
         }
         kc.barrier(); */
     }
@@ -307,13 +307,13 @@ public class PrefixSum {
         int[] data = dataBuf.arrayView();
         //  int[] scratch=scratchBuf.arrayView();
 
-        scratchBuf.array(kc.lix, data[kc.gix]); // scratch[kc.lix] = data[kc.gix];
+        scratchBuf.array(KernelContext.LIX(), data[KernelContext.GIX()]); // scratch[KernelContext.LIX()] = data[KernelContext.GIX()];
         kc.barrier();
-        if ((kc.lix + 1) != kc.gsx && kc.gix > 0) {// don't do this for last in group
-            scratchBuf.array(kc.lix, scratchBuf.array(kc.lix) + data[(kc.gix * kc.gsx) - 1]); // scratch[kc.lix]+= data[(kc.gix*kc.gsx)-1];
+        if ((KernelContext.LIX() + 1) != KernelContext.GSX() && KernelContext.GIX() > 0) {// don't do this for last in group
+            scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + data[(KernelContext.GIX() * KernelContext.GSX()) - 1]); // scratch[KernelContext.LIX()]+= data[(KernelContext.GIX()*KernelContext.GSX())-1];
         }
         kc.barrier();
-        data[kc.gix] = scratchBuf.array(kc.lix); // data[kc.gix]=scratch[kc.lix];
+        data[KernelContext.GIX()] = scratchBuf.array(KernelContext.LIX()); // data[KernelContext.GIX()]=scratch[KernelContext.LIX()];
     }
     static String view(int[] data){
         StringBuilder sb = new StringBuilder();

--- a/hat/examples/experiments/src/main/java/experiments/PrefixSum.java
+++ b/hat/examples/experiments/src/main/java/experiments/PrefixSum.java
@@ -30,6 +30,7 @@ import hat.ComputeContext;
 import hat.NDRange;
 import hat.annotations.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.annotations.Preformatted;
 import hat.annotations.TypeDef;
 import hat.backend.Backend;
@@ -171,36 +172,36 @@ public class PrefixSum {
         // int[] scratch=scratchBuf.arrayView();
         int[] data = dataBuf.arrayView();
 
-        scratchBuf.array(KernelContext.LIX(), data[KernelContext.GIX()]); // scratch[KernelContext.LIX()]=data[KernelContext.GIX()];
-        KernelContext.barrier();
+        scratchBuf.array(LIX(), data[GIX()]); // scratch[LIX()]=data[GIX()];
+        barrier();
 
-        for (int step = 2; step <= KernelContext.LSX(); step <<= 1) {
-            if (((KernelContext.LIX() + 1) % step) == 0) {
-                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + scratchBuf.array(KernelContext.LIX() - (step >> 1))); // scratch[KernelContext.LIX()]+=scratch[KernelContext.LIX()-(step>>1)];
+        for (int step = 2; step <= LSX(); step <<= 1) {
+            if (((LIX() + 1) % step) == 0) {
+                scratchBuf.array(LIX(), scratchBuf.array(LIX()) + scratchBuf.array(LIX() - (step >> 1))); // scratch[LIX()]+=scratch[LIX()-(step>>1)];
             }
-            KernelContext.barrier();
+            barrier();
         }
         int sum = 0;
-        if ((KernelContext.LIX() + 1) == KernelContext.LSX()) {
-            sum = scratchBuf.array(KernelContext.LIX());    // sum = scratch[KernelContext.LIX()];
-            scratchBuf.array(KernelContext.LIX(), 0); // scratch[KernelContext.LIX()]=0;
+        if ((LIX() + 1) == LSX()) {
+            sum = scratchBuf.array(LIX());    // sum = scratch[LIX()];
+            scratchBuf.array(LIX(), 0); // scratch[LIX()]=0;
         }
-        KernelContext.barrier();
-        for (int step = KernelContext.LSX(); step > 1; step >>= 1) {
-            if (((KernelContext.LIX() + 1) % step) == 0) {
-                int prev = scratchBuf.array(KernelContext.LIX() - (step >> 1));                // int prev = scratch[KernelContext.LIX()-(step>>1)];
-                scratchBuf.array(KernelContext.LIX() - (step >> 1), scratchBuf.array(KernelContext.LIX())); // scratch[KernelContext.LIX()-(step>>1)]=scratch[KernelContext.LIX()];
-                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + prev);        //  scratch[KernelContext.LIX()]+= prev;
+        barrier();
+        for (int step = LSX(); step > 1; step >>= 1) {
+            if (((LIX() + 1) % step) == 0) {
+                int prev = scratchBuf.array(LIX() - (step >> 1));                // int prev = scratch[LIX()-(step>>1)];
+                scratchBuf.array(LIX() - (step >> 1), scratchBuf.array(LIX())); // scratch[LIX()-(step>>1)]=scratch[LIX()];
+                scratchBuf.array(LIX(), scratchBuf.array(LIX()) + prev);        //  scratch[LIX()]+= prev;
             }
-            KernelContext.barrier();
+            barrier();
         }
 
-        if ((KernelContext.LIX() + 1) == KernelContext.LSX()) {
-            data[KernelContext.GIX()] = sum;
+        if ((LIX() + 1) == LSX()) {
+            data[GIX()] = sum;
         } else {
-            data[KernelContext.GIX()] = scratchBuf.array(KernelContext.LIX() + 1);  // data[ KernelContext.GIX()] = scratch[KernelContext.LIX()+1];
+            data[GIX()] = scratchBuf.array(LIX() + 1);  // data[ GIX()] = scratch[LIX()+1];
         }
-        KernelContext.barrier();
+        barrier();
 
     }
 
@@ -260,35 +261,35 @@ public class PrefixSum {
         var scratchBuf = SharedS32x256Array.createLocal();
         int[] data = dataBuf.arrayView();  // int[] scratch=scratchBuf.arrayView();
 
-        int gid = (KernelContext.GIX() * (KernelContext.GSX())) - 1; // 0-> -1?  hence the >0 checks below.
+        int gid = (GIX() * (GSX())) - 1; // 0-> -1?  hence the >0 checks below.
 
-        scratchBuf.array(KernelContext.LIX(), (gid > 0) ? data[gid] : 0);   // scratch[KernelContext.LIX()]= (gid>0)?data[gid]:0;
+        scratchBuf.array(LIX(), (gid > 0) ? data[gid] : 0);   // scratch[LIX()]= (gid>0)?data[gid]:0;
         kc.barrier();
-        for (int step = 2; step <= KernelContext.GSX(); step <<= 1) {
-            if (((KernelContext.LIX() + 1) % step) == 0) {
-                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + scratchBuf.array(KernelContext.LIX() - (step >> 1))); // scratch[KernelContext.LIX()]+=scratch[KernelContext.LIX()-(step>>1)];
+        for (int step = 2; step <= GSX(); step <<= 1) {
+            if (((LIX() + 1) % step) == 0) {
+                scratchBuf.array(LIX(), scratchBuf.array(LIX()) + scratchBuf.array(LIX() - (step >> 1))); // scratch[LIX()]+=scratch[LIX()-(step>>1)];
             }
             kc.barrier();
         }
         int sum = 0;
-        if ((KernelContext.LIX() + 1) == KernelContext.GSX()) {
-            sum = scratchBuf.array(KernelContext.LIX());     // sum = scratch[KernelContext.LIX()];
-            scratchBuf.array(KernelContext.LIX(), 0);  // scratch[KernelContext.LIX()]=0;
+        if ((LIX() + 1) == GSX()) {
+            sum = scratchBuf.array(LIX());     // sum = scratch[LIX()];
+            scratchBuf.array(LIX(), 0);  // scratch[LIX()]=0;
         }
         kc.barrier();
-        for (int step = KernelContext.GSX(); step > 1; step >>= 1) {
-            if (((KernelContext.LIX() + 1) % step) == 0) {
-                int swap = scratchBuf.array(KernelContext.LIX() - (step >> 1));                // int swap = scratch[KernelContext.LIX()-(step>>1)];
-                scratchBuf.array(KernelContext.LIX() - (step >> 1), scratchBuf.array(KernelContext.LIX())); // scratch[KernelContext.LIX()-(step>>1)]=scratch[KernelContext.LIX()];
-                scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + swap);        // scratch[KernelContext.LIX()]+= swap;
+        for (int step = GSX(); step > 1; step >>= 1) {
+            if (((LIX() + 1) % step) == 0) {
+                int swap = scratchBuf.array(LIX() - (step >> 1));                // int swap = scratch[LIX()-(step>>1)];
+                scratchBuf.array(LIX() - (step >> 1), scratchBuf.array(LIX())); // scratch[LIX()-(step>>1)]=scratch[LIX()];
+                scratchBuf.array(LIX(), scratchBuf.array(LIX()) + swap);        // scratch[LIX()]+= swap;
             }
             kc.barrier();
         }
 
-        if ((KernelContext.LIX() + 1) == KernelContext.GSX()) {
+        if ((LIX() + 1) == GSX()) {
             data[gid] = sum;
         } else if (gid > 0) {
-            data[gid] = scratchBuf.array(KernelContext.LIX() + 1); //  data[ gid] = scratch[KernelContext.LIX()+1];
+            data[gid] = scratchBuf.array(LIX() + 1); //  data[ gid] = scratch[LIX()+1];
         }
         kc.barrier(); */
     }
@@ -307,13 +308,13 @@ public class PrefixSum {
         int[] data = dataBuf.arrayView();
         //  int[] scratch=scratchBuf.arrayView();
 
-        scratchBuf.array(KernelContext.LIX(), data[KernelContext.GIX()]); // scratch[KernelContext.LIX()] = data[KernelContext.GIX()];
+        scratchBuf.array(LIX(), data[GIX()]); // scratch[LIX()] = data[GIX()];
         kc.barrier();
-        if ((KernelContext.LIX() + 1) != KernelContext.GSX() && KernelContext.GIX() > 0) {// don't do this for last in group
-            scratchBuf.array(KernelContext.LIX(), scratchBuf.array(KernelContext.LIX()) + data[(KernelContext.GIX() * KernelContext.GSX()) - 1]); // scratch[KernelContext.LIX()]+= data[(KernelContext.GIX()*KernelContext.GSX())-1];
+        if ((LIX() + 1) != GSX() && GIX() > 0) {// don't do this for last in group
+            scratchBuf.array(LIX(), scratchBuf.array(LIX()) + data[(GIX() * GSX()) - 1]); // scratch[LIX()]+= data[(GIX()*GSX())-1];
         }
         kc.barrier();
-        data[KernelContext.GIX()] = scratchBuf.array(KernelContext.LIX()); // data[KernelContext.GIX()]=scratch[KernelContext.LIX()];
+        data[GIX()] = scratchBuf.array(LIX()); // data[GIX()]=scratch[LIX()];
     }
     static String view(int[] data){
         StringBuilder sb = new StringBuilder();

--- a/hat/examples/experiments/src/main/java/experiments/QuotedArrayArg.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedArrayArg.java
@@ -38,7 +38,7 @@ import java.lang.invoke.MethodHandles;
 public class QuotedArrayArg {
     @Reflect
     public static void addScalerKernel(@MappableIface.RO KernelContext kc, @MappableIface.RO S32Array in, @MappableIface.WO S32Array out, int scaler) {
-        out.array(kc.gix, in.array(kc.gix) + scaler);
+        out.array(KernelContext.GIX(), in.array(KernelContext.GIX()) + scaler);
     }
 
     @Reflect

--- a/hat/examples/experiments/src/main/java/experiments/QuotedArrayArg.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedArrayArg.java
@@ -27,6 +27,7 @@ package experiments;
 import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.KernelContext;
 import hat.buffer.S32Array;
@@ -38,7 +39,7 @@ import java.lang.invoke.MethodHandles;
 public class QuotedArrayArg {
     @Reflect
     public static void addScalerKernel(@MappableIface.RO KernelContext kc, @MappableIface.RO S32Array in, @MappableIface.WO S32Array out, int scaler) {
-        out.array(KernelContext.GIX(), in.array(KernelContext.GIX()) + scaler);
+        out.array(GIX(), in.array(GIX()) + scaler);
     }
 
     @Reflect

--- a/hat/examples/experiments/src/main/java/experiments/QuotedConstantArgs.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedConstantArgs.java
@@ -27,6 +27,7 @@ package experiments;
 import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.KernelContext;
 import hat.buffer.S32Array;
@@ -38,7 +39,7 @@ import java.lang.invoke.MethodHandles;
 public class QuotedConstantArgs {
     @Reflect
     public static void addScalerKernel(@MappableIface.RO KernelContext kc, @MappableIface.RO S32Array in, @MappableIface.WO S32Array out, int scaler) {
-        out.array(KernelContext.GIX(), in.array(KernelContext.GIX()) + scaler);
+        out.array(GIX(), in.array(GIX()) + scaler);
     }
 
     @Reflect

--- a/hat/examples/experiments/src/main/java/experiments/QuotedConstantArgs.java
+++ b/hat/examples/experiments/src/main/java/experiments/QuotedConstantArgs.java
@@ -38,7 +38,7 @@ import java.lang.invoke.MethodHandles;
 public class QuotedConstantArgs {
     @Reflect
     public static void addScalerKernel(@MappableIface.RO KernelContext kc, @MappableIface.RO S32Array in, @MappableIface.WO S32Array out, int scaler) {
-        out.array(kc.gix, in.array(kc.gix) + scaler);
+        out.array(KernelContext.GIX(), in.array(KernelContext.GIX()) + scaler);
     }
 
     @Reflect

--- a/hat/examples/experiments/src/main/java/experiments/Reduction.java
+++ b/hat/examples/experiments/src/main/java/experiments/Reduction.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import optkl.ifacemapper.BoundSchema;
 import optkl.ifacemapper.Buffer;
@@ -78,9 +79,9 @@ public class Reduction {
      */
     @Reflect
     private static void reduce(@RO KernelContext context, @RW S32Array input, @RW S32Array partialSums) {
-        int localId = KernelContext.LIX();
-        int localSize = KernelContext.LSX();
-        int blockId = KernelContext.BIX();
+        int localId = LIX();
+        int localSize = LSX();
+        int blockId = BIX();
         int baseIndex = localSize * blockId + localId;
 
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
@@ -89,7 +90,7 @@ public class Reduction {
                 val += input.array((baseIndex + offset));
                 input.array(baseIndex, val);
             }
-            KernelContext.barrier();
+            barrier();
         }
         if (localId == 0) {
             // copy from shared memory to global memory
@@ -107,19 +108,19 @@ public class Reduction {
      */
     @Reflect
     private static void reduceLocal(@RO KernelContext context, @RW S32Array input, @RW S32Array partialSums) {
-        int localId = KernelContext.LIX();
-        int localSize = KernelContext.LSX();
-        int blockId = KernelContext.BIX();
+        int localId = LIX();
+        int localSize = LSX();
+        int blockId = BIX();
 
         // Prototype: allocate in shared memory an array of 16 ints
         MySharedArray sharedArray = MySharedArray.createLocal();
 
         // Copy from global to shared memory
-        sharedArray.array(localId, input.array(KernelContext.GIX()));
+        sharedArray.array(localId, input.array(GIX()));
 
         // Reduction using local memory
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
-            KernelContext.barrier();
+            barrier();
             if (localId < offset) {
                 sharedArray.array(localId,  sharedArray.array(localId) +  sharedArray.array(localId + offset));
             }

--- a/hat/examples/experiments/src/main/java/experiments/Reduction.java
+++ b/hat/examples/experiments/src/main/java/experiments/Reduction.java
@@ -78,9 +78,9 @@ public class Reduction {
      */
     @Reflect
     private static void reduce(@RO KernelContext context, @RW S32Array input, @RW S32Array partialSums) {
-        int localId = context.lix;
-        int localSize = context.lsx;
-        int blockId = context.bix;
+        int localId = KernelContext.LIX();
+        int localSize = KernelContext.LSX();
+        int blockId = KernelContext.BIX();
         int baseIndex = localSize * blockId + localId;
 
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
@@ -89,7 +89,7 @@ public class Reduction {
                 val += input.array((baseIndex + offset));
                 input.array(baseIndex, val);
             }
-            context.barrier();
+            KernelContext.barrier();
         }
         if (localId == 0) {
             // copy from shared memory to global memory
@@ -107,19 +107,19 @@ public class Reduction {
      */
     @Reflect
     private static void reduceLocal(@RO KernelContext context, @RW S32Array input, @RW S32Array partialSums) {
-        int localId = context.lix;
-        int localSize = context.lsx;
-        int blockId = context.bix;
+        int localId = KernelContext.LIX();
+        int localSize = KernelContext.LSX();
+        int blockId = KernelContext.BIX();
 
         // Prototype: allocate in shared memory an array of 16 ints
         MySharedArray sharedArray = MySharedArray.createLocal();
 
         // Copy from global to shared memory
-        sharedArray.array(localId, input.array(context.gix));
+        sharedArray.array(localId, input.array(KernelContext.GIX()));
 
         // Reduction using local memory
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
-            context.barrier();
+            KernelContext.barrier();
             if (localId < offset) {
                 sharedArray.array(localId,  sharedArray.array(localId) +  sharedArray.array(localId + offset));
             }

--- a/hat/examples/experiments/src/main/java/experiments/Square.java
+++ b/hat/examples/experiments/src/main/java/experiments/Square.java
@@ -48,8 +48,8 @@ public class Square {
 
     @Reflect
     public static void squareKernel(@RO KernelContext kc, @RW S32Array a) {
-        int id = kc.gix;
-        if (id < kc.gsx) {
+        int id = KernelContext.GIX();
+        if (id < KernelContext.GSX()) {
             int value = a.array(id);
             a.array(id, square(value));
         }

--- a/hat/examples/experiments/src/main/java/experiments/Square.java
+++ b/hat/examples/experiments/src/main/java/experiments/Square.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.buffer.S32Array;
 import jdk.incubator.code.Reflect;
@@ -48,8 +49,8 @@ public class Square {
 
     @Reflect
     public static void squareKernel(@RO KernelContext kc, @RW S32Array a) {
-        int id = KernelContext.GIX();
-        if (id < KernelContext.GSX()) {
+        int id = GIX();
+        if (id < GSX()) {
             int value = a.array(id);
             a.array(id, square(value));
         }

--- a/hat/examples/experiments/src/main/java/experiments/TestFuncOpViewer.java
+++ b/hat/examples/experiments/src/main/java/experiments/TestFuncOpViewer.java
@@ -26,6 +26,7 @@ package experiments;
 
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.buffer.S32Array;
 import hat.buffer.S32Array2D;
@@ -42,11 +43,11 @@ public class TestFuncOpViewer {
     static class Compute {
         @Reflect
         public static void mandel(@MappableIface.RO KernelContext kc, @MappableIface.RW S32Array2D s32Array2D, @MappableIface.RO S32Array pallette, float offsetx, float offsety, float scale) {
-            if (KernelContext.GIX() < KernelContext.GSX()) {
+            if (GIX() < GSX()) {
                 float width = s32Array2D.width();
                 float height = s32Array2D.height();
-                float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-                float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+                float x = ((GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+                float y = ((GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
                 float zx = x;
                 float zy = y;
                 float new_zx;
@@ -58,7 +59,7 @@ public class TestFuncOpViewer {
                     colorIdx++;
                 }
                 int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
-                s32Array2D.array(KernelContext.GIX(), color);
+                s32Array2D.array(GIX(), color);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/TestFuncOpViewer.java
+++ b/hat/examples/experiments/src/main/java/experiments/TestFuncOpViewer.java
@@ -42,11 +42,11 @@ public class TestFuncOpViewer {
     static class Compute {
         @Reflect
         public static void mandel(@MappableIface.RO KernelContext kc, @MappableIface.RW S32Array2D s32Array2D, @MappableIface.RO S32Array pallette, float offsetx, float offsety, float scale) {
-            if (kc.gix < kc.gsx) {
+            if (KernelContext.GIX() < KernelContext.GSX()) {
                 float width = s32Array2D.width();
                 float height = s32Array2D.height();
-                float x = ((kc.gix % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-                float y = ((kc.gix / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+                float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+                float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
                 float zx = x;
                 float zy = y;
                 float new_zx;
@@ -58,7 +58,7 @@ public class TestFuncOpViewer {
                     colorIdx++;
                 }
                 int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
-                s32Array2D.array(kc.gix, color);
+                s32Array2D.array(KernelContext.GIX(), color);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/TestJavaHATCodeBuilder.java
+++ b/hat/examples/experiments/src/main/java/experiments/TestJavaHATCodeBuilder.java
@@ -27,6 +27,7 @@ package experiments;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.buffer.S32Array;
 import hat.buffer.S32Array2D;
 import optkl.codebuilders.JavaCodeBuilder;
@@ -46,11 +47,11 @@ public class TestJavaHATCodeBuilder {
                                   @MappableIface.RO S32Array pallette,
                                   @MappableIface.RW S32Array2D s32Array2D,
                                   float offsetx, float offsety, float scale) {
-            if (KernelContext.GIX() < KernelContext.GSX()) {
+            if (GIX() < GSX()) {
                 float width = s32Array2D.width();
                 float height = s32Array2D.height();
-                float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-                float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+                float x = ((GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+                float y = ((GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
                 float zx = x;
                 float zy = y;
                 float new_zx;
@@ -62,7 +63,7 @@ public class TestJavaHATCodeBuilder {
                     colorIdx++;
                 }
                 int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
-                s32Array2D.array(KernelContext.GIX(), color);
+                s32Array2D.array(GIX(), color);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/TestJavaHATCodeBuilder.java
+++ b/hat/examples/experiments/src/main/java/experiments/TestJavaHATCodeBuilder.java
@@ -46,11 +46,11 @@ public class TestJavaHATCodeBuilder {
                                   @MappableIface.RO S32Array pallette,
                                   @MappableIface.RW S32Array2D s32Array2D,
                                   float offsetx, float offsety, float scale) {
-            if (kc.gix < kc.gsx) {
+            if (KernelContext.GIX() < KernelContext.GSX()) {
                 float width = s32Array2D.width();
                 float height = s32Array2D.height();
-                float x = ((kc.gix % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-                float y = ((kc.gix / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+                float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+                float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
                 float zx = x;
                 float zy = y;
                 float new_zx;
@@ -62,7 +62,7 @@ public class TestJavaHATCodeBuilder {
                     colorIdx++;
                 }
                 int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
-                s32Array2D.array(kc.gix, color);
+                s32Array2D.array(KernelContext.GIX(), color);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/spirv/GetBackend.java
+++ b/hat/examples/experiments/src/main/java/experiments/spirv/GetBackend.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 
@@ -94,16 +95,16 @@ public class GetBackend {
          */
         @Reflect
         static void kernel(KernelContext kid, F32Array a, F32Array b, F32Array c) {
-            for (int j = 0; j < KernelContext.GSX(); j++) {
+            for (int j = 0; j < GSX(); j++) {
                 float sum = 0f;
-                for (int k = 0; k < KernelContext.GSX(); k++) {
+                for (int k = 0; k < GSX(); k++) {
                     //sum += a[kid.x * kid.max + k] * b[k * kid.max + j];
-                    sum += a.array(KernelContext.GIX() * KernelContext.GSX() + k) * b.array(k * KernelContext.GSX() + j);
+                    sum += a.array(GIX() * GSX() + k) * b.array(k * GSX() + j);
                     //sum += a[kid.x * kid.max + k] * b[k * kid.max + j];
-                    sum += a.array(KernelContext.GIX() * KernelContext.GSX() + k) * b.array(k * KernelContext.GSX() + j);
+                    sum += a.array(GIX() * GSX() + k) * b.array(k * GSX() + j);
                 }
                 //c[kid.x * kid.max + j] = sum;
-                c.array(KernelContext.GIX() * KernelContext.GSX() + j, sum);
+                c.array(GIX() * GSX() + j, sum);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/spirv/GetBackend.java
+++ b/hat/examples/experiments/src/main/java/experiments/spirv/GetBackend.java
@@ -94,16 +94,16 @@ public class GetBackend {
          */
         @Reflect
         static void kernel(KernelContext kid, F32Array a, F32Array b, F32Array c) {
-            for (int j = 0; j < kid.gsx; j++) {
+            for (int j = 0; j < KernelContext.GSX(); j++) {
                 float sum = 0f;
-                for (int k = 0; k < kid.gsx; k++) {
+                for (int k = 0; k < KernelContext.GSX(); k++) {
                     //sum += a[kid.x * kid.max + k] * b[k * kid.max + j];
-                    sum += a.array(kid.gix * kid.gsx + k) * b.array(k * kid.gsx + j);
+                    sum += a.array(KernelContext.GIX() * KernelContext.GSX() + k) * b.array(k * KernelContext.GSX() + j);
                     //sum += a[kid.x * kid.max + k] * b[k * kid.max + j];
-                    sum += a.array(kid.gix * kid.gsx + k) * b.array(k * kid.gsx + j);
+                    sum += a.array(KernelContext.GIX() * KernelContext.GSX() + k) * b.array(k * KernelContext.GSX() + j);
                 }
                 //c[kid.x * kid.max + j] = sum;
-                c.array(kid.gix * kid.gsx + j, sum);
+                c.array(KernelContext.GIX() * KernelContext.GSX() + j, sum);
             }
         }
 

--- a/hat/examples/experiments/src/main/java/experiments/spirv/MatrixMultiply.java
+++ b/hat/examples/experiments/src/main/java/experiments/spirv/MatrixMultiply.java
@@ -98,7 +98,7 @@ public class MatrixMultiply {
             //   OpenCL kc.x -> get_global_id(0)
             //   CUDA   kc.x -> blockIdx.x*blockDim.x+threadIdx.x
             //   SPIRV  kc.x -> builtin GlobalInvocationId.x?
-            long i = kc.gix;
+            long i = KernelContext.GIX();
             long size = sz;
 
             for (long j = 0; j < size; j++) {

--- a/hat/examples/experiments/src/main/java/experiments/spirv/MatrixMultiply.java
+++ b/hat/examples/experiments/src/main/java/experiments/spirv/MatrixMultiply.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 import optkl.ifacemapper.SchemaBuilder;
@@ -98,7 +99,7 @@ public class MatrixMultiply {
             //   OpenCL kc.x -> get_global_id(0)
             //   CUDA   kc.x -> blockIdx.x*blockDim.x+threadIdx.x
             //   SPIRV  kc.x -> builtin GlobalInvocationId.x?
-            long i = KernelContext.GIX();
+            long i = GIX();
             long size = sz;
 
             for (long j = 0; j < size; j++) {

--- a/hat/examples/flashattention/src/main/java/flashattention/Main.java
+++ b/hat/examples/flashattention/src/main/java/flashattention/Main.java
@@ -106,7 +106,7 @@ public class Main {
                                           F32Array Q, F32Array K, F32Array V,
                                           F32Array attentionMatrix, F32Array O,
                                           final int N, final int d, final float softMaxScale) {
-        int idx = kernelContext.gix;
+        int idx = KernelContext.GIX();
         if (idx < N) {
             // Compute the attention scores: Q * K^T and scale it to sqrt(d) => softMaxScale
             for (int j = 0; j < N; j++) {
@@ -383,8 +383,8 @@ public class Main {
                                       F32Array Q, F32Array K, F32Array V,
                                       F32Array O, F32Array m, F32Array l,
                                       final int N, final int d, final float softmaxScale) {
-        int bx = kernelContext.bix;
-        int tid = kernelContext.lix;
+        int bx = KernelContext.BIX();
+        int tid = KernelContext.LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -409,7 +409,7 @@ public class Main {
             sharedArray.array((tid * d + k) + sQ_index,
                     Q.array((startIndex + (tid * d + k) * d + k)));
         }
-        kernelContext.barrier();
+        KernelContext.barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -421,7 +421,7 @@ public class Main {
                 sharedArray.array((tid * d + k) + sK_index, K.array(kvTileRow * d + k));
                 sharedArray.array((tid + d + k) + sV_index, V.array(kvTileRow * d + k));
             }
-            kernelContext.barrier();
+            KernelContext.barrier();
 
             // m we accumulate the max values
             float m_prev = m.array(tileId * blockN + tid);
@@ -478,7 +478,7 @@ public class Main {
             m.array(tileId * blockN + tid, m_new);
             l.array(tileId * blockN + tid, l_new);
 
-            kernelContext.barrier();
+            KernelContext.barrier();
         }
     }
 
@@ -520,12 +520,12 @@ public class Main {
     }
 
     @Reflect
-    public static void flashAttentionF16(KernelContext kernelContext,
+    public static void flashAttentionF16(KernelContext __,
                                       F16Array Q, F16Array K, F16Array V,
                                       F16Array O, F16Array m, F16Array l,
                                       final int N, final int d, final float softmaxScale) {
-        int bx = kernelContext.bix;
-        int tid = kernelContext.lix;
+        int bx = KernelContext.BIX();
+        int tid = KernelContext.LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -554,7 +554,7 @@ public class Main {
             sharedArray.array((tid * d + k) + sQ_index).value(valQ.value());
         }
 
-        kernelContext.barrier();
+        KernelContext.barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -568,7 +568,7 @@ public class Main {
                 sharedArray.array((tid * d + k) + sK_index).value(kVal.value());
                 sharedArray.array((tid + d + k) + sV_index).value(vVal.value());
             }
-            kernelContext.barrier();
+            KernelContext.barrier();
 
             // m we accumulate the max values
             F16 m_prev = m.array(tileId * blockN + tid);
@@ -644,7 +644,7 @@ public class Main {
             m.array(tileId * blockN + tid).value(m_new.value());
             l.array(tileId * blockN + tid).value(l_new.value());
 
-            kernelContext.barrier();
+            KernelContext.barrier();
         }
     }
 

--- a/hat/examples/flashattention/src/main/java/flashattention/Main.java
+++ b/hat/examples/flashattention/src/main/java/flashattention/Main.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.HATMath;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F16Array;
 import hat.buffer.F32Array;
@@ -102,11 +103,11 @@ public class Main {
      * @param softMaxScale
      */
     @Reflect
-    public static void selfAttentionV2HAT(KernelContext kernelContext,
+    public static void selfAttentionV2HAT(KernelContext unused,
                                           F32Array Q, F32Array K, F32Array V,
                                           F32Array attentionMatrix, F32Array O,
                                           final int N, final int d, final float softMaxScale) {
-        int idx = KernelContext.GIX();
+        int idx = GIX();
         if (idx < N) {
             // Compute the attention scores: Q * K^T and scale it to sqrt(d) => softMaxScale
             for (int j = 0; j < N; j++) {
@@ -379,12 +380,12 @@ public class Main {
      * @param softmaxScale
      */
     @Reflect
-    public static void flashAttention(KernelContext kernelContext,
+    public static void flashAttention(KernelContext unused,
                                       F32Array Q, F32Array K, F32Array V,
                                       F32Array O, F32Array m, F32Array l,
                                       final int N, final int d, final float softmaxScale) {
-        int bx = KernelContext.BIX();
-        int tid = KernelContext.LIX();
+        int bx = BIX();
+        int tid = LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -409,7 +410,7 @@ public class Main {
             sharedArray.array((tid * d + k) + sQ_index,
                     Q.array((startIndex + (tid * d + k) * d + k)));
         }
-        KernelContext.barrier();
+        barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -421,7 +422,7 @@ public class Main {
                 sharedArray.array((tid * d + k) + sK_index, K.array(kvTileRow * d + k));
                 sharedArray.array((tid + d + k) + sV_index, V.array(kvTileRow * d + k));
             }
-            KernelContext.barrier();
+            barrier();
 
             // m we accumulate the max values
             float m_prev = m.array(tileId * blockN + tid);
@@ -478,7 +479,7 @@ public class Main {
             m.array(tileId * blockN + tid, m_new);
             l.array(tileId * blockN + tid, l_new);
 
-            KernelContext.barrier();
+            barrier();
         }
     }
 
@@ -524,8 +525,8 @@ public class Main {
                                       F16Array Q, F16Array K, F16Array V,
                                       F16Array O, F16Array m, F16Array l,
                                       final int N, final int d, final float softmaxScale) {
-        int bx = KernelContext.BIX();
-        int tid = KernelContext.LIX();
+        int bx = BIX();
+        int tid = LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -554,7 +555,7 @@ public class Main {
             sharedArray.array((tid * d + k) + sQ_index).value(valQ.value());
         }
 
-        KernelContext.barrier();
+        barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -568,7 +569,7 @@ public class Main {
                 sharedArray.array((tid * d + k) + sK_index).value(kVal.value());
                 sharedArray.array((tid + d + k) + sV_index).value(vVal.value());
             }
-            KernelContext.barrier();
+            barrier();
 
             // m we accumulate the max values
             F16 m_prev = m.array(tileId * blockN + tid);
@@ -644,7 +645,7 @@ public class Main {
             m.array(tileId * blockN + tid).value(m_new.value());
             l.array(tileId * blockN + tid).value(l_new.value());
 
-            KernelContext.barrier();
+            barrier();
         }
     }
 

--- a/hat/examples/heal/src/main/java/heal/ComputeHeal.java
+++ b/hat/examples/heal/src/main/java/heal/ComputeHeal.java
@@ -50,6 +50,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.buffer.F32Array;
 import hat.buffer.S32Array2D;
 
@@ -238,7 +239,7 @@ public class ComputeHeal {
                                      Box selectionBox,
                                      XYRGBList xyrgbList,
                                      F32Array sumArray) {
-        bestFitCore(KernelContext.GIX(), s32Array2D, searchArea, selectionBox, xyrgbList, sumArray);
+        bestFitCore(GIX(), s32Array2D, searchArea, selectionBox, xyrgbList, sumArray);
     }
 
     @Reflect

--- a/hat/examples/heal/src/main/java/heal/ComputeHeal.java
+++ b/hat/examples/heal/src/main/java/heal/ComputeHeal.java
@@ -238,7 +238,7 @@ public class ComputeHeal {
                                      Box selectionBox,
                                      XYRGBList xyrgbList,
                                      F32Array sumArray) {
-        bestFitCore(kc.gix, s32Array2D, searchArea, selectionBox, xyrgbList, sumArray);
+        bestFitCore(KernelContext.GIX(), s32Array2D, searchArea, selectionBox, xyrgbList, sumArray);
     }
 
     @Reflect

--- a/hat/examples/life/src/main/java/life/Main.java
+++ b/hat/examples/life/src/main/java/life/Main.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import optkl.ifacemapper.BoundSchema;
 import optkl.ifacemapper.Buffer;
 import optkl.ifacemapper.MappableIface;
@@ -36,7 +37,7 @@ import optkl.ifacemapper.Schema;
 import io.github.robertograham.rleparser.RleParser;
 import io.github.robertograham.rleparser.domain.PatternData;
 import jdk.incubator.code.Reflect;
-import java.lang.foreign.Arena;
+
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
@@ -200,8 +201,8 @@ public class Main {
 
         @Reflect
         public static void life(KernelContext kc, Control control, CellGrid cellGrid) {
-            if (kc.gix < kc.gsx) {
-                ComputeLife.lifePerIdx(kc.gix, control, cellGrid);
+            if (GIX() < GSX()) {
+                ComputeLife.lifePerIdx(GIX(), control, cellGrid);
             }
         }
 

--- a/hat/examples/mandel/src/main/java/mandel/Main.java
+++ b/hat/examples/mandel/src/main/java/mandel/Main.java
@@ -27,9 +27,10 @@ package mandel;
 import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
-import hat.NDRange;
 import hat.KernelContext;
+import hat.NDRange;
 import hat.backend.Backend;
+import static hat.KernelContext.*;
 import hat.buffer.S32Array;
 import hat.buffer.S32Array2D;
 
@@ -38,14 +39,16 @@ import java.lang.invoke.MethodHandles;
 
 import jdk.incubator.code.Reflect;
 
+
+
 public class Main {
     @Reflect
-    public static void mandel(KernelContext kc, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
-        if (kc.gix < kc.gsx) {
+    public static void mandel(KernelContext kernelContext, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
+        if (GIX() < GSX()) {
             float width = s32Array2D.width();
             float height = s32Array2D.height();
-            float x = ((kc.gix % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-            float y = ((kc.gix / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+            float x = ((GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+            float y = ((GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
             float zx = x;
             float zy = y;
             float new_zx;
@@ -56,8 +59,9 @@ public class Main {
                 zx = new_zx;
                 colorIdx++;
             }
+            KernelContext.barrier();
             int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
-            s32Array2D.array(kc.gix, color);
+            s32Array2D.array(GIX(), color);
         }
     }
 
@@ -66,7 +70,7 @@ public class Main {
     static public void compute(final ComputeContext computeContext, S32Array pallete, S32Array2D s32Array2D, float x, float y, float scale) {
         computeContext.dispatchKernel(
                 NDRange.of1D(s32Array2D.width()*s32Array2D.height()),               //0..S32Array2D.size()
-                kc -> Main.mandel(kc, s32Array2D, pallete, x, y, scale));
+                kc -> Main.mandel( kc,s32Array2D, pallete, x, y, scale));
     }
 
     static void main(String[] args) {

--- a/hat/examples/mandel/src/main/java/mandel/Main.java
+++ b/hat/examples/mandel/src/main/java/mandel/Main.java
@@ -43,7 +43,7 @@ import jdk.incubator.code.Reflect;
 
 public class Main {
     @Reflect
-    public static void mandel(KernelContext kernelContext, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
+    public static void mandel(KernelContext unused, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
         if (GIX() < GSX()) {
             float width = s32Array2D.width();
             float height = s32Array2D.height();
@@ -59,7 +59,6 @@ public class Main {
                 zx = new_zx;
                 colorIdx++;
             }
-            KernelContext.barrier();
             int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
             s32Array2D.array(GIX(), color);
         }

--- a/hat/examples/matmul/src/main/java/matmul/Main.java
+++ b/hat/examples/matmul/src/main/java/matmul/Main.java
@@ -83,13 +83,13 @@ public class Main {
      */
     @Reflect
     public static void matrixMultiplyKernel2D(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
-            if (kc.giy < kc.gsy) {
+        if (kc.GIX() < kc.GSX()) {
+            if (kc.GIY() < kc.GSY()) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(kc.gix * size + k) * matrixB.array(k * size + kc.giy));
+                    acc += (matrixA.array(kc.GIX() * size + k) * matrixB.array(k * size + kc.GIY()));
                 }
-                matrixC.array(kc.gix * size + kc.giy, acc);
+                matrixC.array(kc.GIX() * size + kc.GIY(), acc);
             }
         }
     }
@@ -105,30 +105,30 @@ public class Main {
      */
     @Reflect
     public static void matrixMultiplyKernel2DLI(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
-            if (kc.giy < kc.gsy) {
+        if (kc.GIX() < kc.GSX()) {
+            if (kc.GIY() < kc.GSY()) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(kc.giy * size + k) * matrixB.array(k * size + kc.gix));
+                    acc += (matrixA.array(kc.GIY() * size + k) * matrixB.array(k * size + kc.GIX()));
                 }
-                matrixC.array(kc.giy * size + kc.gix, acc);
+                matrixC.array(kc.GIY() * size + kc.GIX(), acc);
             }
         }
     }
 
     @Reflect
     public static void matrixMultiplyKernel2DLIF16(KernelContext kc, F16Array matrixA, F16Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
-            if (kc.giy < kc.gsy) {
+        if (kc.GIX() < kc.GSX()) {
+            if (kc.GIY() < kc.GSY()) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    F16 ha = matrixA.array(kc.giy * size + k);
-                    F16 hb = matrixB.array(k * size + kc.gix);
+                    F16 ha = matrixA.array(kc.GIY() * size + k);
+                    F16 hb = matrixB.array(k * size + kc.GIX());
                     F16 hc = F16.mul(ha, hb);
                     float fc = F16.f16ToFloat(hc);
                     acc += fc;
                 }
-                matrixC.array(kc.giy * size + kc.gix, acc);
+                matrixC.array(kc.GIY() * size + kc.GIX(), acc);
             }
         }
     }
@@ -155,16 +155,16 @@ public class Main {
     }
 
     @Reflect
-    public static void matrixMultiplyKernel2DTiling(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
+    public static void matrixMultiplyKernel2DTiling(KernelContext __, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
 
         final int tileSize = 16;
         MyLocalArrayFixedSize tileA = MyLocalArrayFixedSize.createLocal();
         MyLocalArrayFixedSize tileB = MyLocalArrayFixedSize.createLocal();
 
-        int groupIndexX = kc.bix;
-        int groupIndexY = kc.biy;
-        int localIdx = kc.lix;
-        int localIdy = kc.liy;
+        int groupIndexX = KernelContext.BIX();
+        int groupIndexY = KernelContext.BIY();
+        int localIdx = KernelContext.LIX();
+        int localIdy = KernelContext.LIY();
 
         // we identify the row and column
         int row = groupIndexY * tileSize + localIdy;
@@ -179,7 +179,7 @@ public class Main {
 
             // Apply a barrier for the local group: we need to guarantee that all threads that belong
             // to the same group reach this point before doing the partial reduction
-            kc.barrier();
+            KernelContext.barrier();
 
             // compute partial reductions over the tile
             for (int k = 0; k < tileSize; k++) {
@@ -189,7 +189,7 @@ public class Main {
             // A new local barrier for all threads that belong to the same group before loading a new tile into
             // share memory. With the following barrier, we can ensure that all threads within the same workgroup
             // finished the compute for the partial reduction
-            kc.barrier();
+            KernelContext.barrier();
         }
 
         // copy result from shared memory to global memory
@@ -261,14 +261,14 @@ public class Main {
      * {@url https://siboehm.com/articles/22/CUDA-MMM}
      * </p>
      *
-     * @param kc
+     * @param __
      * @param matrixA
      * @param matrixB
      * @param matrixC
      * @param size
      */
     @Reflect
-    public static void matrixMultiplyKernel2DRegisterTiling(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
+    public static void matrixMultiplyKernel2DRegisterTiling(KernelContext __, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
 
         // Configuration for the kernel: Keep in mind that if you change the following parameters,
         // also change the scheduling (global and local work sizes).
@@ -278,15 +278,15 @@ public class Main {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = kc.bix;
-        int by = kc.biy;
+        int bx = KernelContext.BIX();
+        int by = KernelContext.BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = kc.liy * kc.lsx + kc.lix;
-        final int threadCol = kc.lix;
-        final int threadRow = kc.liy;
+        final int linearLocalId =  KernelContext.LIY() *  KernelContext.LSX() +  KernelContext.LIX();
+        final int threadCol =  KernelContext.LIX();
+        final int threadRow =  KernelContext.LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -329,7 +329,7 @@ public class Main {
                 tileB.array((innerRowB + loadOffset) * BN + innerColB,
                         matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom));
             }
-            kc.barrier();
+            KernelContext.barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -355,7 +355,7 @@ public class Main {
                     }
                 }
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -390,7 +390,7 @@ public class Main {
      * @param size
      */
     @Reflect
-    public static void matrixMultiplyKernel2DRegisterTilingVectorized(KernelContext kc, F32ArrayPadded matrixA, F32ArrayPadded matrixB, F32ArrayPadded matrixC, int size) {
+    public static void matrixMultiplyKernel2DRegisterTilingVectorized(KernelContext __, F32ArrayPadded matrixA, F32ArrayPadded matrixB, F32ArrayPadded matrixC, int size) {
 
         // Configuration for the kernel: Keep in mind that if you change the following parameters,
         // also change the scheduling (global and local work sizes).
@@ -403,12 +403,12 @@ public class Main {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = kc.bix;
-        int by = kc.biy;
+        int bx = KernelContext.BIX();
+        int by = KernelContext.BIY();
 
-        final int linearLocalId = kc.liy * kc.lsx + kc.lix;
-        final int threadCol = kc.lix;
-        final int threadRow = kc.liy;
+        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
+        final int threadCol = KernelContext.LIX();
+        final int threadRow = KernelContext.LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -450,7 +450,7 @@ public class Main {
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 2, loadB.z());
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 3, loadB.w());
 
-            kc.barrier();
+            KernelContext.barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -476,7 +476,7 @@ public class Main {
                     }
                 }
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -535,7 +535,7 @@ public class Main {
     }
 
     @Reflect
-    public static void matrixMultiplyKernel2DRegisterTilingHalf(KernelContext kc, F16Array matrixA, F16Array matrixB, F16Array matrixC, int size) {
+    public static void matrixMultiplyKernel2DRegisterTilingHalf(KernelContext __, F16Array matrixA, F16Array matrixB, F16Array matrixC, int size) {
 
         // Configuration for the kernel: Keep in mind that if you change the following parameters,
         // also change the scheduling (global and local work sizes).
@@ -545,15 +545,15 @@ public class Main {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = kc.bix;
-        int by = kc.biy;
+        int bx = KernelContext.BIX();
+        int by = KernelContext.BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = kc.liy * kc.lsx + kc.lix;
-        final int threadCol = kc.lix;
-        final int threadRow = kc.liy;
+        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
+        final int threadCol = KernelContext.LIX();
+        final int threadRow = KernelContext.LIY();
 
         SharedMemoryHalf tileA = SharedMemoryHalf.createLocal();
         SharedMemoryHalf tileB = SharedMemoryHalf.createLocal();
@@ -597,7 +597,7 @@ public class Main {
                 F16 hb = matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom);
                 tileB.array((innerRowB + loadOffset) * BN + innerColB).value(hb.value());
             }
-            kc.barrier();
+            KernelContext.barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -627,7 +627,7 @@ public class Main {
                     }
                 }
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -644,7 +644,7 @@ public class Main {
     public static float compute(KernelContext kc, F32Array matrixA, F32Array matrixB, int size, int j) {
         float acc = 0.0f;
         for (int k = 0; k < size; k++) {
-            acc += (matrixA.array(kc.gix * size + k) * matrixB.array(k * size + j));
+            acc += (matrixA.array(kc.GIX() * size + k) * matrixB.array(k * size + j));
         }
         return acc;
     }
@@ -652,21 +652,21 @@ public class Main {
     /**
      * Naive Matrix Multiplication implemented in 1D.
      *
-     * @param kc
+     * @param __
      * @param matrixA
      * @param matrixB
      * @param matrixC
      * @param size
      */
     @Reflect
-    public static void matrixMultiplyKernel1D(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
+    public static void matrixMultiplyKernel1D(KernelContext __, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
             for (int j = 0; j < size; j++) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(kc.gix * size + k) * matrixB.array(k * size + j));
+                    acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + j));
                 }
-                matrixC.array(kc.gix * size + j, acc);
+                matrixC.array(KernelContext.GIX() * size + j, acc);
             }
         }
     }
@@ -676,10 +676,10 @@ public class Main {
      */
     @Reflect
     public static void matrixMultiplyKernel1DWithFunctionCalls(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
+        if (kc.GIX() < kc.GSX()) {
             for (int j = 0; j < size; j++) {
                 float acc = compute(kc, matrixA, matrixB, size, j);
-                matrixC.array(kc.gix * size + j, acc);
+                matrixC.array(kc.GIX() * size + j, acc);
             }
         }
     }

--- a/hat/examples/matmul/src/main/java/matmul/Main.java
+++ b/hat/examples/matmul/src/main/java/matmul/Main.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange.Global2D;
 import hat.NDRange.Local2D;
 import hat.backend.Backend;
@@ -161,10 +162,10 @@ public class Main {
         MyLocalArrayFixedSize tileA = MyLocalArrayFixedSize.createLocal();
         MyLocalArrayFixedSize tileB = MyLocalArrayFixedSize.createLocal();
 
-        int groupIndexX = KernelContext.BIX();
-        int groupIndexY = KernelContext.BIY();
-        int localIdx = KernelContext.LIX();
-        int localIdy = KernelContext.LIY();
+        int groupIndexX = BIX();
+        int groupIndexY = BIY();
+        int localIdx = LIX();
+        int localIdy = LIY();
 
         // we identify the row and column
         int row = groupIndexY * tileSize + localIdy;
@@ -179,7 +180,7 @@ public class Main {
 
             // Apply a barrier for the local group: we need to guarantee that all threads that belong
             // to the same group reach this point before doing the partial reduction
-            KernelContext.barrier();
+            barrier();
 
             // compute partial reductions over the tile
             for (int k = 0; k < tileSize; k++) {
@@ -189,7 +190,7 @@ public class Main {
             // A new local barrier for all threads that belong to the same group before loading a new tile into
             // share memory. With the following barrier, we can ensure that all threads within the same workgroup
             // finished the compute for the partial reduction
-            KernelContext.barrier();
+            barrier();
         }
 
         // copy result from shared memory to global memory
@@ -278,15 +279,15 @@ public class Main {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = KernelContext.BIX();
-        int by = KernelContext.BIY();
+        int bx = BIX();
+        int by = BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId =  KernelContext.LIY() *  KernelContext.LSX() +  KernelContext.LIX();
-        final int threadCol =  KernelContext.LIX();
-        final int threadRow =  KernelContext.LIY();
+        final int linearLocalId =  LIY() *  LSX() +  LIX();
+        final int threadCol =  LIX();
+        final int threadRow =  LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -329,7 +330,7 @@ public class Main {
                 tileB.array((innerRowB + loadOffset) * BN + innerColB,
                         matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom));
             }
-            KernelContext.barrier();
+            barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -355,7 +356,7 @@ public class Main {
                     }
                 }
             }
-            KernelContext.barrier();
+            barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -403,12 +404,12 @@ public class Main {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = KernelContext.BIX();
-        int by = KernelContext.BIY();
+        int bx = BIX();
+        int by = BIY();
 
-        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
-        final int threadCol = KernelContext.LIX();
-        final int threadRow = KernelContext.LIY();
+        final int linearLocalId = LIY() * LSX() + LIX();
+        final int threadCol = LIX();
+        final int threadRow = LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -450,7 +451,7 @@ public class Main {
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 2, loadB.z());
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 3, loadB.w());
 
-            KernelContext.barrier();
+            barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -476,7 +477,7 @@ public class Main {
                     }
                 }
             }
-            KernelContext.barrier();
+            barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -545,15 +546,15 @@ public class Main {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = KernelContext.BIX();
-        int by = KernelContext.BIY();
+        int bx = BIX();
+        int by = BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
-        final int threadCol = KernelContext.LIX();
-        final int threadRow = KernelContext.LIY();
+        final int linearLocalId = LIY() * LSX() + LIX();
+        final int threadCol = LIX();
+        final int threadRow = LIY();
 
         SharedMemoryHalf tileA = SharedMemoryHalf.createLocal();
         SharedMemoryHalf tileB = SharedMemoryHalf.createLocal();
@@ -597,7 +598,7 @@ public class Main {
                 F16 hb = matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom);
                 tileB.array((innerRowB + loadOffset) * BN + innerColB).value(hb.value());
             }
-            KernelContext.barrier();
+            barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -627,7 +628,7 @@ public class Main {
                     }
                 }
             }
-            KernelContext.barrier();
+            barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -660,13 +661,13 @@ public class Main {
      */
     @Reflect
     public static void matrixMultiplyKernel1D(KernelContext __, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
+        if (GIX() < GSX()) {
             for (int j = 0; j < size; j++) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + j));
+                    acc += (matrixA.array(GIX() * size + k) * matrixB.array(k * size + j));
                 }
-                matrixC.array(KernelContext.GIX() * size + j, acc);
+                matrixC.array(GIX() * size + j, acc);
             }
         }
     }

--- a/hat/examples/nbody/src/main/java/nbody/Main.java
+++ b/hat/examples/nbody/src/main/java/nbody/Main.java
@@ -29,6 +29,7 @@ import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.buffer.F32Array;
 import hat.buffer.S32RGBAImage;
@@ -275,14 +276,14 @@ public class Main extends JFrame implements Runnable {
             float delT,
             float espSqr
     ) {
-        run(KernelContext.GIX(), bodies, xyzPos, xyzVel, image, imageWidth, mass, delT, espSqr);
+        run(GIX(), bodies, xyzPos, xyzVel, image, imageWidth, mass, delT, espSqr);
     }
 
     @Reflect
     public static void clearImage(
             KernelContext kc,
             S32RGBAImage image) {
-        image.data(KernelContext.GIX(), 0);
+        image.data(GIX(), 0);
     }
 
     @Reflect

--- a/hat/examples/nbody/src/main/java/nbody/Main.java
+++ b/hat/examples/nbody/src/main/java/nbody/Main.java
@@ -275,14 +275,14 @@ public class Main extends JFrame implements Runnable {
             float delT,
             float espSqr
     ) {
-        run(kc.gix, bodies, xyzPos, xyzVel, image, imageWidth, mass, delT, espSqr);
+        run(KernelContext.GIX(), bodies, xyzPos, xyzVel, image, imageWidth, mass, delT, espSqr);
     }
 
     @Reflect
     public static void clearImage(
             KernelContext kc,
             S32RGBAImage image) {
-        image.data(kc.gix, 0);
+        image.data(KernelContext.GIX(), 0);
     }
 
     @Reflect

--- a/hat/examples/nbodygl/src/main/java/nbodygl/opencl/OpenCLNBodyGLWindow.java
+++ b/hat/examples/nbodygl/src/main/java/nbodygl/opencl/OpenCLNBodyGLWindow.java
@@ -29,6 +29,7 @@ import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.types.Float4;
 import optkl.ifacemapper.BufferState;
 import hat.NDRange;
@@ -74,9 +75,9 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
         float accx = 0.0f;
         float accy = 0.0f;
         float accz = 0.0f;
-        Universe.Body me = universe.body(kc.gix);
+        Universe.Body me = universe.body(GIX());
 
-        for (int i = 0; i < kc.gsx; i++) {
+        for (int i = 0; i < GSX(); i++) {
             Universe.Body otherBody = universe.body(i);
             float dx = otherBody.x() - me.x();
             float dy = otherBody.y() - me.y();
@@ -105,9 +106,9 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
         var acc = Float4.of(0,0,0,0);
         var posArr = universe.posArrView();
         var velArr = universe.velArrView();
-        var pos = posArr[kc.gix];
-        var vel = velArr[kc.gix];
-        for (int i = 0; i < kc.gix; i++) {
+        var pos = posArr[GIX()];
+        var vel = velArr[GIX()];
+        for (int i = 0; i < GIX(); i++) {
             var delta = posArr[i].sub(pos);
             var delSqr = delta.sqr();
             var delSqrSum = delSqr.x() + delSqr.y() + delSqr.z();
@@ -118,8 +119,8 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
         acc = acc.mul(delT);
         pos = pos.add(vel.mul(delT).add(acc.mul(.5f * delT)));
         vel = vel.add(acc);
-        posArr[kc.gix] = pos;
-        velArr[kc.gix] = vel;
+        posArr[GIX()] = pos;
+        velArr[GIX()] = vel;
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/Main.java
+++ b/hat/examples/shade/src/main/java/shade/Main.java
@@ -50,10 +50,10 @@ public class Main {
     @Reflect
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
-        var fragColor = JuliaShader.mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(kc.gix / width)));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = JuliaShader.mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(KernelContext.GIX() / width)));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/Main.java
+++ b/hat/examples/shade/src/main/java/shade/Main.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -50,10 +51,10 @@ public class Main {
     @Reflect
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
-        var fragColor = JuliaShader.mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(KernelContext.GIX() / width)));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = JuliaShader.mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(GIX() / width)));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/AcesShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/AcesShader.java
@@ -139,10 +139,10 @@ public class AcesShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/AcesShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/AcesShader.java
@@ -30,6 +30,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -139,10 +140,10 @@ public class AcesShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/AnimShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/AnimShader.java
@@ -163,10 +163,10 @@ public class AnimShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/AnimShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/AnimShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -163,10 +164,10 @@ public class AnimShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/GalaxyShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/GalaxyShader.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -175,10 +176,10 @@ public class GalaxyShader {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/GalaxyShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/GalaxyShader.java
@@ -175,10 +175,10 @@ public class GalaxyShader {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/GroovyShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/GroovyShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -94,10 +95,10 @@ public class GroovyShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/GroovyShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/GroovyShader.java
@@ -94,10 +94,10 @@ public class GroovyShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/IntroShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/IntroShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -255,10 +256,10 @@ public class IntroShader {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/IntroShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/IntroShader.java
@@ -255,10 +255,10 @@ public class IntroShader {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/JuliaShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/JuliaShader.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -212,10 +213,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/JuliaShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/JuliaShader.java
@@ -212,10 +212,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/MobiusShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/MobiusShader.java
@@ -323,10 +323,10 @@ public class MobiusShader{
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/MobiusShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/MobiusShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -323,10 +324,10 @@ public class MobiusShader{
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/MouseSensitiveShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/MouseSensitiveShader.java
@@ -30,6 +30,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -74,10 +75,10 @@ public class MouseSensitiveShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/MouseSensitiveShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/MouseSensitiveShader.java
@@ -74,10 +74,10 @@ public class MouseSensitiveShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/PaintShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/PaintShader.java
@@ -105,10 +105,10 @@ public class PaintShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/PaintShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/PaintShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 
@@ -105,10 +106,10 @@ public class PaintShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/PiratesShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/PiratesShader.java
@@ -192,10 +192,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/PiratesShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/PiratesShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -192,10 +193,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/RandShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/RandShader.java
@@ -331,10 +331,10 @@ public class RandShader   {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/RandShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/RandShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -331,10 +332,10 @@ public class RandShader   {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SeaScapeShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SeaScapeShader.java
@@ -543,10 +543,10 @@ public class SeaScapeShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SeaScapeShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SeaScapeShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -540,13 +541,13 @@ public class SeaScapeShader  {
     }
 
     @Reflect
-    public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
+    public static void penumbra(@MappableIface.RO KernelContext unused, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SeveranceShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SeveranceShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -157,10 +158,10 @@ public class SeveranceShader {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SeveranceShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SeveranceShader.java
@@ -157,10 +157,10 @@ public class SeveranceShader {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SpiralShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SpiralShader.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -184,10 +185,10 @@ public class SpiralShader{
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SpiralShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SpiralShader.java
@@ -184,10 +184,10 @@ public class SpiralShader{
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SquareWaveShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SquareWaveShader.java
@@ -30,6 +30,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -214,10 +215,10 @@ public class SquareWaveShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/SquareWaveShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/SquareWaveShader.java
@@ -214,10 +214,10 @@ public class SquareWaveShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/TextureShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/TextureShader.java
@@ -284,12 +284,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
         var fragColor = mainImage(uniforms, vec4.vec4(0f),
-                vec2.vec2((float)(kc.gix % width),
-                        (float)(height-(kc.gix / width))),tex,tw,th
+                vec2.vec2((float)(KernelContext.GIX() % width),
+                        (float)(height-(KernelContext.GIX() / width))),tex,tw,th
         );
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/TextureShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/TextureShader.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -284,12 +285,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
         var fragColor = mainImage(uniforms, vec4.vec4(0f),
-                vec2.vec2((float)(KernelContext.GIX() % width),
-                        (float)(height-(KernelContext.GIX() / width))),tex,tw,th
+                vec2.vec2((float)(GIX() % width),
+                        (float)(height-(GIX() / width))),tex,tw,th
         );
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/Truchet2Shader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/Truchet2Shader.java
@@ -190,10 +190,10 @@ public class Truchet2Shader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/Truchet2Shader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/Truchet2Shader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -190,10 +191,10 @@ public class Truchet2Shader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/TruchetShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/TruchetShader.java
@@ -30,6 +30,7 @@ import hat.ComputeContext;
 
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -212,10 +213,10 @@ public class TruchetShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/TruchetShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/TruchetShader.java
@@ -212,10 +212,10 @@ public class TruchetShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/TutorialShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/TutorialShader.java
@@ -137,10 +137,10 @@ public class TutorialShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/TutorialShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/TutorialShader.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -137,10 +138,10 @@ public class TutorialShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/WavesShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/WavesShader.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.Accelerator.Compute;
 import hat.ComputeContext.Kernel;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -463,10 +464,10 @@ public class WavesShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
-        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
-        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
-        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(GIX() % width), (float)(height-(GIX() / width))));
+        f32Array.array(GIX() * 3, fragColor.x());
+        f32Array.array(GIX() * 3+1, fragColor.y());
+        f32Array.array(GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/shade/src/main/java/shade/shaders/WavesShader.java
+++ b/hat/examples/shade/src/main/java/shade/shaders/WavesShader.java
@@ -463,10 +463,10 @@ public class WavesShader  {
     public static void penumbra(@MappableIface.RO KernelContext kc, @MappableIface.RO Uniforms uniforms, @MappableIface.RW F32Array f32Array) {
         int width = (int) uniforms.iResolution().x();
         int height = (int) uniforms.iResolution().y();
-        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(kc.gix % width), (float)(height-(kc.gix / width))));
-        f32Array.array(kc.gix * 3, fragColor.x());
-        f32Array.array(kc.gix * 3+1, fragColor.y());
-        f32Array.array(kc.gix * 3+2, fragColor.z());
+        var fragColor = mainImage(uniforms, vec4.vec4(0f), vec2.vec2((float)(KernelContext.GIX() % width), (float)(height-(KernelContext.GIX() / width))));
+        f32Array.array(KernelContext.GIX() * 3, fragColor.x());
+        f32Array.array(KernelContext.GIX() * 3+1, fragColor.y());
+        f32Array.array(KernelContext.GIX() * 3+2, fragColor.z());
     }
 
     @Reflect

--- a/hat/examples/squares/src/main/java/squares/Main.java
+++ b/hat/examples/squares/src/main/java/squares/Main.java
@@ -29,6 +29,8 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.S32Array;
 
@@ -45,9 +47,9 @@ public class Main {
 
     @Reflect
     public static void squareKernel(KernelContext kc, S32Array s32Array) {
-        if (KernelContext.GIX() < KernelContext.GSX()){
-           int value = s32Array.array(KernelContext.GIX());       // arr[cc.x]
-           s32Array.array(KernelContext.GIX(), squareit(value));  // arr[cc.x]=value*value
+        if (GIX() < GSX()){
+           int value = s32Array.array(GIX());       // arr[cc.x]
+           s32Array.array(GIX(), squareit(value));  // arr[cc.x]=value*value
         }
     }
 

--- a/hat/examples/squares/src/main/java/squares/Main.java
+++ b/hat/examples/squares/src/main/java/squares/Main.java
@@ -45,9 +45,9 @@ public class Main {
 
     @Reflect
     public static void squareKernel(KernelContext kc, S32Array s32Array) {
-        if (kc.gix < kc.gsx){
-           int value = s32Array.array(kc.gix);       // arr[cc.x]
-           s32Array.array(kc.gix, squareit(value));  // arr[cc.x]=value*value
+        if (KernelContext.GIX() < KernelContext.GSX()){
+           int value = s32Array.array(KernelContext.GIX());       // arr[cc.x]
+           s32Array.array(KernelContext.GIX(), squareit(value));  // arr[cc.x]=value*value
         }
     }
 

--- a/hat/examples/tensors/src/main/java/tensors/Main.java
+++ b/hat/examples/tensors/src/main/java/tensors/Main.java
@@ -28,6 +28,8 @@ import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.KernelContext;
+
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F16Array;
@@ -70,8 +72,8 @@ public class Main {
         final int WMMA_M = shapeSize;
         final int WMMA_N = shapeSize;
         final int WMMA_K = shapeSize;
-        int warpM = kc.gix / kc.wrs;
-        int warpN = kc.giy;
+        int warpM = GIX() / WRS();
+        int warpN = GIY();
 
         final int lda = size;
         final int ldb = size;
@@ -106,12 +108,12 @@ public class Main {
 
     @Reflect
     public static void mxmNaiveF32(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx && kc.giy < kc.gsy) {
+        if (GIX() < GSX() && GIY() < GSY()) {
             float acc = 0.0f;
             for (int k = 0; k < size; k++) {
-                acc += (matrixA.array(k * size + kc.giy) * matrixB.array(kc.gix * size + k));
+                acc += (matrixA.array(k * size + GIY()) * matrixB.array(GIX() * size + k));
             }
-            matrixC.array(kc.gix * size + kc.giy, acc);
+            matrixC.array(GIX() * size + GIY(), acc);
         }
     }
 
@@ -124,16 +126,16 @@ public class Main {
 
     @Reflect
     public static void mxmNaiveF16(KernelContext kc, F16Array matrixA, F16Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx && kc.giy < kc.gsy) {
+        if (GIX() < GSX() && GIY() < GSY()) {
             float acc = 0.0f;
             for (int k = 0; k < size; k++) {
-                F16 ha = matrixA.array(k * size + kc.giy);
-                F16 hb = matrixB.array(kc.gix * size + k);
+                F16 ha = matrixA.array(k * size + GIY());
+                F16 hb = matrixB.array(GIX() * size + k);
                 F16 hc = F16.mul(ha, hb);
                 float fc = F16.f16ToFloat(hc);
                 acc += fc;
             }
-            matrixC.array(kc.gix * size + kc.giy, acc);
+            matrixC.array(GIX() * size + GIY(), acc);
         }
 
     }

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
@@ -27,6 +27,7 @@ package violajones;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.buffer.F32Array2D;
 import hat.buffer.S08x3RGBImage;
 import violajones.ifaces.Cascade;
@@ -71,8 +72,8 @@ public class ViolaJonesCoreCompute {
 
     @Reflect
     public static void rgbToGreyKernel(KernelContext kc, S08x3RGBImage rgbImage, F32Array2D greyImage) {
-        if (KernelContext.GIX() < KernelContext.GSX()){
-           rgbToGrey(KernelContext.GIX(), rgbImage, greyImage);
+        if (GIX() < GSX()){
+           rgbToGrey(GIX(), rgbImage, greyImage);
         }
     }
 
@@ -86,9 +87,9 @@ public class ViolaJonesCoreCompute {
 
     @Reflect
     public static void integralColKernel(KernelContext kc, F32Array2D greyImage, F32Array2D integral, F32Array2D integralSq) {
-        if (KernelContext.GIX() <KernelContext.GSX()){  // KernelContext.GSX() = imageWidth
-           int x = KernelContext.GIX();
-           int width = KernelContext.GSX();
+        if (GIX() <GSX()){  // GSX() = imageWidth
+           int x = GIX();
+           int width = GSX();
            int height = greyImage.height();
            for (int y = 1; y < height; y++) {
                int id =(y * width) + x;
@@ -116,8 +117,8 @@ public class ViolaJonesCoreCompute {
 
     @Reflect
     public static void integralRowKernel(KernelContext kc, F32Array2D integral, F32Array2D integralSq) {
-        if (KernelContext.GIX() <KernelContext.GSX()){  // KernelContext.GSX() == imageHeight
-           int y = KernelContext.GIX();
+        if (GIX() <GSX()){  // GSX() == imageHeight
+           int y = GIX();
            int width = integral.width();
            for (int x = 1; x < width; x++) {
                int id =(y * width) + x;
@@ -239,7 +240,7 @@ public class ViolaJonesCoreCompute {
 
     ) {
 
-        if (KernelContext.GIX() < KernelContext.GSX()){//;scaleTable.multiScaleAccumulativeRange()) {
+        if (GIX() < GSX()){//;scaleTable.multiScaleAccumulativeRange()) {
             // We need to determine the scale information for a given gid.
             // we check each scale in the scale table and check if our gid is
             // covered by the scale.
@@ -248,7 +249,7 @@ public class ViolaJonesCoreCompute {
           //  var offset=scale.offset();
            // System.out.println("scale offset "+offset);
             scalc++;
-            while (KernelContext.GIX() >= scale.accumGridSizeMax() && scalc<scaleTable.length()) {
+            while (GIX() >= scale.accumGridSizeMax() && scalc<scaleTable.length()) {
                 scale = scaleTable.scale(scalc);
              //   var layout =scale.layout();
               //  offset=scale.offset();
@@ -257,7 +258,7 @@ public class ViolaJonesCoreCompute {
             }
 
             // Now we need to convert our scale relative git to an x,y,w,h
-            int scaleGid = KernelContext.GIX() - scale.accumGridSizeMin();
+            int scaleGid = GIX() - scale.accumGridSizeMin();
 
             int x = (int) ((scaleGid % scale.gridWidth()) * scale.scaledXInc());
             int y = (int) ((scaleGid / scale.gridWidth()) * scale.scaledYInc());
@@ -285,7 +286,7 @@ public class ViolaJonesCoreCompute {
                 Cascade.Stage stage = cascade.stage(stagec);
               //  Class stageClass = stage.getClass();
                // long stageOffset = stage.offset();
-                stillLooksLikeAFace = isAFaceStage(KernelContext.GIX(), scale.scaleValue(), scale.invArea(), x, y, vnorm, integral, stage, cascade);
+                stillLooksLikeAFace = isAFaceStage(GIX(), scale.scaleValue(), scale.invArea(), x, y, vnorm, integral, stage, cascade);
             }
 
             if (stillLooksLikeAFace) {

--- a/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
+++ b/hat/examples/violajones/src/main/java/violajones/ViolaJonesCoreCompute.java
@@ -71,8 +71,8 @@ public class ViolaJonesCoreCompute {
 
     @Reflect
     public static void rgbToGreyKernel(KernelContext kc, S08x3RGBImage rgbImage, F32Array2D greyImage) {
-        if (kc.gix < kc.gsx){
-           rgbToGrey(kc.gix, rgbImage, greyImage);
+        if (KernelContext.GIX() < KernelContext.GSX()){
+           rgbToGrey(KernelContext.GIX(), rgbImage, greyImage);
         }
     }
 
@@ -86,9 +86,9 @@ public class ViolaJonesCoreCompute {
 
     @Reflect
     public static void integralColKernel(KernelContext kc, F32Array2D greyImage, F32Array2D integral, F32Array2D integralSq) {
-        if (kc.gix <kc.gsx){  // kc.gsx = imageWidth
-           int x = kc.gix;
-           int width = kc.gsx;
+        if (KernelContext.GIX() <KernelContext.GSX()){  // KernelContext.GSX() = imageWidth
+           int x = KernelContext.GIX();
+           int width = KernelContext.GSX();
            int height = greyImage.height();
            for (int y = 1; y < height; y++) {
                int id =(y * width) + x;
@@ -116,8 +116,8 @@ public class ViolaJonesCoreCompute {
 
     @Reflect
     public static void integralRowKernel(KernelContext kc, F32Array2D integral, F32Array2D integralSq) {
-        if (kc.gix <kc.gsx){  // kc.gsx == imageHeight
-           int y = kc.gix;
+        if (KernelContext.GIX() <KernelContext.GSX()){  // KernelContext.GSX() == imageHeight
+           int y = KernelContext.GIX();
            int width = integral.width();
            for (int x = 1; x < width; x++) {
                int id =(y * width) + x;
@@ -239,7 +239,7 @@ public class ViolaJonesCoreCompute {
 
     ) {
 
-        if (kc.gix < kc.gsx){//;scaleTable.multiScaleAccumulativeRange()) {
+        if (KernelContext.GIX() < KernelContext.GSX()){//;scaleTable.multiScaleAccumulativeRange()) {
             // We need to determine the scale information for a given gid.
             // we check each scale in the scale table and check if our gid is
             // covered by the scale.
@@ -248,7 +248,7 @@ public class ViolaJonesCoreCompute {
           //  var offset=scale.offset();
            // System.out.println("scale offset "+offset);
             scalc++;
-            while (kc.gix >= scale.accumGridSizeMax() && scalc<scaleTable.length()) {
+            while (KernelContext.GIX() >= scale.accumGridSizeMax() && scalc<scaleTable.length()) {
                 scale = scaleTable.scale(scalc);
              //   var layout =scale.layout();
               //  offset=scale.offset();
@@ -257,7 +257,7 @@ public class ViolaJonesCoreCompute {
             }
 
             // Now we need to convert our scale relative git to an x,y,w,h
-            int scaleGid = kc.gix - scale.accumGridSizeMin();
+            int scaleGid = KernelContext.GIX() - scale.accumGridSizeMin();
 
             int x = (int) ((scaleGid % scale.gridWidth()) * scale.scaledXInc());
             int y = (int) ((scaleGid / scale.gridWidth()) * scale.scaledYInc());
@@ -285,7 +285,7 @@ public class ViolaJonesCoreCompute {
                 Cascade.Stage stage = cascade.stage(stagec);
               //  Class stageClass = stage.getClass();
                // long stageOffset = stage.offset();
-                stillLooksLikeAFace = isAFaceStage(kc.gix, scale.scaleValue(), scale.invArea(), x, y, vnorm, integral, stage, cascade);
+                stillLooksLikeAFace = isAFaceStage(KernelContext.GIX(), scale.scaleValue(), scale.invArea(), x, y, vnorm, integral, stage, cascade);
             }
 
             if (stillLooksLikeAFace) {

--- a/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
+++ b/hat/examples/violajones/src/main/java/violajones/attic/ViolaJones.java
@@ -327,7 +327,8 @@ public class ViolaJones {
 */
 
         if (true) {
-            long start = System.currentTimeMillis();
+            throw new RuntimeException("Refactor violajones. It Seems to always use workstealer?");
+        /*    long start = System.currentTimeMillis();
             WorkStealer.usingAllProcessors()
                     .forEachInRange(accelerator.range(NDRange.of1D(scaleTable.multiScaleAccumulativeRange())), kc -> {
                         ReferenceJavaViolaJones.findFeatures(
@@ -340,7 +341,7 @@ public class ViolaJones {
                     });
             long ms = (System.currentTimeMillis() - start);
             System.out.println("done " + ms + "ms");
-            harViz.showResults(resultTable, null, null, ms);
+            harViz.showResults(resultTable, null, null, ms); */
         }
         //   } else if (mode.equals("javaSegments")) {
 

--- a/hat/intellij/.idea/modules.xml
+++ b/hat/intellij/.idea/modules.xml
@@ -9,30 +9,29 @@
       <module fileurl="file://$PROJECT_DIR$/backend_ffi_spirv.iml" filepath="$PROJECT_DIR$/backend_ffi_spirv.iml" />
       <module fileurl="file://$PROJECT_DIR$/backend_java_mt.iml" filepath="$PROJECT_DIR$/backend_java_mt.iml" />
       <module fileurl="file://$PROJECT_DIR$/backend_java_seq.iml" filepath="$PROJECT_DIR$/backend_java_seq.iml" />
-      <module fileurl="file://$PROJECT_DIR$/backend_jextracted_opencl.iml" filepath="$PROJECT_DIR$/backend_jextracted_opencl.iml" />
       <module fileurl="file://$PROJECT_DIR$/backend_jextracted_shared.iml" filepath="$PROJECT_DIR$/backend_jextracted_shared.iml" />
-      <module fileurl="file://$PROJECT_DIR$/optkl.iml" filepath="$PROJECT_DIR$/optkl.iml" />
       <module fileurl="file://$PROJECT_DIR$/core.iml" filepath="$PROJECT_DIR$/core.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_blackscholes.iml" filepath="$PROJECT_DIR$/example_blackscholes.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_experiments.iml" filepath="$PROJECT_DIR$/example_experiments.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example_flashattention.iml" filepath="$PROJECT_DIR$/example_flashattention.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_heal.iml" filepath="$PROJECT_DIR$/example_heal.iml" />
-      <module fileurl="file://$PROJECT_DIR$/example_shade.iml" filepath="$PROJECT_DIR$/example_shade.iml" />
-      <module fileurl="file://$PROJECT_DIR$/example_normmap.iml" filepath="$PROJECT_DIR$/example_normmap.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_life.iml" filepath="$PROJECT_DIR$/example_life.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example_fft.iml" filepath="$PROJECT_DIR$/example_fft.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example_dft.iml" filepath="$PROJECT_DIR$/example_dft.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example_tensors.iml" filepath="$PROJECT_DIR$/example_tensors.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_mandel.iml" filepath="$PROJECT_DIR$/example_mandel.iml" />
-      <module fileurl="file://$PROJECT_DIR$/example_nbodygl.iml" filepath="$PROJECT_DIR$/example_nbodygl.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example_matmul.iml" filepath="$PROJECT_DIR$/example_matmul.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_nbody.iml" filepath="$PROJECT_DIR$/example_nbody.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example_normmap.iml" filepath="$PROJECT_DIR$/example_normmap.iml" />
+      <module fileurl="file://$PROJECT_DIR$/example_shade.iml" filepath="$PROJECT_DIR$/example_shade.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_shared.iml" filepath="$PROJECT_DIR$/example_shared.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_squares.iml" filepath="$PROJECT_DIR$/example_squares.iml" />
-      <module fileurl="file://$PROJECT_DIR$/example_flashattention.iml" filepath="$PROJECT_DIR$/example_flashattention.iml" />
-      <module fileurl="file://$PROJECT_DIR$/example_matmul.iml" filepath="$PROJECT_DIR$/example_matmul.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_view.iml" filepath="$PROJECT_DIR$/example_view.iml" />
       <module fileurl="file://$PROJECT_DIR$/example_violajones.iml" filepath="$PROJECT_DIR$/example_violajones.iml" />
       <module fileurl="file://$PROJECT_DIR$/job.iml" filepath="$PROJECT_DIR$/job.iml" />
+      <module fileurl="file://$PROJECT_DIR$/optkl.iml" filepath="$PROJECT_DIR$/optkl.iml" />
       <module fileurl="file://$PROJECT_DIR$/tests.iml" filepath="$PROJECT_DIR$/tests.iml" />
       <module fileurl="file://$PROJECT_DIR$/wrap_cuda.iml" filepath="$PROJECT_DIR$/wrap_cuda.iml" />
-      <module fileurl="file://$PROJECT_DIR$/wrap_opencl.iml" filepath="$PROJECT_DIR$/wrap_opencl.iml" />
-      <module fileurl="file://$PROJECT_DIR$/wrap_opengl.iml" filepath="$PROJECT_DIR$/wrap_opengl.iml" />
       <module fileurl="file://$PROJECT_DIR$/wrap_shared.iml" filepath="$PROJECT_DIR$/wrap_shared.iml" />
     </modules>
   </component>

--- a/hat/intellij/example_dft.iml
+++ b/hat/intellij/example_dft.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../examples/dft">
+      <sourceFolder url="file://$MODULE_DIR$/../examples/dft/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../examples/dft/src/main/resources" type="java-resource" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="core" />
+    <orderEntry type="module" module-name="example_shared" />
+    <orderEntry type="module" module-name="optkl" />
+  </component>
+</module>

--- a/hat/intellij/example_fft.iml
+++ b/hat/intellij/example_fft.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../examples/fft">
+      <sourceFolder url="file://$MODULE_DIR$/../examples/fft/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../examples/fft/src/main/resources" type="java-resource" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="core" />
+    <orderEntry type="module" module-name="example_shared" />
+    <orderEntry type="module" module-name="optkl" />
+  </component>
+</module>

--- a/hat/intellij/example_nbody.iml
+++ b/hat/intellij/example_nbody.iml
@@ -11,8 +11,6 @@
     <orderEntry type="module" module-name="core" />
     <orderEntry type="module" module-name="backend_ffi_opencl" />
     <orderEntry type="module" module-name="wrap_shared" />
-    <orderEntry type="module" module-name="wrap_opencl" />
-    <orderEntry type="module" module-name="wrap_opengl" />
     <orderEntry type="module" module-name="backend_ffi_shared" />
     <orderEntry type="module" module-name="optkl" />
     <orderEntry type="module-library">

--- a/hat/intellij/example_nbodygl.iml
+++ b/hat/intellij/example_nbodygl.iml
@@ -11,8 +11,6 @@
     <orderEntry type="module" module-name="core" />
     <orderEntry type="module" module-name="backend_ffi_opencl" />
     <orderEntry type="module" module-name="wrap_shared" />
-    <orderEntry type="module" module-name="wrap_opencl" />
-    <orderEntry type="module" module-name="wrap_opengl" />
     <orderEntry type="module" module-name="backend_ffi_shared" />
     <orderEntry type="module" module-name="optkl" />
     <orderEntry type="module-library">

--- a/hat/intellij/example_tensors.iml
+++ b/hat/intellij/example_tensors.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../examples/tensors">
+      <sourceFolder url="file://$MODULE_DIR$/../examples/tensors/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../examples/tensors/src/main/resources" type="java-resource" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="core" />
+    <orderEntry type="module" module-name="example_shared" />
+    <orderEntry type="module" module-name="optkl" />
+  </component>
+</module>

--- a/hat/tests/src/main/java/hat/test/TestArrayView.java
+++ b/hat/tests/src/main/java/hat/test/TestArrayView.java
@@ -52,9 +52,9 @@ public class TestArrayView {
      */
     @Reflect
     public static void squareKernel(KernelContext kc, S32Array s32Array) {
-        if (kc.gix < kc.gsx){
+        if (KernelContext.GIX() < KernelContext.GSX()){
             int[] arr = s32Array.arrayView();
-            arr[kc.gix] *= arr[kc.gix];
+            arr[KernelContext.GIX()] *= arr[KernelContext.GIX()];
         }
     }
 
@@ -87,8 +87,8 @@ public class TestArrayView {
      */
     @Reflect
     public static void squareKernelNoVarOp(KernelContext kc, S32Array s32Array) {
-        if (kc.gix<kc.gsx){
-            s32Array.arrayView()[kc.gix] *= s32Array.arrayView()[kc.gix];
+        if (KernelContext.GIX()<KernelContext.GSX()){
+            s32Array.arrayView()[KernelContext.GIX()] *= s32Array.arrayView()[KernelContext.GIX()];
         }
     }
 
@@ -117,9 +117,9 @@ public class TestArrayView {
 
     @Reflect
     public static void square2DKernel(KernelContext kc, S32Array2D s32Array2D) {
-        if (kc.gix < kc.gsx){
+        if (KernelContext.GIX() < KernelContext.GSX()){
             int[][] arr = s32Array2D.arrayView();
-            arr[kc.gix][kc.giy] *= arr[kc.gix][kc.giy];
+            arr[KernelContext.GIX()][KernelContext.GIY()] *= arr[KernelContext.GIX()][KernelContext.GIY()];
         }
     }
 
@@ -290,8 +290,8 @@ public class TestArrayView {
 
         @Reflect
         public static void life(KernelContext kc, CellGrid cellGrid, CellGrid cellGridRes) {
-            if (kc.gix < kc.gsx) {
-                Compute.lifePerIdx(kc.gix, cellGrid, cellGridRes);
+            if (KernelContext.GIX() < KernelContext.GSX()) {
+                Compute.lifePerIdx(KernelContext.GIX(), cellGrid, cellGridRes);
             }
         }
 
@@ -388,13 +388,13 @@ public class TestArrayView {
 
     @Reflect
     public static void mandel(KernelContext kc, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
-        if (kc.gix < kc.gsx) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
             int[] pal = pallette.arrayView();
             int[][] s32 = s32Array2D.arrayView();
             float width = s32Array2D.width();
             float height = s32Array2D.height();
-            float x = ((kc.gix % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-            float y = ((kc.gix / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+            float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+            float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
             float zx = x;
             float zy = y;
             float new_zx;
@@ -406,7 +406,7 @@ public class TestArrayView {
                 colorIdx++;
             }
             int color = colorIdx < pal.length ? pal[colorIdx] : 0;
-            s32[kc.gix % s32Array2D.width()][kc.gix / s32Array2D.width()] = color;
+            s32[KernelContext.GIX() % s32Array2D.width()][KernelContext.GIX() / s32Array2D.width()] = color;
         }
     }
 
@@ -466,21 +466,21 @@ public class TestArrayView {
                                           F32Array tArray,
                                           float r,
                                           float v) {
-        if (kc.gix<kc.gsx){
+        if (KernelContext.GIX()<KernelContext.GSX()){
             float[] callArr = call.arrayView();
             float[] putArr = put.arrayView();
             float[] sArr = sArray.arrayView();
             float[] xArr = xArray.arrayView();
             float[] tArr = tArray.arrayView();
 
-            float expNegRt = (float) Math.exp(-r * tArr[kc.gix]);
-            float d1 = (float) ((Math.log(sArr[kc.gix] / xArr[kc.gix]) + (r + v * v * .5f) * tArr[kc.gix]) / (v * Math.sqrt(tArr[kc.gix])));
-            float d2 = (float) (d1 - v * Math.sqrt(tArr[kc.gix]));
+            float expNegRt = (float) Math.exp(-r * tArr[KernelContext.GIX()]);
+            float d1 = (float) ((Math.log(sArr[KernelContext.GIX()] / xArr[KernelContext.GIX()]) + (r + v * v * .5f) * tArr[KernelContext.GIX()]) / (v * Math.sqrt(tArr[KernelContext.GIX()])));
+            float d2 = (float) (d1 - v * Math.sqrt(tArr[KernelContext.GIX()]));
             float cnd1 = CND(d1);
             float cnd2 = CND(d2);
-            float value = sArr[kc.gix] * cnd1 - expNegRt * xArr[kc.gix] * cnd2;
-            callArr[kc.gix] = value;
-            putArr[kc.gix] = expNegRt * xArr[kc.gix] * (1 - cnd2) - sArr[kc.gix] * (1 - cnd1);
+            float value = sArr[KernelContext.GIX()] * cnd1 - expNegRt * xArr[KernelContext.GIX()] * cnd2;
+            callArr[KernelContext.GIX()] = value;
+            putArr[KernelContext.GIX()] = expNegRt * xArr[KernelContext.GIX()] * (1 - cnd2) - sArr[KernelContext.GIX()] * (1 - cnd1);
         }
     }
 
@@ -619,19 +619,19 @@ public class TestArrayView {
     @Reflect
     public static void squareKernelWithPrivateAndLocal(KernelContext kc, S32Array s32Array) {
         SharedMemory shared = SharedMemory.createLocal();
-        if (kc.gix < kc.gsx){
+        if (KernelContext.GIX() < KernelContext.GSX()){
             int[] arr = s32Array.arrayView();
-            arr[kc.gix] += arr[kc.gix];
+            arr[KernelContext.GIX()] += arr[KernelContext.GIX()];
 
             PrivateArray priv = PrivateArray.createPrivate();
             int[] privView = priv.privateArrayView();
             privView[0] = 1;
-            arr[kc.gix] += privView[0];
+            arr[KernelContext.GIX()] += privView[0];
 
             int[] sharedView = shared.localArrayView();
             sharedView[0] = 16;
-            kc.barrier();
-            arr[kc.gix] += sharedView[0];
+            KernelContext.barrier();
+            arr[KernelContext.GIX()] += sharedView[0];
         }
     }
 
@@ -700,17 +700,17 @@ public class TestArrayView {
     @Reflect
     public static void kernelBasicDeviceType( KernelContext kc, S32Array s32Array) {
         SharedNonMappableIface shared = SharedNonMappableIface.createLocal();
-        if (kc.gix < kc.gsx){
+        if (KernelContext.GIX() < KernelContext.GSX()){
             PrivateNonMappableIface priv = PrivateNonMappableIface.createPrivate();
 
             int[] arr = s32Array.arrayView();
             int[] privView = priv.privateArrayView();
             int[] sharedView = shared.localArrayView();
 
-            privView[kc.gix] = arr[kc.gix];
-            sharedView[kc.gix] = arr[kc.gix];
-            kc.barrier();
-            arr[kc.gix] = privView[kc.gix] + sharedView[kc.gix];
+            privView[KernelContext.GIX()] = arr[KernelContext.GIX()];
+            sharedView[KernelContext.GIX()] = arr[KernelContext.GIX()];
+            KernelContext.barrier();
+            arr[KernelContext.GIX()] = privView[KernelContext.GIX()] + sharedView[KernelContext.GIX()];
         }
     }
 
@@ -738,17 +738,17 @@ public class TestArrayView {
     @Reflect
     public static void squareKernelDeviceType( KernelContext kc, S32Array s32Array) {
         SharedNonMappableIface shared = SharedNonMappableIface.createLocal();
-        if (kc.gix < kc.gsx){
+        if (KernelContext.GIX() < KernelContext.GSX()){
             PrivateNonMappableIface priv = PrivateNonMappableIface.createPrivate();
 
             int[] arr = s32Array.arrayView();
             int[] privView = priv.privateArrayView();
             int[] sharedView = shared.localArrayView();
 
-            privView[kc.gix] = arr[kc.gix];
-            sharedView[privView[kc.gix]] = 16 * privView[kc.gix];
-            kc.barrier();
-            arr[kc.gix] += privView[kc.gix] + sharedView[kc.gix];
+            privView[KernelContext.GIX()] = arr[KernelContext.GIX()];
+            sharedView[privView[KernelContext.GIX()]] = 16 * privView[KernelContext.GIX()];
+            KernelContext.barrier();
+            arr[KernelContext.GIX()] += privView[KernelContext.GIX()] + sharedView[KernelContext.GIX()];
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestArrayView.java
+++ b/hat/tests/src/main/java/hat/test/TestArrayView.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.*;
 import hat.device.DeviceSchema;
@@ -51,10 +52,10 @@ public class TestArrayView {
      * simple square kernel example using S32Array's ArrayView
      */
     @Reflect
-    public static void squareKernel(KernelContext kc, S32Array s32Array) {
-        if (KernelContext.GIX() < KernelContext.GSX()){
+    public static void squareKernel(KernelContext unused, S32Array s32Array) {
+        if (GIX() < GSX()){
             int[] arr = s32Array.arrayView();
-            arr[KernelContext.GIX()] *= arr[KernelContext.GIX()];
+            arr[GIX()] *= arr[GIX()];
         }
     }
 
@@ -86,9 +87,9 @@ public class TestArrayView {
      * making sure arrayviews aren't reliant on varOps
      */
     @Reflect
-    public static void squareKernelNoVarOp(KernelContext kc, S32Array s32Array) {
-        if (KernelContext.GIX()<KernelContext.GSX()){
-            s32Array.arrayView()[KernelContext.GIX()] *= s32Array.arrayView()[KernelContext.GIX()];
+    public static void squareKernelNoVarOp(KernelContext unused, S32Array s32Array) {
+        if (GIX()<GSX()){
+            s32Array.arrayView()[GIX()] *= s32Array.arrayView()[GIX()];
         }
     }
 
@@ -116,10 +117,10 @@ public class TestArrayView {
     }
 
     @Reflect
-    public static void square2DKernel(KernelContext kc, S32Array2D s32Array2D) {
-        if (KernelContext.GIX() < KernelContext.GSX()){
+    public static void square2DKernel(KernelContext unused, S32Array2D s32Array2D) {
+        if (GIX() < GSX()){
             int[][] arr = s32Array2D.arrayView();
-            arr[KernelContext.GIX()][KernelContext.GIY()] *= arr[KernelContext.GIX()][KernelContext.GIY()];
+            arr[GIX()][GIY()] *= arr[GIX()][GIY()];
         }
     }
 
@@ -289,9 +290,9 @@ public class TestArrayView {
         }
 
         @Reflect
-        public static void life(KernelContext kc, CellGrid cellGrid, CellGrid cellGridRes) {
-            if (KernelContext.GIX() < KernelContext.GSX()) {
-                Compute.lifePerIdx(KernelContext.GIX(), cellGrid, cellGridRes);
+        public static void life(KernelContext unused, CellGrid cellGrid, CellGrid cellGridRes) {
+            if (GIX() < GSX()) {
+                Compute.lifePerIdx(GIX(), cellGrid, cellGridRes);
             }
         }
 
@@ -387,14 +388,14 @@ public class TestArrayView {
     }
 
     @Reflect
-    public static void mandel(KernelContext kc, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
+    public static void mandel(KernelContext unused, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
+        if (GIX() < GSX()) {
             int[] pal = pallette.arrayView();
             int[][] s32 = s32Array2D.arrayView();
             float width = s32Array2D.width();
             float height = s32Array2D.height();
-            float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-            float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+            float x = ((GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+            float y = ((GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
             float zx = x;
             float zy = y;
             float new_zx;
@@ -406,7 +407,7 @@ public class TestArrayView {
                 colorIdx++;
             }
             int color = colorIdx < pal.length ? pal[colorIdx] : 0;
-            s32[KernelContext.GIX() % s32Array2D.width()][KernelContext.GIX() / s32Array2D.width()] = color;
+            s32[GIX() % s32Array2D.width()][GIX() / s32Array2D.width()] = color;
         }
     }
 
@@ -458,7 +459,7 @@ public class TestArrayView {
      * simplified version of BlackScholes using ArrayView
      */
     @Reflect
-    public static void blackScholesKernel(KernelContext kc,
+    public static void blackScholesKernel(KernelContext unused,
                                           F32Array call,
                                           F32Array put,
                                           F32Array sArray,
@@ -466,21 +467,21 @@ public class TestArrayView {
                                           F32Array tArray,
                                           float r,
                                           float v) {
-        if (KernelContext.GIX()<KernelContext.GSX()){
+        if (GIX()<GSX()){
             float[] callArr = call.arrayView();
             float[] putArr = put.arrayView();
             float[] sArr = sArray.arrayView();
             float[] xArr = xArray.arrayView();
             float[] tArr = tArray.arrayView();
 
-            float expNegRt = (float) Math.exp(-r * tArr[KernelContext.GIX()]);
-            float d1 = (float) ((Math.log(sArr[KernelContext.GIX()] / xArr[KernelContext.GIX()]) + (r + v * v * .5f) * tArr[KernelContext.GIX()]) / (v * Math.sqrt(tArr[KernelContext.GIX()])));
-            float d2 = (float) (d1 - v * Math.sqrt(tArr[KernelContext.GIX()]));
+            float expNegRt = (float) Math.exp(-r * tArr[GIX()]);
+            float d1 = (float) ((Math.log(sArr[GIX()] / xArr[GIX()]) + (r + v * v * .5f) * tArr[GIX()]) / (v * Math.sqrt(tArr[GIX()])));
+            float d2 = (float) (d1 - v * Math.sqrt(tArr[GIX()]));
             float cnd1 = CND(d1);
             float cnd2 = CND(d2);
-            float value = sArr[KernelContext.GIX()] * cnd1 - expNegRt * xArr[KernelContext.GIX()] * cnd2;
-            callArr[KernelContext.GIX()] = value;
-            putArr[KernelContext.GIX()] = expNegRt * xArr[KernelContext.GIX()] * (1 - cnd2) - sArr[KernelContext.GIX()] * (1 - cnd1);
+            float value = sArr[GIX()] * cnd1 - expNegRt * xArr[GIX()] * cnd2;
+            callArr[GIX()] = value;
+            putArr[GIX()] = expNegRt * xArr[GIX()] * (1 - cnd2) - sArr[GIX()] * (1 - cnd1);
         }
     }
 
@@ -619,19 +620,19 @@ public class TestArrayView {
     @Reflect
     public static void squareKernelWithPrivateAndLocal(KernelContext kc, S32Array s32Array) {
         SharedMemory shared = SharedMemory.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()){
+        if (GIX() < GSX()){
             int[] arr = s32Array.arrayView();
-            arr[KernelContext.GIX()] += arr[KernelContext.GIX()];
+            arr[GIX()] += arr[GIX()];
 
             PrivateArray priv = PrivateArray.createPrivate();
             int[] privView = priv.privateArrayView();
             privView[0] = 1;
-            arr[KernelContext.GIX()] += privView[0];
+            arr[GIX()] += privView[0];
 
             int[] sharedView = shared.localArrayView();
             sharedView[0] = 16;
-            KernelContext.barrier();
-            arr[KernelContext.GIX()] += sharedView[0];
+            barrier();
+            arr[GIX()] += sharedView[0];
         }
     }
 
@@ -700,17 +701,17 @@ public class TestArrayView {
     @Reflect
     public static void kernelBasicDeviceType( KernelContext kc, S32Array s32Array) {
         SharedNonMappableIface shared = SharedNonMappableIface.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()){
+        if (GIX() < GSX()){
             PrivateNonMappableIface priv = PrivateNonMappableIface.createPrivate();
 
             int[] arr = s32Array.arrayView();
             int[] privView = priv.privateArrayView();
             int[] sharedView = shared.localArrayView();
 
-            privView[KernelContext.GIX()] = arr[KernelContext.GIX()];
-            sharedView[KernelContext.GIX()] = arr[KernelContext.GIX()];
-            KernelContext.barrier();
-            arr[KernelContext.GIX()] = privView[KernelContext.GIX()] + sharedView[KernelContext.GIX()];
+            privView[GIX()] = arr[GIX()];
+            sharedView[GIX()] = arr[GIX()];
+            barrier();
+            arr[GIX()] = privView[GIX()] + sharedView[GIX()];
         }
     }
 
@@ -738,17 +739,17 @@ public class TestArrayView {
     @Reflect
     public static void squareKernelDeviceType( KernelContext kc, S32Array s32Array) {
         SharedNonMappableIface shared = SharedNonMappableIface.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()){
+        if (GIX() < GSX()){
             PrivateNonMappableIface priv = PrivateNonMappableIface.createPrivate();
 
             int[] arr = s32Array.arrayView();
             int[] privView = priv.privateArrayView();
             int[] sharedView = shared.localArrayView();
 
-            privView[KernelContext.GIX()] = arr[KernelContext.GIX()];
-            sharedView[privView[KernelContext.GIX()]] = 16 * privView[KernelContext.GIX()];
-            KernelContext.barrier();
-            arr[KernelContext.GIX()] += privView[KernelContext.GIX()] + sharedView[KernelContext.GIX()];
+            privView[GIX()] = arr[GIX()];
+            sharedView[privView[GIX()]] = 16 * privView[GIX()];
+            barrier();
+            arr[GIX()] += privView[GIX()] + sharedView[GIX()];
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestArrays.java
+++ b/hat/tests/src/main/java/hat/test/TestArrays.java
@@ -48,9 +48,9 @@ public class TestArrays {
 
     @Reflect
     public static void squareKernel(KernelContext kc, S32Array array) {
-        if (kc.gix < kc.gsx) {
-            int value = array.array(kc.gix);
-            array.array(kc.gix, squareit(value));
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int value = array.array(KernelContext.GIX());
+            array.array(KernelContext.GIX(), squareit(value));
         }
     }
 
@@ -63,10 +63,10 @@ public class TestArrays {
 
     @Reflect
     public static void vectorAddition(KernelContext kc, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
-        if (kc.gix < kc.gsx) {
-            int valueA = arrayA.array(kc.gix);
-            int valueB = arrayB.array(kc.gix);
-            arrayC.array(kc.gix, (valueA + valueB));
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int valueA = arrayA.array(KernelContext.GIX());
+            int valueB = arrayB.array(KernelContext.GIX());
+            arrayC.array(KernelContext.GIX(), (valueA + valueB));
         }
     }
 
@@ -79,11 +79,11 @@ public class TestArrays {
 
     @Reflect
     public static void saxpy(KernelContext kc, F32Array arrayA, F32Array arrayB, F32Array arrayC, float alpha) {
-        if (kc.gix < kc.gsx) {
-            float valueA = arrayA.array(kc.gix);
-            float valueB = arrayB.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            float valueA = arrayA.array(KernelContext.GIX());
+            float valueB = arrayB.array(KernelContext.GIX());
             float result = alpha * valueA + valueB;
-            arrayC.array(kc.gix, result);
+            arrayC.array(KernelContext.GIX(), result);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestArrays.java
+++ b/hat/tests/src/main/java/hat/test/TestArrays.java
@@ -27,6 +27,7 @@ package hat.test;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
@@ -47,10 +48,10 @@ public class TestArrays {
     }
 
     @Reflect
-    public static void squareKernel(KernelContext kc, S32Array array) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int value = array.array(KernelContext.GIX());
-            array.array(KernelContext.GIX(), squareit(value));
+    public static void squareKernel(KernelContext unused, S32Array array) {
+        if (GIX() < GSX()) {
+            int value = array.array(GIX());
+            array.array(GIX(), squareit(value));
         }
     }
 
@@ -62,11 +63,11 @@ public class TestArrays {
     }
 
     @Reflect
-    public static void vectorAddition(KernelContext kc, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int valueA = arrayA.array(KernelContext.GIX());
-            int valueB = arrayB.array(KernelContext.GIX());
-            arrayC.array(KernelContext.GIX(), (valueA + valueB));
+    public static void vectorAddition(KernelContext unused, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
+        if (GIX() < GSX()) {
+            int valueA = arrayA.array(GIX());
+            int valueB = arrayB.array(GIX());
+            arrayC.array(GIX(), (valueA + valueB));
         }
     }
 
@@ -78,12 +79,12 @@ public class TestArrays {
     }
 
     @Reflect
-    public static void saxpy(KernelContext kc, F32Array arrayA, F32Array arrayB, F32Array arrayC, float alpha) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            float valueA = arrayA.array(KernelContext.GIX());
-            float valueB = arrayB.array(KernelContext.GIX());
+    public static void saxpy(KernelContext unused, F32Array arrayA, F32Array arrayB, F32Array arrayC, float alpha) {
+        if (GIX() < GSX()) {
+            float valueA = arrayA.array(GIX());
+            float valueB = arrayB.array(GIX());
             float result = alpha * valueA + valueB;
-            arrayC.array(KernelContext.GIX(), result);
+            arrayC.array(GIX(), result);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestBFloat16Type.java
+++ b/hat/tests/src/main/java/hat/test/TestBFloat16Type.java
@@ -46,55 +46,55 @@ public class TestBFloat16Type {
 
     @Reflect
     public static void kernelCopy(KernelContext kernelContext, BF16Array a, BF16Array b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
-            b.array(kernelContext.gix).value(ha.value());
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
+            b.array(KernelContext.GIX()).value(ha.value());
         }
     }
 
     @Reflect
     public static void bf16_02(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
-            BF16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
+            BF16 hb = b.array(KernelContext.GIX());
             BF16 result = BF16.add(ha, hb);
-            BF16 hc = c.array(kernelContext.gix);
+            BF16 hc = c.array(KernelContext.GIX());
             hc.value(result.value());
         }
     }
 
     @Reflect
     public static void bf16_03(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
-            BF16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
+            BF16 hb = b.array(KernelContext.GIX());
 
             BF16 result = BF16.add(ha, BF16.add(hb, hb));
-            BF16 hC = c.array(kernelContext.gix);
+            BF16 hC = c.array(KernelContext.GIX());
             hC.value(result.value());
         }
     }
 
     @Reflect
     public static void bf16_04(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
-            BF16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
+            BF16 hb = b.array(KernelContext.GIX());
 
             BF16 r1 = BF16.mul(ha, hb);
             BF16 r2 = BF16.div(ha, hb);
             BF16 r3 = BF16.sub(ha, hb);
             BF16 r4 = BF16.add(r1, r2);
             BF16 r5 = BF16.add(r4, r3);
-            BF16 hC = c.array(kernelContext.gix);
+            BF16 hC = c.array(KernelContext.GIX());
             hC.value(r5.value());
         }
     }
 
     @Reflect
     public static void bf16_05(KernelContext kernelContext, BF16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
             BF16 initVal = BF16.of( 2.1f);
             ha.value(initVal.value());
         }
@@ -102,37 +102,37 @@ public class TestBFloat16Type {
 
     @Reflect
     public static void bf16_06(KernelContext kernelContext, BF16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 initVal = BF16.of(kernelContext.gix);
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 initVal = BF16.of(KernelContext.GIX());
+            BF16 ha = a.array(KernelContext.GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
     public static void bf16_08(KernelContext kernelContext, BF16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 initVal = BF16.float2bfloat16(kernelContext.gix);
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 initVal = BF16.float2bfloat16(KernelContext.GIX());
+            BF16 ha = a.array(KernelContext.GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
     public static void bf16_09(KernelContext kernelContext, BF16Array a, BF16Array b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
             float f = BF16.bfloat162float(ha);
             BF16 result = BF16.float2bfloat16(f);
-            BF16 hb = b.array(kernelContext.gix);
+            BF16 hb = b.array(KernelContext.GIX());
             hb.value(result.value());
         }
     }
 
     @Reflect
     public static void bf16_10(KernelContext kernelContext, BF16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
             BF16 f16 = BF16.of(1.1f);
             float f = BF16.bfloat162float(f16);
             BF16 result = BF16.float2bfloat16(f);
@@ -157,48 +157,48 @@ public class TestBFloat16Type {
     @Reflect
     public static void bf16_11(KernelContext kernelContext, BF16Array a, BF16Array b) {
         LocalArray sm = LocalArray.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int lix = kernelContext.lix;
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int lix = KernelContext.LIX();
+            BF16 ha = a.array(KernelContext.GIX());
 
             sm.array(lix).value(ha.value());
-            kernelContext.barrier();
+            KernelContext.barrier();
 
             BF16 hb = sm.array(lix);
-            b.array(kernelContext.gix).value(hb.value());
+            b.array(KernelContext.GIX()).value(hb.value());
         }
     }
 
     @Reflect
     public static void bf16_12(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
         // Test the fluent API style
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
-            BF16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
+            BF16 hb = b.array(KernelContext.GIX());
             BF16 result = BF16.add(ha,hb);
-            c.array(kernelContext.gix).value(result.value());
+            c.array(KernelContext.GIX()).value(result.value());
         }
     }
 
     @Reflect
     public static void bf16_13(KernelContext kernelContext, BF16Array a, BF16Array b,  BF16Array c) {
         // Test the fluent API style
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
-            BF16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
+            BF16 hb = b.array(KernelContext.GIX());
             BF16 result = BF16.div(BF16.mul(BF16.sub(BF16.add(ha,hb),hb),ha),ha);
-            c.array(kernelContext.gix).value(result.value());
+            c.array(KernelContext.GIX()).value(result.value());
         }
     }
 
     @Reflect
     public static void bf16_14(KernelContext kernelContext, BF16Array a, BF16Array b) {
         // Testing mixed float types
-        if (kernelContext.gix < kernelContext.gsx) {
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            BF16 ha = a.array(KernelContext.GIX());
             float myFloat = 32.1f;
             BF16 result = BF16.add(myFloat, ha);
-            b.array(kernelContext.gix).value(result.value());
+            b.array(KernelContext.GIX()).value(result.value());
         }
     }
 
@@ -219,12 +219,12 @@ public class TestBFloat16Type {
     @Reflect
     public static void bf16_15(KernelContext kernelContext, BF16Array a, BF16Array b) {
         PrivateArray privateArray = PrivateArray.createPrivate();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int lix = kernelContext.lix;
-            BF16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int lix = KernelContext.LIX();
+            BF16 ha = a.array(KernelContext.GIX());
             privateArray.array(lix).value(ha.value());
             BF16 hb = privateArray.array(lix);
-            b.array(kernelContext.gix).value(hb.value());
+            b.array(KernelContext.GIX()).value(hb.value());
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestBFloat16Type.java
+++ b/hat/tests/src/main/java/hat/test/TestBFloat16Type.java
@@ -27,6 +27,7 @@ package hat.test;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.types.BF16;
@@ -45,94 +46,94 @@ import java.util.Random;
 public class TestBFloat16Type {
 
     @Reflect
-    public static void kernelCopy(KernelContext kernelContext, BF16Array a, BF16Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
-            b.array(KernelContext.GIX()).value(ha.value());
+    public static void kernelCopy(KernelContext unused, BF16Array a, BF16Array b) {
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
+            b.array(GIX()).value(ha.value());
         }
     }
 
     @Reflect
-    public static void bf16_02(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
-            BF16 hb = b.array(KernelContext.GIX());
+    public static void bf16_02(KernelContext unused, BF16Array a, BF16Array b, BF16Array c) {
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
+            BF16 hb = b.array(GIX());
             BF16 result = BF16.add(ha, hb);
-            BF16 hc = c.array(KernelContext.GIX());
+            BF16 hc = c.array(GIX());
             hc.value(result.value());
         }
     }
 
     @Reflect
-    public static void bf16_03(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
-            BF16 hb = b.array(KernelContext.GIX());
+    public static void bf16_03(KernelContext unused, BF16Array a, BF16Array b, BF16Array c) {
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
+            BF16 hb = b.array(GIX());
 
             BF16 result = BF16.add(ha, BF16.add(hb, hb));
-            BF16 hC = c.array(KernelContext.GIX());
+            BF16 hC = c.array(GIX());
             hC.value(result.value());
         }
     }
 
     @Reflect
-    public static void bf16_04(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
-            BF16 hb = b.array(KernelContext.GIX());
+    public static void bf16_04(KernelContext unused, BF16Array a, BF16Array b, BF16Array c) {
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
+            BF16 hb = b.array(GIX());
 
             BF16 r1 = BF16.mul(ha, hb);
             BF16 r2 = BF16.div(ha, hb);
             BF16 r3 = BF16.sub(ha, hb);
             BF16 r4 = BF16.add(r1, r2);
             BF16 r5 = BF16.add(r4, r3);
-            BF16 hC = c.array(KernelContext.GIX());
+            BF16 hC = c.array(GIX());
             hC.value(r5.value());
         }
     }
 
     @Reflect
-    public static void bf16_05(KernelContext kernelContext, BF16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
+    public static void bf16_05(KernelContext unused, BF16Array a) {
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
             BF16 initVal = BF16.of( 2.1f);
             ha.value(initVal.value());
         }
     }
 
     @Reflect
-    public static void bf16_06(KernelContext kernelContext, BF16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 initVal = BF16.of(KernelContext.GIX());
-            BF16 ha = a.array(KernelContext.GIX());
+    public static void bf16_06(KernelContext unused, BF16Array a) {
+        if (GIX() < GSX()) {
+            BF16 initVal = BF16.of(GIX());
+            BF16 ha = a.array(GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
-    public static void bf16_08(KernelContext kernelContext, BF16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 initVal = BF16.float2bfloat16(KernelContext.GIX());
-            BF16 ha = a.array(KernelContext.GIX());
+    public static void bf16_08(KernelContext unused, BF16Array a) {
+        if (GIX() < GSX()) {
+            BF16 initVal = BF16.float2bfloat16(GIX());
+            BF16 ha = a.array(GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
-    public static void bf16_09(KernelContext kernelContext, BF16Array a, BF16Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
+    public static void bf16_09(KernelContext unused, BF16Array a, BF16Array b) {
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
             float f = BF16.bfloat162float(ha);
             BF16 result = BF16.float2bfloat16(f);
-            BF16 hb = b.array(KernelContext.GIX());
+            BF16 hb = b.array(GIX());
             hb.value(result.value());
         }
     }
 
     @Reflect
-    public static void bf16_10(KernelContext kernelContext, BF16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
+    public static void bf16_10(KernelContext unused, BF16Array a) {
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
             BF16 f16 = BF16.of(1.1f);
             float f = BF16.bfloat162float(f16);
             BF16 result = BF16.float2bfloat16(f);
@@ -155,50 +156,50 @@ public class TestBFloat16Type {
     }
 
     @Reflect
-    public static void bf16_11(KernelContext kernelContext, BF16Array a, BF16Array b) {
+    public static void bf16_11(KernelContext unused, BF16Array a, BF16Array b) {
         LocalArray sm = LocalArray.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int lix = KernelContext.LIX();
-            BF16 ha = a.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            int lix = LIX();
+            BF16 ha = a.array(GIX());
 
             sm.array(lix).value(ha.value());
-            KernelContext.barrier();
+            barrier();
 
             BF16 hb = sm.array(lix);
-            b.array(KernelContext.GIX()).value(hb.value());
+            b.array(GIX()).value(hb.value());
         }
     }
 
     @Reflect
-    public static void bf16_12(KernelContext kernelContext, BF16Array a, BF16Array b, BF16Array c) {
+    public static void bf16_12(KernelContext unused, BF16Array a, BF16Array b, BF16Array c) {
         // Test the fluent API style
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
-            BF16 hb = b.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
+            BF16 hb = b.array(GIX());
             BF16 result = BF16.add(ha,hb);
-            c.array(KernelContext.GIX()).value(result.value());
+            c.array(GIX()).value(result.value());
         }
     }
 
     @Reflect
-    public static void bf16_13(KernelContext kernelContext, BF16Array a, BF16Array b,  BF16Array c) {
+    public static void bf16_13(KernelContext unused, BF16Array a, BF16Array b,  BF16Array c) {
         // Test the fluent API style
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
-            BF16 hb = b.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
+            BF16 hb = b.array(GIX());
             BF16 result = BF16.div(BF16.mul(BF16.sub(BF16.add(ha,hb),hb),ha),ha);
-            c.array(KernelContext.GIX()).value(result.value());
+            c.array(GIX()).value(result.value());
         }
     }
 
     @Reflect
-    public static void bf16_14(KernelContext kernelContext, BF16Array a, BF16Array b) {
+    public static void bf16_14(KernelContext unused, BF16Array a, BF16Array b) {
         // Testing mixed float types
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            BF16 ha = a.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            BF16 ha = a.array(GIX());
             float myFloat = 32.1f;
             BF16 result = BF16.add(myFloat, ha);
-            b.array(KernelContext.GIX()).value(result.value());
+            b.array(GIX()).value(result.value());
         }
     }
 
@@ -217,19 +218,19 @@ public class TestBFloat16Type {
     }
 
     @Reflect
-    public static void bf16_15(KernelContext kernelContext, BF16Array a, BF16Array b) {
+    public static void bf16_15(KernelContext unused, BF16Array a, BF16Array b) {
         PrivateArray privateArray = PrivateArray.createPrivate();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int lix = KernelContext.LIX();
-            BF16 ha = a.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            int lix = LIX();
+            BF16 ha = a.array(GIX());
             privateArray.array(lix).value(ha.value());
             BF16 hb = privateArray.array(lix);
-            b.array(KernelContext.GIX()).value(hb.value());
+            b.array(GIX()).value(hb.value());
         }
     }
 
     @Reflect
-    public static void bf16_16(KernelContext kernelContext, BF16Array a) {
+    public static void bf16_16(KernelContext unused, BF16Array a) {
         BF16 ha = a.array(0);
         BF16 hre = BF16.add(ha, ha);
         hre = BF16.add(hre, hre);
@@ -237,7 +238,7 @@ public class TestBFloat16Type {
     }
 
     @Reflect
-    public static void bf16_17(KernelContext kernelContext, BF16Array a) {
+    public static void bf16_17(KernelContext unused, BF16Array a) {
 
         BF16 ha = a.array(0);
         PrivateArray privateArray = PrivateArray.createPrivate();

--- a/hat/tests/src/main/java/hat/test/TestBlackscholes.java
+++ b/hat/tests/src/main/java/hat/test/TestBlackscholes.java
@@ -43,18 +43,18 @@ public class TestBlackscholes {
     public static void blackScholesKernel(KernelContext kc, F32Array call, F32Array put,
                                           F32Array sArray, F32Array xArray, F32Array tArray,
                                           float r, float v) {
-        if (kc.gix < kc.gsx) {
-            float S = sArray.array(kc.gix);
-            float X = xArray.array(kc.gix);
-            float T = tArray.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            float S = sArray.array(KernelContext.GIX());
+            float X = xArray.array(KernelContext.GIX());
+            float T = tArray.array(KernelContext.GIX());
             float expNegRt = (float) Math.exp(-r * T);
             float d1 = (float) ((Math.log(S / X) + (r + v * v * .5f) * T) / (v * Math.sqrt(T)));
             float d2 = (float) (d1 - v * Math.sqrt(T));
             float cnd1 = CND(d1);
             float cnd2 = CND(d2);
             float value = S * cnd1 - expNegRt * X * cnd2;
-            call.array(kc.gix, value);
-            put.array(kc.gix, expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
+            call.array(KernelContext.GIX(), value);
+            put.array(KernelContext.GIX(), expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestBlackscholes.java
+++ b/hat/tests/src/main/java/hat/test/TestBlackscholes.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 import jdk.incubator.code.Reflect;
@@ -40,21 +41,21 @@ import java.util.Random;
 public class TestBlackscholes {
 
     @Reflect
-    public static void blackScholesKernel(KernelContext kc, F32Array call, F32Array put,
+    public static void blackScholesKernel(KernelContext unused, F32Array call, F32Array put,
                                           F32Array sArray, F32Array xArray, F32Array tArray,
                                           float r, float v) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            float S = sArray.array(KernelContext.GIX());
-            float X = xArray.array(KernelContext.GIX());
-            float T = tArray.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            float S = sArray.array(GIX());
+            float X = xArray.array(GIX());
+            float T = tArray.array(GIX());
             float expNegRt = (float) Math.exp(-r * T);
             float d1 = (float) ((Math.log(S / X) + (r + v * v * .5f) * T) / (v * Math.sqrt(T)));
             float d2 = (float) (d1 - v * Math.sqrt(T));
             float cnd1 = CND(d1);
             float cnd2 = CND(d2);
             float value = S * cnd1 - expNegRt * X * cnd2;
-            call.array(KernelContext.GIX(), value);
-            put.array(KernelContext.GIX(), expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
+            call.array(GIX(), value);
+            put.array(GIX(), expNegRt * X * (1 - cnd2) - S * (1 - cnd1));
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestConstants.java
+++ b/hat/tests/src/main/java/hat/test/TestConstants.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.S32Array;
 import jdk.incubator.code.Reflect;
@@ -41,12 +42,12 @@ public class TestConstants {
     public static final int CONSTANT = 100;
 
     @Reflect
-    public static void vectorWithConstants(KernelContext kc, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
+    public static void vectorWithConstants(KernelContext unused, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
         final int BM = 100;
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            final int valueA = arrayA.array(KernelContext.GIX());
-            final int valueB = arrayB.array(KernelContext.GIX());
-            arrayC.array(KernelContext.GIX(), (BM + valueA + valueB));
+        if (GIX() < GSX()) {
+            final int valueA = arrayA.array(GIX());
+            final int valueB = arrayB.array(GIX());
+            arrayC.array(GIX(), (BM + valueA + valueB));
         }
     }
 
@@ -91,12 +92,12 @@ public class TestConstants {
     }
 
     @Reflect
-    public static void vectorWithConstants2(KernelContext kc, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            final int valueA = arrayA.array(KernelContext.GIX());
-            final int valueB = arrayB.array(KernelContext.GIX());
+    public static void vectorWithConstants2(KernelContext unused, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
+        if (GIX() < GSX()) {
+            final int valueA = arrayA.array(GIX());
+            final int valueB = arrayB.array(GIX());
             final int result = compute(valueA, valueB);
-            arrayC.array(KernelContext.GIX(), result);
+            arrayC.array(GIX(), result);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestConstants.java
+++ b/hat/tests/src/main/java/hat/test/TestConstants.java
@@ -43,10 +43,10 @@ public class TestConstants {
     @Reflect
     public static void vectorWithConstants(KernelContext kc, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
         final int BM = 100;
-        if (kc.gix < kc.gsx) {
-            final int valueA = arrayA.array(kc.gix);
-            final int valueB = arrayB.array(kc.gix);
-            arrayC.array(kc.gix, (BM + valueA + valueB));
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            final int valueA = arrayA.array(KernelContext.GIX());
+            final int valueB = arrayB.array(KernelContext.GIX());
+            arrayC.array(KernelContext.GIX(), (BM + valueA + valueB));
         }
     }
 
@@ -92,11 +92,11 @@ public class TestConstants {
 
     @Reflect
     public static void vectorWithConstants2(KernelContext kc, S32Array arrayA, S32Array arrayB, S32Array arrayC) {
-        if (kc.gix < kc.gsx) {
-            final int valueA = arrayA.array(kc.gix);
-            final int valueB = arrayB.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            final int valueA = arrayA.array(KernelContext.GIX());
+            final int valueB = arrayB.array(KernelContext.GIX());
             final int result = compute(valueA, valueB);
-            arrayC.array(kc.gix, result);
+            arrayC.array(KernelContext.GIX(), result);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestDFT.java
+++ b/hat/tests/src/main/java/hat/test/TestDFT.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.HATMath;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.device.DeviceSchema;
@@ -75,8 +76,8 @@ public class TestDFT {
                                   ArrayComplex input,
                                   ArrayComplex output) {
         int size = input.length();
-        int idx = KernelContext.GIX();
-        if (idx < KernelContext.GSX()) {
+        int idx = GIX();
+        if (idx < GSX()) {
             float sumReal = 0.0f;
             float sumImag = 0.0f;
             for (int k = 0; k < size; k++) {
@@ -160,7 +161,7 @@ public class TestDFT {
     public static void testPrivateDS(KernelContext kc,
                                       ArrayComplex input,
                                       ArrayComplex output) {
-        int idx = KernelContext.GIX();
+        int idx = GIX();
         ArrayComplexPrivate priv = ArrayComplexPrivate.createPrivate();
         ArrayComplexPrivate.PrivateComplex complex = priv.complex(0);
         complex.real(1.0f);

--- a/hat/tests/src/main/java/hat/test/TestDFT.java
+++ b/hat/tests/src/main/java/hat/test/TestDFT.java
@@ -75,8 +75,8 @@ public class TestDFT {
                                   ArrayComplex input,
                                   ArrayComplex output) {
         int size = input.length();
-        int idx = kc.gix;
-        if (idx < kc.gsx) {
+        int idx = KernelContext.GIX();
+        if (idx < KernelContext.GSX()) {
             float sumReal = 0.0f;
             float sumImag = 0.0f;
             for (int k = 0; k < size; k++) {
@@ -160,7 +160,7 @@ public class TestDFT {
     public static void testPrivateDS(KernelContext kc,
                                       ArrayComplex input,
                                       ArrayComplex output) {
-        int idx = kc.gix;
+        int idx = KernelContext.GIX();
         ArrayComplexPrivate priv = ArrayComplexPrivate.createPrivate();
         ArrayComplexPrivate.PrivateComplex complex = priv.complex(0);
         complex.real(1.0f);

--- a/hat/tests/src/main/java/hat/test/TestF16Type.java
+++ b/hat/tests/src/main/java/hat/test/TestF16Type.java
@@ -48,56 +48,56 @@ public class TestF16Type {
 
     @Reflect
     public static void copy01(KernelContext kernelContext, F16Array a, F16Array b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
-            b.array(kernelContext.gix).value(ha.value());
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            b.array(KernelContext.GIX()).value(ha.value());
         }
     }
 
     @Reflect
     public static void f16Ops_02(KernelContext kernelContext, F16Array a, F16Array b, F16Array c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
-            F16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
 
             F16 result = F16.add(ha, hb);
-            F16 hC = c.array(kernelContext.gix);
+            F16 hC = c.array(KernelContext.GIX());
             hC.value(result.value());
         }
     }
 
     @Reflect
     public static void f16Ops_03(KernelContext kernelContext, F16Array a, F16Array b, F16Array c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
-            F16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
 
             F16 result = F16.add(ha, F16.add(hb, hb));
-            F16 hC = c.array(kernelContext.gix);
+            F16 hC = c.array(KernelContext.GIX());
             hC.value(result.value());
         }
     }
 
     @Reflect
     public static void f16Ops_04(KernelContext kernelContext, F16Array a, F16Array b, F16Array c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
-            F16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
 
             F16 r1 = F16.mul(ha, hb);
             F16 r2 = F16.div(ha, hb);
             F16 r3 = F16.sub(ha, hb);
             F16 r4 = F16.add(r1, r2);
             F16 r5 = F16.add(r4, r3);
-            F16 hC = c.array(kernelContext.gix);
+            F16 hC = c.array(KernelContext.GIX());
             hC.value(r5.value());
         }
     }
 
     @Reflect
     public static void f16Ops_05(KernelContext kernelContext, F16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
             F16 initVal = F16.of( 2.1f);
             ha.value(initVal.value());
         }
@@ -105,37 +105,37 @@ public class TestF16Type {
 
     @Reflect
     public static void f16Ops_06(KernelContext kernelContext, F16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 initVal = F16.of(kernelContext.gix);
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 initVal = F16.of(KernelContext.GIX());
+            F16 ha = a.array(KernelContext.GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
     public static void f16Ops_08(KernelContext kernelContext, F16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 initVal = F16.floatToF16(kernelContext.gix);
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 initVal = F16.floatToF16(KernelContext.GIX());
+            F16 ha = a.array(KernelContext.GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
     public static void f16Ops_09(KernelContext kernelContext, F16Array a, F16Array b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
             float f = F16.f16ToFloat(ha);
             F16 result = F16.floatToF16(f);
-            F16 hb = b.array(kernelContext.gix);
+            F16 hb = b.array(KernelContext.GIX());
             hb.value(result.value());
         }
     }
 
     @Reflect
     public static void f16Ops_10(KernelContext kernelContext, F16Array a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
             F16 f16 = F16.of(1.1f);
             float f = F16.f16ToFloat(f16);
             F16 result = F16.floatToF16(f);
@@ -163,48 +163,48 @@ public class TestF16Type {
     @Reflect
     public static void f16Ops_11(KernelContext kernelContext, F16Array a, F16Array b) {
         DeviceLocalArray sm = DeviceLocalArray.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int lix = kernelContext.lix;
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int lix = KernelContext.LIX();
+            F16 ha = a.array(KernelContext.GIX());
 
             // store into local memory
             sm.array(lix).value(ha.value());
-            kernelContext.barrier();
+            KernelContext.barrier();
 
             F16 hb = sm.array(lix);
-            b.array(kernelContext.gix).value(hb.value());
+            b.array(KernelContext.GIX()).value(hb.value());
         }
     }
 
     @Reflect
     public static void f16Ops_12(KernelContext kernelContext, F16Array a, F16Array b,  F16Array c) {
         // Test the fluent API style
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
-            F16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
             F16 result = F16.add(ha,hb);
-            c.array(kernelContext.gix).value(result.value());
+            c.array(KernelContext.GIX()).value(result.value());
         }
     }
 
     @Reflect
     public static void f16Ops_13(KernelContext kernelContext, F16Array a, F16Array b,  F16Array c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
-            F16 hb = b.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
             F16 result = F16.div(F16.mul(F16.sub(F16.add(ha,hb),hb),ha),ha);
-            c.array(kernelContext.gix).value(result.value());
+            c.array(KernelContext.GIX()).value(result.value());
         }
     }
 
     @Reflect
     public static void f16Ops_14(KernelContext kernelContext, F16Array a, F16Array b) {
         // Testing mixed float types
-        if (kernelContext.gix < kernelContext.gsx) {
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
             float myFloat = 32.1f;
             F16 result = F16.add(myFloat, ha);
-            b.array(kernelContext.gix).value(result.value());
+            b.array(KernelContext.GIX()).value(result.value());
         }
     }
 
@@ -227,15 +227,15 @@ public class TestF16Type {
     @Reflect
     public static void f16Ops_15(KernelContext kernelContext, F16Array a, F16Array b) {
         DevicePrivateArray privateArray = DevicePrivateArray.createPrivate();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int lix = kernelContext.lix;
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int lix = KernelContext.LIX();
+            F16 ha = a.array(KernelContext.GIX());
 
             // store into the private object
             privateArray.array(lix).value(ha.value());
 
             F16 hb = privateArray.array(lix);
-            b.array(kernelContext.gix).value(hb.value());
+            b.array(KernelContext.GIX()).value(hb.value());
         }
     }
 
@@ -259,9 +259,9 @@ public class TestF16Type {
     @Reflect
     public static void f16Ops_16(KernelContext kernelContext, F16Array a, F16Array b) {
         DevicePrivateArray2 privateArray = DevicePrivateArray2.createPrivate();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int lix = kernelContext.lix;
-            F16 ha = a.array(kernelContext.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int lix = KernelContext.LIX();
+            F16 ha = a.array(KernelContext.GIX());
 
             // This is expected to fail on the GPU due to the assigment of different types.
             // ha is a typed F16Impl, which is a subtype of F16.
@@ -271,7 +271,7 @@ public class TestF16Type {
             privateArray.array(lix, ha);
 
             F16 hb = privateArray.array(lix);
-            b.array(kernelContext.gix).value(hb.value());
+            b.array(KernelContext.GIX()).value(hb.value());
         }
     }
 
@@ -302,17 +302,17 @@ public class TestF16Type {
 
     @Reflect
     public static void f16Ops_19(KernelContext kernelContext, F16Array a, F32Array b, F32Array c) {
-        if (kernelContext.gix < a.length()) {
-            float mul = F16.f16ToFloat(a.array(kernelContext.gix)) * b.array(kernelContext.gix);
-            c.array(kernelContext.gix, mul);
+        if (KernelContext.GIX() < a.length()) {
+            float mul = F16.f16ToFloat(a.array(KernelContext.GIX())) * b.array(KernelContext.GIX());
+            c.array(KernelContext.GIX(), mul);
         }
     }
 
     @Reflect
     public static void f16Ops_20(KernelContext kernelContext, F16Array a, F32Array b, F32Array c) {
-        if (kernelContext.gix < a.length()) {
-            float mul = b.array(kernelContext.gix) * F16.f16ToFloat(a.array(kernelContext.gix));
-                    c.array(kernelContext.gix, mul);
+        if (KernelContext.GIX() < a.length()) {
+            float mul = b.array(KernelContext.GIX()) * F16.f16ToFloat(a.array(KernelContext.GIX()));
+                    c.array(KernelContext.GIX(), mul);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestF16Type.java
+++ b/hat/tests/src/main/java/hat/test/TestF16Type.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 import hat.types.F16;
@@ -47,95 +48,95 @@ import java.util.Random;
 public class TestF16Type {
 
     @Reflect
-    public static void copy01(KernelContext kernelContext, F16Array a, F16Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            b.array(KernelContext.GIX()).value(ha.value());
+    public static void copy01(KernelContext unused, F16Array a, F16Array b) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            b.array(GIX()).value(ha.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_02(KernelContext kernelContext, F16Array a, F16Array b, F16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
+    public static void f16Ops_02(KernelContext unused, F16Array a, F16Array b, F16Array c) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
 
             F16 result = F16.add(ha, hb);
-            F16 hC = c.array(KernelContext.GIX());
+            F16 hC = c.array(GIX());
             hC.value(result.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_03(KernelContext kernelContext, F16Array a, F16Array b, F16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
+    public static void f16Ops_03(KernelContext unused, F16Array a, F16Array b, F16Array c) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
 
             F16 result = F16.add(ha, F16.add(hb, hb));
-            F16 hC = c.array(KernelContext.GIX());
+            F16 hC = c.array(GIX());
             hC.value(result.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_04(KernelContext kernelContext, F16Array a, F16Array b, F16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
+    public static void f16Ops_04(KernelContext unused, F16Array a, F16Array b, F16Array c) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
 
             F16 r1 = F16.mul(ha, hb);
             F16 r2 = F16.div(ha, hb);
             F16 r3 = F16.sub(ha, hb);
             F16 r4 = F16.add(r1, r2);
             F16 r5 = F16.add(r4, r3);
-            F16 hC = c.array(KernelContext.GIX());
+            F16 hC = c.array(GIX());
             hC.value(r5.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_05(KernelContext kernelContext, F16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
+    public static void f16Ops_05(KernelContext unused, F16Array a) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
             F16 initVal = F16.of( 2.1f);
             ha.value(initVal.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_06(KernelContext kernelContext, F16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 initVal = F16.of(KernelContext.GIX());
-            F16 ha = a.array(KernelContext.GIX());
+    public static void f16Ops_06(KernelContext unused, F16Array a) {
+        if (GIX() < GSX()) {
+            F16 initVal = F16.of(GIX());
+            F16 ha = a.array(GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_08(KernelContext kernelContext, F16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 initVal = F16.floatToF16(KernelContext.GIX());
-            F16 ha = a.array(KernelContext.GIX());
+    public static void f16Ops_08(KernelContext unused, F16Array a) {
+        if (GIX() < GSX()) {
+            F16 initVal = F16.floatToF16(GIX());
+            F16 ha = a.array(GIX());
             ha.value(initVal.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_09(KernelContext kernelContext, F16Array a, F16Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
+    public static void f16Ops_09(KernelContext unused, F16Array a, F16Array b) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
             float f = F16.f16ToFloat(ha);
             F16 result = F16.floatToF16(f);
-            F16 hb = b.array(KernelContext.GIX());
+            F16 hb = b.array(GIX());
             hb.value(result.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_10(KernelContext kernelContext, F16Array a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
+    public static void f16Ops_10(KernelContext unused, F16Array a) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
             F16 f16 = F16.of(1.1f);
             float f = F16.f16ToFloat(f16);
             F16 result = F16.floatToF16(f);
@@ -161,50 +162,50 @@ public class TestF16Type {
     }
 
     @Reflect
-    public static void f16Ops_11(KernelContext kernelContext, F16Array a, F16Array b) {
+    public static void f16Ops_11(KernelContext unused, F16Array a, F16Array b) {
         DeviceLocalArray sm = DeviceLocalArray.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int lix = KernelContext.LIX();
-            F16 ha = a.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            int lix = LIX();
+            F16 ha = a.array(GIX());
 
             // store into local memory
             sm.array(lix).value(ha.value());
-            KernelContext.barrier();
+            barrier();
 
             F16 hb = sm.array(lix);
-            b.array(KernelContext.GIX()).value(hb.value());
+            b.array(GIX()).value(hb.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_12(KernelContext kernelContext, F16Array a, F16Array b,  F16Array c) {
+    public static void f16Ops_12(KernelContext unused, F16Array a, F16Array b,  F16Array c) {
         // Test the fluent API style
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
             F16 result = F16.add(ha,hb);
-            c.array(KernelContext.GIX()).value(result.value());
+            c.array(GIX()).value(result.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_13(KernelContext kernelContext, F16Array a, F16Array b,  F16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
+    public static void f16Ops_13(KernelContext unused, F16Array a, F16Array b,  F16Array c) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
             F16 result = F16.div(F16.mul(F16.sub(F16.add(ha,hb),hb),ha),ha);
-            c.array(KernelContext.GIX()).value(result.value());
+            c.array(GIX()).value(result.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_14(KernelContext kernelContext, F16Array a, F16Array b) {
+    public static void f16Ops_14(KernelContext unused, F16Array a, F16Array b) {
         // Testing mixed float types
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
             float myFloat = 32.1f;
             F16 result = F16.add(myFloat, ha);
-            b.array(KernelContext.GIX()).value(result.value());
+            b.array(GIX()).value(result.value());
         }
     }
 
@@ -225,17 +226,17 @@ public class TestF16Type {
     }
 
     @Reflect
-    public static void f16Ops_15(KernelContext kernelContext, F16Array a, F16Array b) {
+    public static void f16Ops_15(KernelContext unused, F16Array a, F16Array b) {
         DevicePrivateArray privateArray = DevicePrivateArray.createPrivate();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int lix = KernelContext.LIX();
-            F16 ha = a.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            int lix = LIX();
+            F16 ha = a.array(GIX());
 
             // store into the private object
             privateArray.array(lix).value(ha.value());
 
             F16 hb = privateArray.array(lix);
-            b.array(KernelContext.GIX()).value(hb.value());
+            b.array(GIX()).value(hb.value());
         }
     }
 
@@ -257,11 +258,11 @@ public class TestF16Type {
     }
 
     @Reflect
-    public static void f16Ops_16(KernelContext kernelContext, F16Array a, F16Array b) {
+    public static void f16Ops_16(KernelContext unused, F16Array a, F16Array b) {
         DevicePrivateArray2 privateArray = DevicePrivateArray2.createPrivate();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int lix = KernelContext.LIX();
-            F16 ha = a.array(KernelContext.GIX());
+        if (GIX() < GSX()) {
+            int lix = LIX();
+            F16 ha = a.array(GIX());
 
             // This is expected to fail on the GPU due to the assigment of different types.
             // ha is a typed F16Impl, which is a subtype of F16.
@@ -271,12 +272,12 @@ public class TestF16Type {
             privateArray.array(lix, ha);
 
             F16 hb = privateArray.array(lix);
-            b.array(KernelContext.GIX()).value(hb.value());
+            b.array(GIX()).value(hb.value());
         }
     }
 
     @Reflect
-    public static void f16Ops_17(KernelContext kernelContext, F16Array a) {
+    public static void f16Ops_17(KernelContext unused, F16Array a) {
         F16 ha = a.array(0);
         F16 hre = F16.add(ha, ha);
         hre = F16.add(hre, hre);
@@ -284,7 +285,7 @@ public class TestF16Type {
     }
 
     @Reflect
-    public static void f16Ops_18(KernelContext kernelContext, F16Array a) {
+    public static void f16Ops_18(KernelContext unused, F16Array a) {
 
         F16 ha = a.array(0);
         DevicePrivateArray2 privateArray = DevicePrivateArray2.createPrivate();
@@ -301,18 +302,18 @@ public class TestF16Type {
     }
 
     @Reflect
-    public static void f16Ops_19(KernelContext kernelContext, F16Array a, F32Array b, F32Array c) {
-        if (KernelContext.GIX() < a.length()) {
-            float mul = F16.f16ToFloat(a.array(KernelContext.GIX())) * b.array(KernelContext.GIX());
-            c.array(KernelContext.GIX(), mul);
+    public static void f16Ops_19(KernelContext unused, F16Array a, F32Array b, F32Array c) {
+        if (GIX() < a.length()) {
+            float mul = F16.f16ToFloat(a.array(GIX())) * b.array(GIX());
+            c.array(GIX(), mul);
         }
     }
 
     @Reflect
-    public static void f16Ops_20(KernelContext kernelContext, F16Array a, F32Array b, F32Array c) {
-        if (KernelContext.GIX() < a.length()) {
-            float mul = b.array(KernelContext.GIX()) * F16.f16ToFloat(a.array(KernelContext.GIX()));
-                    c.array(KernelContext.GIX(), mul);
+    public static void f16Ops_20(KernelContext unused, F16Array a, F32Array b, F32Array c) {
+        if (GIX() < a.length()) {
+            float mul = b.array(GIX()) * F16.f16ToFloat(a.array(GIX()));
+                    c.array(GIX(), mul);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestFlashAttention.java
+++ b/hat/tests/src/main/java/hat/test/TestFlashAttention.java
@@ -82,8 +82,8 @@ public class TestFlashAttention {
                                          F16Array Q, F16Array K, F16Array V,
                                          F16Array O, F16Array m, F16Array l,
                                          final int N, final int d, final float softmaxScale) {
-        int bx = kernelContext.bix;
-        int tid = kernelContext.lix;
+        int bx = kernelContext.BIX();
+        int tid = kernelContext.LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -112,7 +112,7 @@ public class TestFlashAttention {
             sharedArray.array((tid * d + k) + sQ_index).value(valQ.value());
         }
 
-        kernelContext.barrier();
+        KernelContext.barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -126,7 +126,7 @@ public class TestFlashAttention {
                 sharedArray.array((tid * d + k) + sK_index).value(kVal.value());
                 sharedArray.array((tid + d + k) + sV_index).value(vVal.value());
             }
-            kernelContext.barrier();
+            KernelContext.barrier();
 
             // m we accumulate the max values
             F16 m_prev = m.array(tileId * blockN + tid);
@@ -202,7 +202,7 @@ public class TestFlashAttention {
             m.array(tileId * blockN + tid).value(m_new.value());
             l.array(tileId * blockN + tid).value(l_new.value());
 
-            kernelContext.barrier();
+            KernelContext.barrier();
         }
     }
 
@@ -251,12 +251,12 @@ public class TestFlashAttention {
     }
 
     @Reflect
-    public static void flashAttention(KernelContext kernelContext,
+    public static void flashAttention(KernelContext __,
                                       F32Array Q, F32Array K, F32Array V,
                                       F32Array O, F32Array m, F32Array l,
                                       final int N, final int d, final float softmaxScale) {
-        int bx = kernelContext.bix;
-        int tid = kernelContext.lix;
+        int bx = KernelContext.BIX();
+        int tid = KernelContext.LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -281,7 +281,7 @@ public class TestFlashAttention {
             sharedArray.array((tid * d + k) + sQ_index,
                     Q.array((startIndex + (tid * d + k) * d + k)));
         }
-        kernelContext.barrier();
+        KernelContext.barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -293,7 +293,7 @@ public class TestFlashAttention {
                 sharedArray.array((tid * d + k) + sK_index, K.array(kvTileRow * d + k));
                 sharedArray.array((tid + d + k) + sV_index, V.array(kvTileRow * d + k));
             }
-            kernelContext.barrier();
+            KernelContext.barrier();
 
             // m we accumulate the max values
             float m_prev = m.array(tileId * blockN + tid);
@@ -350,7 +350,7 @@ public class TestFlashAttention {
             m.array(tileId * blockN + tid, m_new);
             l.array(tileId * blockN + tid, l_new);
 
-            kernelContext.barrier();
+            KernelContext.barrier();
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestFlashAttention.java
+++ b/hat/tests/src/main/java/hat/test/TestFlashAttention.java
@@ -29,6 +29,7 @@ import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.HATMath;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F16Array;
 import hat.buffer.F32Array;
@@ -78,12 +79,12 @@ public class TestFlashAttention {
     }
 
     @Reflect
-    public static void flashAttentionF16(KernelContext kernelContext,
+    public static void flashAttentionF16(KernelContext unused,
                                          F16Array Q, F16Array K, F16Array V,
                                          F16Array O, F16Array m, F16Array l,
                                          final int N, final int d, final float softmaxScale) {
-        int bx = kernelContext.BIX();
-        int tid = kernelContext.LIX();
+        int bx = BIX();
+        int tid = LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -112,7 +113,7 @@ public class TestFlashAttention {
             sharedArray.array((tid * d + k) + sQ_index).value(valQ.value());
         }
 
-        KernelContext.barrier();
+        barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -126,7 +127,7 @@ public class TestFlashAttention {
                 sharedArray.array((tid * d + k) + sK_index).value(kVal.value());
                 sharedArray.array((tid + d + k) + sV_index).value(vVal.value());
             }
-            KernelContext.barrier();
+            barrier();
 
             // m we accumulate the max values
             F16 m_prev = m.array(tileId * blockN + tid);
@@ -202,7 +203,7 @@ public class TestFlashAttention {
             m.array(tileId * blockN + tid).value(m_new.value());
             l.array(tileId * blockN + tid).value(l_new.value());
 
-            KernelContext.barrier();
+            barrier();
         }
     }
 
@@ -255,8 +256,8 @@ public class TestFlashAttention {
                                       F32Array Q, F32Array K, F32Array V,
                                       F32Array O, F32Array m, F32Array l,
                                       final int N, final int d, final float softmaxScale) {
-        int bx = KernelContext.BIX();
-        int tid = KernelContext.LIX();
+        int bx = BIX();
+        int tid = LIX();
 
         // Parameters used
         final int headDim = 64;
@@ -281,7 +282,7 @@ public class TestFlashAttention {
             sharedArray.array((tid * d + k) + sQ_index,
                     Q.array((startIndex + (tid * d + k) * d + k)));
         }
-        KernelContext.barrier();
+        barrier();
 
         int numBlocks = ceilFunction(N, blockN);
         for (int tileId = 0; tileId < numBlocks; tileId++) {
@@ -293,7 +294,7 @@ public class TestFlashAttention {
                 sharedArray.array((tid * d + k) + sK_index, K.array(kvTileRow * d + k));
                 sharedArray.array((tid + d + k) + sV_index, V.array(kvTileRow * d + k));
             }
-            KernelContext.barrier();
+            barrier();
 
             // m we accumulate the max values
             float m_prev = m.array(tileId * blockN + tid);
@@ -350,7 +351,7 @@ public class TestFlashAttention {
             m.array(tileId * blockN + tid, m_new);
             l.array(tileId * blockN + tid, l_new);
 
-            KernelContext.barrier();
+            barrier();
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestFloat2.java
+++ b/hat/tests/src/main/java/hat/test/TestFloat2.java
@@ -44,8 +44,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps01(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = Float2.add(vA, vB);
@@ -55,8 +55,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps02(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2.MutableImpl vA = a.float2View(index * 2);
             float scaleX = vA.x() * 10.0f;
             vA.x(scaleX);
@@ -66,8 +66,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps03(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             // Obtain a view of the input data as a float4 and
             // store that view in private memory
@@ -87,8 +87,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps04(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2.MutableImpl vA = a.float2View(index * 2);
             vA.x(vA.x() * 10.0f);
             vA.y(vA.y() * 20.0f);
@@ -98,8 +98,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps05(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vB).add(vB);
@@ -109,8 +109,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps06(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
          //   Float2 vD = Float2.sub(vA, vB);
@@ -121,8 +121,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps07(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vB).sub(vB);
@@ -132,8 +132,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps08(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vB).mul(vA).div(vB);
@@ -144,8 +144,8 @@ public class TestFloat2 {
     @Reflect
     public static void vectorOps09(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
         // Checking composition
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vA.mul(vB));
@@ -174,12 +174,12 @@ public class TestFloat2 {
     @Reflect
     public static void vectorOps10(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         SharedArray sm = SharedArray.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
-            int lix = kernelContext.lix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
+            int lix = KernelContext.LIX();
             Float2 vA = a.float2View(index * 2);
             sm.storeFloat2View(vA, lix * 2);
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float2 r = sm.float2View(lix * 2);
             b.storeFloat2View(r, index * 2);
         }
@@ -206,11 +206,11 @@ public class TestFloat2 {
     @Reflect
     public static void vectorOps11(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         PrivateMemory pm = PrivateMemory.createPrivate();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             pm.storeFloat2View(vA, 0);
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float2 r = pm.float2View(0);
             b.storeFloat2View(r, index * 2);
         }
@@ -219,13 +219,13 @@ public class TestFloat2 {
     @Reflect
     public static void vectorOps12(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         SharedArray sm = SharedArray.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
-            int lix = kernelContext.lix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
+            int lix = KernelContext.LIX();
             Float2 vA = a.float2View(index * 2);
             sm.array(lix * 2 + 0, vA.x());
             sm.array(lix * 2 + 1, vA.y());
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float2 r = sm.float2View(lix * 2);
             b.storeFloat2View(r, index * 2);
         }
@@ -233,8 +233,8 @@ public class TestFloat2 {
 
     @Reflect
     public static void vectorOps14(KernelContext kernelContext, F32ArrayPadded a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 vA = a.float2View(index * 2);
             Float2.MutableImpl vB = Float2.makeMutable(vA);
             vB.x(10.0f);
@@ -247,8 +247,8 @@ public class TestFloat2 {
     public static void vectorOps15(KernelContext kernelContext, F32ArrayPadded a) {
         // in this sample, we don't perform the vload, but rather the vstore directly
         // from a new float2.
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float2 result = Float2.of(1.0f, 2.0f);
             a.storeFloat2View(result, index * 2);
         }

--- a/hat/tests/src/main/java/hat/test/TestFloat2.java
+++ b/hat/tests/src/main/java/hat/test/TestFloat2.java
@@ -27,6 +27,7 @@ package hat.test;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F32ArrayPadded;
@@ -43,9 +44,9 @@ import java.util.Random;
 public class TestFloat2 {
 
     @Reflect
-    public static void vectorOps01(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps01(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = Float2.add(vA, vB);
@@ -54,9 +55,9 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps02(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps02(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2.MutableImpl vA = a.float2View(index * 2);
             float scaleX = vA.x() * 10.0f;
             vA.x(scaleX);
@@ -65,9 +66,9 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps03(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps03(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             // Obtain a view of the input data as a float4 and
             // store that view in private memory
@@ -86,9 +87,9 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps04(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps04(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2.MutableImpl vA = a.float2View(index * 2);
             vA.x(vA.x() * 10.0f);
             vA.y(vA.y() * 20.0f);
@@ -97,9 +98,9 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps05(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps05(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vB).add(vB);
@@ -108,9 +109,9 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps06(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps06(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
          //   Float2 vD = Float2.sub(vA, vB);
@@ -120,9 +121,9 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps07(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps07(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vB).sub(vB);
@@ -131,9 +132,9 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps08(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps08(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vB).mul(vA).div(vB);
@@ -142,10 +143,10 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps09(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+    public static void vectorOps09(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
         // Checking composition
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             Float2 vB = b.float2View(index * 2);
             Float2 vC = vA.add(vA.mul(vB));
@@ -172,14 +173,14 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps10(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps10(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         SharedArray sm = SharedArray.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
-            int lix = KernelContext.LIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
+            int lix = LIX();
             Float2 vA = a.float2View(index * 2);
             sm.storeFloat2View(vA, lix * 2);
-            KernelContext.barrier();
+            barrier();
             Float2 r = sm.float2View(lix * 2);
             b.storeFloat2View(r, index * 2);
         }
@@ -204,37 +205,37 @@ public class TestFloat2 {
     }
 
     @Reflect
-    public static void vectorOps11(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps11(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         PrivateMemory pm = PrivateMemory.createPrivate();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             pm.storeFloat2View(vA, 0);
-            KernelContext.barrier();
+            barrier();
             Float2 r = pm.float2View(0);
             b.storeFloat2View(r, index * 2);
         }
     }
 
     @Reflect
-    public static void vectorOps12(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps12(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         SharedArray sm = SharedArray.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
-            int lix = KernelContext.LIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
+            int lix = LIX();
             Float2 vA = a.float2View(index * 2);
             sm.array(lix * 2 + 0, vA.x());
             sm.array(lix * 2 + 1, vA.y());
-            KernelContext.barrier();
+            barrier();
             Float2 r = sm.float2View(lix * 2);
             b.storeFloat2View(r, index * 2);
         }
     }
 
     @Reflect
-    public static void vectorOps14(KernelContext kernelContext, F32ArrayPadded a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps14(KernelContext unused, F32ArrayPadded a) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 vA = a.float2View(index * 2);
             Float2.MutableImpl vB = Float2.makeMutable(vA);
             vB.x(10.0f);
@@ -244,11 +245,11 @@ public class TestFloat2 {
 
 
     @Reflect
-    public static void vectorOps15(KernelContext kernelContext, F32ArrayPadded a) {
+    public static void vectorOps15(KernelContext unused, F32ArrayPadded a) {
         // in this sample, we don't perform the vload, but rather the vstore directly
         // from a new float2.
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float2 result = Float2.of(1.0f, 2.0f);
             a.storeFloat2View(result, index * 2);
         }

--- a/hat/tests/src/main/java/hat/test/TestHATMathLib.java
+++ b/hat/tests/src/main/java/hat/test/TestHATMathLib.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.HATMath;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.backend.Backend;
 import hat.buffer.F16Array;
@@ -44,12 +45,12 @@ import java.util.stream.IntStream;
 public class TestHATMathLib {
 
     @Reflect
-    private static void testMathLib01(KernelContext kc, F16Array a, F16Array b, F16Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
+    private static void testMathLib01(KernelContext unused, F16Array a, F16Array b, F16Array c) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
             F16 result = HATMath.maxf16(ha, hb);
-            F16 hC = c.array(KernelContext.GIX());
+            F16 hC = c.array(GIX());
             hC.value(result.value());
         }
     }
@@ -61,12 +62,12 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib02(KernelContext kc, F32Array a, F32Array b, F32Array c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            float ha = a.array(KernelContext.GIX());
-            float hb = b.array(KernelContext.GIX());
+    private static void testMathLib02(KernelContext unused, F32Array a, F32Array b, F32Array c) {
+        if (GIX() < GSX()) {
+            float ha = a.array(GIX());
+            float hb = b.array(GIX());
             float result = HATMath.maxf(ha, hb);
-            c.array(KernelContext.GIX(), result);
+            c.array(GIX(), result);
         }
     }
 
@@ -77,16 +78,16 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib03(KernelContext kc, F16Array a, F16Array b, F16Array c, F16Array d) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
-            F16 hC = c.array(KernelContext.GIX());
+    private static void testMathLib03(KernelContext unused, F16Array a, F16Array b, F16Array c, F16Array d) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
+            F16 hC = c.array(GIX());
 
             F16 result = HATMath.maxf16(ha, hb);
             result = HATMath.maxf16(result, hC);
 
-            F16 hD = d.array(KernelContext.GIX());
+            F16 hD = d.array(GIX());
             hD.value(result.value());
         }
     }
@@ -98,16 +99,16 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib04(KernelContext kc, F16Array a, F16Array b, F16Array c, F16Array d) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
-            F16 hC = c.array(KernelContext.GIX());
+    private static void testMathLib04(KernelContext unused, F16Array a, F16Array b, F16Array c, F16Array d) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
+            F16 hC = c.array(GIX());
 
             F16 init = F16.of(2.0f);
             F16 result = HATMath.maxf16(F16.add(ha, hb), F16.mul(hC, init));
 
-            F16 hD = d.array(KernelContext.GIX());
+            F16 hD = d.array(GIX());
             hD.value(result.value());
         }
     }
@@ -119,16 +120,16 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib05(KernelContext kc, F16Array a, F16Array b, F16Array c, F16Array d) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
-            F16 hb = b.array(KernelContext.GIX());
-            F16 hC = c.array(KernelContext.GIX());
+    private static void testMathLib05(KernelContext unused, F16Array a, F16Array b, F16Array c, F16Array d) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
+            F16 hb = b.array(GIX());
+            F16 hC = c.array(GIX());
 
             F16 init = F16.of(2.0f);
             F16 result = HATMath.maxf16(HATMath.maxf16(ha, hb), HATMath.maxf16(hC, init));
 
-            F16 hD = d.array(KernelContext.GIX());
+            F16 hD = d.array(GIX());
             hD.value(result.value());
         }
     }
@@ -140,11 +141,11 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib06(KernelContext kc, F16Array a, F16Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            F16 ha = a.array(KernelContext.GIX());
+    private static void testMathLib06(KernelContext unused, F16Array a, F16Array b) {
+        if (GIX() < GSX()) {
+            F16 ha = a.array(GIX());
             F16 result = HATMath.expf16(ha);
-            F16 hB = b.array(KernelContext.GIX());
+            F16 hB = b.array(GIX());
             hB.value(result.value());
         }
     }
@@ -156,11 +157,11 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib07(KernelContext kc, F32Array a, F32Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            float fa = a.array(KernelContext.GIX());
+    private static void testMathLib07(KernelContext unused, F32Array a, F32Array b) {
+        if (GIX() < GSX()) {
+            float fa = a.array(GIX());
             float result = HATMath.cosf(fa);
-            b.array(KernelContext.GIX(), result);
+            b.array(GIX(), result);
         }
     }
 
@@ -171,11 +172,11 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib08(KernelContext kc, F32Array a, F32Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            float fa = a.array(KernelContext.GIX());
+    private static void testMathLib08(KernelContext unused, F32Array a, F32Array b) {
+        if (GIX() < GSX()) {
+            float fa = a.array(GIX());
             float result = HATMath.sinf(fa);
-            b.array(KernelContext.GIX(), result);
+            b.array(GIX(), result);
         }
     }
 
@@ -186,11 +187,11 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib09(KernelContext kc, F32Array a, F32Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            float fa = a.array(KernelContext.GIX());
+    private static void testMathLib09(KernelContext unused, F32Array a, F32Array b) {
+        if (GIX() < GSX()) {
+            float fa = a.array(GIX());
             float result = HATMath.tanf(fa);
-            b.array(KernelContext.GIX(), result);
+            b.array(GIX(), result);
         }
     }
 
@@ -201,11 +202,11 @@ public class TestHATMathLib {
     }
 
     @Reflect
-    private static void testMathLib10(KernelContext kc, F32Array a, F32Array b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            float fa = a.array(KernelContext.GIX());
+    private static void testMathLib10(KernelContext unused, F32Array a, F32Array b) {
+        if (GIX() < GSX()) {
+            float fa = a.array(GIX());
             float result = HATMath.sqrtf(fa);
-            b.array(KernelContext.GIX(), result);
+            b.array(GIX(), result);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestHATMathLib.java
+++ b/hat/tests/src/main/java/hat/test/TestHATMathLib.java
@@ -45,11 +45,11 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib01(KernelContext kc, F16Array a, F16Array b, F16Array c) {
-        if (kc.gix < kc.gsx) {
-            F16 ha = a.array(kc.gix);
-            F16 hb = b.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
             F16 result = HATMath.maxf16(ha, hb);
-            F16 hC = c.array(kc.gix);
+            F16 hC = c.array(KernelContext.GIX());
             hC.value(result.value());
         }
     }
@@ -62,11 +62,11 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib02(KernelContext kc, F32Array a, F32Array b, F32Array c) {
-        if (kc.gix < kc.gsx) {
-            float ha = a.array(kc.gix);
-            float hb = b.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            float ha = a.array(KernelContext.GIX());
+            float hb = b.array(KernelContext.GIX());
             float result = HATMath.maxf(ha, hb);
-            c.array(kc.gix, result);
+            c.array(KernelContext.GIX(), result);
         }
     }
 
@@ -78,15 +78,15 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib03(KernelContext kc, F16Array a, F16Array b, F16Array c, F16Array d) {
-        if (kc.gix < kc.gsx) {
-            F16 ha = a.array(kc.gix);
-            F16 hb = b.array(kc.gix);
-            F16 hC = c.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
+            F16 hC = c.array(KernelContext.GIX());
 
             F16 result = HATMath.maxf16(ha, hb);
             result = HATMath.maxf16(result, hC);
 
-            F16 hD = d.array(kc.gix);
+            F16 hD = d.array(KernelContext.GIX());
             hD.value(result.value());
         }
     }
@@ -99,15 +99,15 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib04(KernelContext kc, F16Array a, F16Array b, F16Array c, F16Array d) {
-        if (kc.gix < kc.gsx) {
-            F16 ha = a.array(kc.gix);
-            F16 hb = b.array(kc.gix);
-            F16 hC = c.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
+            F16 hC = c.array(KernelContext.GIX());
 
             F16 init = F16.of(2.0f);
             F16 result = HATMath.maxf16(F16.add(ha, hb), F16.mul(hC, init));
 
-            F16 hD = d.array(kc.gix);
+            F16 hD = d.array(KernelContext.GIX());
             hD.value(result.value());
         }
     }
@@ -120,15 +120,15 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib05(KernelContext kc, F16Array a, F16Array b, F16Array c, F16Array d) {
-        if (kc.gix < kc.gsx) {
-            F16 ha = a.array(kc.gix);
-            F16 hb = b.array(kc.gix);
-            F16 hC = c.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
+            F16 hb = b.array(KernelContext.GIX());
+            F16 hC = c.array(KernelContext.GIX());
 
             F16 init = F16.of(2.0f);
             F16 result = HATMath.maxf16(HATMath.maxf16(ha, hb), HATMath.maxf16(hC, init));
 
-            F16 hD = d.array(kc.gix);
+            F16 hD = d.array(KernelContext.GIX());
             hD.value(result.value());
         }
     }
@@ -141,10 +141,10 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib06(KernelContext kc, F16Array a, F16Array b) {
-        if (kc.gix < kc.gsx) {
-            F16 ha = a.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            F16 ha = a.array(KernelContext.GIX());
             F16 result = HATMath.expf16(ha);
-            F16 hB = b.array(kc.gix);
+            F16 hB = b.array(KernelContext.GIX());
             hB.value(result.value());
         }
     }
@@ -157,10 +157,10 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib07(KernelContext kc, F32Array a, F32Array b) {
-        if (kc.gix < kc.gsx) {
-            float fa = a.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            float fa = a.array(KernelContext.GIX());
             float result = HATMath.cosf(fa);
-            b.array(kc.gix, result);
+            b.array(KernelContext.GIX(), result);
         }
     }
 
@@ -172,10 +172,10 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib08(KernelContext kc, F32Array a, F32Array b) {
-        if (kc.gix < kc.gsx) {
-            float fa = a.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            float fa = a.array(KernelContext.GIX());
             float result = HATMath.sinf(fa);
-            b.array(kc.gix, result);
+            b.array(KernelContext.GIX(), result);
         }
     }
 
@@ -187,10 +187,10 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib09(KernelContext kc, F32Array a, F32Array b) {
-        if (kc.gix < kc.gsx) {
-            float fa = a.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            float fa = a.array(KernelContext.GIX());
             float result = HATMath.tanf(fa);
-            b.array(kc.gix, result);
+            b.array(KernelContext.GIX(), result);
         }
     }
 
@@ -202,10 +202,10 @@ public class TestHATMathLib {
 
     @Reflect
     private static void testMathLib10(KernelContext kc, F32Array a, F32Array b) {
-        if (kc.gix < kc.gsx) {
-            float fa = a.array(kc.gix);
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            float fa = a.array(KernelContext.GIX());
             float result = HATMath.sqrtf(fa);
-            b.array(kc.gix, result);
+            b.array(KernelContext.GIX(), result);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestLocal.java
+++ b/hat/tests/src/main/java/hat/test/TestLocal.java
@@ -59,11 +59,11 @@ public class TestLocal {
     @Reflect
     private static void compute(KernelContext kernelContext, F32Array data) {
         MySharedArray mySharedArray = MySharedArray.createLocal();
-        int lix = kernelContext.lix;
-        int blockId = kernelContext.bix;
-        int blockSize = kernelContext.lsx;
+        int lix = KernelContext.LIX();
+        int blockId = KernelContext.BIX();
+        int blockSize = KernelContext.LSX();
         mySharedArray.array(lix, lix);
-        kernelContext.barrier();
+        KernelContext.barrier();
         data.array(lix + (long) blockId * blockSize, mySharedArray.array(lix));
     }
 

--- a/hat/tests/src/main/java/hat/test/TestLocal.java
+++ b/hat/tests/src/main/java/hat/test/TestLocal.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 import hat.device.DeviceSchema;
@@ -57,13 +58,13 @@ public class TestLocal {
     }
 
     @Reflect
-    private static void compute(KernelContext kernelContext, F32Array data) {
+    private static void compute(KernelContext unused, F32Array data) {
         MySharedArray mySharedArray = MySharedArray.createLocal();
-        int lix = KernelContext.LIX();
-        int blockId = KernelContext.BIX();
-        int blockSize = KernelContext.LSX();
+        int lix = LIX();
+        int blockId = BIX();
+        int blockSize = LSX();
         mySharedArray.array(lix, lix);
-        KernelContext.barrier();
+        barrier();
         data.array(lix + (long) blockId * blockSize, mySharedArray.array(lix));
     }
 

--- a/hat/tests/src/main/java/hat/test/TestMandel.java
+++ b/hat/tests/src/main/java/hat/test/TestMandel.java
@@ -41,11 +41,11 @@ public class TestMandel {
 
     @Reflect
     public static void mandel(KernelContext kc, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
-        if (kc.gix < kc.gsx) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
             float width = s32Array2D.width();
             float height = s32Array2D.height();
-            float x = ((kc.gix % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-            float y = ((kc.gix / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+            float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+            float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
             float zx = x;
             float zy = y;
             float new_zx;
@@ -57,7 +57,7 @@ public class TestMandel {
                 colorIdx++;
             }
             int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
-            s32Array2D.array(kc.gix, color);
+            s32Array2D.array(KernelContext.GIX(), color);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestMandel.java
+++ b/hat/tests/src/main/java/hat/test/TestMandel.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.S32Array;
 import hat.buffer.S32Array2D;
@@ -40,12 +41,12 @@ import java.lang.invoke.MethodHandles;
 public class TestMandel {
 
     @Reflect
-    public static void mandel(KernelContext kc, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
+    public static void mandel(KernelContext unused, S32Array2D s32Array2D, S32Array pallette, float offsetx, float offsety, float scale) {
+        if (GIX() < GSX()) {
             float width = s32Array2D.width();
             float height = s32Array2D.height();
-            float x = ((KernelContext.GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
-            float y = ((KernelContext.GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
+            float x = ((GIX() % s32Array2D.width()) * scale - (scale / 2f * width)) / width + offsetx;
+            float y = ((GIX() / s32Array2D.width()) * scale - (scale / 2f * height)) / height + offsety;
             float zx = x;
             float zy = y;
             float new_zx;
@@ -57,7 +58,7 @@ public class TestMandel {
                 colorIdx++;
             }
             int color = colorIdx < pallette.length() ? pallette.array(colorIdx) : 0;
-            s32Array2D.array(KernelContext.GIX(), color);
+            s32Array2D.array(GIX(), color);
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestMatMul.java
+++ b/hat/tests/src/main/java/hat/test/TestMatMul.java
@@ -53,42 +53,42 @@ public class TestMatMul {
 
     @Reflect
     public static void matrixMultiplyKernel2D(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
-            if (kc.giy < kc.gsy) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            if (KernelContext.GIY() < KernelContext.GSY()) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(kc.gix * size + k) * matrixB.array(k * size + kc.giy));
+                    acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + KernelContext.GIY()));
                 }
-                matrixC.array(kc.gix * size + kc.giy, acc);
+                matrixC.array(KernelContext.GIX() * size + KernelContext.GIY(), acc);
             }
         }
     }
 
     @Reflect
     public static void matrixMultiplyKernel2DLI(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
-            if (kc.giy < kc.gsy) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            if (KernelContext.GIY() < KernelContext.GSY()) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(kc.giy * size + k) * matrixB.array(k * size + kc.gix));
+                    acc += (matrixA.array(KernelContext.GIY() * size + k) * matrixB.array(k * size + KernelContext.GIX()));
                 }
-                matrixC.array(kc.giy * size + kc.gix, acc);
+                matrixC.array(KernelContext.GIY() * size + KernelContext.GIX(), acc);
             }
         }
     }
 
     @Reflect
     public static void matrixMultiplyKernel2DLIF16(KernelContext kc, F16Array matrixA, F16Array matrixB, F16Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
-            if (kc.giy < kc.gsy) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            if (KernelContext.GIY() < KernelContext.GSY()) {
                 F16 acc = F16.of(0.0f);
                 for (int k = 0; k < size; k++) {
-                    F16 valA = matrixA.array(kc.giy * size + k);
-                    F16 valB = matrixB.array(k * size + kc.gix);
+                    F16 valA = matrixA.array(KernelContext.GIY() * size + k);
+                    F16 valB = matrixB.array(k * size + KernelContext.GIX());
                     F16 valc = F16.mul(valA, valB);
                     acc = F16.add(acc, valc);
                 }
-                F16 resultC = matrixC.array(kc.giy * size + kc.gix);
+                F16 resultC = matrixC.array(KernelContext.GIY() * size + KernelContext.GIX());
                 resultC.value(acc.value());
             }
         }
@@ -119,10 +119,10 @@ public class TestMatMul {
         MyLocalArrayFixedSize tileA = MyLocalArrayFixedSize.createLocal();
         MyLocalArrayFixedSize tileB = MyLocalArrayFixedSize.createLocal();
 
-        int groupIndexX = kc.bix;
-        int groupIndexY = kc.biy;
-        int localIdx = kc.lix;
-        int localIdy = kc.liy;
+        int groupIndexX = KernelContext.BIX();
+        int groupIndexY = KernelContext.BIY();
+        int localIdx = KernelContext.LIX();
+        int localIdy = KernelContext.LIY();
 
         // we identify the row and column
         int row = groupIndexY * tileSize + localIdy;
@@ -137,7 +137,7 @@ public class TestMatMul {
 
             // Apply a barrier for the local group: we need to guarantee that all threads that belong
             // to the same group reach this point before doing the partial reduction
-            kc.barrier();
+            KernelContext.barrier();
 
             // compute partial reductions over the tile
             for (int k = 0; k < tileSize; k++) {
@@ -147,7 +147,7 @@ public class TestMatMul {
             // A new local barrier for all threads that belong to the same group before loading a new tile into
             // share memory. With the following barrier, we can ensure that all threads within the same workgroup
             // finished the compute for the partial reduction
-            kc.barrier();
+            KernelContext.barrier();
         }
 
         // copy result from shared memory to global memory
@@ -158,30 +158,30 @@ public class TestMatMul {
     public static float compute(KernelContext kc, F32Array matrixA, F32Array matrixB, int size, int j) {
         float acc = 0.0f;
         for (int k = 0; k < size; k++) {
-            acc += (matrixA.array(kc.gix * size + k) * matrixB.array(k * size + j));
+            acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + j));
         }
         return acc;
     }
 
     @Reflect
     public static void matrixMultiplyKernel1D(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
             for (int j = 0; j < size; j++) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(kc.gix * size + k) * matrixB.array(k * size + j));
+                    acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + j));
                 }
-                matrixC.array(kc.gix * size + j, acc);
+                matrixC.array(KernelContext.GIX() * size + j, acc);
             }
         }
     }
 
     @Reflect
     public static void matrixMultiplyKernel1DWithFunctionCalls(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (kc.gix < kc.gsx) {
+        if (KernelContext.GIX() < KernelContext.GSX()) {
             for (int j = 0; j < size; j++) {
                 float acc = compute(kc, matrixA, matrixB, size, j);
-                matrixC.array(kc.gix * size + j, acc);
+                matrixC.array(KernelContext.GIX() * size + j, acc);
             }
         }
     }
@@ -570,15 +570,15 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = kc.bix;
-        int by = kc.biy;
+        int bx = KernelContext.BIX();
+        int by = KernelContext.BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = kc.liy * kc.lsx + kc.lix;
-        final int threadCol = kc.lix;
-        final int threadRow = kc.liy;
+        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
+        final int threadCol = KernelContext.LIX();
+        final int threadRow = KernelContext.LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -621,7 +621,7 @@ public class TestMatMul {
                 tileB.array((innerRowB + loadOffset) * BN + innerColB,
                         matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom));
             }
-            kc.barrier();
+            KernelContext.barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -647,7 +647,7 @@ public class TestMatMul {
                     }
                 }
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -675,12 +675,12 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = kc.bix;
-        int by = kc.biy;
+        int bx = KernelContext.BIX();
+        int by = KernelContext.BIY();
 
-        final int linearLocalId = kc.liy * kc.lsx + kc.lix;
-        final int threadCol = kc.lix;
-        final int threadRow = kc.liy;
+        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
+        final int threadCol = KernelContext.LIX();
+        final int threadRow = KernelContext.LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -722,7 +722,7 @@ public class TestMatMul {
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 2, loadB.z());
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 3, loadB.w());
 
-            kc.barrier();
+            KernelContext.barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -748,7 +748,7 @@ public class TestMatMul {
                     }
                 }
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -902,15 +902,15 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = kc.bix;
-        int by = kc.biy;
+        int bx = KernelContext.BIX();
+        int by = KernelContext.BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = kc.liy * kc.lsx + kc.lix;
-        final int threadCol = kc.lix;
-        final int threadRow = kc.liy;
+        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
+        final int threadCol = KernelContext.LIX();
+        final int threadRow = KernelContext.LIY();
 
         SharedMemoryHalf tileA = SharedMemoryHalf.createLocal();
         SharedMemoryHalf tileB = SharedMemoryHalf.createLocal();
@@ -947,7 +947,7 @@ public class TestMatMul {
                 F16 hb = matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom);
                 tileB.array((innerRowB + loadOffset) * BN + innerColB).value(hb.value());
             }
-            kc.barrier();
+            KernelContext.barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -973,7 +973,7 @@ public class TestMatMul {
                     }
                 }
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
         for (int resIdxM = 0; resIdxM < TM; resIdxM++) {
             for (int resIdxN = 0; resIdxN < TN; resIdxN++) {
@@ -1039,15 +1039,15 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = kc.bix;
-        int by = kc.biy;
+        int bx = KernelContext.BIX();
+        int by = KernelContext.BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = kc.liy * kc.lsx + kc.lix;
-        final int threadCol = kc.lix;
-        final int threadRow = kc.liy;
+        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
+        final int threadCol = KernelContext.LIX();
+        final int threadRow = KernelContext.LIY();
 
         SharedMemoryBfloat16 tileA = SharedMemoryBfloat16.createLocal();
         SharedMemoryBfloat16 tileB = SharedMemoryBfloat16.createLocal();
@@ -1084,7 +1084,7 @@ public class TestMatMul {
                 BF16 hb = matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom);
                 tileB.array((innerRowB + loadOffset) * BN + innerColB).value(hb.value());
             }
-            kc.barrier();
+            KernelContext.barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -1110,7 +1110,7 @@ public class TestMatMul {
                     }
                 }
             }
-            kc.barrier();
+            KernelContext.barrier();
         }
         for (int resIdxM = 0; resIdxM < TM; resIdxM++) {
             for (int resIdxN = 0; resIdxN < TN; resIdxN++) {

--- a/hat/tests/src/main/java/hat/test/TestMatMul.java
+++ b/hat/tests/src/main/java/hat/test/TestMatMul.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.types.BF16;
 import hat.buffer.BF16Array;
@@ -52,43 +53,43 @@ public class TestMatMul {
     private static final int SIZE = 256;
 
     @Reflect
-    public static void matrixMultiplyKernel2D(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            if (KernelContext.GIY() < KernelContext.GSY()) {
+    public static void matrixMultiplyKernel2D(KernelContext unused, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
+        if (GIX() < GSX()) {
+            if (GIY() < GSY()) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + KernelContext.GIY()));
+                    acc += (matrixA.array(GIX() * size + k) * matrixB.array(k * size + GIY()));
                 }
-                matrixC.array(KernelContext.GIX() * size + KernelContext.GIY(), acc);
+                matrixC.array(GIX() * size + GIY(), acc);
             }
         }
     }
 
     @Reflect
-    public static void matrixMultiplyKernel2DLI(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            if (KernelContext.GIY() < KernelContext.GSY()) {
+    public static void matrixMultiplyKernel2DLI(KernelContext unused, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
+        if (GIX() < GSX()) {
+            if (GIY() < GSY()) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(KernelContext.GIY() * size + k) * matrixB.array(k * size + KernelContext.GIX()));
+                    acc += (matrixA.array(GIY() * size + k) * matrixB.array(k * size + GIX()));
                 }
-                matrixC.array(KernelContext.GIY() * size + KernelContext.GIX(), acc);
+                matrixC.array(GIY() * size + GIX(), acc);
             }
         }
     }
 
     @Reflect
-    public static void matrixMultiplyKernel2DLIF16(KernelContext kc, F16Array matrixA, F16Array matrixB, F16Array matrixC, int size) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            if (KernelContext.GIY() < KernelContext.GSY()) {
+    public static void matrixMultiplyKernel2DLIF16(KernelContext unused, F16Array matrixA, F16Array matrixB, F16Array matrixC, int size) {
+        if (GIX() < GSX()) {
+            if (GIY() < GSY()) {
                 F16 acc = F16.of(0.0f);
                 for (int k = 0; k < size; k++) {
-                    F16 valA = matrixA.array(KernelContext.GIY() * size + k);
-                    F16 valB = matrixB.array(k * size + KernelContext.GIX());
+                    F16 valA = matrixA.array(GIY() * size + k);
+                    F16 valB = matrixB.array(k * size + GIX());
                     F16 valc = F16.mul(valA, valB);
                     acc = F16.add(acc, valc);
                 }
-                F16 resultC = matrixC.array(KernelContext.GIY() * size + KernelContext.GIX());
+                F16 resultC = matrixC.array(GIY() * size + GIX());
                 resultC.value(acc.value());
             }
         }
@@ -113,16 +114,16 @@ public class TestMatMul {
     }
 
     @Reflect
-    public static void matrixMultiplyKernel2DTiling(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
+    public static void matrixMultiplyKernel2DTiling(KernelContext unused, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
 
         final int tileSize = 16;
         MyLocalArrayFixedSize tileA = MyLocalArrayFixedSize.createLocal();
         MyLocalArrayFixedSize tileB = MyLocalArrayFixedSize.createLocal();
 
-        int groupIndexX = KernelContext.BIX();
-        int groupIndexY = KernelContext.BIY();
-        int localIdx = KernelContext.LIX();
-        int localIdy = KernelContext.LIY();
+        int groupIndexX = BIX();
+        int groupIndexY = BIY();
+        int localIdx = LIX();
+        int localIdy = LIY();
 
         // we identify the row and column
         int row = groupIndexY * tileSize + localIdy;
@@ -137,7 +138,7 @@ public class TestMatMul {
 
             // Apply a barrier for the local group: we need to guarantee that all threads that belong
             // to the same group reach this point before doing the partial reduction
-            KernelContext.barrier();
+            barrier();
 
             // compute partial reductions over the tile
             for (int k = 0; k < tileSize; k++) {
@@ -147,7 +148,7 @@ public class TestMatMul {
             // A new local barrier for all threads that belong to the same group before loading a new tile into
             // share memory. With the following barrier, we can ensure that all threads within the same workgroup
             // finished the compute for the partial reduction
-            KernelContext.barrier();
+            barrier();
         }
 
         // copy result from shared memory to global memory
@@ -155,33 +156,33 @@ public class TestMatMul {
     }
 
     @Reflect
-    public static float compute(KernelContext kc, F32Array matrixA, F32Array matrixB, int size, int j) {
+    public static float compute(KernelContext unused, F32Array matrixA, F32Array matrixB, int size, int j) {
         float acc = 0.0f;
         for (int k = 0; k < size; k++) {
-            acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + j));
+            acc += (matrixA.array(GIX() * size + k) * matrixB.array(k * size + j));
         }
         return acc;
     }
 
     @Reflect
     public static void matrixMultiplyKernel1D(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
+        if (GIX() < GSX()) {
             for (int j = 0; j < size; j++) {
                 float acc = 0.0f;
                 for (int k = 0; k < size; k++) {
-                    acc += (matrixA.array(KernelContext.GIX() * size + k) * matrixB.array(k * size + j));
+                    acc += (matrixA.array(GIX() * size + k) * matrixB.array(k * size + j));
                 }
-                matrixC.array(KernelContext.GIX() * size + j, acc);
+                matrixC.array(GIX() * size + j, acc);
             }
         }
     }
 
     @Reflect
     public static void matrixMultiplyKernel1DWithFunctionCalls(KernelContext kc, F32Array matrixA, F32Array matrixB, F32Array matrixC, int size) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
+        if (GIX() < GSX()) {
             for (int j = 0; j < size; j++) {
                 float acc = compute(kc, matrixA, matrixB, size, j);
-                matrixC.array(KernelContext.GIX() * size + j, acc);
+                matrixC.array(GIX() * size + j, acc);
             }
         }
     }
@@ -570,15 +571,15 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = KernelContext.BIX();
-        int by = KernelContext.BIY();
+        int bx = BIX();
+        int by = BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
-        final int threadCol = KernelContext.LIX();
-        final int threadRow = KernelContext.LIY();
+        final int linearLocalId = LIY() * LSX() + LIX();
+        final int threadCol = LIX();
+        final int threadRow = LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -621,7 +622,7 @@ public class TestMatMul {
                 tileB.array((innerRowB + loadOffset) * BN + innerColB,
                         matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom));
             }
-            KernelContext.barrier();
+            barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -647,7 +648,7 @@ public class TestMatMul {
                     }
                 }
             }
-            KernelContext.barrier();
+            barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -675,12 +676,12 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = KernelContext.BIX();
-        int by = KernelContext.BIY();
+        int bx = BIX();
+        int by = BIY();
 
-        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
-        final int threadCol = KernelContext.LIX();
-        final int threadRow = KernelContext.LIY();
+        final int linearLocalId = LIY() * LSX() + LIX();
+        final int threadCol = LIX();
+        final int threadRow = LIY();
 
         SharedMemory tileA = SharedMemory.createLocal();
         SharedMemory tileB = SharedMemory.createLocal();
@@ -722,7 +723,7 @@ public class TestMatMul {
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 2, loadB.z());
             tileB.array(innerRowB * (BN + extraCols) + innerColB * 4 + 3, loadB.w());
 
-            KernelContext.barrier();
+            barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -748,7 +749,7 @@ public class TestMatMul {
                     }
                 }
             }
-            KernelContext.barrier();
+            barrier();
         }
 
         // Finally, we store the results of the reductions for the whole 2D register block into global memory.
@@ -902,15 +903,15 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = KernelContext.BIX();
-        int by = KernelContext.BIY();
+        int bx = BIX();
+        int by = BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
-        final int threadCol = KernelContext.LIX();
-        final int threadRow = KernelContext.LIY();
+        final int linearLocalId = LIY() * LSX() + LIX();
+        final int threadCol = LIX();
+        final int threadRow = LIY();
 
         SharedMemoryHalf tileA = SharedMemoryHalf.createLocal();
         SharedMemoryHalf tileB = SharedMemoryHalf.createLocal();
@@ -947,7 +948,7 @@ public class TestMatMul {
                 F16 hb = matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom);
                 tileB.array((innerRowB + loadOffset) * BN + innerColB).value(hb.value());
             }
-            KernelContext.barrier();
+            barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -973,7 +974,7 @@ public class TestMatMul {
                     }
                 }
             }
-            KernelContext.barrier();
+            barrier();
         }
         for (int resIdxM = 0; resIdxM < TM; resIdxM++) {
             for (int resIdxN = 0; resIdxN < TN; resIdxN++) {
@@ -1039,15 +1040,15 @@ public class TestMatMul {
         final int TM = 4;
         final int TN = 4;
 
-        int bx = KernelContext.BIX();
-        int by = KernelContext.BIY();
+        int bx = BIX();
+        int by = BIY();
 
         int totalResultsBlockTile = BM * BN;
         final int numThreadsBlockTile = totalResultsBlockTile / (TM * TN);
 
-        final int linearLocalId = KernelContext.LIY() * KernelContext.LSX() + KernelContext.LIX();
-        final int threadCol = KernelContext.LIX();
-        final int threadRow = KernelContext.LIY();
+        final int linearLocalId = LIY() * LSX() + LIX();
+        final int threadCol = LIX();
+        final int threadRow = LIY();
 
         SharedMemoryBfloat16 tileA = SharedMemoryBfloat16.createLocal();
         SharedMemoryBfloat16 tileB = SharedMemoryBfloat16.createLocal();
@@ -1084,7 +1085,7 @@ public class TestMatMul {
                 BF16 hb = matrixB.array(((innerRowB + loadOffset) * size + innerColB) + bFrom);
                 tileB.array((innerRowB + loadOffset) * BN + innerColB).value(hb.value());
             }
-            KernelContext.barrier();
+            barrier();
 
             aFrom += (BK);
             int f = BK * size;
@@ -1110,7 +1111,7 @@ public class TestMatMul {
                     }
                 }
             }
-            KernelContext.barrier();
+            barrier();
         }
         for (int resIdxM = 0; resIdxM < TM; resIdxM++) {
             for (int resIdxN = 0; resIdxN < TN; resIdxN++) {

--- a/hat/tests/src/main/java/hat/test/TestMissingReflectAnnotation.java
+++ b/hat/tests/src/main/java/hat/test/TestMissingReflectAnnotation.java
@@ -47,16 +47,16 @@ public class TestMissingReflectAnnotation {
 
     @Reflect
     public static void squareKernel(KernelContext kc, S32Array array) {
-        if (kc.gix < kc.gsx){
-            int value = array.array(kc.gix);
-            array.array(kc.gix, squareit(value));
+        if (KernelContext.GIX() < KernelContext.GSX()){
+            int value = array.array(KernelContext.GIX());
+            array.array(KernelContext.GIX(), squareit(value));
         }
     }
 
     public static void squareKernelWithoutReflectAnnotation(KernelContext kc, S32Array array) {
-        if (kc.gix < kc.gsx){
-            int value = array.array(kc.gix);
-            array.array(kc.gix, squareit(value));
+        if (KernelContext.GIX() < KernelContext.GSX()){
+            int value = array.array(KernelContext.GIX());
+            array.array(KernelContext.GIX(), squareit(value));
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestMissingReflectAnnotation.java
+++ b/hat/tests/src/main/java/hat/test/TestMissingReflectAnnotation.java
@@ -29,6 +29,7 @@ import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
 import hat.backend.Backend;
+import static hat.KernelContext.*;
 import hat.buffer.S32Array;
 import jdk.incubator.code.Reflect;
 import hat.test.annotation.HatTest;
@@ -46,17 +47,17 @@ public class TestMissingReflectAnnotation {
     }
 
     @Reflect
-    public static void squareKernel(KernelContext kc, S32Array array) {
-        if (KernelContext.GIX() < KernelContext.GSX()){
-            int value = array.array(KernelContext.GIX());
-            array.array(KernelContext.GIX(), squareit(value));
+    public static void squareKernel(KernelContext unused, S32Array array) {
+        if (GIX() < GSX()){
+            int value = array.array(GIX());
+            array.array(GIX(), squareit(value));
         }
     }
 
-    public static void squareKernelWithoutReflectAnnotation(KernelContext kc, S32Array array) {
-        if (KernelContext.GIX() < KernelContext.GSX()){
-            int value = array.array(KernelContext.GIX());
-            array.array(KernelContext.GIX(), squareit(value));
+    public static void squareKernelWithoutReflectAnnotation(KernelContext unused, S32Array array) {
+        if (GIX() < GSX()){
+            int value = array.array(GIX());
+            array.array(GIX(), squareit(value));
         }
     }
 

--- a/hat/tests/src/main/java/hat/test/TestNbody.java
+++ b/hat/tests/src/main/java/hat/test/TestNbody.java
@@ -80,7 +80,7 @@ public class TestNbody {
         float accx = 0.0f;
         float accy = 0.0f;
         float accz = 0.0f;
-        Body body = universe.body(kc.gix);
+        Body body = universe.body(KernelContext.GIX());
 
         for (int i = 0; i < universe.length(); i++) {
             Body otherBody = universe.body(i);

--- a/hat/tests/src/main/java/hat/test/TestNbody.java
+++ b/hat/tests/src/main/java/hat/test/TestNbody.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import optkl.ifacemapper.BoundSchema;
 import optkl.ifacemapper.Buffer;
@@ -80,7 +81,7 @@ public class TestNbody {
         float accx = 0.0f;
         float accy = 0.0f;
         float accz = 0.0f;
-        Body body = universe.body(KernelContext.GIX());
+        Body body = universe.body(GIX());
 
         for (int i = 0; i < universe.length(); i++) {
             Body otherBody = universe.body(i);

--- a/hat/tests/src/main/java/hat/test/TestNumBlocks.java
+++ b/hat/tests/src/main/java/hat/test/TestNumBlocks.java
@@ -44,8 +44,8 @@ public class TestNumBlocks {
 
     @Reflect
     private static void kernel_numblocks_X(KernelContext kernelContext, F32Array output) {
-        int idx = kernelContext.gix;
-        int bsx = kernelContext.bsx;
+        int idx = KernelContext.GIX();
+        int bsx = KernelContext.BSX();
         // Write the number of blocks
         output.array(idx, bsx);
     }

--- a/hat/tests/src/main/java/hat/test/TestNumBlocks.java
+++ b/hat/tests/src/main/java/hat/test/TestNumBlocks.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.Accelerator.Compute;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 import hat.test.annotation.HatTest;
@@ -43,9 +44,9 @@ import static hat.NDRange.NDRange1D;
 public class TestNumBlocks {
 
     @Reflect
-    private static void kernel_numblocks_X(KernelContext kernelContext, F32Array output) {
-        int idx = KernelContext.GIX();
-        int bsx = KernelContext.BSX();
+    private static void kernel_numblocks_X(KernelContext unused, F32Array output) {
+        int idx = GIX();
+        int bsx = BSX();
         // Write the number of blocks
         output.array(idx, bsx);
     }

--- a/hat/tests/src/main/java/hat/test/TestParenthesis.java
+++ b/hat/tests/src/main/java/hat/test/TestParenthesis.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.S32Array;
 import jdk.incubator.code.Reflect;
@@ -44,7 +45,7 @@ public class TestParenthesis {
         final int TF = 128;
         final int MAX = 1024;
         int c = MAX / (TN * TF);
-        data.array(KernelContext.GIX(), c);
+        data.array(GIX(), c);
     }
 
     @Reflect
@@ -53,7 +54,7 @@ public class TestParenthesis {
         final int TF = 128;
         final int MAX = 1024;
         int c = MAX / ((TN * TF) / (TN * TN));
-        data.array(KernelContext.GIX(), c);
+        data.array(GIX(), c);
     }
 
     @Reflect
@@ -62,7 +63,7 @@ public class TestParenthesis {
         final int TF = 128;
         final int MAX = 1024;
         int c = MAX * (TF + 2) / ((TN * TF) / (TN * TN));
-        data.array(KernelContext.GIX(), c);
+        data.array(GIX(), c);
     }
 
     @Reflect

--- a/hat/tests/src/main/java/hat/test/TestParenthesis.java
+++ b/hat/tests/src/main/java/hat/test/TestParenthesis.java
@@ -44,7 +44,7 @@ public class TestParenthesis {
         final int TF = 128;
         final int MAX = 1024;
         int c = MAX / (TN * TF);
-        data.array(context.gix, c);
+        data.array(KernelContext.GIX(), c);
     }
 
     @Reflect
@@ -53,7 +53,7 @@ public class TestParenthesis {
         final int TF = 128;
         final int MAX = 1024;
         int c = MAX / ((TN * TF) / (TN * TN));
-        data.array(context.gix, c);
+        data.array(KernelContext.GIX(), c);
     }
 
     @Reflect
@@ -62,7 +62,7 @@ public class TestParenthesis {
         final int TF = 128;
         final int MAX = 1024;
         int c = MAX * (TF + 2) / ((TN * TF) / (TN * TN));
-        data.array(context.gix, c);
+        data.array(KernelContext.GIX(), c);
     }
 
     @Reflect

--- a/hat/tests/src/main/java/hat/test/TestPrivate.java
+++ b/hat/tests/src/main/java/hat/test/TestPrivate.java
@@ -60,9 +60,9 @@ public class TestPrivate {
     @Reflect
     private static void compute(KernelContext kernelContext, F32Array data) {
         PrivateArray privateArray = PrivateArray.createPrivate();
-        int lix = kernelContext.lix;
-        int blockId = kernelContext.bix;
-        int blockSize = kernelContext.lsx;
+        int lix = KernelContext.LIX();
+        int blockId = KernelContext.BIX();
+        int blockSize = KernelContext.LSX();
         privateArray.array(0, lix);
         data.array(lix + (long) blockId * blockSize, privateArray.array(0));
     }

--- a/hat/tests/src/main/java/hat/test/TestPrivate.java
+++ b/hat/tests/src/main/java/hat/test/TestPrivate.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32Array;
 import hat.device.DeviceSchema;
@@ -58,11 +59,11 @@ public class TestPrivate {
     }
 
     @Reflect
-    private static void compute(KernelContext kernelContext, F32Array data) {
+    private static void compute(KernelContext unused, F32Array data) {
         PrivateArray privateArray = PrivateArray.createPrivate();
-        int lix = KernelContext.LIX();
-        int blockId = KernelContext.BIX();
-        int blockSize = KernelContext.LSX();
+        int lix = LIX();
+        int blockId = BIX();
+        int blockSize = LSX();
         privateArray.array(0, lix);
         data.array(lix + (long) blockId * blockSize, privateArray.array(0));
     }

--- a/hat/tests/src/main/java/hat/test/TestReductions.java
+++ b/hat/tests/src/main/java/hat/test/TestReductions.java
@@ -66,9 +66,9 @@ public class TestReductions {
      */
     @Reflect
     private static void reduceGlobal(KernelContext context, S32Array input, S32Array partialSums) {
-        int localId = context.lix;
-        int localSize = context.lsx;
-        int blockId = context.bix;
+        int localId = KernelContext.LIX();
+        int localSize = KernelContext.LSX();
+        int blockId = KernelContext.BIX();
         int baseIndex = localSize * blockId + localId;
 
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
@@ -77,7 +77,7 @@ public class TestReductions {
                 val += input.array((baseIndex + offset));
                 input.array(baseIndex, val);
             }
-            context.barrier();
+            KernelContext.barrier();
         }
         if (localId == 0) {
             // copy from shared memory to global memory
@@ -95,19 +95,19 @@ public class TestReductions {
      */
     @Reflect
     private static void reduceLocal(KernelContext context, S32Array input, S32Array partialSums) {
-        int localId = context.lix;
-        int localSize = context.lsx;
-        int blockId = context.bix;
+        int localId = KernelContext.LIX();
+        int localSize = KernelContext.LSX();
+        int blockId = KernelContext.BIX();
 
         // Prototype: allocate in shared memory an array of 16 ints
         MySharedArray sharedArray = MySharedArray.createLocal();
 
         // Copy from global to shared memory
-        sharedArray.array(localId, input.array(context.gix));
+        sharedArray.array(localId, input.array(KernelContext.GIX()));
 
         // Reduction using local memory
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
-            context.barrier();
+            KernelContext.barrier();
             if (localId < offset) {
                 sharedArray.array(localId,  sharedArray.array(localId) +  sharedArray.array(localId + offset));
             }

--- a/hat/tests/src/main/java/hat/test/TestReductions.java
+++ b/hat/tests/src/main/java/hat/test/TestReductions.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.S32Array;
 import hat.device.DeviceSchema;
@@ -66,9 +67,9 @@ public class TestReductions {
      */
     @Reflect
     private static void reduceGlobal(KernelContext context, S32Array input, S32Array partialSums) {
-        int localId = KernelContext.LIX();
-        int localSize = KernelContext.LSX();
-        int blockId = KernelContext.BIX();
+        int localId = LIX();
+        int localSize = LSX();
+        int blockId = BIX();
         int baseIndex = localSize * blockId + localId;
 
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
@@ -77,7 +78,7 @@ public class TestReductions {
                 val += input.array((baseIndex + offset));
                 input.array(baseIndex, val);
             }
-            KernelContext.barrier();
+            barrier();
         }
         if (localId == 0) {
             // copy from shared memory to global memory
@@ -95,19 +96,19 @@ public class TestReductions {
      */
     @Reflect
     private static void reduceLocal(KernelContext context, S32Array input, S32Array partialSums) {
-        int localId = KernelContext.LIX();
-        int localSize = KernelContext.LSX();
-        int blockId = KernelContext.BIX();
+        int localId = LIX();
+        int localSize = LSX();
+        int blockId = BIX();
 
         // Prototype: allocate in shared memory an array of 16 ints
         MySharedArray sharedArray = MySharedArray.createLocal();
 
         // Copy from global to shared memory
-        sharedArray.array(localId, input.array(KernelContext.GIX()));
+        sharedArray.array(localId, input.array(GIX()));
 
         // Reduction using local memory
         for (int offset = localSize / 2; offset > 0; offset /= 2) {
-            KernelContext.barrier();
+            barrier();
             if (localId < offset) {
                 sharedArray.array(localId,  sharedArray.array(localId) +  sharedArray.array(localId + offset));
             }

--- a/hat/tests/src/main/java/hat/test/TestTensors.java
+++ b/hat/tests/src/main/java/hat/test/TestTensors.java
@@ -27,6 +27,7 @@ package hat.test;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange.Tile2D;
 import hat.backend.Backend;
 import hat.buffer.F16Array;
@@ -73,8 +74,8 @@ public class TestTensors {
         final int WMMA_M = SHAPE;
         final int WMMA_N = SHAPE;
         final int WMMA_K = SHAPE;
-        int warpM = kc.gix / kc.wrs;
-        int warpN = kc.giy;
+        int warpM = GIX() / WRS();
+        int warpN = GIY();
 
         final int lda = 1024;
         final int ldb = 1024;
@@ -134,8 +135,8 @@ public class TestTensors {
         final int WMMA_M = 16;
         final int WMMA_N = 16;
         final int WMMA_K = 16;
-        int warpM = kc.gix / kc.wrs;
-        int warpN = kc.giy;
+        int warpM = GIX() / WRS();
+        int warpN = GIY();
 
         final int lda = 1024;
         final int ldb = 1024;
@@ -185,8 +186,8 @@ public class TestTensors {
         final int WMMA_M = 16;
         final int WMMA_N = 16;
         final int WMMA_K = 16;
-        int warpM = kc.gix / kc.wrs;
-        int warpN = kc.giy;
+        int warpM = GIX() / WRS();
+        int warpN = GIY();
 
         final int lda = 1024;
         final int ldb = 1024;
@@ -235,8 +236,8 @@ public class TestTensors {
         final int WMMA_M = sizeShape;
         final int WMMA_N = sizeShape;
         final int WMMA_K = sizeShape;
-        int warpM = kc.gix / kc.wrs;
-        int warpN = kc.giy;
+        int warpM = GIX() / WRS();
+        int warpN = GIY();
 
         final int lda = 1024;
         final int ldb = 1024;

--- a/hat/tests/src/main/java/hat/test/TestVectorArrayView.java
+++ b/hat/tests/src/main/java/hat/test/TestVectorArrayView.java
@@ -27,6 +27,7 @@ package hat.test;
 import hat.Accelerator;
 import hat.ComputeContext;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.NDRange;
 import hat.buffer.F32ArrayPadded;
 import hat.device.DeviceSchema;
@@ -44,9 +45,9 @@ import java.util.Random;
 public class TestVectorArrayView {
 
     @Reflect
-    public static void vectorOps01(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps01(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -59,9 +60,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps01WithFloat4s(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps01WithFloat4s(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -73,9 +74,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps01WithSeparateAdd(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps01WithSeparateAdd(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -86,9 +87,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps02(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps02(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4.MutableImpl[] vArr = a.float4ArrayView();
             Float4.MutableImpl[] bArr = b.float4ArrayView();
@@ -100,9 +101,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps03(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps03(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4.MutableImpl[] vA = a.float4ArrayView();
             Float4.MutableImpl[] vB = b.float4ArrayView();
@@ -120,9 +121,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps04(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps04(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4.MutableImpl[] vA = a.float4ArrayView();
             Float4.MutableImpl[] vB = b.float4ArrayView();
@@ -136,9 +137,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps05(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps05(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -152,9 +153,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps06(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps06(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -168,9 +169,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps07(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps07(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] vAArray = a.float4ArrayView();
             Float4[] vBArray = b.float4ArrayView();
@@ -185,9 +186,9 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps08(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps08(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] vAArray = a.float4ArrayView();
             Float4[] vBArray = b.float4ArrayView();
@@ -203,10 +204,10 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps09(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+    public static void vectorOps09(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
         // Checking composition
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4[] vAArray = a.float4ArrayView();
             Float4[] vBArray = b.float4ArrayView();
             Float4[] vCArray = c.float4ArrayView();
@@ -233,11 +234,11 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps10(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps10(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
-            int lix = KernelContext.LIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
+            int lix = LIX();
 
             Float4[] aArr = a.float4ArrayView();
             Float4[] bArr = b.float4ArrayView();
@@ -245,7 +246,7 @@ public class TestVectorArrayView {
 
             Float4 vA = aArr[index * 4];
             smArr[lix * 4] = vA;
-            KernelContext.barrier();
+            barrier();
             Float4 r = smArr[lix * 4];
             bArr[index * 4] = r;
         }
@@ -265,10 +266,10 @@ public class TestVectorArrayView {
     }
 
     @Reflect
-    public static void vectorOps11(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps11(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         PrivateMemory pm = PrivateMemory.createPrivate();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             Float4[] aArr = a.float4ArrayView();
             Float4[] bArr = b.float4ArrayView();
@@ -276,18 +277,18 @@ public class TestVectorArrayView {
 
             Float4 vA = aArr[index * 4];
             pmArr[0] = vA;
-            KernelContext.barrier();
+            barrier();
             Float4 r = pmArr[0];
             bArr[index * 4] = r;
         }
     }
 
     @Reflect
-    public static void vectorOps12(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps12(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
-            int lix = KernelContext.LIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
+            int lix = LIX();
             Float4.MutableImpl[] aArr = a.float4ArrayView();
             Float4.MutableImpl[] bArr = b.float4ArrayView();
             Float4.MutableImpl[] smArr = sm.float4LocalArrayView();
@@ -299,7 +300,7 @@ public class TestVectorArrayView {
             smVector.z(vA.z());
             smVector.w(vA.w());
             smArr[lix * 4] = smVector;
-            KernelContext.barrier();
+            barrier();
             Float4.MutableImpl r = smArr[lix * 4];
             bArr[index * 4] = r;
         }

--- a/hat/tests/src/main/java/hat/test/TestVectorArrayView.java
+++ b/hat/tests/src/main/java/hat/test/TestVectorArrayView.java
@@ -45,8 +45,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps01(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -60,8 +60,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps01WithFloat4s(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -74,8 +74,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps01WithSeparateAdd(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -87,8 +87,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps02(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4.MutableImpl[] vArr = a.float4ArrayView();
             Float4.MutableImpl[] bArr = b.float4ArrayView();
@@ -101,8 +101,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps03(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4.MutableImpl[] vA = a.float4ArrayView();
             Float4.MutableImpl[] vB = b.float4ArrayView();
@@ -121,8 +121,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps04(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4.MutableImpl[] vA = a.float4ArrayView();
             Float4.MutableImpl[] vB = b.float4ArrayView();
@@ -137,8 +137,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps05(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -153,8 +153,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps06(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] vA = a.float4ArrayView();
             Float4[] vB = b.float4ArrayView();
@@ -169,8 +169,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps07(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] vAArray = a.float4ArrayView();
             Float4[] vBArray = b.float4ArrayView();
@@ -186,8 +186,8 @@ public class TestVectorArrayView {
 
     @Reflect
     public static void vectorOps08(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] vAArray = a.float4ArrayView();
             Float4[] vBArray = b.float4ArrayView();
@@ -205,8 +205,8 @@ public class TestVectorArrayView {
     @Reflect
     public static void vectorOps09(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
         // Checking composition
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4[] vAArray = a.float4ArrayView();
             Float4[] vBArray = b.float4ArrayView();
             Float4[] vCArray = c.float4ArrayView();
@@ -235,9 +235,9 @@ public class TestVectorArrayView {
     @Reflect
     public static void vectorOps10(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
-            int lix = kernelContext.lix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
+            int lix = KernelContext.LIX();
 
             Float4[] aArr = a.float4ArrayView();
             Float4[] bArr = b.float4ArrayView();
@@ -245,7 +245,7 @@ public class TestVectorArrayView {
 
             Float4 vA = aArr[index * 4];
             smArr[lix * 4] = vA;
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float4 r = smArr[lix * 4];
             bArr[index * 4] = r;
         }
@@ -267,8 +267,8 @@ public class TestVectorArrayView {
     @Reflect
     public static void vectorOps11(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         PrivateMemory pm = PrivateMemory.createPrivate();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             Float4[] aArr = a.float4ArrayView();
             Float4[] bArr = b.float4ArrayView();
@@ -276,7 +276,7 @@ public class TestVectorArrayView {
 
             Float4 vA = aArr[index * 4];
             pmArr[0] = vA;
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float4 r = pmArr[0];
             bArr[index * 4] = r;
         }
@@ -285,9 +285,9 @@ public class TestVectorArrayView {
     @Reflect
     public static void vectorOps12(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
-            int lix = kernelContext.lix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
+            int lix = KernelContext.LIX();
             Float4.MutableImpl[] aArr = a.float4ArrayView();
             Float4.MutableImpl[] bArr = b.float4ArrayView();
             Float4.MutableImpl[] smArr = sm.float4LocalArrayView();
@@ -299,7 +299,7 @@ public class TestVectorArrayView {
             smVector.z(vA.z());
             smVector.w(vA.w());
             smArr[lix * 4] = smVector;
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float4.MutableImpl r = smArr[lix * 4];
             bArr[index * 4] = r;
         }

--- a/hat/tests/src/main/java/hat/test/TestVectorTypes.java
+++ b/hat/tests/src/main/java/hat/test/TestVectorTypes.java
@@ -28,6 +28,7 @@ import hat.Accelerator;
 import hat.ComputeContext;
 import hat.NDRange;
 import hat.KernelContext;
+import static hat.KernelContext.*;
 import hat.backend.Backend;
 import hat.buffer.F32ArrayPadded;
 import hat.types.Float4;
@@ -43,9 +44,9 @@ import java.util.Random;
 public class TestVectorTypes {
 
     @Reflect
-    public static void vectorOps01(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps01(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = Float4.add(vA, vB);
@@ -54,9 +55,9 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps02(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps02(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4.MutableImpl vA = a.float4View(index * 4);
             float scaleX = vA.x() * 10.0f;
             vA.x(scaleX);
@@ -65,9 +66,9 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps03(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps03(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
 
             // Obtain a view of the input data as a float4 and
             // store that view in private memory
@@ -88,9 +89,9 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps04(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps04(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4.MutableImpl vA = a.float4View(index * 4);
             vA.x(vA.x() * 10.0f);
             vA.y(vA.y() * 20.0f);
@@ -101,9 +102,9 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps05(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps05(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vB).add(vB);
@@ -112,9 +113,9 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps06(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps06(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
          //   Float4 vD = Float4.sub(vA, vB);
@@ -124,9 +125,9 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps07(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps07(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vB).sub(vB);
@@ -135,9 +136,9 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps08(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps08(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vB).mul(vA).div(vB);
@@ -146,10 +147,10 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps09(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
+    public static void vectorOps09(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
         // Checking composition
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vA.mul(vB));
@@ -176,14 +177,14 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps10(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps10(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
-            int lix = KernelContext.LIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
+            int lix = LIX();
             Float4 vA = a.float4View(index * 4);
             sm.storeFloat4View(vA, lix * 4);
-            KernelContext.barrier();
+            barrier();
             Float4 r = sm.float4View(lix * 4);
             b.storeFloat4View(r, index * 4);
         }
@@ -208,39 +209,39 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps11(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps11(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         PrivateMemory pm = PrivateMemory.createPrivate();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             pm.storeFloat4View(vA, 0);
-            KernelContext.barrier();
+            barrier();
             Float4 r = pm.float4View(0);
             b.storeFloat4View(r, index * 4);
         }
     }
 
     @Reflect
-    public static void vectorOps12(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
+    public static void vectorOps12(KernelContext unused, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
-            int lix = KernelContext.LIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
+            int lix = LIX();
             Float4 vA = a.float4View(index * 4);
             sm.array(lix * 4 + 0, vA.x());
             sm.array(lix * 4 + 1, vA.y());
             sm.array(lix * 4 + 2, vA.z());
             sm.array(lix * 4 + 3, vA.w());
-            KernelContext.barrier();
+            barrier();
             Float4 r = sm.float4View(lix * 4);
             b.storeFloat4View(r, index * 4);
         }
     }
 
     @Reflect
-    public static void vectorOps14(KernelContext kernelContext, F32ArrayPadded a) {
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+    public static void vectorOps14(KernelContext unused, F32ArrayPadded a) {
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 vA = a.float4View(index * 4);
             Float4.MutableImpl vB = Float4.makeMutable(vA);
             vB.x(10.0f);
@@ -249,11 +250,11 @@ public class TestVectorTypes {
     }
 
     @Reflect
-    public static void vectorOps15(KernelContext kernelContext, F32ArrayPadded a) {
+    public static void vectorOps15(KernelContext unused, F32ArrayPadded a) {
         // in this sample, we don't perform the vload, but rather the vstore directly
         // from a new float4.
-        if (KernelContext.GIX() < KernelContext.GSX()) {
-            int index = KernelContext.GIX();
+        if (GIX() < GSX()) {
+            int index = GIX();
             Float4 result = Float4.of(1.0f, 2.0f, 3.0f, 4.0f);
             a.storeFloat4View(result, index * 4);
         }

--- a/hat/tests/src/main/java/hat/test/TestVectorTypes.java
+++ b/hat/tests/src/main/java/hat/test/TestVectorTypes.java
@@ -44,8 +44,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps01(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = Float4.add(vA, vB);
@@ -55,8 +55,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps02(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4.MutableImpl vA = a.float4View(index * 4);
             float scaleX = vA.x() * 10.0f;
             vA.x(scaleX);
@@ -66,8 +66,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps03(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
 
             // Obtain a view of the input data as a float4 and
             // store that view in private memory
@@ -89,8 +89,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps04(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4.MutableImpl vA = a.float4View(index * 4);
             vA.x(vA.x() * 10.0f);
             vA.y(vA.y() * 20.0f);
@@ -102,8 +102,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps05(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vB).add(vB);
@@ -113,8 +113,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps06(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
          //   Float4 vD = Float4.sub(vA, vB);
@@ -125,8 +125,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps07(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vB).sub(vB);
@@ -136,8 +136,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps08(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vB).mul(vA).div(vB);
@@ -148,8 +148,8 @@ public class TestVectorTypes {
     @Reflect
     public static void vectorOps09(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b, F32ArrayPadded c) {
         // Checking composition
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             Float4 vB = b.float4View(index * 4);
             Float4 vC = vA.add(vA.mul(vB));
@@ -178,12 +178,12 @@ public class TestVectorTypes {
     @Reflect
     public static void vectorOps10(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
-            int lix = kernelContext.lix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
+            int lix = KernelContext.LIX();
             Float4 vA = a.float4View(index * 4);
             sm.storeFloat4View(vA, lix * 4);
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float4 r = sm.float4View(lix * 4);
             b.storeFloat4View(r, index * 4);
         }
@@ -210,11 +210,11 @@ public class TestVectorTypes {
     @Reflect
     public static void vectorOps11(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         PrivateMemory pm = PrivateMemory.createPrivate();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             pm.storeFloat4View(vA, 0);
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float4 r = pm.float4View(0);
             b.storeFloat4View(r, index * 4);
         }
@@ -223,15 +223,15 @@ public class TestVectorTypes {
     @Reflect
     public static void vectorOps12(KernelContext kernelContext, F32ArrayPadded a, F32ArrayPadded b) {
         SharedMemory sm = SharedMemory.createLocal();
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
-            int lix = kernelContext.lix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
+            int lix = KernelContext.LIX();
             Float4 vA = a.float4View(index * 4);
             sm.array(lix * 4 + 0, vA.x());
             sm.array(lix * 4 + 1, vA.y());
             sm.array(lix * 4 + 2, vA.z());
             sm.array(lix * 4 + 3, vA.w());
-            kernelContext.barrier();
+            KernelContext.barrier();
             Float4 r = sm.float4View(lix * 4);
             b.storeFloat4View(r, index * 4);
         }
@@ -239,8 +239,8 @@ public class TestVectorTypes {
 
     @Reflect
     public static void vectorOps14(KernelContext kernelContext, F32ArrayPadded a) {
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 vA = a.float4View(index * 4);
             Float4.MutableImpl vB = Float4.makeMutable(vA);
             vB.x(10.0f);
@@ -252,8 +252,8 @@ public class TestVectorTypes {
     public static void vectorOps15(KernelContext kernelContext, F32ArrayPadded a) {
         // in this sample, we don't perform the vload, but rather the vstore directly
         // from a new float4.
-        if (kernelContext.gix < kernelContext.gsx) {
-            int index = kernelContext.gix;
+        if (KernelContext.GIX() < KernelContext.GSX()) {
+            int index = KernelContext.GIX();
             Float4 result = Float4.of(1.0f, 2.0f, 3.0f, 4.0f);
             a.storeFloat4View(result, index * 4);
         }

--- a/hat/tests/src/main/java/hat/test/TestWriteOnly.java
+++ b/hat/tests/src/main/java/hat/test/TestWriteOnly.java
@@ -59,7 +59,7 @@ public class TestWriteOnly {
     }
 
     @Reflect
-    public static void life(KernelContext kc, CellGrid cellGrid, CellGrid cellGridRes) {
+    public static void life(KernelContext unused, CellGrid cellGrid, CellGrid cellGridRes) {
     }
 
     @Reflect


### PR DESCRIPTION
Swapping thread id access from KernelContext instance fields to static methods. 

This is an initial PR, which proves we can make the change in the kernels. A followup PR will remove the KernelContext first arg in all tests and exampless

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1117/head:pull/1117` \
`$ git checkout pull/1117`

Update a local copy of the PR: \
`$ git checkout pull/1117` \
`$ git pull https://git.openjdk.org/babylon.git pull/1117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1117`

View PR using the GUI difftool: \
`$ git pr show -t 1117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1117.diff">https://git.openjdk.org/babylon/pull/1117.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1117#issuecomment-5128708072)
</details>
