### PR TITLE
8390943: ReflectMethods uses generic declaration type for unqualified field access

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1042,7 +1042,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         result = loadVar(sym);
                     } else {
                         FieldRef fr = symbolToErasedFieldRef(sym, symbolSiteType(sym));
-                        CodeType resultType = typeToCodeType(sym.type);
+                        CodeType resultType = typeToCodeType(tree.type);
                         if (sym.isStatic()) {
                             result = append(JavaOp.fieldLoad(resultType, fr));
                         } else {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -963,7 +963,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                             FieldRef fr = symbolToErasedFieldRef(sym, symbolSiteType(sym));
 
                             Op.Result lhsOpValue;
-                            CodeType resultType = typeToCodeType(sym.type);
+                            CodeType resultType = typeToCodeType(assign.type);
                             if (sym.isStatic()) {
                                 lhsOpValue = append(JavaOp.fieldLoad(resultType, fr));
                             } else {
@@ -990,7 +990,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     FieldRef fr = symbolToErasedFieldRef(sym, assign.selected.type);
 
                     Op.Result lhsOpValue;
-                    CodeType resultType = typeToCodeType(sym.type);
+                    CodeType resultType = typeToCodeType(assign.type);
                     if (sym.isStatic()) {
                         lhsOpValue = append(JavaOp.fieldLoad(resultType, fr));
                     } else {

--- a/test/jdk/jdk/incubator/code/bytecode/TestGenericFieldReceiverCast.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestGenericFieldReceiverCast.java
@@ -37,34 +37,45 @@ import org.junit.jupiter.api.Test;
 
 public class TestGenericFieldReceiverCast {
 
-    static class Base {
-    }
+    static class Wrapper<T extends Number> {
+        T n;
 
-    static class Child extends Base {
-        int value = 42;
-    }
-
-    static class TestBase<B extends Base> {
-        final B b;
-
-        TestBase(B b) {
-            this.b = b;
+        Wrapper(T n) {
+            this.n = n;
         }
     }
 
-    static final class TestClass extends TestBase<Child> {
+    static final class TestClass extends Wrapper<Integer> {
         TestClass() {
-            super(new Child());
+            super(42);
         }
 
         @Reflect
-        int value() {
-            return b.value;
+        int test() {
+            return n.compareTo(0);
+        }
+
+        @Reflect
+        static int test(TestClass t) {
+            return t.n.compareTo(0);
+        }
+
+        @Reflect
+        int testCA() {
+            return (n++).compareTo(0);
+        }
+
+        @Reflect
+        static int testCA(TestClass t) {
+            return (t.n++).compareTo(0);
         }
     }
 
     @Test
     public void test() throws Throwable {
-        Assertions.assertEquals(42, new TestClass().value());
+        Assertions.assertTrue(new TestClass().test() > 0);
+        Assertions.assertTrue(TestClass.test(new TestClass()) > 0);
+        Assertions.assertTrue(new TestClass().testCA() > 0);
+        Assertions.assertTrue(TestClass.testCA(new TestClass()) > 0);
     }
 }

--- a/test/jdk/jdk/incubator/code/bytecode/TestGenericFieldReceiverCast.java
+++ b/test/jdk/jdk/incubator/code/bytecode/TestGenericFieldReceiverCast.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library ../
+ * @modules jdk.incubator.code
+ * @run junit TestGenericFieldReceiverCast
+ * @run main Unreflect TestGenericFieldReceiverCast
+ * @run junit TestGenericFieldReceiverCast
+ */
+
+
+import jdk.incubator.code.Reflect;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestGenericFieldReceiverCast {
+
+    static class Base {
+    }
+
+    static class Child extends Base {
+        int value = 42;
+    }
+
+    static class TestBase<B extends Base> {
+        final B b;
+
+        TestBase(B b) {
+            this.b = b;
+        }
+    }
+
+    static final class TestClass extends TestBase<Child> {
+        TestClass() {
+            super(new Child());
+        }
+
+        @Reflect
+        int value() {
+            return b.value;
+        }
+    }
+
+    @Test
+    public void test() throws Throwable {
+        Assertions.assertEquals(42, new TestClass().value());
+    }
+}

--- a/test/langtools/tools/javac/reflect/FieldAccessTest.java
+++ b/test/langtools/tools/javac/reflect/FieldAccessTest.java
@@ -538,6 +538,67 @@ public class FieldAccessTest {
         int test1() {
             return x.yf;
         }
+
+        @IR("""
+                func @"test2" (%0 : java.type:"FieldAccessTest$ZZ")java.type:"int" -> {
+                    %1 : Var<java.type:"FieldAccessTest$ZZ"> = var %0 @"zz";
+                    %2 : java.type:"FieldAccessTest$ZZ" = var.load %1;
+                    %3 : java.type:"FieldAccessTest$Y" = field.load %2 @java.ref:"FieldAccessTest$ZZ::x:FieldAccessTest$X";
+                    %4 : java.type:"int" = field.load %3 @java.ref:"FieldAccessTest$Y::yf:int";
+                    return %4;
+                };
+                """)
+        @Reflect
+        static int test2(ZZ zz) {
+            return zz.x.yf;
+        }
+    }
+
+    static class W<T extends Number> {
+        T n;
+    }
+
+    static class WW extends W<Integer> {
+
+        @IR("""
+                func @"test1" (%0 : java.type:"FieldAccessTest$WW")java.type:"int" -> {
+                    %1 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
+                    %2 : java.type:"int" = invoke %1 @java.ref:"java.lang.Integer::intValue():int";
+                    %3 : java.type:"int" = constant @1;
+                    %4 : java.type:"int" = add %2 %3;
+                    %5 : java.type:"java.lang.Integer" = invoke %4 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    field.store %0 %5 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
+                    %6 : java.type:"int" = constant @0;
+                    %7 : java.type:"java.lang.Integer" = invoke %6 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    %8 : java.type:"int" = invoke %1 %7 @java.ref:"java.lang.Integer::compareTo(java.lang.Integer):int";
+                    return %8;
+                };
+                """)
+        @Reflect
+        int test1() {
+            return (n++).compareTo(0);
+        }
+
+        @IR("""
+                func @"test2" (%0 : java.type:"FieldAccessTest$WW")java.type:"int" -> {
+                    %1 : Var<java.type:"FieldAccessTest$WW"> = var %0 @"w";
+                    %2 : java.type:"FieldAccessTest$WW" = var.load %1;
+                    %3 : java.type:"java.lang.Integer" = field.load %2 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
+                    %4 : java.type:"int" = invoke %3 @java.ref:"java.lang.Integer::intValue():int";
+                    %5 : java.type:"int" = constant @1;
+                    %6 : java.type:"int" = add %4 %5;
+                    %7 : java.type:"java.lang.Integer" = invoke %6 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    field.store %2 %7 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
+                    %8 : java.type:"int" = constant @0;
+                    %9 : java.type:"java.lang.Integer" = invoke %8 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    %10 : java.type:"int" = invoke %3 %9 @java.ref:"java.lang.Integer::compareTo(java.lang.Integer):int";
+                    return %10;
+                };
+                """)
+        @Reflect
+        static int test2(WW w) {
+            return (w.n++).compareTo(0);
+        }
     }
 
     @Reflect

--- a/test/langtools/tools/javac/reflect/FieldAccessTest.java
+++ b/test/langtools/tools/javac/reflect/FieldAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -518,6 +518,25 @@ public class FieldAccessTest {
         void test3() {
             f++;
             s_f++;
+        }
+    }
+
+    static class Z<T extends X> {
+        T x;
+    }
+
+    static class ZZ extends Z<Y> {
+
+        @IR("""
+                func @"test1" (%0 : java.type:"FieldAccessTest$ZZ")java.type:"int" -> {
+                    %1 : java.type:"FieldAccessTest$Y" = field.load %0 @java.ref:"FieldAccessTest$ZZ::x:FieldAccessTest$X";
+                    %2 : java.type:"int" = field.load %1 @java.ref:"FieldAccessTest$Y::yf:int";
+                    return %2;
+                };
+                """)
+        @Reflect
+        int test1() {
+            return x.yf;
         }
     }
 


### PR DESCRIPTION
Consider the following code snippet:
```
class Builder {}

class SpecializedBuilder extends Builder {
    int value;
}

class Writer<B extends Builder> {
    B builder;
}

class SpecializedWriter extends Writer<SpecializedBuilder> {
    @Reflect
    int value() {
        return builder.value;
    }
}
```
Attempting to run bytecode generated from the reflected code model of the `SpecializedWriter.value` method fails with:
```
VerifyError: Bad type on operand stack
Builder is not assignable to SpecializedBuilder
```
The problem is that the code model represents `builder` as `B extends Builder`, followed by a field load whose receiver must be `SpecializedBuilder`. `BytecodeGenerator` therefore emits:
```
getfield Writer.builder:Builder
getfield SpecializedBuilder.value
```
without the required `checkcast SpecializedBuilder.`

The proposal is to modify `ReflectMethods.visitIdent` to model the field result using the attributed use-site `tree.type` instead of `sym.type` when reflecting an unqualified inherited field whose generic type is specialized by a subclass.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8390943](https://bugs.openjdk.org/browse/JDK-8390943): ReflectMethods uses generic declaration type for unqualified field access (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [5e0c8190](https://git.openjdk.org/babylon/pull/1157/files/5e0c81906d56477a2626e62a2ae1359c1ea120ed)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1157/head:pull/1157` \
`$ git checkout pull/1157`

Update a local copy of the PR: \
`$ git checkout pull/1157` \
`$ git pull https://git.openjdk.org/babylon.git pull/1157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1157`

View PR using the GUI difftool: \
`$ git pr show -t 1157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1157.diff">https://git.openjdk.org/babylon/pull/1157.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1157#issuecomment-5398201144)
</details>
