### PR TITLE
8391251: Code model creation crashes when a local variable declared in one switch case is assigned in another

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -79,12 +79,14 @@ import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
 import com.sun.tools.javac.tree.JCTree.JCNewArray;
 import com.sun.tools.javac.tree.JCTree.JCNewClass;
 import com.sun.tools.javac.tree.JCTree.JCReturn;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.JCTypeCast;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.JCTree.JCAssert;
 import com.sun.tools.javac.tree.JCTree.Tag;
 import com.sun.tools.javac.tree.TreeInfo;
 import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
@@ -1644,6 +1646,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                                                           List<JCTree.JCCase> cases, FunctionType caseBodyType,
                                                           boolean isDefaultCaseNeeded) {
             List<Body.Builder> bodies = new ArrayList<>();
+            Map<Symbol, JCVariableDecl> prevCaseVars = new LinkedHashMap<>();
             boolean hasDefaultCase = false;
             boolean handlesNull = false;
 
@@ -1655,7 +1658,8 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     hasDefaultCase = true;
                 }
                 Body.Builder caseLabel = visitCaseLabel(tree, target, c);
-                Body.Builder caseBody = visitCaseBody(tree, c, caseBodyType, cases.getLast() == c);
+                Body.Builder caseBody = visitCaseBody(tree, c, prevCaseVars, caseBodyType, cases.getLast() == c);
+                addVars(c.stats, prevCaseVars);
                 bodies.add(caseLabel);
                 bodies.add(caseBody);
             }
@@ -1681,6 +1685,15 @@ public class ReflectMethods extends TreeTranslatorPrev {
             }
 
             return new SwitchBodyInfo(handlesNull, bodies);
+        }
+
+        private static void addVars(com.sun.tools.javac.util.List<JCStatement> stats, Map<Symbol, JCVariableDecl> vars) {
+            for (; stats.nonEmpty(); stats = stats.tail) {
+                JCTree stat = stats.head;
+                if (stat.hasTag(Tag.VARDEF)) {
+                    vars.put(((JCVariableDecl) stat).sym, (JCVariableDecl) stat);
+                }
+            }
         }
 
         boolean handlesNull(JCTree.JCCase caseTree) {
@@ -1815,7 +1828,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             return body;
         }
 
-        private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, FunctionType caseBodyType, boolean isLastCase) {
+        private Body.Builder visitCaseBody(JCTree tree, JCTree.JCCase c, Map<Symbol, JCVariableDecl> prevCaseVars, FunctionType caseBodyType, boolean isLastCase) {
             Body.Builder body = null;
 
             switch (c.caseKind) {
@@ -1841,6 +1854,11 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     // boolean oneBlock = c.stats.size() == 1 && c.stats.head instanceof JCBlock;
                     pushBody(c, caseBodyType);
 
+                    for (JCVariableDecl var : assignedIn(prevCaseVars, c.stats)) {
+                        result = append(CoreOp.var(var.name.toString(), typeToCodeType(var.type)));
+                        stack.localToOp.put(var.sym, result);
+                    }
+
                     scan(c.stats);
 
                     appendTerminating(c.completesNormally
@@ -1854,6 +1872,27 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 }
             }
             return body;
+        }
+
+        private Set<JCVariableDecl> assignedIn(Map<Symbol, JCVariableDecl> vars, com.sun.tools.javac.util.List<JCStatement> stats) {
+            final Set<JCVariableDecl> initVars = new LinkedHashSet<>();
+            new TreeScanner() {
+                @Override
+                public void visitAssign(JCAssign tree) {
+                    JCVariableDecl var = vars.get(TreeInfo.symbol(TreeInfo.skipParens(tree.lhs)));
+                    if (var != null) {
+                        initVars.add(var);
+                    }
+                    super.visitAssign(tree);
+                }
+                @Override
+                public void visitLambda(JCLambda tree) {
+                }
+                @Override
+                public void visitClassDef(JCClassDecl tree) {
+                }
+            }.scan(stats);
+            return initVars;
         }
 
         @Override

--- a/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
@@ -695,6 +695,93 @@ public class TestSwitchStatementOp {
         return r;
     }
 
+    @Reflect
+    private static int caseReassignVar(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                i = 2;
+                return i;
+            default:
+                return -1;
+        }
+    }
+
+    @Reflect
+    private static int caseReassignVarFallThrough(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+            case 1:
+                i = 2;
+                return i;
+            default:
+                return -1;
+        }
+    }
+
+    @Reflect
+    private static int caseReassignVarNested(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                int j = (i = 2);
+                return i + j;
+            default:
+                return -1;
+        }
+    }
+
+    @Reflect
+    private static int caseReassignVarNestedBlock(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                {
+                    i = 2;
+                }
+                return i;
+            default:
+                return -1;
+        }
+    }
+
+    @Reflect
+    private static int caseReassignVarExpression(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                return i = 2;
+            default:
+                return -1;
+        }
+    }
+
+    @Test
+    void testCaseReassignVar() {
+        CoreOp.FuncOp lfrv = lower("caseReassignVar");
+        CoreOp.FuncOp lfrvft = lower("caseReassignVarFallThrough");
+        CoreOp.FuncOp lfrvn = lower("caseReassignVarNested");
+        CoreOp.FuncOp lfrvnb = lower("caseReassignVarNestedBlock");
+        CoreOp.FuncOp lfrve = lower("caseReassignVarExpression");
+        int[] args = {0, 1, 2};
+        for (int a : args) {
+            Assertions.assertEquals(caseReassignVar(a), Interpreter.invoke(MethodHandles.lookup(), lfrv, a));
+            Assertions.assertEquals(caseReassignVarFallThrough(a), Interpreter.invoke(MethodHandles.lookup(), lfrvft, a));
+            Assertions.assertEquals(caseReassignVarNested(a), Interpreter.invoke(MethodHandles.lookup(), lfrvn, a));
+            Assertions.assertEquals(caseReassignVarNestedBlock(a), Interpreter.invoke(MethodHandles.lookup(), lfrvnb, a));
+            Assertions.assertEquals(caseReassignVarExpression(a), Interpreter.invoke(MethodHandles.lookup(), lfrve, a));
+        }
+    }
+
     private static CoreOp.FuncOp lower(String methodName) {
         return lower(getCodeModel(methodName));
     }

--- a/test/langtools/tools/javac/reflect/SwitchStatementTest.java
+++ b/test/langtools/tools/javac/reflect/SwitchStatementTest.java
@@ -2637,4 +2637,273 @@ public class SwitchStatementTest {
         }
         return r;
     }
+
+    @IR("""
+        func @"caseReassignVar" (%0 : java.type:"int")java.type:"int" -> {
+            %1 : Var<java.type:"int"> = var %0 @"sel";
+            %2 : java.type:"int" = var.load %1;
+            java.switch.statement %2
+                (%3 : java.type:"int")java.type:"boolean" -> {
+                    %4 : java.type:"int" = constant @0;
+                    %5 : java.type:"boolean" = eq %3 %4;
+                    yield %5;
+                }
+                ()java.type:"void" -> {
+                    %6 : java.type:"int" = constant @1;
+                    %7 : Var<java.type:"int"> = var %6 @"i";
+                    %8 : java.type:"int" = var.load %7;
+                    return %8;
+                }
+                (%9 : java.type:"int")java.type:"boolean" -> {
+                    %10 : java.type:"int" = constant @1;
+                    %11 : java.type:"boolean" = eq %9 %10;
+                    yield %11;
+                }
+                ()java.type:"void" -> {
+                    %12 : Var<java.type:"int"> = var @"i";
+                    %13 : java.type:"int" = constant @2;
+                    var.store %12 %13;
+                    %14 : java.type:"int" = var.load %12;
+                    return %14;
+                }
+                ()java.type:"boolean" -> {
+                    %15 : java.type:"boolean" = constant @true;
+                    yield %15;
+                }
+                ()java.type:"void" -> {
+                    %16 : java.type:"int" = constant @-1;
+                    return %16;
+                };
+            unreachable;
+        };
+        """)
+    @Reflect
+    private static int caseReassignVar(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                i = 2;
+                return i;
+            default:
+                return -1;
+        }
+    }
+
+    @IR("""
+        func @"caseReassignVarFallThrough" (%0 : java.type:"int")java.type:"int" -> {
+            %1 : Var<java.type:"int"> = var %0 @"sel";
+            %2 : java.type:"int" = var.load %1;
+            java.switch.statement %2
+                (%3 : java.type:"int")java.type:"boolean" -> {
+                    %4 : java.type:"int" = constant @0;
+                    %5 : java.type:"boolean" = eq %3 %4;
+                    yield %5;
+                }
+                ()java.type:"void" -> {
+                    %6 : java.type:"int" = constant @1;
+                    %7 : Var<java.type:"int"> = var %6 @"i";
+                    java.switch.fallthrough;
+                }
+                (%9 : java.type:"int")java.type:"boolean" -> {
+                    %10 : java.type:"int" = constant @1;
+                    %11 : java.type:"boolean" = eq %9 %10;
+                    yield %11;
+                }
+                ()java.type:"void" -> {
+                    %12 : Var<java.type:"int"> = var @"i";
+                    %13 : java.type:"int" = constant @2;
+                    var.store %12 %13;
+                    %14 : java.type:"int" = var.load %12;
+                    return %14;
+                }
+                ()java.type:"boolean" -> {
+                    %15 : java.type:"boolean" = constant @true;
+                    yield %15;
+                }
+                ()java.type:"void" -> {
+                    %16 : java.type:"int" = constant @-1;
+                    return %16;
+                };
+            unreachable;
+        };
+        """)
+    @Reflect
+    private static int caseReassignVarFallThrough(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+            case 1:
+                i = 2;
+                return i;
+            default:
+                return -1;
+        }
+    }
+
+    @IR("""
+        func @"caseReassignVarNested" (%0 : java.type:"int")java.type:"int" -> {
+            %1 : Var<java.type:"int"> = var %0 @"sel";
+            %2 : java.type:"int" = var.load %1;
+            java.switch.statement %2
+                (%3 : java.type:"int")java.type:"boolean" -> {
+                    %4 : java.type:"int" = constant @0;
+                    %5 : java.type:"boolean" = eq %3 %4;
+                    yield %5;
+                }
+                ()java.type:"void" -> {
+                    %6 : java.type:"int" = constant @1;
+                    %7 : Var<java.type:"int"> = var %6 @"i";
+                    %8 : java.type:"int" = var.load %7;
+                    return %8;
+                }
+                (%9 : java.type:"int")java.type:"boolean" -> {
+                    %10 : java.type:"int" = constant @1;
+                    %11 : java.type:"boolean" = eq %9 %10;
+                    yield %11;
+                }
+                ()java.type:"void" -> {
+                    %12 : Var<java.type:"int"> = var @"i";
+                    %13 : java.type:"int" = constant @2;
+                    var.store %12 %13;
+                    %14 : Var<java.type:"int"> = var %13 @"j";
+                    %15 : java.type:"int" = var.load %12;
+                    %16 : java.type:"int" = var.load %14;
+                    %17 : java.type:"int" = add %15 %16;
+                    return %17;
+                }
+                ()java.type:"boolean" -> {
+                    %18 : java.type:"boolean" = constant @true;
+                    yield %18;
+                }
+                ()java.type:"void" -> {
+                    %19 : java.type:"int" = constant @-1;
+                    return %19;
+                };
+            unreachable;
+        };
+        """)
+    @Reflect
+    private static int caseReassignVarNested(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                int j = (i = 2);
+                return i + j;
+            default:
+                return -1;
+        }
+    }
+
+    @IR("""
+        func @"caseReassignVarNestedBlock" (%0 : java.type:"int")java.type:"int" -> {
+            %1 : Var<java.type:"int"> = var %0 @"sel";
+            %2 : java.type:"int" = var.load %1;
+            java.switch.statement %2
+                (%3 : java.type:"int")java.type:"boolean" -> {
+                    %4 : java.type:"int" = constant @0;
+                    %5 : java.type:"boolean" = eq %3 %4;
+                    yield %5;
+                }
+                ()java.type:"void" -> {
+                    %6 : java.type:"int" = constant @1;
+                    %7 : Var<java.type:"int"> = var %6 @"i";
+                    %8 : java.type:"int" = var.load %7;
+                    return %8;
+                }
+                (%9 : java.type:"int")java.type:"boolean" -> {
+                    %10 : java.type:"int" = constant @1;
+                    %11 : java.type:"boolean" = eq %9 %10;
+                    yield %11;
+                }
+                ()java.type:"void" -> {
+                    %12 : Var<java.type:"int"> = var @"i";
+                    java.block ()java.type:"void" -> {
+                        %13 : java.type:"int" = constant @2;
+                        var.store %12 %13;
+                        yield;
+                    };
+                    %14 : java.type:"int" = var.load %12;
+                    return %14;
+                }
+                ()java.type:"boolean" -> {
+                    %15 : java.type:"boolean" = constant @true;
+                    yield %15;
+                }
+                ()java.type:"void" -> {
+                    %16 : java.type:"int" = constant @-1;
+                    return %16;
+                };
+            unreachable;
+        };
+        """)
+    @Reflect
+    private static int caseReassignVarNestedBlock(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                {
+                    i = 2;
+                }
+                return i;
+            default:
+                return -1;
+        }
+    }
+
+    @IR("""
+        func @"caseReassignVarExpression" (%0 : java.type:"int")java.type:"int" -> {
+            %1 : Var<java.type:"int"> = var %0 @"sel";
+            %2 : java.type:"int" = var.load %1;
+            java.switch.statement %2
+                (%3 : java.type:"int")java.type:"boolean" -> {
+                    %4 : java.type:"int" = constant @0;
+                    %5 : java.type:"boolean" = eq %3 %4;
+                    yield %5;
+                }
+                ()java.type:"void" -> {
+                    %6 : java.type:"int" = constant @1;
+                    %7 : Var<java.type:"int"> = var %6 @"i";
+                    %8 : java.type:"int" = var.load %7;
+                    return %8;
+                }
+                (%9 : java.type:"int")java.type:"boolean" -> {
+                    %10 : java.type:"int" = constant @1;
+                    %11 : java.type:"boolean" = eq %9 %10;
+                    yield %11;
+                }
+                ()java.type:"void" -> {
+                    %12 : Var<java.type:"int"> = var @"i";
+                    %13 : java.type:"int" = constant @2;
+                    var.store %12 %13;
+                    return %13;
+                }
+                ()java.type:"boolean" -> {
+                    %14 : java.type:"boolean" = constant @true;
+                    yield %14;
+                }
+                ()java.type:"void" -> {
+                    %15 : java.type:"int" = constant @-1;
+                    return %15;
+                };
+            unreachable;
+        };
+        """)
+    @Reflect
+    private static int caseReassignVarExpression(int sel) {
+        switch (sel) {
+            case 0:
+                int i = 1;
+                return i;
+            case 1:
+                return i = 2;
+            default:
+                return -1;
+        }
+    }
 }


### PR DESCRIPTION
Consider the following code snippet:
```
@Reflect
static int test(int sel) {
    switch (sel) {
        case 0:
            int i = 1;
            return i;
        case 1:
            i = 2;
            return i;
        default:
            return -1;
    }
}
```
When creating a code model for a switch statement, `ReflectMethods` crashes if a local variable is declared in one statement-style case and assigned in a subsequent case. This is valid Java because the variable’s scope extends to the end of the switch block.
```
java.util.NoSuchElementException: i
at jdk.incubator.code/jdk.incubator.code.internal.ReflectMethods$BodyScanner.varOpValue(ReflectMethods.java:643)
at jdk.incubator.code/jdk.incubator.code.internal.ReflectMethods$BodyScanner.visitAssign(ReflectMethods.java:845)
...
```
The issue is that each switch case is represented by a separate model body, so the `VarOp` created for the declaration is unavailable when translating subsequent case bodies.

This change collects top-level variable declarations from preceding statement groups. Before translating each subsequent case, it identifies variables assigned within that case and creates corresponding uninitialized `VarOp`s in the case body. The assignments can then follow the normal `varStore` path, including assignments within nested blocks or assignment expressions.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8391251](https://bugs.openjdk.org/browse/JDK-8391251): Code model creation crashes when a local variable declared in one switch case is assigned in another (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1164/head:pull/1164` \
`$ git checkout pull/1164`

Update a local copy of the PR: \
`$ git checkout pull/1164` \
`$ git pull https://git.openjdk.org/babylon.git pull/1164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1164`

View PR using the GUI difftool: \
`$ git pr show -t 1164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1164.diff">https://git.openjdk.org/babylon/pull/1164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1164#issuecomment-5452084451)
</details>
