### PR TITLE
8389387: NullPointerException from ReflectMethods

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1151,7 +1151,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     MethodRef mr = symbolToErasedMethodRef(sym, symbolSiteType(sym));
 
-                    // @@@ change to tree.type
+                    // @@@ change to tree.type when type conversion bug is fixed
+                    // see DenotableTypesTest.test12
                     JavaType resultType = typeToCodeType(meth.type.getReturnType());
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             resultType, mr, args);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1180,12 +1180,29 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     args.addAll(scanMethodArguments(tree.args, tree.meth.type, tree.varargsElement));
 
-                    MethodRef mr = symbolToErasedMethodRef(sym, qualifierTarget.hasTag(NONE) ?
-                            access.selected.type : qualifierTarget);
+                    MethodRef mr;
+                    if (sym.owner == syms.arrayClass && sym.name == names.clone) {
+                        // For array.clone use the erased selected type as the reference type,
+                        // which will be an array
+                        mr = MethodRef.method(
+                                typeToCodeType(types.erasure(access.selected.type)),
+                                names.clone.toString(),
+                                JavaType.J_L_OBJECT);
+                    } else {
+                        mr = symbolToErasedMethodRef(sym, qualifierTarget.hasTag(NONE) ?
+                                access.selected.type : qualifierTarget);
+                    }
+
                     JavaType returnType = typeToCodeType(meth.type.getReturnType());
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             returnType, mr, args);
                     Value res = append(iop);
+
+                    if (sym.owner == syms.arrayClass && sym.name == names.clone) {
+                        // For array.clone, cast res (whose type is Object) to the array's type
+                        // we align the res.type with the tree.type
+                        res = append(JavaOp.cast(receiver.type(), res));
+                    }
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;
                     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1196,9 +1196,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     // Use the actual type of the expression, tree.type, rather than meth.type.getReturnType()
                     // This ensures invocation expressions to clone on arrays and getClass are modeled
                     // with the correct result type
-                    JavaType returnType = typeToCodeType(tree.type);//meth.type.getReturnType());
+                    JavaType resultType = typeToCodeType(tree.type);//meth.type.getReturnType());
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
-                            returnType, mr, args);
+                            resultType, mr, args);
                     Value res = append(iop);
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1150,8 +1150,12 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     args.addAll(scanMethodArguments(tree.args, tree.meth.type, tree.varargsElement));
 
                     MethodRef mr = symbolToErasedMethodRef(sym, symbolSiteType(sym));
-                    Value res = append(JavaOp.invoke(ik, tree.varargsElement != null,
-                            typeToCodeType(meth.type.getReturnType()), mr, args));
+
+                    // @@@ change to tree.type
+                    JavaType resultType = typeToCodeType(meth.type.getReturnType());
+                    JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
+                            resultType, mr, args);
+                    Value res = append(iop);
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;
                     }
@@ -1196,7 +1200,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     // Use the actual type of the expression, tree.type, rather than meth.type.getReturnType()
                     // This ensures invocation expressions to clone on arrays and getClass are modeled
                     // with the correct result type
-                    JavaType resultType = typeToCodeType(tree.type);//meth.type.getReturnType());
+                    JavaType resultType = typeToCodeType(tree.type);
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             resultType, mr, args);
                     Value res = append(iop);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1180,8 +1180,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     args.addAll(scanMethodArguments(tree.args, tree.meth.type, tree.varargsElement));
 
+                    boolean isArrayClone = sym.owner == syms.arrayClass && sym.name == names.clone;
                     MethodRef mr;
-                    if (sym.owner == syms.arrayClass && sym.name == names.clone) {
+                    if (isArrayClone) {
                         // For array.clone use the erased selected type as the reference type,
                         // which will be an array
                         mr = MethodRef.method(
@@ -1198,7 +1199,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                             returnType, mr, args);
                     Value res = append(iop);
 
-                    if (sym.owner == syms.arrayClass && sym.name == names.clone) {
+                    if (isArrayClone) {
                         // For array.clone, cast res (whose type is Object) to the array's type
                         // we align the res.type with the tree.type
                         res = append(JavaOp.cast(receiver.type(), res));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1180,9 +1180,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     args.addAll(scanMethodArguments(tree.args, tree.meth.type, tree.varargsElement));
 
-                    boolean isArrayClone = sym.owner == syms.arrayClass && sym.name == names.clone;
                     MethodRef mr;
-                    if (isArrayClone) {
+                    if (sym.owner == syms.arrayClass && sym.name == names.clone) {
                         // For array.clone use the erased selected type as the reference type,
                         // which will be an array
                         mr = MethodRef.method(
@@ -1194,16 +1193,13 @@ public class ReflectMethods extends TreeTranslatorPrev {
                                 access.selected.type : qualifierTarget);
                     }
 
-                    JavaType returnType = typeToCodeType(meth.type.getReturnType());
+                    // Use the actual type of the expression, tree.type, rather than meth.type.getReturnType()
+                    // This ensures invocation expressions to clone on arrays and getClass are modeled
+                    // with the correct result type
+                    JavaType returnType = typeToCodeType(tree.type);//meth.type.getReturnType());
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             returnType, mr, args);
                     Value res = append(iop);
-
-                    if (isArrayClone) {
-                        // For array.clone, cast res (whose type is Object) to the array's type
-                        // we align the res.type with the tree.type
-                        res = append(JavaOp.cast(receiver.type(), res));
-                    }
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;
                     }

--- a/test/langtools/tools/javac/reflect/CodeReflectionTester.java
+++ b/test/langtools/tools/javac/reflect/CodeReflectionTester.java
@@ -132,6 +132,7 @@ public class CodeReflectionTester {
         try {
             o = OpParser.fromText(JavaOp.JAVA_DIALECT_FACTORY, d).get(0);
         } catch (Exception e) {
+            System.out.println(d);
             throw new IllegalStateException(m.toString(), e);
         }
         return serialize(o);

--- a/test/langtools/tools/javac/reflect/CodeReflectionTester.java
+++ b/test/langtools/tools/javac/reflect/CodeReflectionTester.java
@@ -132,7 +132,6 @@ public class CodeReflectionTester {
         try {
             o = OpParser.fromText(JavaOp.JAVA_DIALECT_FACTORY, d).get(0);
         } catch (Exception e) {
-            System.out.println(d);
             throw new IllegalStateException(m.toString(), e);
         }
         return serialize(o);

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -292,5 +292,48 @@ public class MethodCallTest {
         String s = al.get(0);
         List<String> l = al;
         s = l.get(0);
+    }
+
+    @Reflect
+    @IR("""
+            func @"test11" (%0 : java.type:"java.lang.Object[]")java.type:"java.lang.Object[]" -> {
+                  %1 : Var<java.type:"java.lang.Object[]"> = var %0 @"values";
+                  %2 : java.type:"java.lang.Object[]" = var.load %1;
+                  %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"java.lang.Object[]::clone():java.lang.Object";
+                  %4 : java.type:"java.lang.Object[]" = cast %3 @java.type:"java.lang.Object[]";
+                  return %4;
+            };
+            """)
+    static Object[] test11(Object[] values) {
+        return values.clone();
+    }
+
+    @Reflect
+    @IR("""
+            func @"test12" (%0 : java.type:"int[]")java.type:"int[]" -> {
+                  %1 : Var<java.type:"int[]"> = var %0 @"values";
+                  %2 : java.type:"int[]" = var.load %1;
+                  %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"int[]::clone():java.lang.Object";
+                  %4 : java.type:"int[]" = cast %3 @java.type:"int[]";
+                  return %4;
+            };
+            """)
+    static int[] test12(int[] values) {
+        return values.clone();
+    }
+
+
+    @Reflect
+    @IR("""
+            func @"test13" (%0 : java.type:"java.lang.Comparable<java.lang.String>[]")java.type:"java.lang.Comparable<java.lang.String>[]" -> {
+                %1 : Var<java.type:"java.lang.Comparable<java.lang.String>[]"> = var %0 @"values";
+                %2 : java.type:"java.lang.Comparable<java.lang.String>[]" = var.load %1;
+                %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"java.lang.Comparable[]::clone():java.lang.Object";
+                %4 : java.type:"java.lang.Comparable<java.lang.String>[]" = cast %3 @java.type:"java.lang.Comparable<java.lang.String>[]";
+                return %4;
+            };
+            """)
+    static Comparable<String>[] test13(Comparable<String>[] values) {
+        return values.clone();
     }
 }

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -373,4 +373,16 @@ public class MethodCallTest {
     static Class<? extends Comparable[]> test16(Comparable<String>[] values) {
         return values.getClass();
     }
+
+
+//    @Reflect
+//    @IR("""
+//            func @"test16" (%0 : java.type:"MethodCallTest")java.type:"java.lang.Class<? extends MethodCallTest>" -> {
+//                %1 : java.type:"java.lang.Class<? extends MethodCallTest>" = invoke %0 @java.ref:"java.lang.Object::getClass():java.lang.Class";
+//                return %1;
+//            };
+//            """)
+//    Class<? extends MethodCallTest> test16() {
+//        return getClass();
+//    }
 }

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -299,9 +299,8 @@ public class MethodCallTest {
             func @"test11" (%0 : java.type:"java.lang.Object[]")java.type:"java.lang.Object[]" -> {
                   %1 : Var<java.type:"java.lang.Object[]"> = var %0 @"values";
                   %2 : java.type:"java.lang.Object[]" = var.load %1;
-                  %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"java.lang.Object[]::clone():java.lang.Object";
-                  %4 : java.type:"java.lang.Object[]" = cast %3 @java.type:"java.lang.Object[]";
-                  return %4;
+                  %3 : java.type:"java.lang.Object[]" = invoke %2 @java.ref:"java.lang.Object[]::clone():java.lang.Object";
+                  return %3;
             };
             """)
     static Object[] test11(Object[] values) {
@@ -313,9 +312,8 @@ public class MethodCallTest {
             func @"test12" (%0 : java.type:"int[]")java.type:"int[]" -> {
                   %1 : Var<java.type:"int[]"> = var %0 @"values";
                   %2 : java.type:"int[]" = var.load %1;
-                  %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"int[]::clone():java.lang.Object";
-                  %4 : java.type:"int[]" = cast %3 @java.type:"int[]";
-                  return %4;
+                  %3 : java.type:"int[]" = invoke %2 @java.ref:"int[]::clone():java.lang.Object";
+                  return %3;
             };
             """)
     static int[] test12(int[] values) {
@@ -328,12 +326,51 @@ public class MethodCallTest {
             func @"test13" (%0 : java.type:"java.lang.Comparable<java.lang.String>[]")java.type:"java.lang.Comparable<java.lang.String>[]" -> {
                 %1 : Var<java.type:"java.lang.Comparable<java.lang.String>[]"> = var %0 @"values";
                 %2 : java.type:"java.lang.Comparable<java.lang.String>[]" = var.load %1;
-                %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"java.lang.Comparable[]::clone():java.lang.Object";
-                %4 : java.type:"java.lang.Comparable<java.lang.String>[]" = cast %3 @java.type:"java.lang.Comparable<java.lang.String>[]";
-                return %4;
+                %3 : java.type:"java.lang.Comparable<java.lang.String>[]" = invoke %2 @java.ref:"java.lang.Comparable[]::clone():java.lang.Object";
+                return %3;
             };
             """)
     static Comparable<String>[] test13(Comparable<String>[] values) {
         return values.clone();
+    }
+
+    @Reflect
+    @IR("""
+            func @"test14" (%0 : java.type:"java.lang.Object[]")java.type:"java.lang.Class<? extends java.lang.Object[]>" -> {
+                %1 : Var<java.type:"java.lang.Object[]"> = var %0 @"values";
+                %2 : java.type:"java.lang.Object[]" = var.load %1;
+                %3 : java.type:"java.lang.Class<? extends java.lang.Object[]>" = invoke %2 @java.ref:"java.lang.Object::getClass():java.lang.Class";
+                return %3;
+            };
+            """)
+    static Class<? extends Object[]> test14(Object[] values) {
+        return values.getClass();
+    }
+
+    @Reflect
+    @IR("""
+            func @"test15" (%0 : java.type:"int[]")java.type:"java.lang.Class<? extends int[]>" -> {
+                %1 : Var<java.type:"int[]"> = var %0 @"values";
+                %2 : java.type:"int[]" = var.load %1;
+                %3 : java.type:"java.lang.Class<? extends int[]>" = invoke %2 @java.ref:"java.lang.Object::getClass():java.lang.Class";
+                return %3;
+            };
+            """)
+    static Class<? extends int[]> test15(int[] values) {
+        return values.getClass();
+    }
+
+
+    @Reflect
+    @IR("""
+            func @"test16" (%0 : java.type:"java.lang.Comparable<java.lang.String>[]")java.type:"java.lang.Class<? extends java.lang.Comparable[]>" -> {
+                %1 : Var<java.type:"java.lang.Comparable<java.lang.String>[]"> = var %0 @"values";
+                %2 : java.type:"java.lang.Comparable<java.lang.String>[]" = var.load %1;
+                %3 : java.type:"java.lang.Class<? extends java.lang.Comparable[]>" = invoke %2 @java.ref:"java.lang.Object::getClass():java.lang.Class";
+                return %3;
+            };
+            """)
+    static Class<? extends Comparable[]> test16(Comparable<String>[] values) {
+        return values.getClass();
     }
 }

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -374,7 +374,8 @@ public class MethodCallTest {
         return values.getClass();
     }
 
-
+    // @@@ Uncomment when type conversion bug is fixed
+    // see DenotableTypesTest.test12
 //    @Reflect
 //    @IR("""
 //            func @"test16" (%0 : java.type:"MethodCallTest")java.type:"java.lang.Class<? extends MethodCallTest>" -> {

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -2177,7 +2177,7 @@ public class SwitchStatementTest {
                             }
                             ()java.type:"boolean" -> {
                                 %31 : java.type:"java.lang.Number" = var.load %8;
-                                %32 : java.type:"java.lang.Class<?>" = invoke %31 @java.ref:"java.lang.Object::getClass():java.lang.Class";
+                                %32 : java.type:"java.lang.Class<? extends java.lang.Number>" = invoke %31 @java.ref:"java.lang.Object::getClass():java.lang.Class";
                                 %33 : java.type:"java.lang.Class" = constant @java.type:"java.lang.Double";
                                 %34 : java.type:"boolean" = invoke %32 %33 @java.ref:"java.lang.Object::equals(java.lang.Object):boolean";
                                 yield %34;


### PR DESCRIPTION
Ensure an invocation to the clone method on an array is modeled correctly and does not fail.

This is a rework of #1119

The result type of the invoke op should use the tree type. Then there is no need for a cast. The bytecode generator will insert a cast because the result type differs from the method return type.

It is only possible to make that change for a method node with a tag of `SELECT`. Doing so for the `IDENT` tag results in a test failure for `DenotableTypesTest` and it reveals a separate issue in upward type projection that first needs to be fixed.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8389387](https://bugs.openjdk.org/browse/JDK-8389387): NullPointerException from ReflectMethods (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1143/head:pull/1143` \
`$ git checkout pull/1143`

Update a local copy of the PR: \
`$ git checkout pull/1143` \
`$ git pull https://git.openjdk.org/babylon.git pull/1143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1143`

View PR using the GUI difftool: \
`$ git pr show -t 1143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1143.diff">https://git.openjdk.org/babylon/pull/1143.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1143#issuecomment-5259793039)
</details>
