### PR TITLE
8389796: IllegalStateException from NormalizeBlocksTransformer

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/core/NormalizeBlocksTransformer.java
@@ -83,18 +83,17 @@ public final class NormalizeBlocksTransformer implements CodeTransformer {
                 // directly to the true or false branch, based on the constant value.
                 CoreOp.ConditionalBranchOp cbo = (CoreOp.ConditionalBranchOp)bop.branch().targetBlock().terminatingOp();
                 Block.Reference br = (Boolean)cop.value() ? cbo.trueBranch() : cbo.falseBranch();
-                if (br.targetBlock().predecessors().size() == 1) {
-                    // Merge the successor's target block with this block
-                    mergeBlock(b, br.targetBlock());
-                } else {
-                    b.add(CoreOp.branch(b.context().getReferenceOrCreate(br)));
-                }
-
                 // Remove the conditional dispatching block if all predecessor reference args are constants
                 if (bop.branch().targetBlock().predecessorReferences().stream()
                         .allMatch(r -> r.arguments().getFirst() instanceof Op.Result orr && orr.op() instanceof CoreOp.ConstantOp)) {
                     mergedBlocks.add(bop.branch().targetBlock());
+                    if (br.targetBlock().predecessors().size() == 1) {
+                        // Merge the successor's target block with this block
+                        mergeBlock(b, br.targetBlock());
+                        break;
+                    }
                 }
+                b.add(CoreOp.branch(b.context().getReferenceOrCreate(br)));
             }
             case CoreOp.BranchOp bop when bop.branch().targetBlock().predecessors().size() == 1 -> {
                 // Merge the successor's target block with this block, and so on

--- a/test/jdk/jdk/incubator/code/TestNormalizeBlocksTransformer.java
+++ b/test/jdk/jdk/incubator/code/TestNormalizeBlocksTransformer.java
@@ -384,6 +384,47 @@ public class TestNormalizeBlocksTransformer {
                 return %14;
             };
             """;
+    static final String TEST7_INPUT = """
+            func @"m" (%0 : java.type:"boolean")java.type:"void" -> {
+                cbranch %0 ^block_1 ^block_2(%0);
+
+              ^block_1:
+                %1 : java.type:"boolean" = constant @true;
+                branch ^block_2(%1);
+
+              ^block_2(%2 : java.type:"boolean"):
+                cbranch %2 ^block_3 ^block_4;
+
+              ^block_3:
+                branch ^block_5;
+
+              ^block_4:
+                branch ^block_5;
+
+              ^block_5:
+                return;
+            };
+            """;
+    static final String TEST7_EXPECTED = """
+            func @"m" (%0 : java.type:"boolean")java.type:"void" -> {
+                cbranch %0 ^block_1 ^block_2(%0);
+
+              ^block_1:
+                branch ^block_3;
+
+              ^block_2(%1 : java.type:"boolean"):
+                cbranch %1 ^block_3 ^block_4;
+
+              ^block_3:
+                branch ^block_5;
+
+              ^block_4:
+                branch ^block_5;
+
+              ^block_5:
+                return;
+            };
+            """;
     static Object[][] testModels() {
         return new Object[][]{
                 parse(TEST1_INPUT, TEST1_EXPECTED),
@@ -392,6 +433,7 @@ public class TestNormalizeBlocksTransformer {
                 parse(TEST4_INPUT, TEST4_EXPECTED),
                 parse(TEST5_INPUT, TEST5_EXPECTED),
                 parse(TEST6_INPUT, TEST6_EXPECTED),
+                parse(TEST7_INPUT, TEST7_EXPECTED),
         };
     }
 

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -626,6 +626,11 @@ public class TestBytecode {
         }
     }
 
+    @Reflect
+    static int constantMerge(boolean value) {
+        return (value && true) ? 1 : 0;
+    }
+
     record TestData(Method testMethod) {
         @Override
         public String toString() {


### PR DESCRIPTION
`NormalizeBlocksTransformer` incorrectly merged target block where not all predecessor reference arguments were constants.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389796](https://bugs.openjdk.org/browse/JDK-8389796): IllegalStateException from NormalizeBlocksTransformer (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1129/head:pull/1129` \
`$ git checkout pull/1129`

Update a local copy of the PR: \
`$ git checkout pull/1129` \
`$ git pull https://git.openjdk.org/babylon.git pull/1129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1129`

View PR using the GUI difftool: \
`$ git pr show -t 1129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1129.diff">https://git.openjdk.org/babylon/pull/1129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1129#issuecomment-5205851167)
</details>
