### PR TITLE
8389766: NullPointerException when lowering unlabeled continue inside a switch

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -2522,21 +2522,23 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
              */
 
             // No label
-            // Get innermost enclosing loop operation
+            // For a break statement get the innermost enclosing loop operation or switch statement operation
+            // For a continue statement get the innermost enclosing loop operation
+
+            Predicate<Op> targetPred = this instanceof BreakOp
+                    ? op -> op instanceof Loop || op instanceof SwitchStatementOp
+                    : op -> op instanceof Loop;
             Op op = this;
-            Body b;
+            Body body;
             do {
-                b = op.ancestorBody();
-                op = b.ancestorOp();
-                if (op == null) {
-                    throw new IllegalStateException("No enclosing loop");
-                }
-            } while (!(op instanceof Op.Loop || op instanceof SwitchStatementOp));
+                body = op.ancestorBody();
+                op = body.ancestorOp();
+            } while (op != null && !targetPred.test(op));
 
             return switch (op) {
-                case Op.Loop lop -> lop.loopBody() == b ? op : null;
-                case SwitchStatementOp swStat -> swStat.bodies().contains(b) ? op : null;
-                default -> throw new IllegalStateException();
+                case Loop lop -> lop.loopBody() == body ? op : null;
+                case SwitchStatementOp _ -> op; // all bodies for switch op are valid
+                case null, default -> throw new IllegalStateException("No enclosing loop or switch statement");
             };
         }
 

--- a/test/jdk/jdk/incubator/code/lower/TestLoop.java
+++ b/test/jdk/jdk/incubator/code/lower/TestLoop.java
@@ -112,4 +112,55 @@ public class TestLoop {
         }
         return sum;
     }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testLoopWithSwitchAndContinue" (%0 : java.type:"boolean", %1 : java.type:"int")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"repeat";
+                %3 : Var<java.type:"int"> = var %1 @"value";
+                branch ^block_1;
+
+              ^block_1:
+                %4 : java.type:"boolean" = var.load %2;
+                cbranch %4 ^block_2 ^block_8;
+
+              ^block_2:
+                %5 : java.type:"int" = var.load %3;
+                %6 : java.type:"int" = constant @0;
+                %7 : java.type:"boolean" = eq %5 %6;
+                cbranch %7 ^block_3 ^block_4;
+
+              ^block_3:
+                branch ^block_1;
+
+              ^block_4:
+                %8 : java.type:"int" = constant @1;
+                %9 : java.type:"boolean" = eq %5 %8;
+                cbranch %9 ^block_5 ^block_7;
+
+              ^block_5:
+                branch ^block_6;
+
+              ^block_6:
+                branch ^block_1;
+
+              ^block_7:
+                return;
+
+              ^block_8:
+                return;
+            };
+            """, ssa = false)
+    static void testLoopWithSwitchAndContinue(boolean repeat, int value) {
+        while (repeat) {
+            switch (value) {
+                case 0:
+                    continue;
+                case 1:
+                    break;
+                default:
+                    return;
+            }
+        }
+    }
 }


### PR DESCRIPTION
`StatementTargetOp.innerMostEnclosingTarget` did not distinguish between continue and break when finding the target operation.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389766](https://bugs.openjdk.org/browse/JDK-8389766): NullPointerException when lowering unlabeled continue inside a switch (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1128/head:pull/1128` \
`$ git checkout pull/1128`

Update a local copy of the PR: \
`$ git checkout pull/1128` \
`$ git pull https://git.openjdk.org/babylon.git pull/1128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1128`

View PR using the GUI difftool: \
`$ git pr show -t 1128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1128.diff">https://git.openjdk.org/babylon/pull/1128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1128#issuecomment-5195962243)
</details>
