### PR TITLE
8390649: BytecodeGenerator produces invalid bytecode for assert statements with primitive detail expressions

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -690,8 +690,10 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 throwBlock.transformBody(bodies.get(1), List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yo) {
                         block.add(throw_(
-                                block.add(new_(MethodRef.constructor(AssertionError.class, Object.class),
-                                        block.context().getValue(yo.yieldValue())))
+                                block.add(new_(MethodRef.constructor(JavaType.type(AssertionError.class), switch (yo.yieldValue().type()) {
+                                    case PrimitiveType pt -> pt == JavaType.BYTE || pt == JavaType.SHORT ? JavaType.INT : pt;
+                                    default -> JavaType.J_L_OBJECT;
+                                }), block.context().getValue(yo.yieldValue())))
                         ));
                         return block;
                     } else {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -689,11 +689,17 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             if (bodies.size() == 2) {
                 throwBlock.transformBody(bodies.get(1), List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yo) {
-                        block.add(throw_(
-                                block.add(new_(MethodRef.constructor(JavaType.type(AssertionError.class), switch (yo.yieldValue().type()) {
-                                    case PrimitiveType pt -> pt == JavaType.BYTE || pt == JavaType.SHORT ? JavaType.INT : pt;
+                        Value detailValue = block.context().getValue(yo.yieldValue());
+                        block.add(throw_(block.add(new_(MethodRef.constructor(JavaType.type(AssertionError.class), switch (detailValue.type()) {
+                                    case PrimitiveType pt -> {
+                                        if (pt == JavaType.BYTE || pt == JavaType.SHORT) {
+                                            detailValue = block.add(conv(INT, detailValue));
+                                            yield JavaType.INT;
+                                        }
+                                        yield pt;
+                                    }
                                     default -> JavaType.J_L_OBJECT;
-                                }), block.context().getValue(yo.yieldValue())))
+                                }), detailValue))
                         ));
                         return block;
                     } else {

--- a/test/jdk/jdk/incubator/code/TestAssertOp.java
+++ b/test/jdk/jdk/incubator/code/TestAssertOp.java
@@ -25,9 +25,9 @@
  * @test
  * @modules jdk.incubator.code
  * @library lib
- * @run junit TestAssertOp
+ * @run junit/othervm -ea TestAssertOp
  * @run main Unreflect TestAssertOp
- * @run junit TestAssertOp
+ * @run junit/othervm -ea TestAssertOp
  */
 
 import java.lang.invoke.MethodHandles;
@@ -44,17 +44,46 @@ import org.junit.jupiter.api.Test;
 public class TestAssertOp {
 
     @Reflect
-    int check(int i) {
+    int checkStringDetail(int i) {
         assert i >= 0 : "Failed";
         return i;
     }
 
     @Test
-    public void test() {
-        CoreOp.FuncOp f = getFuncOp(TestAssertOp.class, "check");
+    public void testStringDetail() {
+        CoreOp.FuncOp f = getFuncOp(TestAssertOp.class, "checkStringDetail");
 
-        Assertions.assertEquals(new TestAssertOp().check(42), Interpreter.invoke(MethodHandles.lookup(), f, new TestAssertOp(), 42));
+        Assertions.assertEquals(new TestAssertOp().checkStringDetail(42), Interpreter.invoke(MethodHandles.lookup(), f, new TestAssertOp(), 42));
+        Assertions.assertThrows(AssertionError.class, () -> new TestAssertOp().checkStringDetail(-42));
         Assertions.assertThrows(AssertionError.class, () -> Interpreter.invoke(MethodHandles.lookup(), f, new TestAssertOp(), -42));
+    }
+
+    @Reflect
+    int checkIntDetail(int i) {
+        assert i >= 0 : i;
+        return i;
+    }
+
+    @Test
+    public void testIntDetail() {
+        CoreOp.FuncOp f = getFuncOp(TestAssertOp.class, "checkIntDetail");
+
+        Assertions.assertThrows(AssertionError.class, () -> new TestAssertOp().checkIntDetail(-42));
+        Assertions.assertThrows(AssertionError.class, () -> Interpreter.invoke(MethodHandles.lookup(), f, new TestAssertOp(), -42));
+    }
+
+    @Reflect
+    int checkShortDetail(short s) {
+        assert s >= 0 : s;
+        return s;
+    }
+
+    @Test
+    public void testShortDetail() {
+        CoreOp.FuncOp f = getFuncOp(TestAssertOp.class, "checkShortDetail");
+
+        Assertions.assertThrows(AssertionError.class, () -> new TestAssertOp().checkShortDetail((short) -42));
+        Assertions.assertThrows(AssertionError.class, () -> Interpreter.invoke(MethodHandles.lookup(), f, new TestAssertOp(), (short) -42));
     }
 
     static CoreOp.FuncOp getFuncOp(Class<?> c, String name) {

--- a/test/jdk/jdk/incubator/code/lower/TestAssert.java
+++ b/test/jdk/jdk/incubator/code/lower/TestAssert.java
@@ -36,7 +36,30 @@ public class TestAssert {
 
     @Reflect
     @LoweredModel(value = """
-            func @"test1" (%0 : java.type:"int")java.type:"int" -> {
+            func @"testNoDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"java.lang.AssertionError" = new @java.ref:"java.lang.AssertionError::()";
+                throw %6;
+            };
+            """, ssa = false)
+    static int testNoDetail(int i) {
+        assert i >= 0;
+        return i;
+    }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testStringDetail" (%0 : java.type:"int")java.type:"int" -> {
                 %1 : Var<java.type:"int"> = var %0 @"i";
                 %2 : java.type:"int" = var.load %1;
                 %3 : java.type:"int" = constant @0;
@@ -53,14 +76,14 @@ public class TestAssert {
                 throw %7;
             };
             """, ssa = false)
-    static int test1(int i) {
+    static int testStringDetail(int i) {
         assert i >= 0 : "Failed";
         return i;
     }
 
     @Reflect
     @LoweredModel(value = """
-            func @"test2" (%0 : java.type:"int")java.type:"int" -> {
+            func @"testBooleanDetail" (%0 : java.type:"int")java.type:"int" -> {
                 %1 : Var<java.type:"int"> = var %0 @"i";
                 %2 : java.type:"int" = var.load %1;
                 %3 : java.type:"int" = constant @0;
@@ -72,13 +95,183 @@ public class TestAssert {
                 return %5;
 
               ^block_2:
-                %6 : java.type:"java.lang.AssertionError" = new @java.ref:"java.lang.AssertionError::()";
-                throw %6;
+                %6 : java.type:"boolean" = constant @false;
+                %7 : java.type:"java.lang.AssertionError" = new %6 @java.ref:"java.lang.AssertionError::(boolean)";
+                throw %7;
             };
             """, ssa = false)
-    static int test2(int i) {
-        assert i >= 0;
+    static int testBooleanDetail(int i) {
+        assert i >= 0 : false;
         return i;
     }
 
+    @Reflect
+    @LoweredModel(value = """
+            func @"testCharDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"char" = constant @'a';
+                %7 : java.type:"java.lang.AssertionError" = new %6 @java.ref:"java.lang.AssertionError::(char)";
+                throw %7;
+            };
+            """, ssa = false)
+    static int testCharDetail(int i) {
+        assert i >= 0 : 'a';
+        return i;
+    }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testByteDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"int" = constant @10;
+                %7 : java.type:"byte" = conv %6;
+                %8 : java.type:"java.lang.AssertionError" = new %7 @java.ref:"java.lang.AssertionError::(int)";
+                throw %8;
+            };
+            """, ssa = false)
+    static int testByteDetail(int i) {
+        assert i >= 0 : (byte) 10;
+        return i;
+    }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testShortDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"int" = constant @10;
+                %7 : java.type:"short" = conv %6;
+                %8 : java.type:"java.lang.AssertionError" = new %7 @java.ref:"java.lang.AssertionError::(int)";
+                throw %8;
+            };
+            """, ssa = false)
+    static int testShortDetail(int i) {
+        assert i >= 0 : (short) 10;
+        return i;
+    }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testIntDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"int" = constant @10;
+                %7 : java.type:"java.lang.AssertionError" = new %6 @java.ref:"java.lang.AssertionError::(int)";
+                throw %7;
+            };
+            """, ssa = false)
+    static int testIntDetail(int i) {
+        assert i >= 0 : 10;
+        return i;
+    }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testLongDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"long" = constant @10;
+                %7 : java.type:"java.lang.AssertionError" = new %6 @java.ref:"java.lang.AssertionError::(long)";
+                throw %7;
+            };
+            """, ssa = false)
+    static int testLongDetail(int i) {
+        assert i >= 0 : 10l;
+        return i;
+    }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testFloatDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"float" = constant @1.0f;
+                %7 : java.type:"java.lang.AssertionError" = new %6 @java.ref:"java.lang.AssertionError::(float)";
+                throw %7;
+            };
+            """, ssa = false)
+    static int testFloatDetail(int i) {
+        assert i >= 0 : 1.0f;
+        return i;
+    }
+
+    @Reflect
+    @LoweredModel(value = """
+            func @"testDoubleDetail" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"i";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"int" = constant @0;
+                %4 : java.type:"boolean" = ge %2 %3;
+                cbranch %4 ^block_1 ^block_2;
+
+              ^block_1:
+                %5 : java.type:"int" = var.load %1;
+                return %5;
+
+              ^block_2:
+                %6 : java.type:"double" = constant @1.0;
+                %7 : java.type:"java.lang.AssertionError" = new %6 @java.ref:"java.lang.AssertionError::(double)";
+                throw %7;
+            };
+            """, ssa = false)
+    static int testDoubleDetail(int i) {
+        assert i >= 0 : 1.0;
+        return i;
+    }
 }

--- a/test/jdk/jdk/incubator/code/lower/TestAssert.java
+++ b/test/jdk/jdk/incubator/code/lower/TestAssert.java
@@ -145,8 +145,9 @@ public class TestAssert {
               ^block_2:
                 %6 : java.type:"int" = constant @10;
                 %7 : java.type:"byte" = conv %6;
-                %8 : java.type:"java.lang.AssertionError" = new %7 @java.ref:"java.lang.AssertionError::(int)";
-                throw %8;
+                %8 : java.type:"int" = conv %7;
+                %9 : java.type:"java.lang.AssertionError" = new %8 @java.ref:"java.lang.AssertionError::(int)";
+                throw %9;
             };
             """, ssa = false)
     static int testByteDetail(int i) {
@@ -170,8 +171,9 @@ public class TestAssert {
               ^block_2:
                 %6 : java.type:"int" = constant @10;
                 %7 : java.type:"short" = conv %6;
-                %8 : java.type:"java.lang.AssertionError" = new %7 @java.ref:"java.lang.AssertionError::(int)";
-                throw %8;
+                %8 : java.type:"int" = conv %7;
+                %9 : java.type:"java.lang.AssertionError" = new %8 @java.ref:"java.lang.AssertionError::(int)";
+                throw %9;
             };
             """, ssa = false)
     static int testShortDetail(int i) {


### PR DESCRIPTION
Consider the following code snippet:
```
@Reflect
static void check(int value) {
    assert value > 0 : value;
}
```
Attempting to run bytecode generated from the reflected code model of the `check` method fails with:
```
java.lang.VerifyError: Bad type on operand stack
Reason:
  Type integer ... is not assignable to 'java/lang/Object'
```
The problem is that the current `AssertOp` lowering always invokes `AssertionError(Object)`. When the assertion detail expression has a primitive type, its value is passed directly to a constructor expecting an object, producing invalid bytecode.

The proposal is to invoke the appropriate `AssertionError` constructor based on the type of the assertion detail expression.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8390649](https://bugs.openjdk.org/browse/JDK-8390649): BytecodeGenerator produces invalid bytecode for assert statements with primitive detail expressions (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1153/head:pull/1153` \
`$ git checkout pull/1153`

Update a local copy of the PR: \
`$ git checkout pull/1153` \
`$ git pull https://git.openjdk.org/babylon.git pull/1153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1153`

View PR using the GUI difftool: \
`$ git pr show -t 1153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1153.diff">https://git.openjdk.org/babylon/pull/1153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1153#issuecomment-5343268893)
</details>
