### PR TITLE
Rename ConditionalAndOrOp to ConditionalOp

### DIFF
--- a/hat/optkl/src/main/java/optkl/OpHelper.java
+++ b/hat/optkl/src/main/java/optkl/OpHelper.java
@@ -284,11 +284,11 @@ public sealed interface OpHelper<T extends Op> extends LookupCarrier
         return (Op.Result) binaryOp.operands().get(1);
     }
 
-    static List<Op> lhsOps(JavaOp.ConditionalAndOrOp javaConditionalOp) {
+    static List<Op> lhsOps(JavaOp.ConditionalOp javaConditionalOp) {
         return javaConditionalOp.bodies().get(0).entryBlock().ops();
     }
 
-    static List<Op> rhsOps(JavaOp.ConditionalAndOrOp javaConditionalOp) {
+    static List<Op> rhsOps(JavaOp.ConditionalOp javaConditionalOp) {
         return javaConditionalOp.bodies().get(1).entryBlock().ops();
     }
 

--- a/hat/optkl/src/main/java/optkl/codebuilders/BabylonOpDispatcher.java
+++ b/hat/optkl/src/main/java/optkl/codebuilders/BabylonOpDispatcher.java
@@ -53,7 +53,7 @@ public interface BabylonOpDispatcher<T extends JavaOrC99StyleCodeBuilder<T,SCBC>
 
     T binaryOp( JavaOp.BinaryOp binaryOp);
 
-    T conditionalOp( JavaOp.ConditionalAndOrOp conditionalOp);
+    T conditionalOp( JavaOp.ConditionalOp conditionalOp);
 
     T compareOp(JavaOp.CompareOp compareOp);
 
@@ -133,7 +133,7 @@ public interface BabylonOpDispatcher<T extends JavaOrC99StyleCodeBuilder<T,SCBC>
             case JavaOp.ContinueOp $ -> continueOp( $);
             case JavaOp.CompareOp $ -> compareOp( $);
             case JavaOp.BinaryOp $ -> binaryOp( $);
-            case JavaOp.ConditionalAndOrOp $ -> conditionalOp( $);
+            case JavaOp.ConditionalOp $ -> conditionalOp( $);
             case JavaOp.UnaryOp $ -> unaryOp( $);
             case JavaOp.NewOp $ -> newOp( $);
             case JavaOp.ArrayAccessOp.ArrayStoreOp  $ ->  arrayStoreOp($);

--- a/hat/optkl/src/main/java/optkl/codebuilders/JavaOrC99StyleCodeBuilder.java
+++ b/hat/optkl/src/main/java/optkl/codebuilders/JavaOrC99StyleCodeBuilder.java
@@ -208,7 +208,7 @@ public abstract class JavaOrC99StyleCodeBuilder<T extends JavaOrC99StyleCodeBuil
 
 
     @Override
-    public final T conditionalOp( JavaOp.ConditionalAndOrOp logicalOp) {
+    public final T conditionalOp( JavaOp.ConditionalOp logicalOp) {
         OpHelper.lhsOps(logicalOp).stream().filter(o -> o instanceof CoreOp.YieldOp).forEach(o ->  recurse( o));
         sp().symbol(logicalOp).sp();
         OpHelper.rhsOps(logicalOp).stream().filter(o -> o instanceof CoreOp.YieldOp).forEach(o-> recurse( o));

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -97,7 +97,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             VarAccessOp.VarLoadOp,
             VarAccessOp.VarStoreOp,
             ConditionalExpressionOp,
-            ConditionalAndOrOp,
+            ConditionalOp,
             SwitchExpressionOp {
 
         /**
@@ -4574,8 +4574,9 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @jls 15.23 Conditional-And Operator {@code &&}
      * @jls 15.24 Conditional-Or Operator {@code ||}
      */
-    public sealed static abstract class ConditionalAndOrOp extends AbstractOp
-            implements JavaOp, Op.Nested, Op.Lowerable, JavaExpression {
+    public sealed static abstract class ConditionalOp extends AbstractOp
+            implements JavaOp, Op.Nested, Op.Lowerable, JavaExpression
+            permits ConditionalAndOp, ConditionalOrOp {
 
         static final FunctionType BODY_TYPE = CoreType.functionType(BOOLEAN);
 
@@ -4583,13 +4584,13 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         // See use for modeling multi-label cases of switch statements/expressions
         final List<Body> bodies;
 
-        ConditionalAndOrOp(ConditionalAndOrOp that, CodeContext cc, CodeTransformer ct) {
+        ConditionalOp(ConditionalOp that, CodeContext cc, CodeTransformer ct) {
             super(that, cc);
 
             this.bodies = that.bodies.stream().map(b -> b.transform(cc, ct).build(this)).toList();
         }
 
-        ConditionalAndOrOp(List<Body.Builder> bodyCs) {
+        ConditionalOp(List<Body.Builder> bodyCs) {
             super(List.of());
 
             this.bodies = bodyCs.stream().map(bc -> bc.build(this)).toList();
@@ -4650,7 +4651,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @jls 15.23 Conditional-And Operator {@code &&}
      */
     @OpDeclaration(ConditionalAndOp.NAME)
-    public static final class ConditionalAndOp extends ConditionalAndOrOp {
+    public static final class ConditionalAndOp extends ConditionalOp {
 
         /**
          * Builder for conditional-and operations.
@@ -4715,7 +4716,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @jls 15.24 Conditional-Or Operator {@code ||}
      */
     @OpDeclaration(ConditionalOrOp.NAME)
-    public static final class ConditionalOrOp extends ConditionalAndOrOp {
+    public static final class ConditionalOrOp extends ConditionalOp {
 
         /**
          * Builder for conditional-or operations.


### PR DESCRIPTION
Rename `ConditionalAndOrOp` to `ConditionalOp`, the former is confusing named likely leading to incorrect use.

The motivation for initially selecting `ConditionalAndOrOp` was to differentiate it more clearer with respect to `ConditionalExpressionOp` that models the conditional operator {@code ?}, which may or may not be a boolean expression. Arguably the JLS terminology for such operators does not help, but we want to align with it.

Dependent HAT code also updated.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1160/head:pull/1160` \
`$ git checkout pull/1160`

Update a local copy of the PR: \
`$ git checkout pull/1160` \
`$ git pull https://git.openjdk.org/babylon.git pull/1160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1160`

View PR using the GUI difftool: \
`$ git pr show -t 1160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1160.diff">https://git.openjdk.org/babylon/pull/1160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1160#issuecomment-5401448751)
</details>
