### PR TITLE
Clarify body construction/transformation with code context/transformer

### DIFF
--- a/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
+++ b/cr-examples/onnx/src/main/java/oracle/code/onnx/compiler/OnnxTransformer.java
@@ -576,9 +576,9 @@ public final class OnnxTransformer {
         // @@@ create a Body.Builder structurally connected as a descendant of a Block.Builder
         // but not yet connected as the child of an operation
         Body.Builder bb = Body.Builder.of(ancestor.parentBody(),
-                outputType, ancestor.context()); // translate types
+                outputType); // translate types
 
-        bb.entryBlock().transformBody(iop.body(), bb.entryBlock().parameters(), ot);
+        bb.entryBlock().transformBody(iop.body(), bb.entryBlock().parameters(), ancestor.context(), ot);
         return bb;
     }
 

--- a/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/SCFOps.java
@@ -57,12 +57,6 @@ public class SCFOps {
                 c.accept(body.entryBlock());
                 return new ForOp(range, body);
             }
-
-            public ForOp body(CodeContext cc, Consumer<Block.Builder> c) {
-                Body.Builder body = Body.Builder.of(ancestorBody, loopType, cc);
-                c.accept(body.entryBlock());
-                return new ForOp(range, body);
-            }
         }
 
         public static final String NAME = "scf.for";

--- a/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
+++ b/cr-examples/triton/src/main/java/oracle/code/triton/TritonTransformer.java
@@ -731,7 +731,7 @@ public final class TritonTransformer {
         // @@@ Build in java code model, then transform?
         SCFOps.ForOp scffor = SCFOps.for_(kblock.parentBody(), start, end, step, iterValues)
                 // Ensure existing context is used
-                .body(CodeContext.create(cc), builder -> {
+                .body(builder -> {
                     // Create index var initialized from entry block parameter
                     Value index = builder.parameters().get(0);
                     valueTypeMap.put(index, JavaType.INT);

--- a/hat/examples/experiments/src/main/java/experiments/BlockGroup.java
+++ b/hat/examples/experiments/src/main/java/experiments/BlockGroup.java
@@ -80,11 +80,10 @@ public class BlockGroup {
         VarTable varTable = new VarTable(mModel.funcName());
          var mGroupModel=  Trxfmr.of(lookup,mModel).transform(opsToGroup::contains, c->{ // Here we use a HAT style transformer
             if (opsToGroup.getLast() == c.op()) {
-                // Create a new body builder connected as a child
-                // Use a child of the code context so values can be shared ???? what does this mean
+                // Create a new body builder connected as a child of the parent builder c.builder()
+                // The new body builder will have a code context that is a child of the parent
                 Body.Builder groupBodyBuilder = Body.Builder.of(
-                        c.builder().parentBody(), CoreType.FUNCTION_TYPE_VOID,
-                        CodeContext.create(c.builder().context()));
+                        c.builder().parentBody(), CoreType.FUNCTION_TYPE_VOID);
 
                 // Add ops to the entry block
                 Block.Builder groupBlockBuilder = groupBodyBuilder.entryBlock();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Block.java
@@ -673,10 +673,30 @@ public final class Block implements CodeElement<Block, Op> {
         /**
          * Transforms the given body into this block builder's parent body, using this block builder as the current
          * output block builder, a {@link CodeContext#create(CodeContext) child} of this block builder's code context,
+         * and the builder's code transformer.
+         * <p>
+         * This method behaves as if invoking {@link #transformBody(Body, List, CodeContext, CodeTransformer)} with the
+         * given body, the given entry values, a child of this block builder's code context, and the builder's code
+         * transformer.
+         *
+         * @param body the body to transform
+         * @param entryValues the output entry values to map, in order, from a prefix of the input body's entry block
+         *                    parameters
+         * @throws IllegalArgumentException if there are more output entry values than entry block parameters
+         * @see #transformBody(Body, List, CodeContext, CodeTransformer)
+         */
+        public void transformBody(Body body, List<? extends Value> entryValues) {
+            transformBody(body, entryValues, CodeContext.create(cc), ct);
+        }
+
+        /**
+         * Transforms the given body into this block builder's parent body, using this block builder as the current
+         * output block builder, a {@link CodeContext#create(CodeContext) child} of this block builder's code context,
          * and the given code transformer.
          * <p>
-         * This method behaves as if invoking {@link #transformBody(Body, List, CodeContext, CodeTransformer)} with the given
-         * body, the given entry values, a child of this block builder's code context, and the given code transformer.
+         * This method behaves as if invoking {@link #transformBody(Body, List, CodeContext, CodeTransformer)} with the
+         * given body, the given entry values, a child of this block builder's code context, and the given code
+         * transformer.
          *
          * @param body the body to transform
          * @param entryValues the output entry values to map, in order, from a prefix of the input body's entry block
@@ -703,11 +723,9 @@ public final class Block implements CodeElement<Block, Op> {
          * Any remaining entry block parameters are not mapped.
          *
          * @apiNote
-         * Supplying an explicit code context can ensure block and value mappings produced by the transformation do not
-         * affect this builder's code context. The explicit code context can also be used when some of the input body's
-         * entry block parameters have already been mapped prior to transforming the body. This is useful when the
-         * transformation removes some entry block parameters. In such cases an empty list of output entry values can be
-         * given.
+         * Supplying an explicit code context is useful when some of the input body's entry block parameters have
+         * already been mapped prior to transforming the body. For example, when the transformation removes some entry
+         * block parameters. In such cases an empty list of output entry values can be given.
          *
          * @param body the body to transform
          * @param entryValues the output entry values to map, in order, from a prefix of the input body's entry block

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -499,9 +499,14 @@ public final class Body implements CodeElement<Body, Block> {
      */
     public final class Builder {
         /**
-         * Creates a body builder, with an entry block {@link #entryBlock builder} that has a
+         * Creates a body builder, with an entry block {@link #entryBlock builder} that has a code context and code
+         * transformer derived from {@code connectedAncestorBody}.
+         * <p>
+         * If {@code connectedAncestorBody} is {@code null} then the entry block builder has a
          * {@link CodeContext#create() new} code context and a {@link CodeTransformer#COPYING_TRANSFORMER copying}
          * code transformer.
+         * If {@code connectedAncestorBody} is {@code non-null} then the entry block builder has the same code context
+         * and code transformer as {@code connectedAncestorBody}'s entry block builder.
          *
          * @param connectedAncestorBody  the nearest ancestor body builder if the created body builder is connected, or
          * {@code null} if the created body builder is isolated
@@ -511,29 +516,48 @@ public final class Body implements CodeElement<Body, Block> {
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
          */
         public static Builder of(Builder connectedAncestorBody, FunctionType bodySignature) {
-            // @@@ Creation of CodeContext
-            return of(connectedAncestorBody, bodySignature, CodeContext.create(), CodeTransformer.COPYING_TRANSFORMER);
+            Block.Builder connectedEntryBlockBuilder = connectedAncestorBody != null
+                ? connectedAncestorBody.entryBlock()
+                : null;
+            CodeContext cc = connectedEntryBlockBuilder != null
+                    ? CodeContext.create(connectedEntryBlockBuilder.context())
+                    : CodeContext.create();
+            CodeTransformer ct = connectedEntryBlockBuilder != null
+                    ? connectedEntryBlockBuilder.transformer()
+                    : CodeTransformer.COPYING_TRANSFORMER;
+            return of(connectedAncestorBody, bodySignature, cc, ct);
         }
 
         /**
-         * Creates a body builder, with an entry block {@link #entryBlock builder} that has the given code context
-         * and a {@link CodeTransformer#COPYING_TRANSFORMER copying} code transformer.
+         * Creates a body builder, with an entry block {@link #entryBlock builder} that has a code context derived
+         * from {@code connectedAncestorBody} and the given code transformer.
+         * <p>
+         * If {@code connectedAncestorBody} is {@code null}, then the entry block builder has a
+         * {@link CodeContext#create() new} code context.
+         * If {@code connectedAncestorBody} is {@code non-null}, then the entry block builder has the same code context
+         * as {@code connectedAncestorBody}'s entry block builder.
          *
          * @param connectedAncestorBody  the nearest ancestor body builder if the created body builder is connected, or
          * {@code null} if the created body builder is isolated
          * @param bodySignature the initial body signature
-         * @param cc            the code context
+         * @param ct            the code transformer for the entry block builder
          * @return the body builder
          * @throws IllegalStateException if the ancestor body builder is finished
          * @see #of(Builder, FunctionType, CodeContext, CodeTransformer)
          */
-        public static Builder of(Builder connectedAncestorBody, FunctionType bodySignature, CodeContext cc) {
-            return of(connectedAncestorBody, bodySignature, cc, CodeTransformer.COPYING_TRANSFORMER);
+        public static Builder of(Builder connectedAncestorBody, FunctionType bodySignature, CodeTransformer ct) {
+            Block.Builder connectedEntryBlockBuilder = connectedAncestorBody != null
+                    ? connectedAncestorBody.entryBlock()
+                    : null;
+            CodeContext cc = connectedEntryBlockBuilder != null
+                    ? CodeContext.create(connectedEntryBlockBuilder.context())
+                    : CodeContext.create();
+            return of(connectedAncestorBody, bodySignature, cc, ct);
         }
 
         /**
-         * Creates a body builder whose entry block {@link #entryBlock builder} uses the given code context and code
-         * transformer.
+         * Creates a body builder, with an entry block {@link #entryBlock builder} that has the given code context and
+         * code transformer.
          * <p>
          * If {@code connectedAncestorBody} is non-{@code null}, the created body builder is
          * <a id="connected-builder"><i>connected</i></a> to {@code connectedAncestorBody} as the

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/Body.java
@@ -505,8 +505,9 @@ public final class Body implements CodeElement<Body, Block> {
          * If {@code connectedAncestorBody} is {@code null} then the entry block builder has a
          * {@link CodeContext#create() new} code context and a {@link CodeTransformer#COPYING_TRANSFORMER copying}
          * code transformer.
-         * If {@code connectedAncestorBody} is {@code non-null} then the entry block builder has the same code context
-         * and code transformer as {@code connectedAncestorBody}'s entry block builder.
+         * If {@code connectedAncestorBody} is {@code non-null} then the entry block builder has a
+         * {@link CodeContext#create(CodeContext) child} of {@code connectedAncestorBody}'s entry block builder's code
+         * context and the same code transformer as {@code connectedAncestorBody}'s entry block builder.
          *
          * @param connectedAncestorBody  the nearest ancestor body builder if the created body builder is connected, or
          * {@code null} if the created body builder is isolated
@@ -534,6 +535,10 @@ public final class Body implements CodeElement<Body, Block> {
          * <p>
          * If {@code connectedAncestorBody} is {@code null}, then the entry block builder has a
          * {@link CodeContext#create() new} code context.
+         * If {@code connectedAncestorBody} is {@code non-null} then the entry block builder has a
+         * {@link CodeContext#create(CodeContext) child} of {@code connectedAncestorBody}'s entry block builder's code
+         * context.
+         *
          * If {@code connectedAncestorBody} is {@code non-null}, then the entry block builder has the same code context
          * as {@code connectedAncestorBody}'s entry block builder.
          *

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5522,25 +5522,24 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// @jls 14.20.3 try-with-resources
         /// @jls 14.20.3.2 Extended try-with-resources
         Op.Result normalizeExtendedTryWithResources(Block.Builder b) {
-            CodeTransformer ct = b.transformer();
             if (handlers.isEmpty() && finallyBody == null) {
-                return b.add(normalizeExtendedTryWithResources(b.parentBody(), b.context(), ct, new ArrayList<>()));
+                return b.add(normalizeExtendedTryWithResources(b.parentBody(), new ArrayList<>()));
             }
 
             CatchBuilder catchBuilder = try_(b.parentBody(), tryBlock -> {
-                tryBlock.add(normalizeExtendedTryWithResources(tryBlock.parentBody(), b.context(), ct, new ArrayList<>()));
+                tryBlock.add(normalizeExtendedTryWithResources(tryBlock.parentBody(), new ArrayList<>()));
                 tryBlock.add(core_yield());
             });
             List<CodeType> catchTypes = catchTypes();
             for (int i = 0; i < handlers.size(); i++) {
                 Body catcher = handlers.get(i);
                 catchBuilder.catch_(catchTypes.get(i), catcher.bodySignature().parameterTypes().getFirst(), catchBlock ->
-                        catchBlock.transformBody(catcher, catchBlock.parameters(), b.context(), ct));
+                        catchBlock.transformBody(catcher, catchBlock.parameters()));
             }
             return b.add(finallyBody == null
                     ? catchBuilder.noFinalizer()
                     : catchBuilder.finally_(finallyBlock ->
-                            finallyBlock.transformBody(finallyBody, List.of(), b.context(), ct)));
+                            finallyBlock.transformBody(finallyBody, List.of())));
         }
 
         /// Recursive step for extended try-with-resources.
@@ -5548,18 +5547,18 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// The next resource becomes the current outer basic try-with-resources.
         ///
         /// @jls 14.20.3.2 Extended try-with-resources
-        TryOp normalizeExtendedTryWithResources(Body.Builder anc, CodeContext ctx, CodeTransformer ct, List<Value> res) {
+        TryOp normalizeExtendedTryWithResources(Body.Builder anc, List<Value> res) {
             Body resource = resourcesBodies.get(res.size());
-            Body.Builder resourceBody = Body.Builder.of(anc, CoreType.functionType(resource.yieldType()), ctx, ct);
-            resourceBody.entryBlock().transformBody(resource, res, ctx, ct);
-            Body.Builder basicBody = Body.Builder.of(anc, CoreType.functionType(VOID, List.of(resource.yieldType())), ctx, ct);
+            Body.Builder resourceBody = Body.Builder.of(anc, CoreType.functionType(resource.yieldType()));
+            resourceBody.entryBlock().transformBody(resource, res);
+            Body.Builder basicBody = Body.Builder.of(anc, CoreType.functionType(VOID, List.of(resource.yieldType())));
             Block.Builder bodyBlock = basicBody.entryBlock();
             res.add(bodyBlock.parameters().getFirst());
             if (res.size() < resourcesBodies.size()) {
-                bodyBlock.add(normalizeExtendedTryWithResources(basicBody, ctx, ct, res));
+                bodyBlock.add(normalizeExtendedTryWithResources(basicBody, res));
                 bodyBlock.add(core_yield());
             } else {
-                bodyBlock.transformBody(body, res, ctx, ct);
+                bodyBlock.transformBody(body, res);
             }
             return try_(List.of(resourceBody), basicBody, List.of(), null);
         }
@@ -5589,7 +5588,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// @jls 14.20.3.1 Basic try-with-resources
         Op.Result normalizeBasicTryWithResources(Block.Builder b) {
             assert resourcesBodies.size() == 1;
-            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID), b.context(), b.transformer());
+            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID));
             Block.Builder entryBlock = normalizedBody.entryBlock();
             Body resourceBody = resourcesBodies.getFirst();
             CodeType resourceType = resourceBody.bodySignature().returnType();
@@ -5613,7 +5612,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             Value primaryExceptionVar = afterAcquire.add(var(afterAcquire.add(constant(type(Throwable.class), null))));
             // @@@ following builder code may be refactored into a reflected template method transformation
             afterAcquire.add(try_(entryBlock.parentBody(), tryEntry -> {
-                tryEntry.transformBody(body, List.of(resourceArgument), afterAcquire.context(), b.transformer());
+                tryEntry.transformBody(body, List.of(resourceArgument));
             }).catch_(type(Throwable.class), catchB -> {
                 Block.Parameter thrown = catchB.parameters().getFirst();
                 catchB.add(varStore(primaryExceptionVar, thrown));
@@ -5676,7 +5675,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         ///
         /// @jls 14.20.2 Execution of try-finally and try-catch-finally
         private Op.Result normalizeFinalizer(Block.Builder b) {
-            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID), b.context());
+            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID));
             Block.Builder output = normalizedBody.entryBlock();
             Value completionVar = output.add(var(output.add(constant(INT, 0))));
             Value exceptionVar = output.add(var(output.add(constant(type(Throwable.class), null))));
@@ -5688,18 +5687,17 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
             CatchBuilder protectedTry = try_(labeledBody, tryBlock -> {
                 if (handlers.isEmpty()) {
-                    tryBlock.transformBody(body, List.of(), output.context(),
+                    tryBlock.transformBody(body, List.of(),
                             finalizerExitTransformer(body, exitLabel, completionVar, exits, output));
                 } else {
                     CatchBuilder innerTry = try_(tryBlock.parentBody(), innerBlock ->
-                            innerBlock.transformBody(body, List.of(), output.context(),
+                            innerBlock.transformBody(body, List.of(),
                                     finalizerExitTransformer(body, exitLabel, completionVar, exits, output)));
                     List<CodeType> catchTypes = catchTypes();
                     for (int i = 0; i < handlers.size(); i++) {
                         Body catcher = handlers.get(i);
                         innerTry.catch_(catchTypes.get(i), catcher.bodySignature().parameterTypes().getFirst(),
-                                catchBlock -> catchBlock.transformBody(
-                                        catcher, catchBlock.parameters(), output.context(),
+                                catchBlock -> catchBlock.transformBody(catcher, catchBlock.parameters(),
                                         finalizerExitTransformer(catcher, exitLabel, completionVar, exits, output)));
                     }
                     tryBlock.add(innerTry.noFinalizer());

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5764,7 +5764,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     return b;
                 }
                 if (op instanceof StatementTargetOp targetOp && targetOp.exits(this)) {
-                    exits.add(new FinallyExit(targetOp.transform(b.context(), CodeTransformer.COPYING_TRANSFORMER), null));
+                    exits.add(new FinallyExit(targetOp, null));
                     completeFinalizer(b, exitLabel, completionVar, exits.size() + 1);
                     return b;
                 }

--- a/test/jdk/jdk/incubator/code/TestBuild.java
+++ b/test/jdk/jdk/incubator/code/TestBuild.java
@@ -38,9 +38,9 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.AccessFlag;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntBinaryOperator;
+import java.util.function.Supplier;
 
 import static jdk.incubator.code.dialect.core.CoreOp.*;
 import static jdk.incubator.code.dialect.core.CoreType.FUNCTION_TYPE_VOID;
@@ -400,6 +400,84 @@ public class TestBuild {
         block.add(constant(INT, 0));
 
         Assertions.assertThrows(IllegalStateException.class, () -> func("f", body));
+    }
+
+    @Test
+    public void testBodyBuilderContextAndTransformer() {
+        var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+        Assertions.assertNull(body.entryBlock().context().parent());
+        Assertions.assertEquals(CodeTransformer.COPYING_TRANSFORMER, body.entryBlock().transformer());
+
+        {
+            var childBody = Body.Builder.of(body, FUNCTION_TYPE_VOID);
+            Assertions.assertEquals(body.entryBlock().context(), childBody.entryBlock().context().parent());
+            Assertions.assertEquals(body.entryBlock().transformer(), childBody.entryBlock().transformer());
+        }
+
+        {
+            CodeTransformer myTransformer = (b, o) -> b;
+            var childBody = Body.Builder.of(body, FUNCTION_TYPE_VOID, myTransformer);
+            Assertions.assertEquals(body.entryBlock().context(), childBody.entryBlock().context().parent());
+            Assertions.assertEquals(myTransformer, childBody.entryBlock().transformer());
+        }
+
+        {
+            var cc = CodeContext.create();
+            CodeTransformer ct = (b, o) -> b;
+            var childBody = Body.Builder.of(body, FUNCTION_TYPE_VOID, cc, ct);
+            Assertions.assertEquals(cc, childBody.entryBlock().context());
+            Assertions.assertEquals(ct, childBody.entryBlock().transformer());
+        }
+    }
+
+    @Test
+    public void testBlockBuilderContextAndTransformer() {
+        @Reflect
+        Runnable r = () -> IO.println("A");
+        var op = Op.ofLambda(r).orElseThrow().op();
+
+        record Pair(CodeContext cc, CodeTransformer ct) {
+        }
+        Pair[] holder = new Pair[1];
+        CodeTransformer ct = (b, o) -> {
+            holder[0] = new Pair(b.context(), b.transformer());
+            return b;
+        };
+
+        {
+            var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+            var cc = CodeContext.create();
+            var block = body.entryBlock().withContextAndTransformer(cc, ct);
+
+            block.transformBody(op.body(), List.of());
+
+            Assertions.assertEquals(cc, holder[0].cc.parent());
+            Assertions.assertEquals(ct, holder[0].ct);
+            holder[0] = null;
+        }
+
+        {
+            var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+            var block = body.entryBlock();
+
+            block.transformBody(op.body(), List.of(), ct);
+
+            Assertions.assertEquals(block.context(), holder[0].cc.parent());
+            Assertions.assertEquals(ct, holder[0].ct);
+            holder[0] = null;
+        }
+
+        {
+            var body = Body.Builder.of(null, FUNCTION_TYPE_VOID);
+            var cc = CodeContext.create();
+            var block = body.entryBlock();
+
+            block.transformBody(op.body(), List.of(), cc, ct);
+
+            Assertions.assertEquals(cc, holder[0].cc);
+            Assertions.assertEquals(ct, holder[0].ct);
+            holder[0] = null;
+        }
     }
 
     @Test

--- a/test/jdk/jdk/incubator/code/anf/AnfTransformer.java
+++ b/test/jdk/jdk/incubator/code/anf/AnfTransformer.java
@@ -60,7 +60,7 @@ public class AnfTransformer {
             builderEntry.context().mapValue(p,newP);
         }
 
-        var outerLetRecBody = Body.Builder.of(outerBodyBuilder, CoreType.functionType(b.yieldType(), List.of()), CodeContext.create(builderEntry.context()));
+        var outerLetRecBody = Body.Builder.of(outerBodyBuilder, CoreType.functionType(b.yieldType(), List.of()));
 
         List<Block> dominatedBlocks = idomMap.idominates(entry);
         List<AnfDialect.AnfFuncOp> funs = dominatedBlocks.stream().map(block -> transformBlock(block, outerLetRecBody)).toList();
@@ -87,7 +87,7 @@ public class AnfTransformer {
 
         var blockFTypeSynth = CoreType.functionType(blockReturnType, synthParamTypes);
 
-        Body.Builder newBodyBuilder = Body.Builder.of(ancestorBodyBuilder, blockFTypeSynth, CodeContext.create(ancestorBodyBuilder.entryBlock().context()));
+        Body.Builder newBodyBuilder = Body.Builder.of(ancestorBodyBuilder, blockFTypeSynth);
 
         var selfRefParam = newBodyBuilder.entryBlock().parameters().get(0);
         funMap.put(b, selfRefParam);
@@ -97,7 +97,7 @@ public class AnfTransformer {
             newBodyBuilder.entryBlock().context().mapValue(param, p);
         }
 
-        var letBody = Body.Builder.of(newBodyBuilder, CoreType.functionType(blockReturnType, List.of()), CodeContext.create(newBodyBuilder.entryBlock().context()));
+        var letBody = Body.Builder.of(newBodyBuilder, CoreType.functionType(blockReturnType, List.of()));
 
         AnfDialect.AnfLetOp let = transformOps(b, letBody);
         newBodyBuilder.entryBlock().add(let);
@@ -115,7 +115,7 @@ public class AnfTransformer {
         var blockFTypeSynth = CoreType.functionType(blockReturnType, synthParamTypes);
 
         //Function body contains letrec and its bodies
-        Body.Builder funcBodyBuilder = Body.Builder.of(ancestorBodyBuilder, blockFTypeSynth, CodeContext.create(ancestorBodyBuilder.entryBlock().context()));
+        Body.Builder funcBodyBuilder = Body.Builder.of(ancestorBodyBuilder, blockFTypeSynth);
 
         //Self param
         var selfRefParam = funcBodyBuilder.entryBlock().parameters().get(0);
@@ -127,7 +127,7 @@ public class AnfTransformer {
         }
 
         //letrec inner body
-        Body.Builder letrecBody = Body.Builder.of(funcBodyBuilder, CoreType.functionType(blockReturnType, List.of()), CodeContext.create(funcBodyBuilder.entryBlock().context()));
+        Body.Builder letrecBody = Body.Builder.of(funcBodyBuilder, CoreType.functionType(blockReturnType, List.of()));
 
         List<Block> dominates = idomMap.idominates(b);
         for (Block dblock : dominates) {
@@ -136,7 +136,7 @@ public class AnfTransformer {
             funMap2.put(dblock, fval);
         }
 
-        var letBody = Body.Builder.of(letrecBody, letrecBody.bodySignature(), CodeContext.create(letrecBody.entryBlock().context()));
+        var letBody = Body.Builder.of(letrecBody, letrecBody.bodySignature());
         transformBlockOps(b, letBody.entryBlock());
         var let = AnfDialect.let(letBody);
 


### PR DESCRIPTION
The `Body.Builder.of` factory methods behavior was confusing with regards to the default code contexts and code transformers.

`Body.Builder.of(Body.Builder connectedAncestorBody, FunctionType bodySignature)` now derives the code context and code transformer from `connectedAncestorBody` if non-`null`. This ensures composite builders behave as expected without the need to explicitly pass contexts and transformers.

The constructor "telescoping" of the three `Body.Builder.of` methods and the three `Block.Builder.transformBody` methods now mirror each other.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1162/head:pull/1162` \
`$ git checkout pull/1162`

Update a local copy of the PR: \
`$ git checkout pull/1162` \
`$ git pull https://git.openjdk.org/babylon.git pull/1162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1162`

View PR using the GUI difftool: \
`$ git pr show -t 1162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1162.diff">https://git.openjdk.org/babylon/pull/1162.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1162#issuecomment-5418362470)
</details>
