### PR TITLE
Revert changes to JCTree API

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -812,8 +812,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     /**
      * Common supertype for all functional expression trees (lambda and method references)
      */
-    public abstract static sealed class JCFunctionalExpression extends JCPolyExpression
-                                                               permits JCLambda, JCMemberReference {
+    public abstract static class JCFunctionalExpression extends JCPolyExpression {
 
         public JCFunctionalExpression() {
             //a functional expression is always a 'true' poly
@@ -2035,7 +2034,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     /**
      * A lambda expression.
      */
-    public static final class JCLambda extends JCFunctionalExpression implements LambdaExpressionTree {
+    public static class JCLambda extends JCFunctionalExpression implements LambdaExpressionTree {
 
         public enum ParameterKind {
             IMPLICIT,
@@ -2624,7 +2623,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     /**
      * Selects a member expression.
      */
-    public static non-sealed class JCMemberReference extends JCFunctionalExpression implements MemberReferenceTree {
+    public static class JCMemberReference extends JCFunctionalExpression implements MemberReferenceTree {
 
         public ReferenceMode mode;
         public ReferenceKind kind;


### PR DESCRIPTION
Remove unnecessary changes in the JCTree API, reverting back to that in master, leaving only required changes for code reflection. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1144/head:pull/1144` \
`$ git checkout pull/1144`

Update a local copy of the PR: \
`$ git checkout pull/1144` \
`$ git pull https://git.openjdk.org/babylon.git pull/1144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1144`

View PR using the GUI difftool: \
`$ git pr show -t 1144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1144.diff">https://git.openjdk.org/babylon/pull/1144.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1144#issuecomment-5260016445)
</details>
