### PR TITLE
8389769: NullPointerException from ReflectMethods$BodyScanner.scanPattern

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1340,7 +1340,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // Find nearest ancestor body stack element associated with a statement tree
             // @@@ Strengthen check of tree?
             BodyStack _variablesStack = stack;
-            while (_variablesStack.parent != null && !(_variablesStack.tree instanceof JCTree.JCStatement)) {
+            while (!(_variablesStack.tree instanceof JCLambda)
+                    && !(_variablesStack.tree instanceof JCTree.JCStatement)) {
                 _variablesStack = _variablesStack.parent;
             }
             BodyStack variablesStack = _variablesStack;
@@ -1474,7 +1475,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
 
             // Push lambda body
-            pushBody(tree.body, lambdaType);
+            pushBody(tree, lambdaType);
 
             // Map lambda parameters to varOp values
             for (int i = 0; i < tree.params.size(); i++) {
@@ -2155,7 +2156,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitBlock(JCTree.JCBlock tree) {
-            if (stack.tree == tree) {
+            if (stack.tree == tree || stack.tree instanceof JCLambda jcl && jcl.body == tree) {
                 // Block is associated with the visit of a parent structure
                 scan(tree.stats);
             } else {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1475,7 +1475,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
 
             // Push lambda body
-            pushBody(tree, lambdaType);
+            // for expression lambda, the body stack need to be mapped to the JCLambda tree
+            // this ensures the logic for computing pattern variable stack, works correctly
+            pushBody(tree.getBodyKind() == LambdaExpressionTree.BodyKind.EXPRESSION ? tree : tree.body, lambdaType);
 
             // Map lambda parameters to varOp values
             for (int i = 0; i < tree.params.size(); i++) {
@@ -2156,7 +2158,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitBlock(JCTree.JCBlock tree) {
-            if (stack.tree == tree || stack.tree instanceof JCLambda jcl && jcl.body == tree) {
+            if (stack.tree == tree) {
                 // Block is associated with the visit of a parent structure
                 scan(tree.stats);
             } else {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1340,7 +1340,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // Find nearest ancestor body stack element associated with a statement tree
             // @@@ Strengthen check of tree?
             BodyStack _variablesStack = stack;
-            while (!(_variablesStack.tree instanceof JCTree.JCStatement)) {
+            while (_variablesStack.parent != null && !(_variablesStack.tree instanceof JCTree.JCStatement)) {
                 _variablesStack = _variablesStack.parent;
             }
             BodyStack variablesStack = _variablesStack;

--- a/test/langtools/tools/javac/reflect/LambdaTest.java
+++ b/test/langtools/tools/javac/reflect/LambdaTest.java
@@ -23,6 +23,7 @@
 
 import jdk.incubator.code.Reflect;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /*
@@ -182,4 +183,75 @@ public class LambdaTest {
     void test6() {
         Supplier<Integer> s = () -> f;
     }
+
+    @Reflect
+    @IR("""
+            func @"test7" (%0 : java.type:"LambdaTest")java.type:"java.util.function.Predicate<java.lang.Object>" -> {
+                  %3 : java.type:"java.util.function.Predicate<java.lang.Object>" = lambda @lambda.isReflectable=true (%4 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                      %5 : Var<java.type:"java.lang.Object"> = var %4 @"v";
+                      %1 : java.type:"java.lang.String" = constant @null;
+                      %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                      %6 : java.type:"boolean" = java.cand
+                          ()java.type:"boolean" -> {
+                              %7 : java.type:"java.lang.Object" = var.load %5;
+                              %8 : java.type:"boolean" = pattern.match %7
+                                  ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.String>" -> {
+                                      %9 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
+                                      yield %9;
+                                  }
+                                  (%10 : java.type:"java.lang.String")java.type:"void" -> {
+                                      var.store %2 %10;
+                                      yield;
+                                  };
+                              yield %8;
+                          }
+                          ()java.type:"boolean" -> {
+                              %11 : java.type:"java.lang.String" = var.load %2;
+                              %12 : java.type:"boolean" = invoke %11 @java.ref:"java.lang.String::isEmpty():boolean";
+                              %13 : java.type:"boolean" = not %12;
+                              yield %13;
+                          };
+                      return %6;
+                  };
+                  return %3;
+              };
+            """)
+    Predicate<Object> test7() {
+        // lambda that has pattern variable, this was crashing the compiler
+        return v -> v instanceof String s && !s.isEmpty();
+    }
+
+    @Reflect
+    @IR("""
+            func @"f" ()java.type:"void" -> {
+                  %3 : java.type:"java.util.function.Predicate<java.lang.Object>" = lambda @lambda.isReflectable=true (%4 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                      %5 : Var<java.type:"java.lang.Object"> = var %4 @"v";
+                      %1 : java.type:"java.lang.String" = constant @null;
+                      %2 : Var<java.type:"java.lang.String"> = var %1 @"s";
+                      %6 : java.type:"boolean" = java.cand
+                          ()java.type:"boolean" -> {
+                              %7 : java.type:"java.lang.Object" = var.load %5;
+                              %8 : java.type:"boolean" = pattern.match %7
+                                  ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.String>" -> {
+                                      %9 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
+                                      yield %9;
+                                  }
+                                  (%10 : java.type:"java.lang.String")java.type:"void" -> {
+                                      var.store %2 %10;
+                                      yield;
+                                  };
+                              yield %8;
+                          }
+                          ()java.type:"boolean" -> {
+                              %11 : java.type:"java.lang.String" = var.load %2;
+                              %12 : java.type:"boolean" = invoke %11 @java.ref:"java.lang.String::isEmpty():boolean";
+                              %13 : java.type:"boolean" = not %12;
+                              yield %13;
+                          };
+                      return %6;
+                  };
+                  return;
+              };
+            """)
+    static Predicate<Object> test8 = v -> v instanceof String s && !s.isEmpty();
 }

--- a/test/langtools/tools/javac/reflect/LambdaTest.java
+++ b/test/langtools/tools/javac/reflect/LambdaTest.java
@@ -217,7 +217,6 @@ public class LambdaTest {
               };
             """)
     Predicate<Object> test7() {
-        // lambda that has pattern variable, this was crashing the compiler
         return v -> v instanceof String s && !s.isEmpty();
     }
 


### PR DESCRIPTION
lambda like `v -> v instanceof String s && !s.isEmpty(); `will crash the compiler, because when trying to find a body stack where to put pattern variables will find none and result in NPE. The fix so far is when no body stack is found use the bottom one.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389769](https://bugs.openjdk.org/browse/JDK-8389769): NullPointerException from ReflectMethods$BodyScanner.scanPattern (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1120/head:pull/1120` \
`$ git checkout pull/1120`

Update a local copy of the PR: \
`$ git checkout pull/1120` \
`$ git pull https://git.openjdk.org/babylon.git pull/1120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1120`

View PR using the GUI difftool: \
`$ git pr show -t 1120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1120.diff">https://git.openjdk.org/babylon/pull/1120.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1120#issuecomment-5154836709)
</details>
