### PR TITLE
8389763: UnreachableOp is unsupported by BytecodeGenerator

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -1010,6 +1010,8 @@ public final class BytecodeGenerator {
                     assignBlockArguments(op.endReference());
                     cob.goto_(getLabel(op.endReference()));
                 }
+                case UnreachableOp _ ->
+                    cob.aconst_null().athrow();
                 default ->
                     throw new UnsupportedOperationException("Terminating operation not supported: " + top);
             }

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -611,6 +611,13 @@ public class TestBytecode {
         return -1;
     }
 
+    @Reflect
+    static int unreachable(int i) {
+        while (true) {
+            if (i-- <= 0) return i;
+        }
+    }
+
     record TestData(Method testMethod) {
         @Override
         public String toString() {


### PR DESCRIPTION
This PR supports `UnreachableOp` in `BytecodeGenerator` by generating a safe bytecode dead-end.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389763](https://bugs.openjdk.org/browse/JDK-8389763): UnreachableOp is unsupported by BytecodeGenerator (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1126/head:pull/1126` \
`$ git checkout pull/1126`

Update a local copy of the PR: \
`$ git checkout pull/1126` \
`$ git pull https://git.openjdk.org/babylon.git pull/1126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1126`

View PR using the GUI difftool: \
`$ git pr show -t 1126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1126.diff">https://git.openjdk.org/babylon/pull/1126.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1126#issuecomment-5193581207)
</details>
