### PR TITLE
Fix protected-access detection for array types in BytecodeGenerator

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -796,12 +796,14 @@ public final class BytecodeGenerator {
                                               "findSpecial",
                                               MTD_FIND_SPECIAL);
                         } else {
-                            try {
-                                var info = lookup.revealDirect(md.resolveToHandle(lookup, op.invokeKind()));
-                                protectedAccess = Modifier.isProtected(info.getModifiers())
-                                        && !info.getDeclaringClass().getPackageName().equals(lookup.lookupClass().getPackageName());
-                            } catch (ReflectiveOperationException | IllegalArgumentException _) {
-                                // @@@ protected access detection failed
+                            if (!(refType instanceof ArrayType)) { // array methods (e.g. clone) are excluded
+                                try {
+                                    var info = lookup.revealDirect(md.resolveToHandle(lookup, op.invokeKind()));
+                                    protectedAccess = Modifier.isProtected(info.getModifiers())
+                                            && !info.getDeclaringClass().getPackageName().equals(lookup.lookupClass().getPackageName());
+                                } catch (ReflectiveOperationException | IllegalArgumentException _) {
+                                    // @@@ protected access detection failed
+                                }
                             }
                             if (protectedAccess) {
                                 lookupHandle(specialCaller, md.name(), mDesc,

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1259,9 +1259,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
         @Override
         public void visitTypeTest(JCTree.JCInstanceOf tree) {
             Value target = toValue(tree.expr);
-
-            if (tree.pattern.getTag() != Tag.IDENT) {
-                result = scanPattern(tree.getPattern(), target);
+            JCTree.JCPattern pattern = tree.getPattern();
+            if (pattern != null) {
+                result = scanPattern(pattern, target);
             } else {
                 result = append(JavaOp.instanceOf(typeToCodeType(tree.pattern.type), target));
             }

--- a/test/jdk/jdk/incubator/code/bytecode/TestProtectedAccess.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestProtectedAccess.java
@@ -29,6 +29,11 @@ import java.lang.reflect.Method;
 import jdk.incubator.code.Reflect;
 import jdk.incubator.code.Op;
 import jdk.incubator.code.bytecode.BytecodeGenerator;
+import jdk.incubator.code.dialect.core.CoreOp;
+import jdk.incubator.code.dialect.core.CoreType;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
+import jdk.incubator.code.dialect.java.MethodRef;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -72,5 +77,19 @@ public class TestProtectedAccess extends PrintWriter {
                                                          Op.ofMethod(accessMethod).orElseThrow());
         Assertions.assertEquals(new TestProtectedAccess().accessProtectedMethod(),
                                 (boolean) handle.invoke(new TestProtectedAccess()));
+    }
+
+    @Test
+    public void testArrayCloneAccess() throws Throwable {
+        var handle = BytecodeGenerator.generate(MethodHandles.lookup(), CoreOp.func("arrayCloneTest",
+                CoreType.functionType(JavaType.J_L_OBJECT, JavaType.array(JavaType.J_L_STRING))).body(bb ->
+                        bb.add(CoreOp.return_(
+                                bb.add(JavaOp.invoke(
+                                        MethodRef.method(JavaType.array(JavaType.J_L_STRING),
+                                                         "clone",
+                                                         JavaType.J_L_OBJECT),
+                                        bb.parameters().getFirst()))))));
+        String[] input = { "a", "b" };
+        Assertions.assertArrayEquals(input, (String[])handle.invoke(input));
     }
 }

--- a/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
+++ b/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
@@ -132,4 +132,18 @@ public class CastInstanceOfTest {
     void test6(List<Object> l) {
         boolean b = l.get(0) instanceof String;
     }
+
+    @Reflect
+    @IR("""
+            func @"test7" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.String";
+                %5 : Var<java.type:"boolean"> = var %4 @"b";
+                return;
+            };
+            """)
+    void test7(Object o) {
+        boolean b = o instanceof java.lang.String;
+    }
 }


### PR DESCRIPTION
Array methods (e.g. `clone`) were wrongly treated as with protected access in `BytecodeGenerator`.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1123/head:pull/1123` \
`$ git checkout pull/1123`

Update a local copy of the PR: \
`$ git checkout pull/1123` \
`$ git pull https://git.openjdk.org/babylon.git pull/1123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1123`

View PR using the GUI difftool: \
`$ git pr show -t 1123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1123.diff">https://git.openjdk.org/babylon/pull/1123.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1123#issuecomment-5176904708)
</details>
