### PR TITLE
Non denotable type normalization skips some intersection types

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -31,15 +31,14 @@ import com.sun.tools.javac.code.Kinds.Kind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
-import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ArrayType;
+import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.IntersectionClassType;
 import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.code.Type.StructuralTypeMapping;
-import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.UnionClassType;
 import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.code.Types;
@@ -1151,9 +1150,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     MethodRef mr = symbolToErasedMethodRef(sym, symbolSiteType(sym));
 
-                    // @@@ change to tree.type when type conversion bug is fixed
-                    // see DenotableTypesTest.test12
-                    JavaType resultType = typeToCodeType(meth.type.getReturnType());
+                    JavaType resultType = typeToCodeType(tree.type);
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             resultType, mr, args);
                     Value res = append(iop);
@@ -2966,6 +2963,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         // CodeType API.
         class DenotableProjection extends StructuralTypeMapping<Void> {
             final ListBuffer<Type> tvars = new ListBuffer<>();
+            final Map<CapturedType, CapturedType> pendingCaptures = new HashMap<>();
             final Type t;
 
             DenotableProjection(Type t) {
@@ -2978,23 +2976,38 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
 
             @Override
+            public Type visitCapturedType(CapturedType t, Void _unused) {
+                CapturedType newVar = pendingCaptures.get(t);
+                if (newVar == null) {
+                    newVar = addTypeVar(t.getUpperBound(), t.getLowerBound(), t.tsym.owner);
+                    try {
+                        pendingCaptures.put(t, newVar);
+                        newVar.setUpperBound(apply(newVar.getUpperBound()));
+                    } finally {
+                        pendingCaptures.remove(t);
+                    }
+                    newVar.lower = apply(newVar.lower);
+                }
+                return newVar;
+            }
+
+            @Override
             public Type visitClassType(Type.ClassType t, Void unused) {
                 if (t.isIntersection()) {
                     Type bound = visit(((IntersectionClassType) t).getExplicitComponents().head, null);
-                    return addTypeVar(bound, t.tsym);
+                    return addTypeVar(bound, syms.botType, t.tsym);
                 } else if (t.isUnion()) {
                     Type bound = visit(((UnionClassType)t).getLub(), null);
-                    return addTypeVar(bound, t.tsym);
+                    return addTypeVar(bound, syms.botType, t.tsym);
                 } else {
                     return super.visitClassType(t, null);
                 }
             }
 
-            Type addTypeVar(Type bound, Symbol owner) {
-                var tvsym = new TypeVariableSymbol(0, names.empty, null, owner);
-                tvsym.type = new TypeVar(tvsym, bound, syms.botType);
-                tvars.append(tvsym.type);
-                return tvsym.type;
+            CapturedType addTypeVar(Type upper, Type lower, Symbol owner) {
+                CapturedType newTvar = new CapturedType(names.empty, owner, upper, lower, null);
+                tvars.append(newTvar);
+                return newTvar;
             }
         }
 

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -374,16 +374,40 @@ public class MethodCallTest {
         return values.getClass();
     }
 
-    // @@@ Uncomment when type conversion bug is fixed
-    // see DenotableTypesTest.test12
-//    @Reflect
-//    @IR("""
-//            func @"test16" (%0 : java.type:"MethodCallTest")java.type:"java.lang.Class<? extends MethodCallTest>" -> {
-//                %1 : java.type:"java.lang.Class<? extends MethodCallTest>" = invoke %0 @java.ref:"java.lang.Object::getClass():java.lang.Class";
-//                return %1;
-//            };
-//            """)
-//    Class<? extends MethodCallTest> test16() {
-//        return getClass();
-//    }
+    @Reflect
+    @IR("""
+            func @"test17" (%0 : java.type:"MethodCallTest")java.type:"java.lang.Class<? extends MethodCallTest>" -> {
+                %1 : java.type:"java.lang.Class<? extends MethodCallTest>" = invoke %0 @java.ref:"java.lang.Object::getClass():java.lang.Class";
+                return %1;
+            };
+            """)
+    Class<? extends MethodCallTest> test17() {
+        return getClass();
+    }
+
+    @Reflect
+    @IR("""
+            func @"test18" (%0 : java.type:"MethodCallTest")java.type:"java.lang.Class<? extends MethodCallTest>" -> {
+                %1 : Var<java.type:"MethodCallTest"> = var %0 @"rec";
+                %2 : java.type:"MethodCallTest" = var.load %1;
+                %3 : java.type:"java.lang.Class<? extends MethodCallTest>" = invoke %2 @java.ref:"java.lang.Object::getClass():java.lang.Class";
+                return %3;
+            };
+            """)
+    static Class<? extends MethodCallTest> test18(MethodCallTest rec) {
+        return rec.getClass();
+    }
+
+    @Reflect
+    @IR("""
+            func @"test19" (%0 : java.type:"java.lang.Enum<?>")java.type:"java.lang.Class<?>" -> {
+                %1 : Var<java.type:"java.lang.Enum<?>"> = var %0 @"value";
+                %2 : java.type:"java.lang.Enum<?>" = var.load %1;
+                %3 : java.type:"java.lang.Class<? extends java.lang.Enum<?>>" = invoke %2 @java.ref:"java.lang.Enum::getDeclaringClass():java.lang.Class";
+                return %3;
+            };
+            """)
+    static Class<?> test19(Enum<?> value) {
+        return value.getDeclaringClass(); // check no stack overflow when normalizing recursive capture type
+    }
 }


### PR DESCRIPTION
The code reflection JavaType API does not deal with intersection types, as those don't have a direct representation in terms of the j.l.r.Type API.

This means that intersection types in the javac AST are normalized to "weaker" model types, by only retaining the first declared bound (note how this preserves erasure).

`ReflectMethods` has already quite a bit of logic to normalize non-denotable types so that they can render correctly as `JavaType`s. Given a type T to normalize, The logic consists in the following steps:

1. replace occurrences in `T` of intersection types `A & B & C` with type variables whose upper bound is `A`
2. this produces a new type `T'` which is free of intersection types (but has more captures)
3. compute an upward projection of `T'`, this is `T''`
4. `T''` is the denotable representation of `T`

Unfortunately, step (2) does not work correctly in the case where `T` contains captured type variables whose upper bound is an intersection type.
The problem is that the visitor we used to implement (2) does not have a visitor method for captured types (as none is inherited).

This PR adds that visitor method. Some care is required to make sure we don't keep recursing endlessly in upper bounds.

Thanks to the fix, the code in `ReflectMethod::visitApply` can go back to use `tree.type` as the type of the invoke operation.

I've added some tests, to check the recursion issue, as well as tests for checking that `getClass` now works normally, both in the "simple name" and "select" variants.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1147/head:pull/1147` \
`$ git checkout pull/1147`

Update a local copy of the PR: \
`$ git checkout pull/1147` \
`$ git pull https://git.openjdk.org/babylon.git pull/1147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1147`

View PR using the GUI difftool: \
`$ git pr show -t 1147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1147.diff">https://git.openjdk.org/babylon/pull/1147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1147#issuecomment-5282301029)
</details>
