### PR TITLE
Simplify lowering of conditional and/or ops

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -97,7 +97,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             VarAccessOp.VarLoadOp,
             VarAccessOp.VarStoreOp,
             ConditionalExpressionOp,
-            JavaConditionalOp,
+            ConditionalAndOrOp,
             SwitchExpressionOp {
 
         /**
@@ -4566,22 +4566,24 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @jls 15.23 Conditional-And Operator {@code &&}
      * @jls 15.24 Conditional-Or Operator {@code ||}
      */
-    public sealed static abstract class JavaConditionalOp extends AbstractOp
+    public sealed static abstract class ConditionalAndOrOp extends AbstractOp
             implements JavaOp, Op.Nested, Op.Lowerable, JavaExpression {
 
         static final FunctionType BODY_TYPE = CoreType.functionType(BOOLEAN);
 
+        // 2 or more bodies
+        // See use for modeling multi-label cases of switch statements/expressions
         final List<Body> bodies;
 
-        JavaConditionalOp(JavaConditionalOp that, CodeContext cc, CodeTransformer ct) {
+        ConditionalAndOrOp(ConditionalAndOrOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
-            // Copy body
             this.bodies = that.bodies.stream().map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
-        JavaConditionalOp(List<Body.Builder> bodyCs) {
+        ConditionalAndOrOp(List<Body.Builder> bodyCs) {
             super(List.of());
+
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
         }
 
@@ -4590,56 +4592,40 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             return bodies;
         }
 
-        static Block.Builder lower(Block.Builder startBlock, BiFunction<Block.Builder, Op, Block.Builder> before, JavaConditionalOp cop) {
-            List<Body> bodies = cop.bodies();
+        @Override
+        public Block.Builder lower(Block.Builder lhs, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
+            Block.Builder exit = lhs.block();
+            lhs.context().mapValue(result(), exit.parameter(resultType()));
 
-            Block.Builder exit = startBlock.block();
-            CodeType oprType = cop.result().type();
-            Block.Parameter arg = exit.parameter(oprType);
-            startBlock.context().mapValue(cop.result(), arg);
-
-            // Transform bodies in reverse order
-            // This makes available the blocks to be referenced as successors in prior blocks
-
-            Block.Builder pred = null;
-            for (int i = bodies.size() - 1; i >= 0; i--) {
-                CodeTransformer bodyTransformer;
-                BiFunction<Block.Builder, Op, Block.Builder> lowering;
-                if (i == bodies.size() - 1) {
-                    bodyTransformer = loweringTransformer(before, (block, op) -> {
-                        if (op instanceof CoreOp.YieldOp yop) {
-                            Value p = block.context().getValue(yop.yieldValue());
-                            block.add(branch(exit.reference(p)));
-                            return block;
+            // Lower all but the last body
+            for (int i = 0; i < bodies().size() - 1; i++) {
+                Block.Builder rhs = lhs.block();
+                lhs.transformBody(bodies().get(i), List.of(), loweringTransformer(inherited, (block, op) -> {
+                    if (op instanceof CoreOp.YieldOp yop) {
+                        Value p = block.context().getValue(yop.yieldValue());
+                        if (this instanceof ConditionalAndOp) {
+                            block.add(conditionalBranch(p, rhs.reference(), exit.reference(p)));
                         } else {
-                            return null;
+                            block.add(conditionalBranch(p, exit.reference(p), rhs.reference()));
                         }
-                    });
-                } else {
-                    Block.Builder nextPred = pred;
-                    bodyTransformer = loweringTransformer(before, (block, op) -> {
-                        if (op instanceof CoreOp.YieldOp yop) {
-                            Value p = block.context().getValue(yop.yieldValue());
-                            if (cop instanceof ConditionalAndOp) {
-                                block.add(conditionalBranch(p, nextPred.reference(), exit.reference(p)));
-                            } else {
-                                block.add(conditionalBranch(p, exit.reference(p), nextPred.reference()));
-                            }
-                            return block;
-                        } else {
-                            return null;
-                        }
-                    });
-                }
-
-                Body fromPred = bodies.get(i);
-                if (i == 0) {
-                    startBlock.transformBody(fromPred, List.of(), bodyTransformer);
-                } else {
-                    pred = startBlock.block(fromPred.bodySignature().parameterTypes());
-                    pred.transformBody(fromPred, pred.parameters(), bodyTransformer);
-                }
+                        return block;
+                    } else {
+                        return null;
+                    }
+                }));
+                lhs = rhs;
             }
+
+            // Lower the last body
+            lhs.transformBody(bodies().getLast(), List.of(), loweringTransformer(inherited, (block, op) -> {
+                if (op instanceof CoreOp.YieldOp yop) {
+                    Value p = block.context().getValue(yop.yieldValue());
+                    block.add(branch(exit.reference(p)));
+                    return block;
+                } else {
+                    return null;
+                }
+            }));
 
             return exit;
         }
@@ -4656,7 +4642,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @jls 15.23 Conditional-And Operator {@code &&}
      */
     @OpDeclaration(ConditionalAndOp.NAME)
-    public static final class ConditionalAndOp extends JavaConditionalOp {
+    public static final class ConditionalAndOp extends ConditionalAndOrOp {
 
         /**
          * Builder for conditional-and operations.
@@ -4713,11 +4699,6 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             bodyCs.forEach(b -> requireBodySignature(NAME, b, BODY_TYPE));
             super(requireMinBodies(NAME, bodyCs, 2));
         }
-
-        @Override
-        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
-            return lower(b, inherited, this);
-        }
     }
 
     /**
@@ -4726,7 +4707,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @jls 15.24 Conditional-Or Operator {@code ||}
      */
     @OpDeclaration(ConditionalOrOp.NAME)
-    public static final class ConditionalOrOp extends JavaConditionalOp {
+    public static final class ConditionalOrOp extends ConditionalAndOrOp {
 
         /**
          * Builder for conditional-or operations.
@@ -4782,11 +4763,6 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         ConditionalOrOp(List<Body.Builder> bodyCs) {
             bodyCs.forEach(b -> requireBodySignature(NAME, b, BODY_TYPE));
             super(requireMinBodies(NAME, bodyCs, 2));
-        }
-
-        @Override
-        public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
-            return lower(b, inherited, this);
         }
     }
 


### PR DESCRIPTION
Simplify the lowering of conditional and/or ops. The prior implementation was harder to reason about given its reverse direction.

Also changed the name of `JavaConditionalOp` to `ConditionalAndOrOp` to line up with the general naming convention and also to better distinguish between `ConditionalExpressionOp`.

This simplification is in preparation to remove the localized control flow of lowered boolean expressions rather than requiring a subsequent transform to remove that control flow.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1154/head:pull/1154` \
`$ git checkout pull/1154`

Update a local copy of the PR: \
`$ git checkout pull/1154` \
`$ git pull https://git.openjdk.org/babylon.git pull/1154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1154`

View PR using the GUI difftool: \
`$ git pr show -t 1154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1154.diff">https://git.openjdk.org/babylon/pull/1154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1154#issuecomment-5361501959)
</details>
