### PR TITLE
Babylon JavaConditionalOp -> ConditionalAndOp change

### DIFF
--- a/hat/optkl/src/main/java/optkl/OpHelper.java
+++ b/hat/optkl/src/main/java/optkl/OpHelper.java
@@ -284,11 +284,11 @@ public sealed interface OpHelper<T extends Op> extends LookupCarrier
         return (Op.Result) binaryOp.operands().get(1);
     }
 
-    static List<Op> lhsOps(JavaOp.JavaConditionalOp javaConditionalOp) {
+    static List<Op> lhsOps(JavaOp.ConditionalAndOp javaConditionalOp) {
         return javaConditionalOp.bodies().get(0).entryBlock().ops();
     }
 
-    static List<Op> rhsOps(JavaOp.JavaConditionalOp javaConditionalOp) {
+    static List<Op> rhsOps(JavaOp.ConditionalAndOp javaConditionalOp) {
         return javaConditionalOp.bodies().get(1).entryBlock().ops();
     }
 

--- a/hat/optkl/src/main/java/optkl/codebuilders/BabylonOpDispatcher.java
+++ b/hat/optkl/src/main/java/optkl/codebuilders/BabylonOpDispatcher.java
@@ -53,7 +53,7 @@ public interface BabylonOpDispatcher<T extends JavaOrC99StyleCodeBuilder<T,SCBC>
 
     T binaryOp( JavaOp.BinaryOp binaryOp);
 
-    T conditionalOp( JavaOp.JavaConditionalOp conditionalOp);
+    T conditionalOp( JavaOp.ConditionalAndOp conditionalOp);
 
     T compareOp(JavaOp.CompareOp compareOp);
 
@@ -133,7 +133,7 @@ public interface BabylonOpDispatcher<T extends JavaOrC99StyleCodeBuilder<T,SCBC>
             case JavaOp.ContinueOp $ -> continueOp( $);
             case JavaOp.CompareOp $ -> compareOp( $);
             case JavaOp.BinaryOp $ -> binaryOp( $);
-            case JavaOp.JavaConditionalOp $ -> conditionalOp( $);
+            case JavaOp.ConditionalAndOp $ -> conditionalOp( $);
             case JavaOp.UnaryOp $ -> unaryOp( $);
             case JavaOp.NewOp $ -> newOp( $);
             case JavaOp.ArrayAccessOp.ArrayStoreOp  $ ->  arrayStoreOp($);

--- a/hat/optkl/src/main/java/optkl/codebuilders/JavaOrC99StyleCodeBuilder.java
+++ b/hat/optkl/src/main/java/optkl/codebuilders/JavaOrC99StyleCodeBuilder.java
@@ -208,7 +208,7 @@ public abstract class JavaOrC99StyleCodeBuilder<T extends JavaOrC99StyleCodeBuil
 
 
     @Override
-    public final T conditionalOp( JavaOp.JavaConditionalOp logicalOp) {
+    public final T conditionalOp( JavaOp.ConditionalAndOp logicalOp) {
         OpHelper.lhsOps(logicalOp).stream().filter(o -> o instanceof CoreOp.YieldOp).forEach(o ->  recurse( o));
         sp().symbol(logicalOp).sp();
         OpHelper.rhsOps(logicalOp).stream().filter(o -> o instanceof CoreOp.YieldOp).forEach(o-> recurse( o));


### PR DESCRIPTION
Required PR after Babylon JavaConditionalOp -> ConditionalAndOp name change

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1156/head:pull/1156` \
`$ git checkout pull/1156`

Update a local copy of the PR: \
`$ git checkout pull/1156` \
`$ git pull https://git.openjdk.org/babylon.git pull/1156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1156`

View PR using the GUI difftool: \
`$ git pr show -t 1156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1156.diff">https://git.openjdk.org/babylon/pull/1156.diff</a>

</details>
