### PR TITLE
8389389: IllegalAccessError when calling a protected method

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -871,8 +871,8 @@ public final class BytecodeGenerator {
                         }
                         push(op.result());
                     }
-                    case FieldAccessOp.FieldLoadOp op -> fieldAccess(op, false);
-                    case FieldAccessOp.FieldStoreOp op -> fieldAccess(op, true);
+                    case FieldAccessOp.FieldLoadOp op -> fieldAccess(op);
+                    case FieldAccessOp.FieldStoreOp op -> fieldAccess(op);
                     case InstanceOfOp op -> {
                         processFirstOperand(op);
                         cob.instanceOf(((JavaType) op.targetType()).toNominalDescriptor());
@@ -1031,10 +1031,11 @@ public final class BytecodeGenerator {
                           type instanceof MethodTypeDesc ? MTD_FIND_METHOD : MTD_FIND_FIELD);
     }
 
-    private void fieldAccess(FieldAccessOp op, boolean store) {
+    private void fieldAccess(FieldAccessOp op) {
         FieldRef ref = op.fieldReference();
         JavaType refType = (JavaType) ref.refType();
         ClassDesc fieldType = ((JavaType) ref.type()).toNominalDescriptor();
+        boolean store = op instanceof FieldAccessOp.FieldStoreOp;
         boolean isStatic = op.operands().size() == (store ? 1 : 0);
         boolean protectedAccess = false;
         try {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -46,9 +46,12 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.StringConcatFactory;
+import java.lang.reflect.Member;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static java.lang.classfile.Opcode.*;
 import static java.lang.constant.ConstantDescs.*;
 import static jdk.incubator.code.dialect.java.JavaOp.*;
 
@@ -61,6 +64,13 @@ public final class BytecodeGenerator {
             StringConcatFactory.class.describeConstable().orElseThrow(),
             "makeConcat",
             CD_CallSite);
+
+    private static final MethodTypeDesc MTD_FIND_FIELD =
+            MethodTypeDesc.of(CD_MethodHandle, CD_Class, CD_String, CD_Class);
+    private static final MethodTypeDesc MTD_FIND_METHOD =
+            MethodTypeDesc.of(CD_MethodHandle, CD_Class, CD_String, CD_MethodType);
+    private static final MethodTypeDesc MTD_FIND_SPECIAL =
+            MethodTypeDesc.of(CD_MethodHandle, CD_Class, CD_String, CD_MethodType, CD_Class);
 
     /**
      * Transforms the invokable operation to bytecode encapsulated in a method of hidden class and exposed
@@ -771,6 +781,7 @@ public final class BytecodeGenerator {
                         JavaType refType = (JavaType)md.refType();
                         ClassDesc specialCaller = lookup.lookupClass().describeConstable().get();
                         MethodTypeDesc mDesc = MethodRef.toNominalDescriptor(md.signature());
+                        boolean protectedAccess = false;
                         if (op.invokeKind() == InvokeOp.InvokeKind.SUPER) {
                             // constructs method handle via lookup.findSpecial using the lookup's class as the specialCaller
                             // original lookup is stored in class data
@@ -783,7 +794,19 @@ public final class BytecodeGenerator {
                                .ldc(specialCaller)
                                .invokevirtual(CD_MethodHandles_Lookup,
                                               "findSpecial",
-                                              MethodTypeDesc.of(CD_MethodHandle, CD_Class, CD_String, CD_MethodType, CD_Class));
+                                              MTD_FIND_SPECIAL);
+                        } else {
+                            try {
+                                var info = lookup.revealDirect(md.resolveToHandle(lookup, op.invokeKind()));
+                                protectedAccess = Modifier.isProtected(info.getModifiers())
+                                        && !info.getDeclaringClass().getPackageName().equals(lookup.lookupClass().getPackageName());
+                            } catch (ReflectiveOperationException | IllegalArgumentException _) {
+                                // @@@ protected access detection failed
+                            }
+                            if (protectedAccess) {
+                                lookupHandle(specialCaller, md.name(), mDesc,
+                                             op.invokeKind() == InvokeOp.InvokeKind.STATIC ? "findStatic" : "findVirtual");
+                            }
                         }
                         if (op.isVarArgs()) {
                             processOperands(op.argOperands());
@@ -799,19 +822,23 @@ public final class BytecodeGenerator {
                         } catch (ReflectiveOperationException e) {
                             throw new IllegalArgumentException(e);
                         }
-                        boolean isInterface =  refClass.isInterface();
+                        boolean isInterface = refClass.isInterface();
                         switch (op.invokeKind()) {
-                            case STATIC ->
-                                    cob.invokestatic(refType.toNominalDescriptor(),
-                                                     md.name(),
-                                                     mDesc,
-                                                     isInterface);
-                            case INSTANCE ->
-                                    cob.invoke(isInterface ? Opcode.INVOKEINTERFACE : Opcode.INVOKEVIRTUAL,
-                                               refType.toNominalDescriptor(),
-                                               md.name(),
-                                               mDesc,
-                                               isInterface);
+                            case STATIC -> {
+                                if (protectedAccess) {
+                                    cob.invokevirtual(CD_MethodHandle, "invokeExact", mDesc);
+                                } else {
+                                    cob.invokestatic(refType.toNominalDescriptor(), md.name(), mDesc, isInterface);
+                                }
+                            }
+                            case INSTANCE -> {
+                                if (protectedAccess) {
+                                    cob.invokevirtual(CD_MethodHandle, "invokeExact", mDesc.insertParameterTypes(0, specialCaller));
+                                } else {
+                                    cob.invoke(isInterface ? INVOKEINTERFACE : INVOKEVIRTUAL,
+                                               refType.toNominalDescriptor(), md.name(), mDesc, isInterface);
+                                }
+                            }
                             case SUPER ->
                                     cob.invokevirtual(CD_MethodHandle,
                                                       "invokeExact",
@@ -832,7 +859,7 @@ public final class BytecodeGenerator {
                         processOperands(op);
                         MethodTypeDesc mDesc = MethodRef.toNominalDescriptor(fop.invokableSignature());
                         cob.invoke(
-                                Opcode.INVOKESTATIC,
+                                INVOKESTATIC,
                                 className,
                                 op.funcName(),
                                 mDesc,
@@ -844,37 +871,8 @@ public final class BytecodeGenerator {
                         }
                         push(op.result());
                     }
-                    case FieldAccessOp.FieldLoadOp op -> {
-                        processOperands(op);
-                        FieldRef fd = op.fieldReference();
-                        if (op.operands().isEmpty()) {
-                            cob.getstatic(
-                                    ((JavaType) fd.refType()).toNominalDescriptor(),
-                                    fd.name(),
-                                    ((JavaType) fd.type()).toNominalDescriptor());
-                        } else {
-                            cob.getfield(
-                                    ((JavaType) fd.refType()).toNominalDescriptor(),
-                                    fd.name(),
-                                    ((JavaType) fd.type()).toNominalDescriptor());
-                        }
-                        push(op.result());
-                    }
-                    case FieldAccessOp.FieldStoreOp op -> {
-                        processOperands(op);
-                        FieldRef fd = op.fieldReference();
-                        if (op.operands().size() == 1) {
-                            cob.putstatic(
-                                    ((JavaType) fd.refType()).toNominalDescriptor(),
-                                    fd.name(),
-                                    ((JavaType) fd.type()).toNominalDescriptor());
-                        } else {
-                            cob.putfield(
-                                    ((JavaType) fd.refType()).toNominalDescriptor(),
-                                    fd.name(),
-                                    ((JavaType) fd.type()).toNominalDescriptor());
-                        }
-                    }
+                    case FieldAccessOp.FieldLoadOp op -> fieldAccess(op, false);
+                    case FieldAccessOp.FieldStoreOp op -> fieldAccess(op, true);
                     case InstanceOfOp op -> {
                         processFirstOperand(op);
                         cob.instanceOf(((JavaType) op.targetType()).toNominalDescriptor());
@@ -950,7 +948,7 @@ public final class BytecodeGenerator {
                         conditionalBranch(prepareConditionalBranch(cop), op.trueBranch(), op.falseBranch());
                     } else {
                         processFirstOperand(op);
-                        conditionalBranch(Opcode.IFEQ, op.trueBranch(), op.falseBranch());
+                        conditionalBranch(IFEQ, op.trueBranch(), op.falseBranch());
                     }
                 }
                 case ConstantLabelSwitchOp op -> {
@@ -1015,6 +1013,59 @@ public final class BytecodeGenerator {
             }
         }
         exceptionRegionsChange(new Block[0]);
+    }
+
+    private void lookupHandle(ClassDesc owner, String name, ConstantDesc type, String finder) {
+        // handle must precede any operand
+        if (oprOnStack != null) {
+            storeIfUsed(oprOnStack);
+            oprOnStack = null;
+        }
+        cob.ldc(DynamicConstantDesc.of(BSM_CLASS_DATA))
+           .checkcast(CD_MethodHandles_Lookup)
+           .ldc(owner)
+           .ldc(name)
+           .ldc(type)
+           .invokevirtual(CD_MethodHandles_Lookup,
+                          finder,
+                          type instanceof MethodTypeDesc ? MTD_FIND_METHOD : MTD_FIND_FIELD);
+    }
+
+    private void fieldAccess(FieldAccessOp op, boolean store) {
+        FieldRef ref = op.fieldReference();
+        JavaType refType = (JavaType) ref.refType();
+        ClassDesc fieldType = ((JavaType) ref.type()).toNominalDescriptor();
+        boolean isStatic = op.operands().size() == (store ? 1 : 0);
+        boolean protectedAccess = false;
+        try {
+            Member m = ref.resolveToField(lookup);
+            protectedAccess = Modifier.isProtected(m.getModifiers())
+                    && !m.getDeclaringClass().getPackageName().equals(lookup.lookupClass().getPackageName());
+        } catch (ReflectiveOperationException | IllegalArgumentException _) {
+            // @@@ protected access detection failed
+        }
+        ClassDesc caller = lookup.lookupClass().describeConstable().orElseThrow();
+        if (protectedAccess) {
+            lookupHandle(caller, ref.name(), fieldType, "find" + (isStatic ? "Static" : "") + (store ? "Setter" : "Getter"));
+        }
+        processOperands(op);
+        if (protectedAccess) {
+            cob.invokevirtual(CD_MethodHandle,
+                              "invokeExact",
+                              isStatic ? (store ? MethodTypeDesc.of(CD_void, fieldType)
+                                                : MethodTypeDesc.of(fieldType))
+                                       : (store ? MethodTypeDesc.of(CD_void, caller, fieldType)
+                                                : MethodTypeDesc.of(fieldType, caller)));
+        } else {
+            cob.fieldAccess(isStatic ? (store ? PUTSTATIC : GETSTATIC)
+                                     : (store ? PUTFIELD : GETFIELD),
+                            refType.toNominalDescriptor(),
+                            ref.name(),
+                            fieldType);
+        }
+        if (!store) {
+            push(op.result());
+        }
     }
 
     private void loadArray(JavaType compType, List<Value> array) {
@@ -1163,19 +1214,19 @@ public final class BytecodeGenerator {
             return switch (typeKind) {
                 case INT, BOOLEAN, BYTE, SHORT, CHAR ->
                     switch (op) {
-                        case EqOp _ -> Opcode.IFNE;
-                        case NeqOp _ -> Opcode.IFEQ;
-                        case GtOp _ -> Opcode.IFLE;
-                        case GeOp _ -> Opcode.IFLT;
-                        case LtOp _ -> Opcode.IFGE;
-                        case LeOp _ -> Opcode.IFGT;
+                        case EqOp _ -> IFNE;
+                        case NeqOp _ -> IFEQ;
+                        case GtOp _ -> IFLE;
+                        case GeOp _ -> IFLT;
+                        case LtOp _ -> IFGE;
+                        case LeOp _ -> IFGT;
                         default ->
                             throw new UnsupportedOperationException(op + " on int");
                     };
                 case REFERENCE ->
                     switch (op) {
-                        case EqOp _ -> Opcode.IFNONNULL;
-                        case NeqOp _ -> Opcode.IFNULL;
+                        case EqOp _ -> IFNONNULL;
+                        case NeqOp _ -> IFNULL;
                         default ->
                             throw new UnsupportedOperationException(op + " on Object");
                     };
@@ -1187,19 +1238,19 @@ public final class BytecodeGenerator {
         return switch (typeKind) {
             case INT, BOOLEAN, BYTE, SHORT, CHAR ->
                 switch (op) {
-                    case EqOp _ -> Opcode.IF_ICMPNE;
-                    case NeqOp _ -> Opcode.IF_ICMPEQ;
-                    case GtOp _ -> Opcode.IF_ICMPLE;
-                    case GeOp _ -> Opcode.IF_ICMPLT;
-                    case LtOp _ -> Opcode.IF_ICMPGE;
-                    case LeOp _ -> Opcode.IF_ICMPGT;
+                    case EqOp _ -> IF_ICMPNE;
+                    case NeqOp _ -> IF_ICMPEQ;
+                    case GtOp _ -> IF_ICMPLE;
+                    case GeOp _ -> IF_ICMPLT;
+                    case LtOp _ -> IF_ICMPGE;
+                    case LeOp _ -> IF_ICMPGT;
                     default ->
                         throw new UnsupportedOperationException(op + " on int");
                 };
             case REFERENCE ->
                 switch (op) {
-                    case EqOp _ -> Opcode.IF_ACMPNE;
-                    case NeqOp _ -> Opcode.IF_ACMPEQ;
+                    case EqOp _ -> IF_ACMPNE;
+                    case NeqOp _ -> IF_ACMPEQ;
                     default ->
                         throw new UnsupportedOperationException(op + " on Object");
                 };
@@ -1236,12 +1287,12 @@ public final class BytecodeGenerator {
 
     private static Opcode reverseIfOpcode(CompareOp op) {
         return switch (op) {
-            case EqOp _ -> Opcode.IFNE;
-            case NeqOp _ -> Opcode.IFEQ;
-            case GtOp _ -> Opcode.IFLE;
-            case GeOp _ -> Opcode.IFLT;
-            case LtOp _ -> Opcode.IFGE;
-            case LeOp _ -> Opcode.IFGT;
+            case EqOp _ -> IFNE;
+            case NeqOp _ -> IFEQ;
+            case GtOp _ -> IFLE;
+            case GeOp _ -> IFLT;
+            case LtOp _ -> IFGE;
+            case LeOp _ -> IFGT;
             default ->
                 throw new UnsupportedOperationException(op.toString());
         };

--- a/test/jdk/jdk/incubator/code/bytecode/TestProtectedAccess.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestProtectedAccess.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import jdk.incubator.code.Reflect;
+import jdk.incubator.code.Op;
+import jdk.incubator.code.bytecode.BytecodeGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/*
+ * @test
+ * @modules jdk.incubator.code
+ * @enablePreview
+ * @run junit TestProtectedAccess
+ */
+public class TestProtectedAccess extends PrintWriter {
+
+    public TestProtectedAccess() {
+        super(new StringWriter());
+        print("hello");
+    }
+
+    @Reflect
+    public String accessProtectedField() {
+        return out.toString();
+    }
+
+    @Reflect
+    public boolean accessProtectedMethod() {
+        setError();
+        return checkError();
+    }
+
+    @Test
+    public void testProtectedFieldAccess() throws Throwable {
+        Method accessMethod = TestProtectedAccess.class.getDeclaredMethod("accessProtectedField");
+        MethodHandle handle = BytecodeGenerator.generate(MethodHandles.lookup(),
+                                                         Op.ofMethod(accessMethod).orElseThrow());
+        Assertions.assertEquals(new TestProtectedAccess().accessProtectedField(),
+                                handle.invoke(new TestProtectedAccess()));
+    }
+
+    @Test
+    public void testProtectedMethodAccess() throws Throwable {
+        Method accessMethod = TestProtectedAccess.class.getDeclaredMethod("accessProtectedMethod");
+        MethodHandle handle = BytecodeGenerator.generate(MethodHandles.lookup(),
+                                                         Op.ofMethod(accessMethod).orElseThrow());
+        Assertions.assertEquals(new TestProtectedAccess().accessProtectedMethod(),
+                                (boolean) handle.invoke(new TestProtectedAccess()));
+    }
+}


### PR DESCRIPTION
Cross-package or cross-module access to protected fields and methods requires special handling, similar to SUPER invocation. 
Instead of emitting direct field access or a direct method call, the generated bytecode invokes a method handle resolved with the original lookup stored in class data.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389389](https://bugs.openjdk.org/browse/JDK-8389389): IllegalAccessError when calling a protected method (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1118/head:pull/1118` \
`$ git checkout pull/1118`

Update a local copy of the PR: \
`$ git checkout pull/1118` \
`$ git pull https://git.openjdk.org/babylon.git pull/1118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1118`

View PR using the GUI difftool: \
`$ git pr show -t 1118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1118.diff">https://git.openjdk.org/babylon/pull/1118.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1118#issuecomment-5132729747)
</details>
