### PR TITLE
Rollback unnecessary preview transform for BytecodeGenerator output

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -2771,10 +2771,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 byte[] data = BytecodeGenerator.generateClassData(MethodHandles.lookup(), classDesc, module);
                 // inject InnerClassesAttribute and NestHostAttribute
                 var clm = ClassFile.of().parse(data);
-                boolean preview = clm.minorVersion() == ClassFile.PREVIEW_MINOR_VERSION;
-                int classInnerFlag = ClassFile.ACC_STATIC | (preview ? ClassFile.ACC_IDENTITY : 0);
                 data = ClassFile.of().transformClass(clm, ClassTransform.endHandler(clb ->
-                        clb.with(InnerClassesAttribute.of(InnerClassInfo.of(classDesc, Optional.of(hostClass), Optional.of("$CM"), classInnerFlag)))
+                        clb.with(InnerClassesAttribute.of(InnerClassInfo.of(classDesc, Optional.of(hostClass), Optional.of("$CM"), ClassFile.ACC_STATIC)))
                            .with(NestHostAttribute.of(hostClass))));
                 try (OutputStream out = outFile.openOutputStream()) {
                     out.write(data);


### PR DESCRIPTION
In retrospective review of #1122 we noted we can leave this change from merge until BytecodeGenerator is generating preview-dependent class files (unlikely)

Testing: jdk/incubator/code

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1125/head:pull/1125` \
`$ git checkout pull/1125`

Update a local copy of the PR: \
`$ git checkout pull/1125` \
`$ git pull https://git.openjdk.org/babylon.git pull/1125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1125`

View PR using the GUI difftool: \
`$ git pr show -t 1125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1125.diff">https://git.openjdk.org/babylon/pull/1125.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1125#issuecomment-5184422659)
</details>
