### PR TITLE
8390454: JavaOp lowering incorrectly matches null against an identity reference type pattern

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -6239,7 +6239,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                             // e.g. Float -> float, unboxing
                             // e.g. Integer -> long, unboxing + widening
                             box = cs;
-                            p = null;
+                            p = neq(target, currentBlock.add(constant(s, null)));
                         }
                         c = invoke(MethodRef.method(box, t + "Value", t), target);
                     } else {
@@ -6264,26 +6264,22 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     p = null;
                     ClassType box = ps.box().orElseThrow();
                     c = invoke(MethodRef.method(box, "valueOf", box, ps), target);
-                } else if (!s.equals(t)) {
-                    // reference to reference, but not identity
+                } else {
+                    // reference to reference
+                    // e.g. Character -> Character
                     // e.g. Number -> Double, narrowing
                     // e.g. Short -> Object, widening
                     p = instanceOf(targetType, target);
-                    c = cast(targetType, target);
-                } else {
-                    // identity reference
-                    // e.g. Character -> Character
-                    p = null;
-                    c = null;
+                    c = s.equals(t) ? null : cast(targetType, target);
                 }
 
+                if (p != null) {
+                    // p != null, we need to perform type check at runtime
+                    Block.Builder nextBlock = currentBlock.block();
+                    currentBlock.add(conditionalBranch(currentBlock.add(p), nextBlock.reference(), endNoMatchBlock.reference()));
+                    currentBlock = nextBlock;
+                }
                 if (c != null) {
-                    if (p != null) {
-                        // p != null, we need to perform type check at runtime
-                        Block.Builder nextBlock = currentBlock.block();
-                        currentBlock.add(conditionalBranch(currentBlock.add(p), nextBlock.reference(), endNoMatchBlock.reference()));
-                        currentBlock = nextBlock;
-                    }
                     target = currentBlock.add(c);
                 }
 

--- a/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
@@ -276,6 +276,7 @@ public class TestPrimitiveTypePatterns {
 
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, 1));
         Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (short) 1));
+        Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (Number) null));
     }
 
     @Reflect
@@ -293,6 +294,7 @@ public class TestPrimitiveTypePatterns {
 
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE));
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE));
+        Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (Integer) null));
     }
 
     @Reflect
@@ -310,6 +312,7 @@ public class TestPrimitiveTypePatterns {
 
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MAX_VALUE));
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, Integer.MIN_VALUE));
+        Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (Integer) null));
     }
 
     @Reflect
@@ -346,6 +349,7 @@ public class TestPrimitiveTypePatterns {
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, Float.MIN_VALUE));
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, Float.POSITIVE_INFINITY));
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, Float.NEGATIVE_INFINITY));
+        Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (Float) null));
     }
 
     @Reflect


### PR DESCRIPTION
Consider the following code snippet:
```
@Reflect
static boolean matches(String value) {
    return value instanceof String ignored;
}

@Reflect
static boolean matches(Integer value) {
    return value instanceof int ignored;
}
```
Both methods correctly return `false` for a `null` operand when executed normally. However, bytecode regenerated from the first method’s reflected code model returns `true`, while bytecode regenerated from the second method's reflected code model throws a `NullPointerException`.

The problem appears to be in type-pattern lowering. The “identity reference” case sets both the runtime type check and the conversion to `null`, effectively treating the pattern as unconditional and therefore incorrectly matching a `null` operand. Similarly, the lowering of boxed-to-primitive patterns invokes `Integer.intValue()` without an `ifnull` guard, resulting in a `NullPointerException`.

The proposal is to modify type-pattern lowering by adding the missing `instanceof` operation for identity reference patterns and an `ifnull` guard for boxed-to-primitive patterns.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8390454](https://bugs.openjdk.org/browse/JDK-8390454): JavaOp lowering incorrectly matches null against an identity reference type pattern (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1152/head:pull/1152` \
`$ git checkout pull/1152`

Update a local copy of the PR: \
`$ git checkout pull/1152` \
`$ git pull https://git.openjdk.org/babylon.git pull/1152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1152`

View PR using the GUI difftool: \
`$ git pr show -t 1152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1152.diff">https://git.openjdk.org/babylon/pull/1152.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1152#issuecomment-5317341634)
</details>
