### PR TITLE
8389896: UnsupportedOperationException from WildcardType.toNominalDescriptor

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1099,7 +1099,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         } else {
                             FieldRef fr = symbolToErasedFieldRef(sym, qualifierTarget.hasTag(NONE) ?
                                     tree.selected.type : qualifierTarget);
-                            CodeType resultType = typeToCodeType(types.memberType(tree.selected.type, sym));
+                            CodeType resultType = typeToCodeType(tree.type);
                             if (sym.isStatic()) {
                                 result = append(JavaOp.fieldLoad(resultType, fr));
                             } else {

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -422,4 +422,30 @@ public class DenotableTypesTest {
         var snd = pickI((C)null, (D)null);
         pickSup(fst, snd);
     }
+
+    @Reflect
+    @IR("""
+            func @"test20" (%0 : java.type:"DenotableTypesTest$Box<? extends java.lang.Number>")java.type:"java.lang.Number" -> {
+                %1 : Var<java.type:"DenotableTypesTest$Box<? extends java.lang.Number>"> = var %0 @"box";
+                %2 : java.type:"DenotableTypesTest$Box<? extends java.lang.Number>" = var.load %1;
+                %3 : java.type:"java.lang.Number" = field.load %2 @java.ref:"DenotableTypesTest$Box::x:java.lang.Object";
+                return %3;
+            };
+            """)
+    static Number test20(Box<? extends Number> box) {
+        return box.x;
+    }
+
+    @Reflect
+    @IR("""
+            func @"test21" (%0 : java.type:"DenotableTypesTest$Box<? super java.lang.Number>")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"DenotableTypesTest$Box<? super java.lang.Number>"> = var %0 @"box";
+                %2 : java.type:"DenotableTypesTest$Box<? super java.lang.Number>" = var.load %1;
+                %3 : java.type:"java.lang.Object" = field.load %2 @java.ref:"DenotableTypesTest$Box::x:java.lang.Object";
+                return %3;
+            };
+            """)
+    static Object test21(Box<? super Number> box) {
+        return box.x;
+    }
 }


### PR DESCRIPTION
The code for `BodyScanner::visitSelect` was recomputing member type from scratch. This led to missing captured conversion (among other things), which resulted in wildcard types leaking in non type-argument positions.

The fix is to just use whatever type javac's Attr has computed for that member access.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389896](https://bugs.openjdk.org/browse/JDK-8389896): UnsupportedOperationException from WildcardType.toNominalDescriptor (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1134/head:pull/1134` \
`$ git checkout pull/1134`

Update a local copy of the PR: \
`$ git checkout pull/1134` \
`$ git pull https://git.openjdk.org/babylon.git pull/1134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1134`

View PR using the GUI difftool: \
`$ git pr show -t 1134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1134.diff">https://git.openjdk.org/babylon/pull/1134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1134#issuecomment-5218008369)
</details>
