### PR TITLE
Switch expression op yields incorrect type

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1813,7 +1813,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, FunctionType caseBodyType, boolean isLastCase) {
             Body.Builder body = null;
-            Type yieldType = tree.type != null ? adaptBottom(tree.type) : Type.noType;
 
             JCTree.JCCaseLabel headCl = c.labels.head;
             switch (c.caseKind) {
@@ -1821,17 +1820,12 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     pushBody(c.body, caseBodyType);
 
                     if (c.body instanceof JCTree.JCExpression e) {
+                        Type yieldType = adaptBottom(tree.type);
                         Value bodyVal = toValue(e, yieldType);
                         append(CoreOp.core_yield(bodyVal));
                     } else if (c.body instanceof JCTree.JCStatement s){ // this includes Block
                         // Otherwise there is a yield statement
-                        Type prevBodyTarget = bodyTarget;
-                        try {
-                            bodyTarget = yieldType;
-                            toValue(s);
-                        } finally {
-                            bodyTarget = prevBodyTarget;
-                        }
+                        toValue(s);
                         appendTerminating(c.completesNormally ? CoreOp::core_yield : CoreOp::unreachable);
                     }
                     body = stack.body;
@@ -1861,7 +1855,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitYield(JCTree.JCYield tree) {
-            Value retVal = toValue(tree.value, bodyTarget);
+            Type yieldType = adaptBottom(tree.target.type);
+            Value retVal = toValue(tree.value, yieldType);
             result = append(JavaOp.java_yield(retVal));
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1814,7 +1814,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
         private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, FunctionType caseBodyType, boolean isLastCase) {
             Body.Builder body = null;
 
-            JCTree.JCCaseLabel headCl = c.labels.head;
             switch (c.caseKind) {
                 case RULE -> {
                     pushBody(c.body, caseBodyType);
@@ -1823,7 +1822,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         Type yieldType = adaptBottom(tree.type);
                         Value bodyVal = toValue(e, yieldType);
                         append(CoreOp.core_yield(bodyVal));
-                    } else if (c.body instanceof JCTree.JCStatement s){ // this includes Block
+                    } else if (c.body instanceof JCTree.JCStatement s) { // this includes Block
                         // Otherwise there is a yield statement
                         toValue(s);
                         appendTerminating(c.completesNormally ? CoreOp::core_yield : CoreOp::unreachable);
@@ -1840,8 +1839,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     scan(c.stats);
 
-                    appendTerminating(c.completesNormally ?
-                            isLastCase ? CoreOp::core_yield : JavaOp::switchFallthroughOp
+                    appendTerminating(c.completesNormally
+                            ? isLastCase ? CoreOp::core_yield : JavaOp::switchFallthroughOp
                             : CoreOp::unreachable);
 
                     body = stack.body;

--- a/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -560,6 +560,90 @@ public class SwitchExpressionTest {
         return switch (o) {
             case Object _ when B -> "match";
             default -> "no match";
+        };
+    }
+
+    @IR("""
+            func @"statementGroupsYieldingBoolean" (%0 : java.type:"int")java.type:"int" -> {
+                %1 : Var<java.type:"int"> = var %0 @"value";
+                java.if
+                    ()java.type:"boolean" -> {
+                        %2 : java.type:"int" = var.load %1;
+                        %3 : java.type:"boolean" = java.switch.expression %2
+                            (%4 : java.type:"int")java.type:"boolean" -> {
+                                %5 : java.type:"int" = constant @0;
+                                %6 : java.type:"boolean" = eq %4 %5;
+                                yield %6;
+                            }
+                            ()java.type:"boolean" -> {
+                                %7 : java.type:"boolean" = constant @false;
+                                java.yield %7;
+                            }
+                            ()java.type:"boolean" -> {
+                                %8 : java.type:"boolean" = constant @true;
+                                yield %8;
+                            }
+                            ()java.type:"boolean" -> {
+                                %9 : java.type:"int" = var.load %1;
+                                %10 : java.type:"int" = constant @0;
+                                %11 : java.type:"boolean" = gt %9 %10;
+                                java.yield %11;
+                            };
+                        yield %3;
+                    }
+                    ()java.type:"void" -> {
+                        %12 : java.type:"int" = constant @1;
+                        return %12;
+                    }
+                    ()java.type:"void" -> {
+                        yield;
+                    };
+                %13 : java.type:"int" = constant @0;
+                return %13;
+            };
+            """)
+    @Reflect
+    private static int statementGroupsYieldingBoolean(int value) {
+        if (switch (value) {
+            case 0: yield false;
+            default: yield value > 0;}) {
+            return 1;
+        }
+        return 0;
+    }
+
+    @IR("""
+            func @"statementGroupsYieldingObjects" (%0 : java.type:"int")java.type:"void" -> {
+                %1 : Var<java.type:"int"> = var %0 @"value";
+                %2 : java.type:"int" = var.load %1;
+                %3 : java.type:"java.lang.Object" = java.switch.expression %2
+                    (%4 : java.type:"int")java.type:"boolean" -> {
+                        %5 : java.type:"int" = constant @0;
+                        %6 : java.type:"boolean" = eq %4 %5;
+                        yield %6;
+                    }
+                    ()java.type:"java.lang.Object" -> {
+                        %7 : java.type:"int" = field.load @java.ref:"java.lang.Integer::MAX_VALUE:int";
+                        %8 : java.type:"java.lang.Integer" = invoke %7 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                        java.yield %8;
+                    }
+                    ()java.type:"boolean" -> {
+                        %9 : java.type:"boolean" = constant @true;
+                        yield %9;
+                    }
+                    ()java.type:"java.lang.Object" -> {
+                        %10 : java.type:"java.lang.String" = constant @"default";
+                        java.yield %10;
+                    };
+                %11 : Var<java.type:"java.lang.Object"> = var %3 @"r";
+                return;
+            };
+            """)
+    @Reflect
+    private static void statementGroupsYieldingObjects(int value) {
+        Object r = switch (value) {
+            case 0: yield Integer.MAX_VALUE;
+            default: yield "default";
         };
     }
 }


### PR DESCRIPTION
When a switch expression has a statement groups the yielded type is incorrect (the return type of the method or lambda is incorrectly selected).

In `visitYield` we can use `tree.target.type` and then there is no need to temporarily adjusting the `bodyTarget` for a case rule with a statement body. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1155/head:pull/1155` \
`$ git checkout pull/1155`

Update a local copy of the PR: \
`$ git checkout pull/1155` \
`$ git pull https://git.openjdk.org/babylon.git pull/1155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1155`

View PR using the GUI difftool: \
`$ git pr show -t 1155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1155.diff">https://git.openjdk.org/babylon/pull/1155.diff</a>

</details>
