### PR TITLE
Remove redundant comment

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1471,7 +1471,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         public void visitLambda(JCTree.JCLambda tree) {
             final FunctionType lambdaType = typeToFunctionType(types.findDescriptorType(tree.target));
 
-            // Push quoted body
+            // Push quoted body for a reflectable lambda
 
             // A reflectable lambda is going to have its model wrapped in QuotedOp
             // only when we are producing the model of the lambda, thus the condition (isReflectable ...)

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1472,10 +1472,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
             final FunctionType lambdaType = typeToFunctionType(types.findDescriptorType(tree.target));
 
             // Push quoted body
-            // We can either be explicitly quoted or a structural quoted expression
-            // within some larger reflected code
 
-            // a reflectable lambda is going to have its model wrapped in QuotedOp
+            // A reflectable lambda is going to have its model wrapped in QuotedOp
             // only when we are producing the model of the lambda, thus the condition (isReflectable ...)
             // also, a lambda contained in a reflectable lambda, will not have its model wrapped in QuotedOp,
             // thus the condition (... body == tree)


### PR DESCRIPTION
Remove the comment related to structural quoted lambdas.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1124/head:pull/1124` \
`$ git checkout pull/1124`

Update a local copy of the PR: \
`$ git checkout pull/1124` \
`$ git pull https://git.openjdk.org/babylon.git pull/1124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1124`

View PR using the GUI difftool: \
`$ git pr show -t 1124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1124.diff">https://git.openjdk.org/babylon/pull/1124.diff</a>

</details>
