### PR TITLE
Ensure pattern (binding) variables can be assigned to

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -842,7 +842,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     Symbol sym = assign.sym;
                     switch (sym.getKind()) {
-                        case LOCAL_VARIABLE, PARAMETER, EXCEPTION_PARAMETER -> {
+                        case LOCAL_VARIABLE, BINDING_VARIABLE, PARAMETER, EXCEPTION_PARAMETER -> {
                             Value varOp = varOpValue(sym);
                             append(CoreOp.varStore(varOp, result));
                         }
@@ -951,7 +951,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     Symbol sym = assign.sym;
                     switch (sym.getKind()) {
-                        case LOCAL_VARIABLE, PARAMETER -> { // exception parameters not valid here!
+                        case LOCAL_VARIABLE, BINDING_VARIABLE, PARAMETER -> { // exception parameters not valid here!
                             Value varOp = varOpValue(sym);
 
                             Op.Result lhsOpValue = append(CoreOp.varLoad(varOp));

--- a/test/langtools/tools/javac/reflect/PatternsTest.java
+++ b/test/langtools/tools/javac/reflect/PatternsTest.java
@@ -446,7 +446,7 @@ public class PatternsTest {
     }
 
     @IR("""
-            func @"m" (%0 : java.type:"int")java.type:"void" -> {
+            func @"test12" (%0 : java.type:"int")java.type:"void" -> {
                   %1 : Var<java.type:"int"> = var %0 @"i";
                   %2 : java.type:"int" = constant @0;
                   %3 : java.type:"byte" = conv %2;
@@ -475,8 +475,161 @@ public class PatternsTest {
               };
             """)
     @Reflect
-    static void m(int i) {
+    static void test12(int i) {
         if (i instanceof byte b) {
         }
     }
+
+    @IR("""
+            func @"test13" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.String" = constant @null;
+                %3 : Var<java.type:"java.lang.String"> = var %2 @"s";
+                java.if
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"java.lang.Object" = var.load %1;
+                        %5 : java.type:"boolean" = pattern.match %4
+                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.String>" -> {
+                                %6 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<java.lang.String>" = pattern.type @"s";
+                                yield %6;
+                            }
+                            (%7 : java.type:"java.lang.String")java.type:"void" -> {
+                                var.store %3 %7;
+                                yield;
+                            };
+                        yield %5;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = constant @"";
+                        var.store %3 %8;
+                        yield;
+                    }
+                    ()java.type:"void" -> {
+                        yield;
+                    };
+                return;
+            };
+            """)
+    @Reflect
+    static void test13(Object o) {
+        if (o instanceof String s) {
+            s = "";
+        }
+    }
+
+    @IR("""
+            func @"test14" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"int" = constant @0;
+                %3 : Var<java.type:"int"> = var %2 @"i";
+                java.if
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"java.lang.Object" = var.load %1;
+                        %5 : java.type:"boolean" = pattern.match %4
+                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<int>" -> {
+                                %6 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<int>" = pattern.type @"i";
+                                yield %6;
+                            }
+                            (%7 : java.type:"int")java.type:"void" -> {
+                                var.store %3 %7;
+                                yield;
+                            };
+                        yield %5;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"int" = constant @1;
+                        var.store %3 %8;
+                        yield;
+                    }
+                    ()java.type:"void" -> {
+                        yield;
+                    };
+                return;
+            };
+            """)
+    @Reflect
+    static void test14(Object o) {
+        if (o instanceof int i) {
+            i = 1;
+        }
+    }
+
+    @IR("""
+            func @"test15" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"int" = constant @0;
+                %3 : Var<java.type:"int"> = var %2 @"i";
+                java.if
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"java.lang.Object" = var.load %1;
+                        %5 : java.type:"boolean" = pattern.match %4
+                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<int>" -> {
+                                %6 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<int>" = pattern.type @"i";
+                                yield %6;
+                            }
+                            (%7 : java.type:"int")java.type:"void" -> {
+                                var.store %3 %7;
+                                yield;
+                            };
+                        yield %5;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"int" = var.load %3;
+                        %9 : java.type:"int" = constant @1;
+                        %10 : java.type:"int" = add %8 %9;
+                        var.store %3 %10;
+                        yield;
+                    }
+                    ()java.type:"void" -> {
+                        yield;
+                    };
+                return;
+            };
+            """)
+    @Reflect
+    static void test15(Object o) {
+        if (o instanceof int i) {
+            i++;
+        }
+    }
+
+    @IR("""
+            func @"test16" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"int" = constant @0;
+                %3 : Var<java.type:"int"> = var %2 @"i";
+                java.if
+                    ()java.type:"boolean" -> {
+                        %4 : java.type:"java.lang.Object" = var.load %1;
+                        %5 : java.type:"boolean" = pattern.match %4
+                            ()java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<int>" -> {
+                                %6 : java.type:"jdk.incubator.code.dialect.java.JavaOp$Pattern$Type<int>" = pattern.type @"i";
+                                yield %6;
+                            }
+                            (%7 : java.type:"int")java.type:"void" -> {
+                                var.store %3 %7;
+                                yield;
+                            };
+                        yield %5;
+                    }
+                    ()java.type:"void" -> {
+                        %8 : java.type:"int" = var.load %3;
+                        %9 : java.type:"int" = constant @1;
+                        %10 : java.type:"int" = add %8 %9;
+                        var.store %3 %10;
+                        yield;
+                    }
+                    ()java.type:"void" -> {
+                        yield;
+                    };
+                return;
+            };
+            """)
+    @Reflect
+    static void test16(Object o) {
+        if (o instanceof int i) {
+            i += 1;
+        }
+    }
+
 }


### PR DESCRIPTION

A symbol of kind `BINDING_VARIABLE` was ignored for variable assignment. Originally I think this was because at one point such variables may have been implicitly final. The fix is simply to add `BINDING_VARIABLE` to the list of cases where `LOCAL_VARIABLE` occurs.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1131/head:pull/1131` \
`$ git checkout pull/1131`

Update a local copy of the PR: \
`$ git checkout pull/1131` \
`$ git pull https://git.openjdk.org/babylon.git pull/1131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1131`

View PR using the GUI difftool: \
`$ git pr show -t 1131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1131.diff">https://git.openjdk.org/babylon/pull/1131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1131#issuecomment-5208965546)
</details>
