### PR TITLE
Use all-powerful lookup

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -517,7 +517,7 @@ public sealed interface Op extends CodeElement<Op, Body> permits Op.Terminating,
         try {
             mh = SharedSecrets.getJavaLangInvokeAccess().findVirtual(oq.getClass(), "__internal_quoted",
                     MethodType.methodType(Quoted.class));
-        } catch (IllegalAccessException e) {
+        } catch (IllegalAccessException e) { // @@@ when this is thrown and what to do about it ?
             throw new RuntimeException(e);
         }
         if (mh == null) {
@@ -527,9 +527,10 @@ public sealed interface Op extends CodeElement<Op, Body> permits Op.Terminating,
         try {
             q = (Quoted<?>) mh.invoke(oq);
         } catch (Throwable e) {
+            // @@@ revisit this
             // op method may throw UOE in case java compile time version doesn't match runtime version
-            if (e instanceof UnsupportedOperationException uoe) {
-                throw uoe;
+            if (e instanceof RuntimeException re) {
+                throw re;
             }
             throw new RuntimeException(e);
         }
@@ -575,7 +576,7 @@ public sealed interface Op extends CodeElement<Op, Body> permits Op.Terminating,
         try {
             mh = SharedSecrets.getJavaLangInvokeAccess().findStatic(method.getDeclaringClass(), opMethodName,
                     MethodType.methodType(Op.class));
-        } catch (IllegalAccessException e) {
+        } catch (IllegalAccessException e) { // @@@ when this is thrown and what to do about it ?
             throw new RuntimeException(e);
         }
         if (mh == null) {
@@ -585,9 +586,10 @@ public sealed interface Op extends CodeElement<Op, Body> permits Op.Terminating,
             FuncOp funcOp = (FuncOp) mh.invoke();
             return Optional.of(funcOp);
         } catch (Throwable e) {
+            // @@@ revisit this
             // op method may throw UOE in case java compile time version doesn't match runtime version
-            if (e instanceof UnsupportedOperationException uoe) {
-                throw uoe;
+            if (e instanceof RuntimeException re) {
+                throw re;
             }
             throw new RuntimeException(e);
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Op.java
@@ -45,6 +45,8 @@ import jdk.internal.access.SharedSecrets;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.*;
@@ -511,21 +513,22 @@ public sealed interface Op extends CodeElement<Op, Body> permits Op.Terminating,
             // supports the internal protocol to access the quoted instance
             oq = Proxy.getInvocationHandler(oq);
         }
-
-        Method method;
+        MethodHandle mh;
         try {
-            method = oq.getClass().getDeclaredMethod("__internal_quoted");
-        } catch (NoSuchMethodException e) {
+            mh = SharedSecrets.getJavaLangInvokeAccess().findVirtual(oq.getClass(), "__internal_quoted",
+                    MethodType.methodType(Quoted.class));
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        if (mh == null) {
             return Optional.empty();
         }
-        method.setAccessible(true);
-
         Quoted<?> q;
         try {
-            q = (Quoted<?>) method.invoke(oq);
-        } catch (ReflectiveOperationException e) {
+            q = (Quoted<?>) mh.invoke(oq);
+        } catch (Throwable e) {
             // op method may throw UOE in case java compile time version doesn't match runtime version
-            if (e.getCause() instanceof UnsupportedOperationException uoe) {
+            if (e instanceof UnsupportedOperationException uoe) {
                 throw uoe;
             }
             throw new RuntimeException(e);
@@ -568,20 +571,22 @@ public sealed interface Op extends CodeElement<Op, Body> permits Op.Terminating,
             }
         }
         String opMethodName = new String(sig);
-        Method opMethod;
+        MethodHandle mh;
         try {
-            // @@@ Use method handle with full power mode
-            opMethod = method.getDeclaringClass().getDeclaredMethod(opMethodName);
-        } catch (NoSuchMethodException e) {
+            mh = SharedSecrets.getJavaLangInvokeAccess().findStatic(method.getDeclaringClass(), opMethodName,
+                    MethodType.methodType(Op.class));
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        if (mh == null) {
             return Optional.empty();
         }
-        opMethod.setAccessible(true);
         try {
-            FuncOp funcOp = (FuncOp) opMethod.invoke(null);
+            FuncOp funcOp = (FuncOp) mh.invoke();
             return Optional.of(funcOp);
-        } catch (ReflectiveOperationException e) {
+        } catch (Throwable e) {
             // op method may throw UOE in case java compile time version doesn't match runtime version
-            if (e.getCause() instanceof UnsupportedOperationException uoe) {
+            if (e instanceof UnsupportedOperationException uoe) {
                 throw uoe;
             }
             throw new RuntimeException(e);


### PR DESCRIPTION
Replace calls to setAccessible in Op.ofMethod and Op.ofLambda with all-powerful lookup.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**) ⚠️ Review applies to [6273cc74](https://git.openjdk.org/babylon/pull/1132/files/6273cc74546b024f0791b66d4be64c72511c5818)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1132/head:pull/1132` \
`$ git checkout pull/1132`

Update a local copy of the PR: \
`$ git checkout pull/1132` \
`$ git pull https://git.openjdk.org/babylon.git pull/1132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1132`

View PR using the GUI difftool: \
`$ git pr show -t 1132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1132.diff">https://git.openjdk.org/babylon/pull/1132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1132#issuecomment-5215609739)
</details>
