### PR TITLE
I missed updating nbodygl example to skip KernelContext

### DIFF
--- a/hat/examples/nbodygl/src/main/java/nbodygl/opencl/OpenCLNBodyGLWindow.java
+++ b/hat/examples/nbodygl/src/main/java/nbodygl/opencl/OpenCLNBodyGLWindow.java
@@ -71,7 +71,7 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
 
 
     @Reflect
-    static public void nbodyKernel(KernelContext kc, Universe universe, float mass, float delT, float espSqr) {
+    static public void nbodyKernel(Universe universe, float mass, float delT, float espSqr) {
         float accx = 0.0f;
         float accy = 0.0f;
         float accz = 0.0f;
@@ -102,7 +102,7 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
 
     }
     @Reflect
-    static public void nbodyKernelf4(KernelContext kc, Universe universe, float mass, float delT, float espSqr) {
+    static public void nbodyKernelf4(Universe universe, float mass, float delT, float espSqr) {
         var acc = Float4.of(0,0,0,0);
         var posArr = universe.posArrView();
         var velArr = universe.velArrView();
@@ -129,7 +129,7 @@ public class OpenCLNBodyGLWindow extends NBodyGLWindow {
         float cdelT = delT;
         float cespSqr = espSqr;
 
-        cc.dispatchKernel(NDRange.of1D(universe.length()), kc -> nbodyKernel(kc, universe, cmass, cdelT, cespSqr));
+        cc.dispatchKernel(NDRange.of1D(universe.length()), () -> nbodyKernel(universe, cmass, cdelT, cespSqr));
     }
 
     final CLPlatform.CLDevice.CLContext.CLProgram.CLKernel kernel;


### PR DESCRIPTION
Sadly I missed updating nbodygl kernels in recent pushes. 

This code is skipped in intellij builds and requires specifically selecting opengl profile (on Mac or linux with Opengl) 

```
mvn clean package -Popencl,opengl
java @.ffi-openclgl-example nbodygl.Main 
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1149/head:pull/1149` \
`$ git checkout pull/1149`

Update a local copy of the PR: \
`$ git checkout pull/1149` \
`$ git pull https://git.openjdk.org/babylon.git pull/1149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1149`

View PR using the GUI difftool: \
`$ git pr show -t 1149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1149.diff">https://git.openjdk.org/babylon/pull/1149.diff</a>

</details>
