### PR TITLE
8389802: BytecodeGenerator misses the cast for generic field loads

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -1067,6 +1067,11 @@ public final class BytecodeGenerator {
                             fieldType);
         }
         if (!store) {
+            ClassDesc ret = toClassDesc(op.resultType());
+            if (!ret.isPrimitive() && !ret.equals(fieldType)) {
+                // Explicit cast if field type differs
+                cob.checkcast(ret);
+            }
             push(op.result());
         }
     }

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -520,6 +520,14 @@ public class TestBytecode {
         return ret;
     }
 
+    record Box<T>(T value) {}
+
+    @Reflect
+    static int genericFieldCast(String s) {
+        Box<String> box = new Box(s);
+        return box.value.length();
+    }
+
     @Reflect
     static String stringConcat(String a, String b) {
         return "a"+ a +"\u0001" + a + "b\u0002c" + b + "\u0001\u0002" + b + "dd";


### PR DESCRIPTION
`BytecodeGenerator` must explicitly cast to the `FieldLoadOp` result type when it differs from the returned value type. 
The same approach is already used for method invocations.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389802](https://bugs.openjdk.org/browse/JDK-8389802): BytecodeGenerator misses the cast for generic field loads (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1127/head:pull/1127` \
`$ git checkout pull/1127`

Update a local copy of the PR: \
`$ git checkout pull/1127` \
`$ git pull https://git.openjdk.org/babylon.git pull/1127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1127`

View PR using the GUI difftool: \
`$ git pr show -t 1127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1127.diff">https://git.openjdk.org/babylon/pull/1127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1127#issuecomment-5194549375)
</details>
