### PR TITLE
8389388: AssertionError from ReflectMethods

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1259,9 +1259,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
         @Override
         public void visitTypeTest(JCTree.JCInstanceOf tree) {
             Value target = toValue(tree.expr);
-
-            if (tree.pattern.getTag() != Tag.IDENT) {
-                result = scanPattern(tree.getPattern(), target);
+            JCTree.JCPattern pattern = tree.getPattern();
+            if (pattern != null) {
+                result = scanPattern(pattern, target);
             } else {
                 result = append(JavaOp.instanceOf(typeToCodeType(tree.pattern.type), target));
             }

--- a/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
+++ b/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
@@ -132,4 +132,18 @@ public class CastInstanceOfTest {
     void test6(List<Object> l) {
         boolean b = l.get(0) instanceof String;
     }
+
+    @Reflect
+    @IR("""
+            func @"test7" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.String";
+                %5 : Var<java.type:"boolean"> = var %4 @"b";
+                return;
+            };
+            """)
+    void test7(Object o) {
+        boolean b = o instanceof java.lang.String;
+    }
 }


### PR DESCRIPTION
Qualified `instanceof` was incorrectly treated as pattern and caused `AssertionError`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389388](https://bugs.openjdk.org/browse/JDK-8389388): AssertionError from ReflectMethods (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1121/head:pull/1121` \
`$ git checkout pull/1121`

Update a local copy of the PR: \
`$ git checkout pull/1121` \
`$ git pull https://git.openjdk.org/babylon.git pull/1121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1121`

View PR using the GUI difftool: \
`$ git pr show -t 1121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1121.diff">https://git.openjdk.org/babylon/pull/1121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1121#issuecomment-5165125742)
</details>
