### PR TITLE
8389894: BytecodeGenerator fails to generate large lambdas

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LambdaExpansionTransformer.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/impl/LambdaExpansionTransformer.java
@@ -102,11 +102,15 @@ final class LambdaExpansionTransformer implements CodeTransformer {
             });
         }
         if (!modelsToBuild.isEmpty()) {
-            functions.addAll(OpBuilder.createBuilderFunctions(
+            CoreOp.ModuleOp module = OpBuilder.createBuilderFunctions(
                     modelsToBuild,
                     b -> b.add(JavaOp.fieldLoad(
-                            FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))))
-                    .functionTable().sequencedValues());
+                            FieldRef.field(JavaOp.class, "JAVA_DIALECT_FACTORY", DialectFactory.class))));
+            names.addAll(module.functionTable().sequencedKeySet());
+            for (FuncOp builder : module.functionTable().sequencedValues()) {
+                // module may contain chunked large lambdas, which must also be expanded
+                functions.add(builder.transform(this));
+            }
         }
         return CoreOp.module(functions);
     }

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -43,7 +43,6 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AccessFlag;
-import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestBytecode.java
@@ -43,6 +43,7 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AccessFlag;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -629,6 +630,18 @@ public class TestBytecode {
     @Reflect
     static int constantMerge(boolean value) {
         return (value && true) ? 1 : 0;
+    }
+
+    @Reflect
+    static int largeLambda(int x, int y) {
+        Supplier<int[][][][][][][][]> lambda = () -> new int[][][][][][][][] {
+                {{{{{{{0}}}}}}, {{{{{{0}}}}}}, {{{{{{1}}}}}}, {{{{{{1}}}}}}, {{{{{{0}}}}}}, {{{{{{0}}}}}}},
+                {{{{{{{0}}}}}}, {{{{{{1}}}}}}, {{{{{{0}}}}}}, {{{{{{0}}}}}}, {{{{{{1}}}}}}, {{{{{{0}}}}}}},
+                {{{{{{{0}}}}}}, {{{{{{1}}}}}}, {{{{{{1}}}}}}, {{{{{{1}}}}}}, {{{{{{1}}}}}}, {{{{{{0}}}}}}},
+                {{{{{{{1}}}}}}, {{{{{{0}}}}}}, {{{{{{0}}}}}}, {{{{{{0}}}}}}, {{{{{{0}}}}}}, {{{{{{1}}}}}}},
+                {{{{{{{1}}}}}}, {{{{{{0}}}}}}, {{{{{{1}}}}}}, {{{{{{1}}}}}}, {{{{{{0}}}}}}, {{{{{{1}}}}}}},
+                {{{{{{{1}}}}}}, {{{{{{1}}}}}}, {{{{{{0}}}}}}, {{{{{{0}}}}}}, {{{{{{1}}}}}}, {{{{{{1}}}}}}}};
+        return lambda.get()[y][x][0][0][0][0][0][0];
     }
 
     record TestData(Method testMethod) {


### PR DESCRIPTION
`LambdaExpansionTransformer` left secondary lambda fragments extracted from a large lambda untransformed, this is now fixed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389894](https://bugs.openjdk.org/browse/JDK-8389894): BytecodeGenerator fails to generate large lambdas (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1135/head:pull/1135` \
`$ git checkout pull/1135`

Update a local copy of the PR: \
`$ git checkout pull/1135` \
`$ git pull https://git.openjdk.org/babylon.git pull/1135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1135`

View PR using the GUI difftool: \
`$ git pr show -t 1135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1135.diff">https://git.openjdk.org/babylon/pull/1135.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1135#issuecomment-5217087575)
</details>
