### PR TITLE
8389387: NullPointerException from ReflectMethods

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -742,15 +742,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
-            if (sourceType.isReference() && targetType.isReference()) {
-                if (!types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
-                    return append(JavaOp.cast(typeToCodeType(targetType), sourceValue));
-                }
-                Type sourceValueType = codeTypeToType(sourceValue.type());
-                if (sourceValueType != Type.noType
-                        && !types.isSubtype(types.erasure(sourceValueType), types.erasure(targetType))) {
-                    return append(JavaOp.cast(typeToCodeType(targetType), sourceValue));
-                }
+            if (sourceType.isReference() && targetType.isReference() &&
+                    !types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
+                return append(JavaOp.cast(typeToCodeType(targetType), sourceValue));
             }
             return convert(sourceValue, targetType);
         }
@@ -1163,6 +1157,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     break;
                 }
                 case SELECT: {
+                    // we need this for cases like array.clone()
+                    // where tree.type is Object[] although the method return type is Object
+                    tree.type = tree.meth.type.getReturnType();
                     JCFieldAccess access = (JCFieldAccess) meth;
 
                     Type qualifierTarget = qualifierTarget(access);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -742,9 +742,15 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
-            if (sourceType.isReference() && targetType.isReference() &&
-                    !types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
-                return append(JavaOp.cast(typeToCodeType(targetType), sourceValue));
+            if (sourceType.isReference() && targetType.isReference()) {
+                if (!types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
+                    return append(JavaOp.cast(typeToCodeType(targetType), sourceValue));
+                }
+                Type sourceValueType = codeTypeToType(sourceValue.type());
+                if (sourceValueType != Type.noType
+                        && !types.isSubtype(types.erasure(sourceValueType), types.erasure(targetType))) {
+                    return append(JavaOp.cast(typeToCodeType(targetType), sourceValue));
+                }
             }
             return convert(sourceValue, targetType);
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -725,24 +725,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 pt = targetType;
                 scan(expression);
                 return (result == null || targetType.hasTag(TypeTag.VOID) || targetType.hasTag(NONE)) ?
-                        result : coerce(result, getSourceType(expression), targetType);
+                        result : coerce(result, expression.type, targetType);
             } finally {
                 pt = prevPt;
             }
-        }
-
-        private Type getSourceType(JCExpression expr) {
-            Symbol ms;
-            // for array.clone the expr.type will be the type of the array (because of Attr)
-            // this will prevent necessary cast from being added to model
-            // so we make sure the sourceType passed to coerece is Object which is the return type of the clone method
-            if (expr instanceof JCMethodInvocation mi &&
-                    (ms = TreeInfo.symbol(mi.meth)) != null &&
-                    ms.owner == syms.arrayClass &&
-                    ms.name == names.clone)
-                return syms.objectType;
-            else
-                return expr.type;
         }
 
         public Value toValue(JCExpression expression) {
@@ -1199,6 +1185,11 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             returnType, mr, args);
                     Value res = append(iop);
+                    if (sym.owner == syms.arrayClass && sym.name == names.clone) {
+                        // for array.clone, cast res (whose type is Object) to the array's type
+                        // we align the res.type with the tree.type
+                        res = append(JavaOp.cast(receiver.type(), res));
+                    }
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;
                     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2903,8 +2903,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
     MethodRef symbolToMethodRef(Symbol s) {
         Type erasedType = s.erasure(types);
+        Type ownerType = s.owner.type.hasTag(TypeTag.ARRAY) && s.name == names.clone ?
+                s.owner.type : s.owner.erasure(types);
         return MethodRef.method(
-                s.owner.name == names.Array ? typeToCodeType(s.owner.type) : typeToCodeType(s.owner.erasure(types)),
+                typeToCodeType(ownerType),
                 s.name.toString(),
                 typeToCodeType(erasedType.getReturnType()),
                 erasedType.getParameterTypes().stream().map(this::typeToCodeType).toArray(CodeType[]::new));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2901,7 +2901,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
     MethodRef symbolToMethodRef(Symbol s) {
         Type erasedType = s.erasure(types);
         return MethodRef.method(
-                typeToCodeType(s.owner.erasure(types)),
+                s.owner.name == names.Array ? typeToCodeType(s.owner.type) : typeToCodeType(s.owner.erasure(types)),
                 s.name.toString(),
                 typeToCodeType(erasedType.getReturnType()),
                 erasedType.getParameterTypes().stream().map(this::typeToCodeType).toArray(CodeType[]::new));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -725,10 +725,24 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 pt = targetType;
                 scan(expression);
                 return (result == null || targetType.hasTag(TypeTag.VOID) || targetType.hasTag(NONE)) ?
-                        result : coerce(result, expression.type, targetType);
+                        result : coerce(result, getSourceType(expression), targetType);
             } finally {
                 pt = prevPt;
             }
+        }
+
+        private Type getSourceType(JCExpression expr) {
+            Symbol ms;
+            // for array.clone the expr.type will be the type of the array (because of Attr)
+            // this will prevent necessary cast from being added to model
+            // so we make sure the sourceType passed to coerece is Object which is the return type of the clone method
+            if (expr instanceof JCMethodInvocation mi &&
+                    (ms = TreeInfo.symbol(mi.meth)) != null &&
+                    ms.owner == syms.arrayClass &&
+                    ms.name == names.clone)
+                return syms.objectType;
+            else
+                return expr.type;
         }
 
         public Value toValue(JCExpression expression) {
@@ -1157,9 +1171,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     break;
                 }
                 case SELECT: {
-                    // we need this for cases like array.clone()
-                    // where tree.type is Object[] although the method return type is Object
-                    tree.type = tree.meth.type.getReturnType();
                     JCFieldAccess access = (JCFieldAccess) meth;
 
                     Type qualifierTarget = qualifierTarget(access);

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -293,4 +293,18 @@ public class MethodCallTest {
         List<String> l = al;
         s = l.get(0);
     }
+
+    @Reflect
+    @IR("""
+            func @"test11" (%0 : java.type:"java.lang.Object[]")java.type:"java.lang.Object[]" -> {
+                  %1 : Var<java.type:"java.lang.Object[]"> = var %0 @"values";
+                  %2 : java.type:"java.lang.Object[]" = var.load %1;
+                  %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"java.lang.Object[]::clone():java.lang.Object";
+                  %4 : java.type:"java.lang.Object[]" = cast %3 @java.type:"java.lang.Object[]";
+                  return %4;
+            };
+            """)
+    static Object[] test11(Object[] values) {
+        return values.clone();
+    }
 }

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -307,4 +307,33 @@ public class MethodCallTest {
     static Object[] test11(Object[] values) {
         return values.clone();
     }
+
+    @Reflect
+    @IR("""
+            func @"test12" (%0 : java.type:"int[]")java.type:"int[]" -> {
+                  %1 : Var<java.type:"int[]"> = var %0 @"values";
+                  %2 : java.type:"int[]" = var.load %1;
+                  %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"int[]::clone():java.lang.Object";
+                  %4 : java.type:"int[]" = cast %3 @java.type:"int[]";
+                  return %4;
+            };
+            """)
+    static int[] test12(int[] values) {
+        return values.clone();
+    }
+
+
+    @Reflect
+    @IR("""
+            func @"test13" (%0 : java.type:"java.lang.Comparable<java.lang.String>[]")java.type:"java.lang.Comparable<java.lang.String>[]" -> {
+                %1 : Var<java.type:"java.lang.Comparable<java.lang.String>[]"> = var %0 @"values";
+                %2 : java.type:"java.lang.Comparable<java.lang.String>[]" = var.load %1;
+                %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"java.lang.Comparable[]::clone():java.lang.Object";
+                %4 : java.type:"java.lang.Comparable<java.lang.String>[]" = cast %3 @java.type:"java.lang.Comparable<java.lang.String>[]";
+                return %4;
+            };
+            """)
+    static Comparable<String>[] test13(Comparable<String>[] values) {
+        return values.clone();
+    }
 }


### PR DESCRIPTION
When constructing method reference from a method symbol and the method symbol owner is Array, that caused NPE in the compiler code, more specifically when processing the Array enclosing type which is `null`.
The solution so far is to the check the method symbol owner and if it's Array use the `Array.type` instead.
We also tweak the conversion code to add cast for code examples like in the issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389387](https://bugs.openjdk.org/browse/JDK-8389387): NullPointerException from ReflectMethods (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**) ⚠️ Review applies to [bbf2d56e](https://git.openjdk.org/babylon/pull/1119/files/bbf2d56e802c97d9c60e4ffc5d4c1c6a07537f2a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1119/head:pull/1119` \
`$ git checkout pull/1119`

Update a local copy of the PR: \
`$ git checkout pull/1119` \
`$ git pull https://git.openjdk.org/babylon.git pull/1119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1119`

View PR using the GUI difftool: \
`$ git pr show -t 1119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1119.diff">https://git.openjdk.org/babylon/pull/1119.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1119#issuecomment-5148919278)
</details>
