### PR TITLE
Improve lowering of boolean expressions with control flow

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ContextStackArg.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ContextStackArg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,33 +22,26 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package jdk.incubator.code.dialect.java;
 
-package jdk.incubator.code.internal;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import jdk.incubator.code.Block;
 import jdk.incubator.code.CodeContext;
-import jdk.incubator.code.CodeElement;
 
-public record BranchTarget(Block.Builder breakBlock, Block.Builder continueBlock) {
+import java.util.ArrayDeque;
 
-    static final Object BRANCH_TARGET_MAP_PROPERTY_KEY = new Object();
+final class ContextStackArg<T> {
 
-    public static BranchTarget getBranchTarget(CodeContext cc, CodeElement<?, ?> codeElement) {
+    void push(CodeContext cc, T arg) {
         @SuppressWarnings("unchecked")
-        var branchMap = (Map<CodeElement<?, ?>, BranchTarget>) cc.getProperty(BRANCH_TARGET_MAP_PROPERTY_KEY);
-        return branchMap != null
-                ? branchMap.get(codeElement)
-                : null;
+        var argStack = (ArrayDeque<T>) cc.computePropertyIfAbsent(this,
+                _ -> new ArrayDeque<>(1));
+        argStack.push(arg);
     }
 
-    public static void setBranchTarget(CodeContext cc, CodeElement<?, ?> codeElement,
-                                       Block.Builder breakBlock, Block.Builder continueBlock) {
+    T poll(CodeContext cc) {
         @SuppressWarnings("unchecked")
-        var branchMap = (Map<CodeElement<?, ?>, BranchTarget>) cc.computePropertyIfAbsent(
-                BRANCH_TARGET_MAP_PROPERTY_KEY, k -> new HashMap<>());
-        branchMap.put(codeElement, new BranchTarget(breakBlock, continueBlock));
+        var argStack = (ArrayDeque<T>) cc.getProperty(this);
+        return argStack != null
+                ? argStack.poll()
+                : null;
     }
 }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ControlFlowBooleanExpressionOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ControlFlowBooleanExpressionOp.java
@@ -35,7 +35,30 @@ import static jdk.incubator.code.Op.Lowerable.loweringTransformer;
 /**
  * An operation characteristic indicating that an operation can model a boolean expression whose evaluation contains
  * control flow. Such operations can lower themselves using a supplied continuation for its boolean result to produce
- * simpler control flow graphs
+ * simpler control flow graphs.
+ * <p>
+ * For example, consider the following code, in which a boolean expression is used by a {@code while} statement:
+ * {@snippet lang = java:
+ * while (a && (b || c)) {
+ *     ...
+ * }
+ * }
+ * The result of the {@code while} loop's boolean expression determines whether the loop body is executed or the loop
+ * finishes. If {@code a} is {@code true} and {@code b} or {@code c} is {@code true} then the loop body is executed.
+ * Conversely, if {@code a} is {@code false} or {@code b} and {@code c} is {@code false} then the loop finishes.
+ * <p>
+ * The code model for this code contains a while operation, modeling the {@code while} statement. When the while
+ * operation lowers itself it creates a boolean result continuation containing block references to the blocks associated
+ * with start of executing the loop body and the loop finishing, referred to respectively as true and false branch
+ * references.
+ * That boolean result continuation is used when lowering operation's predicate body, which models the boolean
+ * expression, the conditional-and operation modeling the conditional-and expression. The continuation is passed along
+ * when lowering the sub-expressions, and when needed the continuation is operated on to continue with a boolean result
+ * or to obtain block references for a statically known boolean result. Consequently, the lowering of the boolean
+ * expression will directly branch to the while operation's continuation's true and false branch references. This is far
+ * more preferable than creating localized control flow behavior that joins to blocks whose boolean block parameter
+ * represents an intermediate boolean result; a result that is then used by a conditional branch operations to continue
+ * towards the blocks of the lowered while operation.
  */
 interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
 
@@ -54,11 +77,11 @@ interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
             codeTransformer = loweringTransformer(inherited, (block, op) -> {
                 if (op == suffix.expression) {
                     // Process the boolean expression
-                    assert op instanceof ControlFlowBooleanExpressionOp;
                     isSuffixProcessed[0] = true;
 
-                    ConditionalBranchContinuation expressionContinuation = suffix.continuationForExpression(block, continuation);
-                    // Push expression continuation as implicit argument to lower method
+                    ConditionalBranchContinuation expressionContinuation =
+                            continuation.forExpression(block, suffix.negatesExpression);
+                    // Pass expression continuation as additional implicit argument
                     BOOLEAN_CONTINUATION_ARG.push(block.context(), expressionContinuation);
                     return suffix.expression.lower(block, inherited);
                 } else if (!isSuffixProcessed[0]) {
@@ -84,23 +107,54 @@ interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
     }
 
     /**
-     * Represents the continuation of a boolean result
+     * Represents the continuation of a boolean result.
+     * <p>
+     * If the lowering of a boolean expression operation needs to continue with expression's boolean result value,
+     * then it can invoke {@link #continueWith(Block.Builder, Value) continueWith}. Otherwise, if lowering statically
+     * knows the value of the expression and requires a block reference targeting a continuing block corresponding to
+     * that known value , then it can invoke {@link #referenceFor(Block.Builder, boolean) referenceFor}.
      */
-    sealed interface BooleanResultContinuation {
+    sealed interface BooleanResultContinuation
+            permits ConditionalBranchContinuation, BranchWithArgumentContinuation {
         /**
+         * Continues with the result of a boolean expression.
+         *
          * @param block the block to add a block terminating operation
          * @param result the boolean result.
          */
         void continueWith(Block.Builder block, Value result);
 
         /**
+         * Creates a block reference to branch to continue the result of the boolean expression when the result is
+         * statically known.
+         *
          * @param block the block to add any necessary operations
          * @param result the static boolean result
-         * @return
+         * @return the block reference to continue the result
          */
         Block.Reference referenceFor(Block.Builder block, boolean result);
+
+        /**
+         * Creates a conditional branch continuation from this continuation to be used as the continuation of a boolean
+         * expression.
+         *
+         * @param negatesExpression true if the result of the expression is negated
+         * @return the conditional branch continuation
+         */
+        default ConditionalBranchContinuation forExpression(Block.Builder block, boolean negatesExpression) {
+            Block.Reference trueRef = referenceFor(block, !negatesExpression);
+            Block.Reference falseRef = referenceFor(block, negatesExpression);
+            return new ConditionalBranchContinuation(trueRef, falseRef);
+        }
     }
 
+    /**
+     * Represents a boolean result continuation as block references to blocks corresponding to continuing the
+     * {@code true} result and the {@code false} result. Both blocks have no parameters.
+     *
+     * @param trueRef the block reference to a block corresponding to continuing the {@code true} result
+     * @param falseRef the block reference to a block corresponding to continuing the {@code false} result
+     */
     record ConditionalBranchContinuation(
             Block.Reference trueRef,
             Block.Reference falseRef) implements BooleanResultContinuation {
@@ -121,8 +175,22 @@ interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
         public Block.Reference referenceFor(Block.Builder block, boolean result) {
             return result ? trueRef : falseRef;
         }
+
+        @Override
+        public ConditionalBranchContinuation forExpression(Block.Builder block, boolean negatesExpression) {
+            return !negatesExpression
+                    ? this
+                    : new ConditionalBranchContinuation(falseRef, trueRef);
+        }
     }
 
+    /**
+     * Represents a boolean result continuation as result block with a boolean parameter, whose value corresponds to
+     * continuing the {@code true} result and the {@code false} result.
+     *
+     * @param resultBlock the result block with a boolean parameter corresponding to continuing the {@code true}
+     *                    and {@code false }result
+     */
     record BranchWithArgumentContinuation(Block.Builder resultBlock) implements BooleanResultContinuation {
         @Override
         public void continueWith(Block.Builder block, Value result) {
@@ -136,11 +204,6 @@ interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
     }
 
     record BooleanExpressionSuffix(ControlFlowBooleanExpressionOp expression, boolean negatesExpression) {
-        ConditionalBranchContinuation continuationForExpression(Block.Builder block, BooleanResultContinuation continuation) {
-            Block.Reference trueRef = continuation.referenceFor(block, !negatesExpression);
-            Block.Reference falseRef = continuation.referenceFor(block, negatesExpression);
-            return new ConditionalBranchContinuation(trueRef, falseRef);
-        }
     }
 
     private static BooleanExpressionSuffix findBooleanExpressionSuffix(Body body) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ControlFlowBooleanExpressionOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ControlFlowBooleanExpressionOp.java
@@ -150,7 +150,7 @@ interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
 
     /**
      * Represents a boolean result continuation as block references to blocks corresponding to continuing the
-     * {@code true} result and the {@code false} result. Both blocks have no parameters.
+     * {@code true} result and the {@code false} result.
      *
      * @param trueRef the block reference to a block corresponding to continuing the {@code true} result
      * @param falseRef the block reference to a block corresponding to continuing the {@code false} result
@@ -185,11 +185,11 @@ interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
     }
 
     /**
-     * Represents a boolean result continuation as result block with a boolean parameter, whose value corresponds to
+     * Represents a boolean result continuation as a result block with a boolean parameter, whose value corresponds to
      * continuing the {@code true} result and the {@code false} result.
      *
      * @param resultBlock the result block with a boolean parameter corresponding to continuing the {@code true}
-     *                    and {@code false }result
+     *                    and {@code false} result
      */
     record BranchWithArgumentContinuation(Block.Builder resultBlock) implements BooleanResultContinuation {
         @Override

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ControlFlowBooleanExpressionOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/ControlFlowBooleanExpressionOp.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.incubator.code.dialect.java;
+
+import jdk.incubator.code.*;
+import jdk.incubator.code.dialect.core.CoreOp;
+
+import java.util.*;
+import java.util.function.BiFunction;
+
+import static jdk.incubator.code.Op.Lowerable.loweringTransformer;
+
+/**
+ * An operation characteristic indicating that an operation can model a boolean expression whose evaluation contains
+ * control flow. Such operations can lower themselves using a supplied continuation for its boolean result to produce
+ * simpler control flow graphs
+ */
+interface ControlFlowBooleanExpressionOp extends Op.Lowerable {
+
+    ContextStackArg<BooleanResultContinuation> BOOLEAN_CONTINUATION_ARG = new ContextStackArg<>();
+
+    static void lowerBooleanBody(
+            Block.Builder startBlock,
+            Body body,
+            List<? extends Value> entryValues,
+            BooleanResultContinuation continuation,
+            BiFunction<Block.Builder, Op, Block.Builder> inherited) {
+        BooleanExpressionSuffix suffix = findBooleanExpressionSuffix(body);
+        CodeTransformer codeTransformer;
+        if (suffix != null) {
+            boolean[] isSuffixProcessed = new boolean[1];
+            codeTransformer = loweringTransformer(inherited, (block, op) -> {
+                if (op == suffix.expression) {
+                    // Process the boolean expression
+                    assert op instanceof ControlFlowBooleanExpressionOp;
+                    isSuffixProcessed[0] = true;
+
+                    ConditionalBranchContinuation expressionContinuation = suffix.continuationForExpression(block, continuation);
+                    // Push expression continuation as implicit argument to lower method
+                    BOOLEAN_CONTINUATION_ARG.push(block.context(), expressionContinuation);
+                    return suffix.expression.lower(block, inherited);
+                } else if (!isSuffixProcessed[0]) {
+                    // Process any operation in the prefix
+                    return null;
+                } else {
+                    // Ignore any operation in the suffix after ControlFlowBooleanExpressionOp
+                    return block;
+                }
+            });
+        } else {
+            codeTransformer = loweringTransformer(inherited, (block, op) -> {
+                if (op instanceof CoreOp.YieldOp yield) {
+                    Value booleanResult = block.context().getValue(yield.yieldValue());
+                    continuation.continueWith(block, booleanResult);
+                    return block;
+                } else {
+                    return null;
+                }
+            });
+        }
+        startBlock.transformBody(body, entryValues, codeTransformer);
+    }
+
+    /**
+     * Represents the continuation of a boolean result
+     */
+    sealed interface BooleanResultContinuation {
+        /**
+         * @param block the block to add a block terminating operation
+         * @param result the boolean result.
+         */
+        void continueWith(Block.Builder block, Value result);
+
+        /**
+         * @param block the block to add any necessary operations
+         * @param result the static boolean result
+         * @return
+         */
+        Block.Reference referenceFor(Block.Builder block, boolean result);
+    }
+
+    record ConditionalBranchContinuation(
+            Block.Reference trueRef,
+            Block.Reference falseRef) implements BooleanResultContinuation {
+        @Override
+        public void continueWith(Block.Builder block, Value result) {
+            // result will be present in a model being built, so only its operation structure can be queried
+            if (result instanceof Op.Result opResult
+                    && opResult.op() instanceof CoreOp.ConstantOp constant
+                    && constant.value() instanceof Boolean booleanValue) {
+                block.add(CoreOp.branch(
+                        booleanValue ? trueRef : falseRef));
+            } else {
+                block.add(CoreOp.conditionalBranch(result, trueRef, falseRef));
+            }
+        }
+
+        @Override
+        public Block.Reference referenceFor(Block.Builder block, boolean result) {
+            return result ? trueRef : falseRef;
+        }
+    }
+
+    record BranchWithArgumentContinuation(Block.Builder resultBlock) implements BooleanResultContinuation {
+        @Override
+        public void continueWith(Block.Builder block, Value result) {
+            block.add(CoreOp.branch(resultBlock.reference(result)));
+        }
+
+        @Override
+        public Block.Reference referenceFor(Block.Builder block, boolean result) {
+            return resultBlock.reference(block.add(CoreOp.constant(JavaType.BOOLEAN, result)));
+        }
+    }
+
+    record BooleanExpressionSuffix(ControlFlowBooleanExpressionOp expression, boolean negatesExpression) {
+        ConditionalBranchContinuation continuationForExpression(Block.Builder block, BooleanResultContinuation continuation) {
+            Block.Reference trueRef = continuation.referenceFor(block, !negatesExpression);
+            Block.Reference falseRef = continuation.referenceFor(block, negatesExpression);
+            return new ConditionalBranchContinuation(trueRef, falseRef);
+        }
+    }
+
+    private static BooleanExpressionSuffix findBooleanExpressionSuffix(Body body) {
+        if (body.blocks().size() != 1) {
+            return null;
+        }
+
+        Block block = body.entryBlock();
+
+        // Find suffix of
+        //  ControlFlowBooleanExpressionOp
+        //  NotOp *
+        //  CoreOp.YieldOp
+
+        Op.Terminating yop = block.terminatingOp();
+        if (!(yop instanceof CoreOp.YieldOp)) {
+            return null;
+        }
+
+        boolean negatesExpression = false;
+        Op next = yop;
+        Op expression = null;
+        List<Op> ops = block.ops();
+        for (int i = ops.size() - 2; i >= 0; i--) {
+            Op op = ops.get(i);
+
+            if (next.operands().isEmpty() || next.operands().getFirst() != op.result()) {
+                return null;
+            } else if (op instanceof JavaOp.NotOp) {
+                negatesExpression = !negatesExpression;
+            } else if (isSupportedBooleanExpressionOp(op)) {
+                expression = op;
+                break;
+            } else {
+                break;
+            }
+
+            next = op;
+        }
+
+        return expression != null
+                ? new BooleanExpressionSuffix((ControlFlowBooleanExpressionOp) expression, negatesExpression)
+                : null;
+    }
+
+    private static boolean isSupportedBooleanExpressionOp(Op op) {
+        return op instanceof ControlFlowBooleanExpressionOp && op.resultType().equals(JavaType.BOOLEAN);
+    }
+}

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -3273,23 +3273,37 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             return bodies;
         }
 
+        static boolean isEmptyBodyAction(Body body) {
+            Block block = body.entryBlock();
+            return body.blocks().size() == 1
+                    && block.ops().size() == 1
+                    && block.terminatingOp() instanceof CoreOp.YieldOp;
+        }
+
         @Override
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Block.Builder exit = b.block();
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
 
+            boolean isEmptyElseActionBody = isEmptyBodyAction(bodies.getLast());
+
             // Create predicate and action blocks
             List<Block.Builder> builders = new ArrayList<>();
             for (int i = 0; i < bodies.size(); i += 2) {
                 if (i == bodies.size() - 1) {
-                    builders.add(b.block());
+                    if (isEmptyElseActionBody) {
+                        builders.add(exit);
+                    } else {
+                        builders.add(b.block());
+                    }
                 } else {
                     builders.add(i == 0 ? b : b.block());
                     builders.add(b.block());
                 }
             }
 
-            for (int i = 0; i < bodies.size(); i += 2) {
+            int nBodies = isEmptyElseActionBody ? bodies.size() - 1 : bodies().size();
+            for (int i = 0; i < nBodies; i += 2) {
                 Body actionBody;
                 Block.Builder action;
                 if (i == bodies.size() - 1) {
@@ -3301,10 +3315,10 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
                     Block.Builder pred = builders.get(i);
                     action = builders.get(i + 1);
-                    Block.Builder next = builders.get(i + 2);
+                    Block.Builder nextAction = builders.get(i + 2);
 
                     ControlFlowBooleanExpressionOp.lowerBooleanBody(pred, predBody, List.of(),
-                            new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(action.reference(), next.reference()),
+                            new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(action.reference(), nextAction.reference()),
                             inherited);
                 }
 
@@ -3530,9 +3544,16 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
             // Create predicate and action blocks
             List<Block.Builder> blocks = new ArrayList<>(reorderedBodies.size());
+            // The first predicate body can lower into b
             blocks.add(b);
-            for (int i = 1; i < reorderedBodies.size(); i ++) {
-                blocks.add(b.block());
+            if (defaultCaseIndex == 0) {
+                // If only the default case, the default action body can lower into b
+                // since the default predicate body is not lowered
+                blocks.add(b);
+            } else {
+                for (int i = 1; i < reorderedBodies.size(); i++) {
+                    blocks.add(b.block());
+                }
             }
 
             boolean hasYieldStatements = hasYieldStatements();
@@ -3574,11 +3595,6 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 BranchTarget.setBranchTarget(b.context(), actionBody, null, nextActionBlock);
             }
 
-            if (defaultCaseIndex == 0) {
-                // If there is only the default case branch to the action block
-                Block.Builder actionBlock = blocks.get(1);
-                b.add(branch(actionBlock.reference()));
-            }
             for (int i = 0; i < reorderedBodies.size(); i += 2) {
                 Body predicateBody = reorderedBodies.get(i);
                 Block.Builder predicateBlock = blocks.get(i);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -723,30 +723,27 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             Block.Builder exit = b.block();
             Block.Builder throwBlock = b.block();
 
-            b.transformBody(bodies.get(0), List.of(), loweringTransformer(inherited, (block, op) -> {
-                if (op instanceof CoreOp.YieldOp yo) {
-                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
-                            exit.reference(), throwBlock.reference()));
-                    return block;
-                } else {
-                    return null;
-                }
-            }));
+            ControlFlowBooleanExpressionOp.lowerBooleanBody(b, predicateBody(), List.of(),
+                    new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(exit.reference(), throwBlock.reference()),
+                    inherited);
 
-            if (bodies.size() == 2) {
-                throwBlock.transformBody(bodies.get(1), List.of(), loweringTransformer(inherited, (block, op) -> {
+            Body detailsBody = detailsBody();
+            if (detailsBody != null) {
+                throwBlock.transformBody(detailsBody, List.of(), loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yo) {
                         Value detailValue = block.context().getValue(yo.yieldValue());
-                        block.add(throw_(block.add(new_(MethodRef.constructor(JavaType.type(AssertionError.class), switch (detailValue.type()) {
+                        MethodRef assertConstructor = MethodRef.constructor(type(AssertionError.class),
+                                switch (detailValue.type()) {
                                     case PrimitiveType pt -> {
-                                        if (pt == JavaType.BYTE || pt == JavaType.SHORT) {
+                                        if (pt == BYTE || pt == SHORT) {
                                             detailValue = block.add(conv(INT, detailValue));
-                                            yield JavaType.INT;
+                                            yield INT;
                                         }
                                         yield pt;
                                     }
-                                    default -> JavaType.J_L_OBJECT;
-                                }), detailValue))
+                                    default -> J_L_OBJECT;
+                                });
+                        block.add(throw_(block.add(new_(assertConstructor, detailValue))
                         ));
                         return block;
                     } else {
@@ -3306,15 +3303,9 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     action = builders.get(i + 1);
                     Block.Builder next = builders.get(i + 2);
 
-                    pred.transformBody(predBody, List.of(), loweringTransformer(inherited, (block, op) -> {
-                        if (op instanceof CoreOp.YieldOp yo) {
-                            block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
-                                    action.reference(), next.reference()));
-                            return block;
-                        } else {
-                            return null;
-                        }
-                    }));
+                    ControlFlowBooleanExpressionOp.lowerBooleanBody(pred, predBody, List.of(),
+                            new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(action.reference(), next.reference()),
+                            inherited);
                 }
 
                 action.transformBody(actionBody, List.of(), loweringTransformer(inherited, (block, op) -> {
@@ -3477,6 +3468,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     Map.of();
         }
 
+        boolean hasYieldStatements() {
+            return this.elements().anyMatch(
+                    e -> e instanceof JavaOp.YieldOp yop && yop.targetsOrAttemptsToExit(this));
+        }
+
         @Override
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
             Value selectorExpression = b.context().getValue(operands().get(0));
@@ -3539,14 +3535,38 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 blocks.add(b.block());
             }
 
-            Block.Builder exit = b.block();
-            if (resultType() != VOID) {
-                Value r = exit.parameter(resultType());
-                exit.context().mapValue(result(), r);
+            boolean hasYieldStatements = hasYieldStatements();
+            boolean isBooleanExpression = resultType().equals(BOOLEAN);
+            // Poll for implicit boolean continuation parameter
+            ControlFlowBooleanExpressionOp.BooleanResultContinuation continuation = isBooleanExpression
+                    ? ControlFlowBooleanExpressionOp.BOOLEAN_CONTINUATION_ARG.poll(b.context())
+                    : null;
+            Block.Builder exit;
+            if (isBooleanExpression) {
+                if (continuation == null) {
+                    exit = b.block();
+                    b.context().mapValue(result(), exit.parameter(resultType()));
+                    continuation = new ControlFlowBooleanExpressionOp.BranchWithArgumentContinuation(exit);
+                } else if (hasYieldStatements) {
+                    exit = b.block();
+                    Value value = exit.parameter(resultType());
+                    continuation.continueWith(exit, value);
+                } else {
+                    exit = b;
+                }
+
+                if (hasYieldStatements) {
+                    BranchTarget.setBranchTarget(b.context(), this, exit, null);
+                }
+            } else {
+                exit = b.block();
+                if (resultType() != VOID) {
+                    Value r = exit.parameter(resultType());
+                    exit.context().mapValue(result(), r);
+                }
+                BranchTarget.setBranchTarget(b.context(), this, exit, null);
             }
 
-            // Set this body's break target to the exit block
-            BranchTarget.setBranchTarget(b.context(), this, exit, null);
             // Set action body's continue target to next action block for lowering of SwitchFallThroughOp
             for (int i = 1; i < reorderedBodies.size() - 2; i += 2) {
                 Body actionBody = reorderedBodies.get(i);
@@ -3589,29 +3609,27 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                         noMatchBlock = nextPredicateBlock;
                     }
 
-                    predicateBlock.transformBody(predicateBody, List.of(selectorExpression), loweringTransformer(inherited,
+                    ControlFlowBooleanExpressionOp.lowerBooleanBody(predicateBlock, predicateBody, List.of(selectorExpression),
+                            new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(actionBlock.reference(), noMatchBlock.reference()),
+                            inherited);
+                }
+
+                if (isBooleanExpression) {
+                    ControlFlowBooleanExpressionOp.lowerBooleanBody(actionBlock, actionBody, List.of(), continuation, inherited);
+                } else {
+                    // Lower action body for all cases
+                    actionBlock.transformBody(actionBody, List.of(), loweringTransformer(inherited,
                             (block, op) -> switch (op) {
                                 case CoreOp.YieldOp yop -> {
-                                    block.add(conditionalBranch(block.context().getValue(yop.yieldValue()),
-                                            actionBlock.reference(), noMatchBlock.reference()));
+                                    List<Value> args = yop.yieldValue() == null
+                                            ? List.of()
+                                            : List.of(block.context().getValue(yop.yieldValue()));
+                                    block.add(branch(exit.reference(args)));
                                     yield block;
                                 }
                                 default -> null;
                             }));
                 }
-
-                // Lower action body for all cases
-                actionBlock.transformBody(actionBody, List.of(), loweringTransformer(inherited,
-                        (block, op) -> switch (op) {
-                            case CoreOp.YieldOp yop -> {
-                                List<Value> args = yop.yieldValue() == null
-                                        ? List.of()
-                                        : List.of(block.context().getValue(yop.yieldValue()));
-                                block.add(branch(exit.reference(args)));
-                                yield block;
-                            }
-                            default -> null;
-                        }));
             }
 
             return exit;
@@ -3643,8 +3661,10 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 if (terminatingOp instanceof CoreOp.YieldOp yieldOp &&
                         yieldOp.yieldValue() instanceof Op.Result opr &&
                         opr.op() instanceof InvokeOp invokeOp &&
-            invokeOp.invokeReference().equals(MethodRef.method(Objects.class, "equals", boolean.class, Object.class, Object.class)) &&
-                        invokeOp.operands().stream().anyMatch(o -> o instanceof Op.Result r && r.op() instanceof ConstantOp cop && cop.value() == null)) {
+                        invokeOp.invokeReference().equals(
+                                MethodRef.method(Objects.class, "equals", boolean.class, Object.class, Object.class)) &&
+                        invokeOp.operands().stream().anyMatch(o -> o instanceof Op.Result r &&
+                                r.op() instanceof ConstantOp cop && cop.value() == null)) {
                     return true;
                 }
             }
@@ -3662,7 +3682,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      */
     @OpDeclaration(SwitchExpressionOp.NAME)
     public static final class SwitchExpressionOp extends SwitchOp
-            implements JavaExpression {
+            implements ControlFlowBooleanExpressionOp, JavaExpression {
         static final String NAME = "java.switch.expression";
 
         final CodeType resultType;
@@ -4045,21 +4065,15 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 default -> null;
             }));
 
-            header.transformBody(condBody, initValues, loweringTransformer(inherited, (block, op) -> {
-                if (op instanceof CoreOp.YieldOp yo) {
-                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
-                            body.reference(), exit.reference()));
-                    return block;
-                } else {
-                    return null;
-                }
-            }));
+            ControlFlowBooleanExpressionOp.lowerBooleanBody(header, condBody, initValues,
+                    new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(body.reference(), exit.reference()),
+                    inherited);
 
             BranchTarget.setBranchTarget(b.context(), this, exit, update);
 
-            body.transformBody(this.loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
+            body.transformBody(loopBody, initValues, loweringTransformer(inherited, (_, _) -> null));
 
-            update.transformBody(this.updateBody, initValues, loweringTransformer(inherited, (block, op) -> {
+            update.transformBody(updateBody, initValues, loweringTransformer(inherited, (block, op) -> {
                 if (op instanceof CoreOp.YieldOp) {
                     block.add(branch(header.reference()));
                     return block;
@@ -4464,15 +4478,9 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
             b.add(branch(header.reference()));
 
-            header.transformBody(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
-                if (op instanceof CoreOp.YieldOp yo) {
-                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
-                            body.reference(), exit.reference()));
-                    return block;
-                } else {
-                    return null;
-                }
-            }));
+            ControlFlowBooleanExpressionOp.lowerBooleanBody(header, predicateBody(), List.of(),
+                    new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(body.reference(), exit.reference()),
+                    inherited);
 
             BranchTarget.setBranchTarget(b.context(), this, exit, header);
 
@@ -4613,15 +4621,9 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
             body.transformBody(loopBody(), List.of(), loweringTransformer(inherited, (_, _) -> null));
 
-            header.transformBody(predicateBody(), List.of(), loweringTransformer(inherited, (block, op) -> {
-                if (op instanceof CoreOp.YieldOp yo) {
-                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
-                            body.reference(), exit.reference()));
-                    return block;
-                } else {
-                    return null;
-                }
-            }));
+            ControlFlowBooleanExpressionOp.lowerBooleanBody(header, predicateBody(), List.of(),
+                    new ControlFlowBooleanExpressionOp.ConditionalBranchContinuation(body.reference(), exit.reference()),
+                    inherited);
 
             return exit;
         }
@@ -4641,7 +4643,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      * @jls 15.24 Conditional-Or Operator {@code ||}
      */
     public sealed static abstract class ConditionalOp extends AbstractOp
-            implements JavaOp, Op.Nested, Op.Lowerable, JavaExpression
+            implements JavaOp, Op.Nested, ControlFlowBooleanExpressionOp, JavaExpression
             permits ConditionalAndOp, ConditionalOrOp {
 
         static final FunctionType BODY_TYPE = CoreType.functionType(BOOLEAN);
@@ -4668,46 +4670,44 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         }
 
         @Override
+        public CodeType resultType() {
+            return BOOLEAN;
+        }
+
+        @Override
         public Block.Builder lower(Block.Builder lhs, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
-            Block.Builder exit = lhs.block();
-            lhs.context().mapValue(result(), exit.parameter(resultType()));
+            // Poll for implicit boolean continuation parameter
+            BooleanResultContinuation continuation = BOOLEAN_CONTINUATION_ARG.poll(lhs.context());
+            Block.Builder exit = lhs;
+            if (continuation == null) {
+                exit = lhs.block();
+                lhs.context().mapValue(result(), exit.parameter(resultType()));
+                continuation = new BranchWithArgumentContinuation(exit);
+            }
+            lowerTo(lhs, inherited, continuation);
+            return exit;
+        }
+
+        void lowerTo(Block.Builder lhs, BiFunction<Block.Builder, Op, Block.Builder> inherited,
+                     BooleanResultContinuation continuation) {
+            boolean isAnd = this instanceof ConditionalAndOp;
+            Block.Reference shortCircuitRef = continuation.referenceFor(lhs, !isAnd);
 
             // Lower all but the last body
             for (int i = 0; i < bodies().size() - 1; i++) {
                 Block.Builder rhs = lhs.block();
-                lhs.transformBody(bodies().get(i), List.of(), loweringTransformer(inherited, (block, op) -> {
-                    if (op instanceof CoreOp.YieldOp yop) {
-                        Value p = block.context().getValue(yop.yieldValue());
-                        if (this instanceof ConditionalAndOp) {
-                            block.add(conditionalBranch(p, rhs.reference(), exit.reference(p)));
-                        } else {
-                            block.add(conditionalBranch(p, exit.reference(p), rhs.reference()));
-                        }
-                        return block;
-                    } else {
-                        return null;
-                    }
-                }));
+
+                ConditionalBranchContinuation bodyContinuation = isAnd
+                        ? new ConditionalBranchContinuation(rhs.reference(), shortCircuitRef)
+                        : new ConditionalBranchContinuation(shortCircuitRef, rhs.reference());
+
+                ControlFlowBooleanExpressionOp.lowerBooleanBody(lhs, bodies().get(i), List.of(), bodyContinuation, inherited);
+
                 lhs = rhs;
             }
 
             // Lower the last body
-            lhs.transformBody(bodies().getLast(), List.of(), loweringTransformer(inherited, (block, op) -> {
-                if (op instanceof CoreOp.YieldOp yop) {
-                    Value p = block.context().getValue(yop.yieldValue());
-                    block.add(branch(exit.reference(p)));
-                    return block;
-                } else {
-                    return null;
-                }
-            }));
-
-            return exit;
-        }
-
-        @Override
-        public CodeType resultType() {
-            return BOOLEAN;
+            ControlFlowBooleanExpressionOp.lowerBooleanBody(lhs, bodies().getLast(),List.of(), continuation, inherited);
         }
     }
 
@@ -4853,7 +4853,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
      */
     @OpDeclaration(ConditionalExpressionOp.NAME)
     public static final class ConditionalExpressionOp extends AbstractOp
-            implements JavaOp, Op.Nested, Op.Lowerable, JavaExpression {
+            implements JavaOp, Op.Nested, ControlFlowBooleanExpressionOp, JavaExpression {
 
         static final String NAME = "java.cexpression";
 
@@ -4918,34 +4918,51 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
         @Override
         public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
-            Block.Builder exit = b.block(resultType());
-            exit.context().mapValue(result(), exit.parameters().get(0));
+            boolean isBooleanExpression = resultType().equals(BOOLEAN);
+            // Poll for implicit boolean continuation parameter
+            BooleanResultContinuation continuation = isBooleanExpression
+                    ? BOOLEAN_CONTINUATION_ARG.poll(b.context())
+                    : null;
 
-            BranchTarget.setBranchTarget(b.context(), this, exit, null);
+            // Lower predicate body
+            Block.Builder trueBlock = b.block();
+            Block.Builder falseBlock = b.block();
+            ControlFlowBooleanExpressionOp.lowerBooleanBody(b, predicateBody(), List.of(),
+                    new ConditionalBranchContinuation(trueBlock.reference(), falseBlock.reference()),
+                    inherited);
 
-            List<Block.Builder> builders = List.of(b.block(), b.block());
-            b.transformBody(bodies.get(0), List.of(), loweringTransformer(inherited, (block, op) -> {
-                if (op instanceof CoreOp.YieldOp yo) {
-                    block.add(conditionalBranch(block.context().getValue(yo.yieldValue()),
-                            builders.get(0).reference(), builders.get(1).reference()));
-                    return block;
+            // Lower true/false bodies depending on if a boolean expression or a value expression
+            if (isBooleanExpression) {
+                Block.Builder exit;
+                if (continuation == null) {
+                    exit = b.block();
+                    b.context().mapValue(result(), exit.parameter(resultType()));
+                    continuation = new BranchWithArgumentContinuation(exit);
                 } else {
-                    return null;
+                    exit = b;
                 }
-            }));
 
-            for (int i = 0; i < 2; i++) {
-                builders.get(i).transformBody(bodies.get(i + 1), List.of(), loweringTransformer(inherited, (block, op) -> {
+                ControlFlowBooleanExpressionOp.lowerBooleanBody(trueBlock, trueBody(), List.of(), continuation, inherited);
+                ControlFlowBooleanExpressionOp.lowerBooleanBody(falseBlock, falseBody(), List.of(), continuation, inherited);
+                return exit;
+            } else {
+                Block.Builder exit = b.block();
+                b.context().mapValue(result(), exit.parameter(resultType()));
+
+                BranchTarget.setBranchTarget(b.context(), this, exit, null);
+
+                CodeTransformer exitTransformer = loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp yop) {
                         block.add(branch(exit.reference(block.context().getValue(yop.yieldValue()))));
                         return block;
                     } else {
                         return null;
                     }
-                }));
+                });
+                trueBlock.transformBody(trueBody(), List.of(), exitTransformer);
+                falseBlock.transformBody(falseBody(), List.of(), exitTransformer);
+                return exit;
             }
-
-            return exit;
         }
 
         @Override
@@ -6278,7 +6295,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
          */
         @OpDeclaration(MatchOp.NAME)
         public static final class MatchOp extends AbstractOp
-                implements JavaOp, Op.Isolated, Op.Lowerable {
+                implements JavaOp, Op.Isolated, ControlFlowBooleanExpressionOp {
             static final String NAME = "pattern.match";
 
             final Body patternBody;
@@ -6342,57 +6359,55 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
             @Override
             public Block.Builder lower(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited) {
-                // No match block
-                Block.Builder endNoMatchBlock = b.block();
-                // Match block
-                Block.Builder endMatchBlock = b.block();
-                // End block
-                Block.Builder endBlock = b.block();
-                Block.Parameter matchResult = endBlock.parameter(resultType());
-                // Map match operation result
-                b.context().mapValue(result(), matchResult);
+                // Poll for implicit boolean continuation parameter
+                BooleanResultContinuation continuation = BOOLEAN_CONTINUATION_ARG.poll(b.context());
+                Block.Builder exit = b;
+                if (continuation == null) {
+                    exit = b.block();
+                    b.context().mapValue(result(), exit.parameter(resultType()));
+                    continuation = new BranchWithArgumentContinuation(exit);
+                }
+                lowerTo(b, inherited, continuation);
+                return exit;
+            }
+
+            void lowerTo(Block.Builder b, BiFunction<Block.Builder, Op, Block.Builder> inherited,
+                         BooleanResultContinuation continuation) {
+                Block.Reference trueRef = continuation.referenceFor(b, true);
+                Block.Reference falseRef = continuation.referenceFor(b, false);
 
                 List<Value> patternValues = new ArrayList<>();
                 Op patternYieldOp = patternBody.entryBlock().terminatingOp();
                 Op.Result rootPatternValue = (Op.Result) patternYieldOp.operands().get(0);
-                Block.Builder currentBlock = lower(endNoMatchBlock, b,
+                Block.Builder matchedBlock = lower(
+                        falseRef,
+                        b,
                         patternValues,
                         rootPatternValue.op(),
                         b.context().getValue(targetOperand()));
-                currentBlock.add(branch(endMatchBlock.reference()));
 
-                // No match block
-                // Pass false
-                endNoMatchBlock.add(branch(endBlock.reference(
-                        endNoMatchBlock.add(constant(BOOLEAN, false)))));
-
-                // Match block
-                // Lower match body and pass true
-                endMatchBlock.transformBody(matchBody, patternValues, loweringTransformer(inherited, (block, op) -> {
+                matchedBlock.transformBody(matchBody, patternValues, loweringTransformer(inherited, (block, op) -> {
                     if (op instanceof CoreOp.YieldOp) {
-                        block.add(branch(endBlock.reference(
-                                block.add(constant(BOOLEAN, true)))));
+                        block.add(branch(trueRef));
                         return block;
                     } else {
                         return null;
                     }
                 }));
-
-                return endBlock;
             }
 
-            static Block.Builder lower(Block.Builder endNoMatchBlock, Block.Builder currentBlock,
+            static Block.Builder lower(Block.Reference falseRef, Block.Builder currentBlock,
                                        List<Value> bindings,
                                        Op pattern, Value target) {
                 return switch (pattern) {
-                    case RecordPatternOp rp -> lowerRecordPattern(endNoMatchBlock, currentBlock, bindings, rp, target);
-                    case TypePatternOp tp -> lowerTypePattern(endNoMatchBlock, currentBlock, bindings, tp, target);
+                    case RecordPatternOp rp -> lowerRecordPattern(falseRef, currentBlock, bindings, rp, target);
+                    case TypePatternOp tp -> lowerTypePattern(falseRef, currentBlock, bindings, tp, target);
                     case MatchAllPatternOp map -> lowerMatchAllPattern(currentBlock);
                     case null, default -> throw new UnsupportedOperationException("Unknown pattern op: " + pattern);
                 };
             }
 
-            static Block.Builder lowerRecordPattern(Block.Builder endNoMatchBlock, Block.Builder currentBlock,
+            static Block.Builder lowerRecordPattern(Block.Reference falseRef, Block.Builder currentBlock,
                                                     List<Value> bindings,
                                                     JavaOp.PatternOps.RecordPatternOp rpOp, Value target) {
                 CodeType targetType = rpOp.targetType();
@@ -6401,7 +6416,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
                 // Check if instance of target type
                 Op.Result isInstance = currentBlock.add(instanceOf(targetType, target));
-                currentBlock.add(conditionalBranch(isInstance, nextBlock.reference(), endNoMatchBlock.reference()));
+                currentBlock.add(conditionalBranch(isInstance, nextBlock.reference(), falseRef));
 
                 currentBlock = nextBlock;
 
@@ -6412,15 +6427,15 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 for (int i = 0; i < dArgs.size(); i++) {
                     Op.Result nestedPattern = (Op.Result) dArgs.get(i);
                     // @@@ Handle exceptions?
-            Value nestedTarget = currentBlock.add(invoke(rpOp.recordReference().methodForComponent(i), target));
+                    Value nestedTarget = currentBlock.add(invoke(rpOp.recordReference().methodForComponent(i), target));
 
-                    currentBlock = lower(endNoMatchBlock, currentBlock, bindings, nestedPattern.op(), nestedTarget);
+                    currentBlock = lower(falseRef, currentBlock, bindings, nestedPattern.op(), nestedTarget);
                 }
 
                 return currentBlock;
             }
 
-            static Block.Builder lowerTypePattern(Block.Builder endNoMatchBlock, Block.Builder currentBlock,
+            static Block.Builder lowerTypePattern(Block.Reference falseRef, Block.Builder currentBlock,
                                                   List<Value> bindings,
                                                   TypePatternOp tpOp, Value target) {
                 CodeType targetType = tpOp.targetType();
@@ -6479,7 +6494,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 if (p != null) {
                     // p != null, we need to perform type check at runtime
                     Block.Builder nextBlock = currentBlock.block();
-                    currentBlock.add(conditionalBranch(currentBlock.add(p), nextBlock.reference(), endNoMatchBlock.reference()));
+                    currentBlock.add(conditionalBranch(currentBlock.add(p), nextBlock.reference(), falseRef));
                     currentBlock = nextBlock;
                 }
                 if (c != null) {

--- a/test/jdk/jdk/incubator/code/lower/TestBooleanExpression.java
+++ b/test/jdk/jdk/incubator/code/lower/TestBooleanExpression.java
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.code
+ * @summary test lowering of boolean expressions
+ * @build TestBooleanExpression
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester TestBooleanExpression
+ */
+
+import jdk.incubator.code.Reflect;
+
+public class TestBooleanExpression {
+
+    @Reflect
+    @LoweredModel("""
+            func @"testIf" (%0 : java.type:"boolean", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"a";
+                %3 : Var<java.type:"boolean"> = var %1 @"b";
+                %4 : java.type:"boolean" = var.load %2;
+                cbranch %4 ^block_1 ^block_3;
+
+              ^block_1:
+                %5 : java.type:"boolean" = var.load %3;
+                cbranch %5 ^block_2 ^block_3;
+
+              ^block_2:
+                %6 : java.type:"java.lang.String" = constant @"BODY";
+                invoke %6 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_3;
+
+              ^block_3:
+                return;
+            };
+            """)
+    static void testIf(boolean a, boolean b) {
+        if (a && b) {
+            IO.println("BODY");
+        }
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testWhile" (%0 : java.type:"boolean", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"a";
+                %3 : Var<java.type:"boolean"> = var %1 @"b";
+                branch ^block_1;
+
+              ^block_1:
+                %4 : java.type:"boolean" = var.load %2;
+                cbranch %4 ^block_2 ^block_4;
+
+              ^block_2:
+                %5 : java.type:"boolean" = var.load %3;
+                cbranch %5 ^block_3 ^block_4;
+
+              ^block_3:
+                %6 : java.type:"java.lang.String" = constant @"BODY";
+                invoke %6 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_1;
+
+              ^block_4:
+                return;
+            };
+            """)
+    static void testWhile(boolean a, boolean b) {
+        while (a && b) {
+            IO.println("BODY");
+        }
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testDoWhile" (%0 : java.type:"boolean", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"a";
+                %3 : Var<java.type:"boolean"> = var %1 @"b";
+                branch ^block_1;
+
+              ^block_1:
+                %4 : java.type:"java.lang.String" = constant @"BODY";
+                invoke %4 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_2;
+
+              ^block_2:
+                %5 : java.type:"boolean" = var.load %2;
+                %6 : java.type:"boolean" = var.load %3;
+                %7 : java.type:"boolean" = and %5 %6;
+                cbranch %7 ^block_1 ^block_3;
+
+              ^block_3:
+                return;
+            };
+            """)
+    static void testDoWhile(boolean a, boolean b) {
+        do {
+            IO.println("BODY");
+        } while (a & b);
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testFor" (%0 : java.type:"boolean", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"a";
+                %3 : Var<java.type:"boolean"> = var %1 @"b";
+                branch ^block_1;
+
+              ^block_1:
+                %4 : java.type:"boolean" = var.load %2;
+                %5 : java.type:"boolean" = var.load %3;
+                %6 : java.type:"boolean" = and %4 %5;
+                cbranch %6 ^block_2 ^block_4;
+
+              ^block_2:
+                %7 : java.type:"java.lang.String" = constant @"BODY";
+                invoke %7 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_3;
+
+              ^block_3:
+                branch ^block_1;
+
+              ^block_4:
+                return;
+            };
+            """)
+    static void testFor(boolean a, boolean b) {
+        for (; a & b;) {
+            IO.println("BODY");
+        }
+    }
+
+    record Box(Object o) {}
+
+    @Reflect
+    @LoweredModel("""
+            func @"testSwitchLabel" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"s";
+                %5 : java.type:"java.lang.Object" = constant @null;
+                %6 : java.type:"boolean" = invoke %2 %5 @java.ref:"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                cbranch %6 ^block_1 ^block_2;
+
+              ^block_1:
+                %7 : java.type:"java.lang.NullPointerException" = new @java.ref:"java.lang.NullPointerException::()";
+                throw %7;
+
+              ^block_2:
+                %8 : java.type:"boolean" = instanceof %2 @java.type:"TestBooleanExpression$Box";
+                cbranch %8 ^block_3 ^block_6;
+
+              ^block_3:
+                %9 : java.type:"TestBooleanExpression$Box" = cast %2 @java.type:"TestBooleanExpression$Box";
+                %10 : java.type:"java.lang.Object" = invoke %9 @java.ref:"TestBooleanExpression$Box::o():java.lang.Object";
+                %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.String";
+                cbranch %11 ^block_4 ^block_6;
+
+              ^block_4:
+                %12 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                var.store %4 %12;
+                branch ^block_5;
+
+              ^block_5:
+                %13 : java.type:"java.lang.String" = constant @"CASE";
+                invoke %13 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_7;
+
+              ^block_6:
+                %14 : java.type:"java.lang.String" = constant @"DEFAULT";
+                invoke %14 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_7;
+
+              ^block_7:
+                return;
+            };
+            """)
+    static void testSwitchLabel(Object o) {
+        switch (o) {
+            case Box(String s) -> {
+                IO.println("CASE");
+            }
+            default -> {
+                IO.println("DEFAULT");
+            }
+        }
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testSwitchLabelAndGuard" (%0 : java.type:"java.lang.Object")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"s";
+                %5 : java.type:"java.lang.Object" = constant @null;
+                %6 : java.type:"boolean" = invoke %2 %5 @java.ref:"java.util.Objects::equals(java.lang.Object, java.lang.Object):boolean";
+                cbranch %6 ^block_1 ^block_2;
+
+              ^block_1:
+                %7 : java.type:"java.lang.NullPointerException" = new @java.ref:"java.lang.NullPointerException::()";
+                throw %7;
+
+              ^block_2:
+                %8 : java.type:"boolean" = instanceof %2 @java.type:"TestBooleanExpression$Box";
+                cbranch %8 ^block_3 ^block_8;
+
+              ^block_3:
+                %9 : java.type:"TestBooleanExpression$Box" = cast %2 @java.type:"TestBooleanExpression$Box";
+                %10 : java.type:"java.lang.Object" = invoke %9 @java.ref:"TestBooleanExpression$Box::o():java.lang.Object";
+                %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.String";
+                cbranch %11 ^block_4 ^block_8;
+
+              ^block_4:
+                %12 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                var.store %4 %12;
+                branch ^block_5;
+
+              ^block_5:
+                %13 : java.type:"java.lang.String" = var.load %4;
+                %14 : java.type:"int" = invoke %13 @java.ref:"java.lang.String::length():int";
+                %15 : java.type:"int" = constant @10;
+                %16 : java.type:"boolean" = gt %14 %15;
+                cbranch %16 ^block_6 ^block_8;
+
+              ^block_6:
+                %17 : java.type:"java.lang.String" = var.load %4;
+                %18 : java.type:"int" = invoke %17 @java.ref:"java.lang.String::length():int";
+                %19 : java.type:"int" = constant @20;
+                %20 : java.type:"boolean" = lt %18 %19;
+                cbranch %20 ^block_7 ^block_8;
+
+              ^block_7:
+                %21 : java.type:"java.lang.String" = constant @"CASE";
+                invoke %21 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_9;
+
+              ^block_8:
+                %22 : java.type:"java.lang.String" = constant @"DEFAULT";
+                invoke %22 @java.ref:"java.lang.IO::println(java.lang.Object):void";
+                branch ^block_9;
+
+              ^block_9:
+                return;
+            };
+            """)
+    static void testSwitchLabelAndGuard(Object o) {
+        switch (o) {
+            case Box(String s) when s.length() > 10 && s.length() < 20 -> {
+                IO.println("CASE");
+            }
+            default -> {
+                IO.println("DEFAULT");
+            }
+        }
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testConditional" (%0 : java.type:"boolean", %1 : java.type:"boolean")java.type:"void" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"a";
+                %3 : Var<java.type:"boolean"> = var %1 @"b";
+                %4 : java.type:"boolean" = var.load %2;
+                %5 : java.type:"boolean" = var.load %3;
+                %6 : java.type:"boolean" = and %4 %5;
+                cbranch %6 ^block_1 ^block_2;
+
+              ^block_1:
+                %7 : java.type:"java.lang.String" = constant @"LEFT";
+                branch ^block_3(%7);
+
+              ^block_2:
+                %8 : java.type:"java.lang.String" = constant @"RIGHT";
+                branch ^block_3(%8);
+
+              ^block_3(%9 : java.type:"java.lang.String"):
+                %10 : Var<java.type:"java.lang.String"> = var %9 @"s";
+                return;
+            };
+            """)
+    static void testConditional(boolean a, boolean b) {
+        String s = (a & b) ? "LEFT" : "RIGHT";
+    }
+
+
+
+    // Boolean expressions
+    // &&
+    // ||
+    // patterns
+    // ternary
+    // switch expression
+    // Composed with !
+
+
+    @Reflect
+    @LoweredModel("""
+            func @"testConditionalAnd" (%0 : java.type:"boolean", %1 : java.type:"boolean", %2 : java.type:"boolean")java.type:"boolean" -> {
+                %3 : Var<java.type:"boolean"> = var %0 @"a";
+                %4 : Var<java.type:"boolean"> = var %1 @"b";
+                %5 : Var<java.type:"boolean"> = var %2 @"c";
+                %6 : java.type:"boolean" = constant @false;
+                %7 : java.type:"boolean" = var.load %3;
+                cbranch %7 ^block_1 ^block_3(%6);
+
+              ^block_1:
+                %8 : java.type:"boolean" = var.load %4;
+                cbranch %8 ^block_2 ^block_3(%6);
+
+              ^block_2:
+                %9 : java.type:"boolean" = var.load %5;
+                branch ^block_3(%9);
+
+              ^block_3(%10 : java.type:"boolean"):
+                return %10;
+            };
+            """)
+    static boolean testConditionalAnd(boolean a, boolean b, boolean c) {
+        return a && b && c;
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testConditionalOr" (%0 : java.type:"boolean", %1 : java.type:"boolean", %2 : java.type:"boolean")java.type:"boolean" -> {
+                %3 : Var<java.type:"boolean"> = var %0 @"a";
+                %4 : Var<java.type:"boolean"> = var %1 @"b";
+                %5 : Var<java.type:"boolean"> = var %2 @"c";
+                %6 : java.type:"boolean" = constant @true;
+                %7 : java.type:"boolean" = var.load %3;
+                cbranch %7 ^block_3(%6) ^block_1;
+
+              ^block_1:
+                %8 : java.type:"boolean" = var.load %4;
+                cbranch %8 ^block_3(%6) ^block_2;
+
+              ^block_2:
+                %9 : java.type:"boolean" = var.load %5;
+                branch ^block_3(%9);
+
+              ^block_3(%10 : java.type:"boolean"):
+                return %10;
+            };
+            """)
+    static boolean testConditionalOr(boolean a, boolean b, boolean c) {
+        return a || b || c;
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testConditionalAndOr" (%0 : java.type:"boolean", %1 : java.type:"boolean", %2 : java.type:"boolean", %3 : java.type:"boolean")java.type:"boolean" -> {
+                %4 : Var<java.type:"boolean"> = var %0 @"a";
+                %5 : Var<java.type:"boolean"> = var %1 @"b";
+                %6 : Var<java.type:"boolean"> = var %2 @"c";
+                %7 : Var<java.type:"boolean"> = var %3 @"d";
+                %8 : java.type:"boolean" = constant @false;
+                %9 : java.type:"boolean" = var.load %4;
+                cbranch %9 ^block_2 ^block_1;
+
+              ^block_1:
+                %10 : java.type:"boolean" = var.load %5;
+                cbranch %10 ^block_2 ^block_4(%8);
+
+              ^block_2:
+                %11 : java.type:"boolean" = constant @true;
+                %12 : java.type:"boolean" = constant @false;
+                %13 : java.type:"boolean" = var.load %6;
+                cbranch %13 ^block_4(%11) ^block_3;
+
+              ^block_3:
+                %14 : java.type:"boolean" = var.load %7;
+                cbranch %14 ^block_4(%11) ^block_4(%12);
+
+              ^block_4(%15 : java.type:"boolean"):
+                return %15;
+            };
+            """)
+    static boolean testConditionalAndOr(boolean a, boolean b, boolean c, boolean d) {
+        return (a || b) && (c || d);
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testPattern" (%0 : java.type:"java.lang.Object")java.type:"boolean" -> {
+                %1 : Var<java.type:"java.lang.Object"> = var %0 @"o";
+                %2 : java.type:"java.lang.Object" = var.load %1;
+                %3 : java.type:"java.lang.String" = constant @null;
+                %4 : Var<java.type:"java.lang.String"> = var %3 @"s";
+                %5 : java.type:"boolean" = constant @true;
+                %6 : java.type:"boolean" = constant @false;
+                %7 : java.type:"boolean" = instanceof %2 @java.type:"TestBooleanExpression$Box";
+                cbranch %7 ^block_1 ^block_4(%6);
+
+              ^block_1:
+                %8 : java.type:"TestBooleanExpression$Box" = cast %2 @java.type:"TestBooleanExpression$Box";
+                %9 : java.type:"java.lang.Object" = invoke %8 @java.ref:"TestBooleanExpression$Box::o():java.lang.Object";
+                %10 : java.type:"boolean" = instanceof %9 @java.type:"TestBooleanExpression$Box";
+                cbranch %10 ^block_2 ^block_4(%6);
+
+              ^block_2:
+                %11 : java.type:"TestBooleanExpression$Box" = cast %9 @java.type:"TestBooleanExpression$Box";
+                %12 : java.type:"java.lang.Object" = invoke %11 @java.ref:"TestBooleanExpression$Box::o():java.lang.Object";
+                %13 : java.type:"boolean" = instanceof %12 @java.type:"java.lang.String";
+                cbranch %13 ^block_3 ^block_4(%6);
+
+              ^block_3:
+                %14 : java.type:"java.lang.String" = cast %12 @java.type:"java.lang.String";
+                var.store %4 %14;
+                branch ^block_4(%5);
+
+              ^block_4(%15 : java.type:"boolean"):
+                return %15;
+            };
+            """)
+    static boolean testPattern(Object o) {
+        return o instanceof Box(Box(String s));
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testBooleanConditional" (%0 : java.type:"boolean", %1 : java.type:"boolean", %2 : java.type:"boolean", %3 : java.type:"boolean")java.type:"boolean" -> {
+                %4 : Var<java.type:"boolean"> = var %0 @"a";
+                %5 : Var<java.type:"boolean"> = var %1 @"b";
+                %6 : Var<java.type:"boolean"> = var %2 @"c";
+                %7 : Var<java.type:"boolean"> = var %3 @"d";
+                %8 : java.type:"boolean" = var.load %4;
+                cbranch %8 ^block_1 ^block_3;
+
+              ^block_1:
+                %9 : java.type:"boolean" = constant @true;
+                %10 : java.type:"boolean" = constant @false;
+                %11 : java.type:"boolean" = var.load %4;
+                cbranch %11 ^block_2 ^block_5(%10);
+
+              ^block_2:
+                %12 : java.type:"boolean" = var.load %5;
+                cbranch %12 ^block_5(%9) ^block_5(%10);
+
+              ^block_3:
+                %13 : java.type:"boolean" = constant @true;
+                %14 : java.type:"boolean" = constant @false;
+                %15 : java.type:"boolean" = var.load %6;
+                cbranch %15 ^block_4 ^block_5(%14);
+
+              ^block_4:
+                %16 : java.type:"boolean" = var.load %7;
+                cbranch %16 ^block_5(%13) ^block_5(%14);
+
+              ^block_5(%17 : java.type:"boolean"):
+                return %17;
+            };
+            """)
+    static boolean testBooleanConditional(boolean a, boolean b, boolean c, boolean d) {
+        return a ? a && b : c && d;
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testBooleanSwitch" (%0 : java.type:"int", %1 : java.type:"boolean", %2 : java.type:"boolean", %3 : java.type:"boolean", %4 : java.type:"boolean")java.type:"boolean" -> {
+                %5 : Var<java.type:"int"> = var %0 @"i";
+                %6 : Var<java.type:"boolean"> = var %1 @"a";
+                %7 : Var<java.type:"boolean"> = var %2 @"b";
+                %8 : Var<java.type:"boolean"> = var %3 @"c";
+                %9 : Var<java.type:"boolean"> = var %4 @"d";
+                %10 : java.type:"int" = var.load %5;
+                %11 : java.type:"int" = constant @0;
+                %12 : java.type:"boolean" = eq %10 %11;
+                cbranch %12 ^block_1 ^block_3;
+
+              ^block_1:
+                %13 : java.type:"boolean" = constant @true;
+                %14 : java.type:"boolean" = constant @false;
+                %15 : java.type:"boolean" = var.load %6;
+                cbranch %15 ^block_2 ^block_5(%14);
+
+              ^block_2:
+                %16 : java.type:"boolean" = var.load %7;
+                cbranch %16 ^block_5(%13) ^block_5(%14);
+
+              ^block_3:
+                %17 : java.type:"boolean" = constant @true;
+                %18 : java.type:"boolean" = constant @false;
+                %19 : java.type:"boolean" = var.load %8;
+                cbranch %19 ^block_4 ^block_5(%18);
+
+              ^block_4:
+                %20 : java.type:"boolean" = var.load %9;
+                cbranch %20 ^block_5(%17) ^block_5(%18);
+
+              ^block_5(%21 : java.type:"boolean"):
+                return %21;
+            };
+            """)
+    static boolean testBooleanSwitch(int i, boolean a, boolean b, boolean c, boolean d) {
+        return switch (i) {
+            case 0 -> a && b;
+            default -> c && d;
+        };
+    }
+
+
+    @Reflect
+    @LoweredModel("""
+            func @"testNot" (%0 : java.type:"int", %1 : java.type:"boolean", %2 : java.type:"boolean", %3 : java.type:"boolean")java.type:"boolean" -> {
+                %4 : Var<java.type:"int"> = var %0 @"i";
+                %5 : Var<java.type:"boolean"> = var %1 @"a";
+                %6 : Var<java.type:"boolean"> = var %2 @"b";
+                %7 : Var<java.type:"boolean"> = var %3 @"c";
+                %8 : java.type:"boolean" = constant @false;
+                %9 : java.type:"boolean" = var.load %5;
+                cbranch %9 ^block_1 ^block_3(%8);
+
+              ^block_1:
+                %10 : java.type:"boolean" = constant @false;
+                %11 : java.type:"boolean" = constant @true;
+                %12 : java.type:"boolean" = var.load %6;
+                cbranch %12 ^block_2 ^block_3(%11);
+
+              ^block_2:
+                %13 : java.type:"boolean" = var.load %7;
+                cbranch %13 ^block_3(%10) ^block_3(%11);
+
+              ^block_3(%14 : java.type:"boolean"):
+                return %14;
+            };
+            """)
+    static boolean testNot(int i, boolean a, boolean b, boolean c) {
+        return (a && !(b && c));
+    }
+
+    @Reflect
+    @LoweredModel("""
+            func @"testNotNot" (%0 : java.type:"int", %1 : java.type:"boolean", %2 : java.type:"boolean", %3 : java.type:"boolean")java.type:"boolean" -> {
+                %4 : Var<java.type:"int"> = var %0 @"i";
+                %5 : Var<java.type:"boolean"> = var %1 @"a";
+                %6 : Var<java.type:"boolean"> = var %2 @"b";
+                %7 : Var<java.type:"boolean"> = var %3 @"c";
+                %8 : java.type:"boolean" = constant @false;
+                %9 : java.type:"boolean" = var.load %5;
+                cbranch %9 ^block_1 ^block_3(%8);
+
+              ^block_1:
+                %10 : java.type:"boolean" = constant @true;
+                %11 : java.type:"boolean" = constant @false;
+                %12 : java.type:"boolean" = var.load %6;
+                cbranch %12 ^block_2 ^block_3(%11);
+
+              ^block_2:
+                %13 : java.type:"boolean" = var.load %7;
+                cbranch %13 ^block_3(%10) ^block_3(%11);
+
+              ^block_3(%14 : java.type:"boolean"):
+                return %14;
+            };
+            """)
+    static boolean testNotNot(int i, boolean a, boolean b, boolean c) {
+        return (a && !!(b && c));
+    }
+}

--- a/test/jdk/jdk/incubator/code/lower/TestSynchronized.java
+++ b/test/jdk/jdk/incubator/code/lower/TestSynchronized.java
@@ -89,48 +89,45 @@ public class TestSynchronized {
 
               ^block_1(%5 : java.type:"java.lang.Object"):
                 monitor.enter %5;
-                %17 : java.type:"java.lang.Throwable" = constant @null;
-                %6 : java.type:"void" = exception.region.enter ^block_2 ^block_8(%17);
+                %6 : java.type:"java.lang.Throwable" = constant @null;
+                %7 : java.type:"void" = exception.region.enter ^block_2 ^block_7(%6);
 
               ^block_2:
-                %7 : java.type:"int" = var.load %3;
-                %8 : java.type:"int" = constant @0;
-                %9 : java.type:"boolean" = gt %7 %8;
-                cbranch %9 ^block_3 ^block_5;
+                %8 : java.type:"int" = var.load %3;
+                %9 : java.type:"int" = constant @0;
+                %10 : java.type:"boolean" = gt %8 %9;
+                cbranch %10 ^block_3 ^block_5;
 
               ^block_3:
-                %10 : java.type:"int" = constant @-1;
+                %11 : java.type:"int" = constant @-1;
                 monitor.exit %5;
-                exception.region.exit %6 ^block_4;
+                exception.region.exit %7 ^block_4;
 
               ^block_4:
-                return %10;
+                return %11;
 
               ^block_5:
-                branch ^block_6;
+                %12 : java.type:"int" = var.load %3;
+                %13 : java.type:"int" = constant @1;
+                %14 : java.type:"int" = add %12 %13;
+                var.store %3 %14;
+                monitor.exit %5;
+                exception.region.exit %7 ^block_6;
 
               ^block_6:
-                %11 : java.type:"int" = var.load %3;
-                %12 : java.type:"int" = constant @1;
-                %13 : java.type:"int" = add %11 %12;
-                var.store %3 %13;
+                %15 : java.type:"int" = var.load %3;
+                return %15;
+
+              ^block_7(%16 : java.type:"java.lang.Throwable"):
+                %17 : java.type:"java.lang.Throwable" = constant @null;
+                %18 : java.type:"void" = exception.region.enter ^block_8 ^block_7(%17);
+
+              ^block_8:
                 monitor.exit %5;
-                exception.region.exit %6 ^block_7;
-
-              ^block_7:
-                %14 : java.type:"int" = var.load %3;
-                return %14;
-
-              ^block_8(%15 : java.type:"java.lang.Throwable"):
-                %18 : java.type:"java.lang.Throwable" = constant @null;
-                %16 : java.type:"void" = exception.region.enter ^block_9 ^block_8(%18);
+                exception.region.exit %18 ^block_9;
 
               ^block_9:
-                monitor.exit %5;
-                exception.region.exit %16 ^block_10;
-
-              ^block_10:
-                throw %15;
+                throw %16;
             };
             """, ssa = false)
     static int test2(Object m, int i) {
@@ -159,54 +156,48 @@ public class TestSynchronized {
                 throw %7;
 
               ^block_2:
-                branch ^block_3;
-
-              ^block_3:
                 %8 : java.type:"java.lang.Object" = var.load %2;
-                branch ^block_4(%8);
+                branch ^block_3(%8);
 
-              ^block_4(%9 : java.type:"java.lang.Object"):
+              ^block_3(%9 : java.type:"java.lang.Object"):
                 monitor.enter %9;
                 %10 : java.type:"java.lang.Throwable" = constant @null;
-                %11 : java.type:"void" = exception.region.enter ^block_5 ^block_12(%10);
+                %11 : java.type:"void" = exception.region.enter ^block_4 ^block_10(%10);
 
-              ^block_5:
+              ^block_4:
                 %12 : java.type:"int" = var.load %3;
                 %13 : java.type:"int" = constant @0;
                 %14 : java.type:"boolean" = gt %12 %13;
-                cbranch %14 ^block_6 ^block_8;
+                cbranch %14 ^block_5 ^block_7;
 
-              ^block_6:
+              ^block_5:
                 %15 : java.type:"int" = var.load %3;
                 monitor.exit %9;
-                exception.region.exit %11 ^block_7;
+                exception.region.exit %11 ^block_6;
+
+              ^block_6:
+                branch ^block_9(%15);
 
               ^block_7:
-                branch ^block_11(%15);
-
-              ^block_8:
-                branch ^block_9;
-
-              ^block_9:
                 %16 : java.type:"int" = constant @0;
                 monitor.exit %9;
-                exception.region.exit %11 ^block_10;
+                exception.region.exit %11 ^block_8;
 
-              ^block_10:
-                branch ^block_11(%16);
+              ^block_8:
+                branch ^block_9(%16);
 
-              ^block_11(%17 : java.type:"int"):
+              ^block_9(%17 : java.type:"int"):
                 return %17;
 
-              ^block_12(%18 : java.type:"java.lang.Throwable"):
+              ^block_10(%18 : java.type:"java.lang.Throwable"):
                 %19 : java.type:"java.lang.Throwable" = constant @null;
-                %20 : java.type:"void" = exception.region.enter ^block_13 ^block_12(%19);
+                %20 : java.type:"void" = exception.region.enter ^block_11 ^block_10(%19);
 
-              ^block_13:
+              ^block_11:
                 monitor.exit %9;
-                exception.region.exit %20 ^block_14;
+                exception.region.exit %20 ^block_12;
 
-              ^block_14:
+              ^block_12:
                 throw %18;
             };
             """, ssa = false)
@@ -235,7 +226,7 @@ public class TestSynchronized {
               ^block_1(%5 : java.type:"java.lang.Object"):
                 monitor.enter %5;
                 %6 : java.type:"java.lang.Throwable" = constant @null;
-                %7 : java.type:"void" = exception.region.enter ^block_2 ^block_9(%6);
+                %7 : java.type:"void" = exception.region.enter ^block_2 ^block_8(%6);
 
               ^block_2:
                 %8 : java.type:"int" = var.load %3;
@@ -250,35 +241,32 @@ public class TestSynchronized {
                 exception.region.exit %7 ^block_4;
 
               ^block_4:
-                branch ^block_7;
-
-              ^block_5:
                 branch ^block_6;
 
-              ^block_6:
+              ^block_5:
                 %12 : java.type:"int" = var.load %3;
                 %13 : java.type:"int" = constant @1;
                 %14 : java.type:"int" = add %12 %13;
                 var.store %3 %14;
                 monitor.exit %5;
-                exception.region.exit %7 ^block_7;
+                exception.region.exit %7 ^block_6;
+
+              ^block_6:
+                branch ^block_7;
 
               ^block_7:
-                branch ^block_8;
-
-              ^block_8:
                 %15 : java.type:"int" = var.load %3;
                 return %15;
 
-              ^block_9(%16 : java.type:"java.lang.Throwable"):
+              ^block_8(%16 : java.type:"java.lang.Throwable"):
                 %17 : java.type:"java.lang.Throwable" = constant @null;
-                %18 : java.type:"void" = exception.region.enter ^block_10 ^block_9(%17);
+                %18 : java.type:"void" = exception.region.enter ^block_9 ^block_8(%17);
+
+              ^block_9:
+                monitor.exit %5;
+                exception.region.exit %18 ^block_10;
 
               ^block_10:
-                monitor.exit %5;
-                exception.region.exit %18 ^block_11;
-
-              ^block_11:
                 throw %16;
             };
             """, ssa = false)
@@ -306,7 +294,7 @@ public class TestSynchronized {
                 %6 : java.type:"int" = var.load %5;
                 %7 : java.type:"int" = constant @10;
                 %8 : java.type:"boolean" = lt %6 %7;
-                cbranch %8 ^block_2 ^block_14;
+                cbranch %8 ^block_2 ^block_13;
 
               ^block_2:
                 %9 : java.type:"java.lang.Object" = var.load %2;
@@ -315,7 +303,7 @@ public class TestSynchronized {
               ^block_3(%10 : java.type:"java.lang.Object"):
                 monitor.enter %10;
                 %11 : java.type:"java.lang.Throwable" = constant @null;
-                %12 : java.type:"void" = exception.region.enter ^block_4 ^block_11(%11);
+                %12 : java.type:"void" = exception.region.enter ^block_4 ^block_10(%11);
 
               ^block_4:
                 %13 : java.type:"int" = var.load %3;
@@ -330,41 +318,38 @@ public class TestSynchronized {
                 exception.region.exit %12 ^block_6;
 
               ^block_6:
-                branch ^block_10;
+                branch ^block_9;
 
               ^block_7:
-                branch ^block_8;
-
-              ^block_8:
                 %17 : java.type:"int" = var.load %3;
                 %18 : java.type:"int" = constant @1;
                 %19 : java.type:"int" = add %17 %18;
                 var.store %3 %19;
                 monitor.exit %10;
-                exception.region.exit %12 ^block_9;
+                exception.region.exit %12 ^block_8;
+
+              ^block_8:
+                branch ^block_9;
 
               ^block_9:
-                branch ^block_10;
-
-              ^block_10:
                 %20 : java.type:"int" = var.load %5;
                 %21 : java.type:"int" = constant @1;
                 %22 : java.type:"int" = add %20 %21;
                 var.store %5 %22;
                 branch ^block_1;
 
-              ^block_11(%23 : java.type:"java.lang.Throwable"):
+              ^block_10(%23 : java.type:"java.lang.Throwable"):
                 %24 : java.type:"java.lang.Throwable" = constant @null;
-                %25 : java.type:"void" = exception.region.enter ^block_12 ^block_11(%24);
+                %25 : java.type:"void" = exception.region.enter ^block_11 ^block_10(%24);
+
+              ^block_11:
+                monitor.exit %10;
+                exception.region.exit %25 ^block_12;
 
               ^block_12:
-                monitor.exit %10;
-                exception.region.exit %25 ^block_13;
-
-              ^block_13:
                 throw %23;
 
-              ^block_14:
+              ^block_13:
                 %26 : java.type:"int" = var.load %3;
                 return %26;
             };

--- a/test/jdk/jdk/incubator/code/pe/TestPE.java
+++ b/test/jdk/jdk/incubator/code/pe/TestPE.java
@@ -213,82 +213,79 @@ public class TestPE {
     @Reflect
     @EvaluatedModel("""
             func @"f" (%0 : java.type:"TestPE", %1 : java.type:"java.util.function.IntConsumer")java.type:"void" -> {
-                 %2 : Var<java.type:"java.util.function.IntConsumer"> = var %1 @"c";
-                 %3 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %4 : java.type:"int" = constant @1;
-                 invoke %3 %4 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %5 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %6 : java.type:"int" = constant @3;
-                 invoke %5 %6 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %7 : java.type:"boolean" = field.load %0 @java.ref:"TestPE::b:boolean";
-                 cbranch %7 ^block_1 ^block_2;
+                %2 : Var<java.type:"java.util.function.IntConsumer"> = var %1 @"c";
+                %3 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %4 : java.type:"int" = constant @1;
+                invoke %3 %4 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %5 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %6 : java.type:"int" = constant @3;
+                invoke %5 %6 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %7 : java.type:"boolean" = field.load %0 @java.ref:"TestPE::b:boolean";
+                cbranch %7 ^block_1 ^block_2;
 
-               ^block_1:
-                 %8 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %9 : java.type:"int" = constant @5;
-                 invoke %8 %9 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %10 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %11 : java.type:"int" = constant @0;
-                 invoke %10 %11 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %12 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %13 : java.type:"int" = constant @6;
-                 invoke %12 %13 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %14 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %15 : java.type:"int" = constant @1;
-                 invoke %14 %15 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %16 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %17 : java.type:"int" = constant @0;
-                 %18 : java.type:"int[]" = field.load %0 @java.ref:"TestPE::x:int[]";
-                 %19 : java.type:"int" = constant @0;
-                 %20 : java.type:"int" = array.load %18 %19;
-                 %21 : java.type:"int" = add %17 %20;
-                 invoke %16 %21 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %22 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %23 : java.type:"int" = constant @1;
-                 invoke %22 %23 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %24 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %25 : java.type:"int" = constant @7;
-                 invoke %24 %25 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %26 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %27 : java.type:"int" = constant @2;
-                 invoke %26 %27 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %28 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %29 : java.type:"int" = constant @1;
-                 %30 : java.type:"int[]" = field.load %0 @java.ref:"TestPE::x:int[]";
-                 %31 : java.type:"int" = constant @1;
-                 %32 : java.type:"int" = array.load %30 %31;
-                 %33 : java.type:"int" = add %29 %32;
-                 invoke %28 %33 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %34 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %35 : java.type:"int" = constant @2;
-                 invoke %34 %35 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %36 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %37 : java.type:"int" = constant @7;
-                 invoke %36 %37 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %38 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %39 : java.type:"int" = constant @2;
-                 invoke %38 %39 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %40 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %41 : java.type:"int" = constant @2;
-                 %42 : java.type:"int[]" = field.load %0 @java.ref:"TestPE::x:int[]";
-                 %43 : java.type:"int" = constant @2;
-                 %44 : java.type:"int" = array.load %42 %43;
-                 %45 : java.type:"int" = add %41 %44;
-                 invoke %40 %45 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 %46 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %47 : java.type:"int" = constant @8;
-                 invoke %46 %47 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 branch ^block_3;
+              ^block_1:
+                %8 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %9 : java.type:"int" = constant @5;
+                invoke %8 %9 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %10 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %11 : java.type:"int" = constant @0;
+                invoke %10 %11 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %12 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %13 : java.type:"int" = constant @6;
+                invoke %12 %13 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %14 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %15 : java.type:"int" = constant @1;
+                invoke %14 %15 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %16 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %17 : java.type:"int" = constant @0;
+                %18 : java.type:"int[]" = field.load %0 @java.ref:"TestPE::x:int[]";
+                %19 : java.type:"int" = constant @0;
+                %20 : java.type:"int" = array.load %18 %19;
+                %21 : java.type:"int" = add %17 %20;
+                invoke %16 %21 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %22 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %23 : java.type:"int" = constant @1;
+                invoke %22 %23 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %24 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %25 : java.type:"int" = constant @7;
+                invoke %24 %25 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %26 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %27 : java.type:"int" = constant @2;
+                invoke %26 %27 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %28 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %29 : java.type:"int" = constant @1;
+                %30 : java.type:"int[]" = field.load %0 @java.ref:"TestPE::x:int[]";
+                %31 : java.type:"int" = constant @1;
+                %32 : java.type:"int" = array.load %30 %31;
+                %33 : java.type:"int" = add %29 %32;
+                invoke %28 %33 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %34 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %35 : java.type:"int" = constant @2;
+                invoke %34 %35 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %36 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %37 : java.type:"int" = constant @7;
+                invoke %36 %37 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %38 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %39 : java.type:"int" = constant @2;
+                invoke %38 %39 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %40 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %41 : java.type:"int" = constant @2;
+                %42 : java.type:"int[]" = field.load %0 @java.ref:"TestPE::x:int[]";
+                %43 : java.type:"int" = constant @2;
+                %44 : java.type:"int" = array.load %42 %43;
+                %45 : java.type:"int" = add %41 %44;
+                invoke %40 %45 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                %46 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %47 : java.type:"int" = constant @8;
+                invoke %46 %47 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                branch ^block_2;
 
-               ^block_2:
-                 branch ^block_3;
-
-               ^block_3:
-                 %48 : java.type:"java.util.function.IntConsumer" = var.load %2;
-                 %49 : java.type:"int" = constant @9;
-                 invoke %48 %49 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                 return;
-             };
+              ^block_2:
+                %48 : java.type:"java.util.function.IntConsumer" = var.load %2;
+                %49 : java.type:"int" = constant @9;
+                invoke %48 %49 @java.ref:"java.util.function.IntConsumer::accept(int):void";
+                return;
+            };
             """)
     @EvaluatedModel(value = """
             func @"f" (%0 : java.type:"TestPE", %1 : java.type:"java.util.function.IntConsumer")java.type:"void" -> {
@@ -334,12 +331,9 @@ public class TestPE {
                    invoke %1 %23 @java.ref:"java.util.function.IntConsumer::accept(int):void";
                    %24 : java.type:"int" = constant @8;
                    invoke %1 %24 @java.ref:"java.util.function.IntConsumer::accept(int):void";
-                   branch ^block_3;
+                   branch ^block_2;
 
                  ^block_2:
-                   branch ^block_3;
-
-                 ^block_3:
                    %25 : java.type:"int" = constant @9;
                    invoke %1 %25 @java.ref:"java.util.function.IntConsumer::accept(int):void";
                    return;
@@ -579,12 +573,9 @@ public class TestPE {
                 return;
 
               ^block_5:
-                branch ^block_7;
+                branch ^block_6;
 
               ^block_6:
-                branch ^block_7;
-
-              ^block_7:
                 invoke %1 %8 @java.ref:"java.util.function.IntConsumer::accept(int):void";
                 %13 : java.type:"int" = constant @1;
                 %14 : java.type:"int" = add %8 %13;
@@ -661,22 +652,19 @@ public class TestPE {
                 return;
 
               ^block_5:
-                branch ^block_7;
+                branch ^block_6;
 
               ^block_6:
-                branch ^block_7;
-
-              ^block_7:
                 %11 : java.type:"int" = constant @5;
                 %12 : java.type:"boolean" = lt %6 %11;
-                cbranch %12 ^block_8 ^block_9;
+                cbranch %12 ^block_7 ^block_8;
 
-              ^block_8:
+              ^block_7:
                 %13 : java.type:"int" = constant @2;
                 %14 : java.type:"int" = add %6 %13;
                 branch ^block_2(%14);
 
-              ^block_9:
+              ^block_8:
                 invoke %1 %6 @java.ref:"java.util.function.IntConsumer::accept(int):void";
                 %15 : java.type:"int" = constant @1;
                 %16 : java.type:"int" = add %6 %15;


### PR DESCRIPTION
In general the lowering of boolean expressions with control flow now produces simpler code models. This is achieved by specializing the lowering of bodies of particular shapes that produce a boolean result and passing a continuation that controls how the result is continued to the next boolean expression.

As an example, consider this code:

```java
while (a && (b || c)) {
    IO.println("LOOP BODY");
}
```

The Java code model is:

```
java.while
    ()java.type:"boolean" -> {
        %8 : java.type:"boolean" = java.cand
            ()java.type:"boolean" -> {
                %9 : java.type:"boolean" = var.load %3;
                yield %9;
            }
            ()java.type:"boolean" -> {
                %10 : java.type:"boolean" = java.cor
                    ()java.type:"boolean" -> {
                        %11 : java.type:"boolean" = var.load %5;
                        yield %11;
                    }
                    ()java.type:"boolean" -> {
                        %12 : java.type:"boolean" = var.load %7;
                        yield %12;
                    };
                yield %10;
            };
        yield %8;
    }
    ()java.type:"void" -> {
        %13 : java.type:"java.lang.String" = constant @"LOOP BODY";
        invoke %13 @java.ref:"java.lang.IO::println(java.lang.Object):void";
        java.continue;
    };
``` 

And the lowered code model is:

```
  ^block_1:
    %8 : java.type:"boolean" = var.load %3;
    cbranch %8 ^block_2 ^block_5;
  
  ^block_2:
    %9 : java.type:"boolean" = var.load %5;
    cbranch %9 ^block_4 ^block_3;
  
  ^block_3:
    %10 : java.type:"boolean" = var.load %7;
    cbranch %10 ^block_4 ^block_5;
  
  ^block_4:
    %11 : java.type:"java.lang.String" = constant @"LOOP BODY";
    invoke %11 @java.ref:"java.lang.IO::println(java.lang.Object):void";
    branch ^block_1;
  
  ^block_5:
```

Notice the consistent branching to `^block_5`, representing the exit of the `while` loop. Lowering prior to this PR would generate blocks that join intermediate boolean results.

As a result many lowered Java code models can now be transformed into pure SSA code models, without a subsequent normalization transformation. Normalization is still required but less so, and it should be made part of the SSA transformation as a follow on PR.

After that is complete it should be possible to fully support the SSA transformation of lowered Java code models produced from source that in general declare uninitialized variables. In addition, in another follow on PR, we can modify the lowering of patterns with pattern variables so they are declared uninitialized.
 
---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1165/head:pull/1165` \
`$ git checkout pull/1165`

Update a local copy of the PR: \
`$ git checkout pull/1165` \
`$ git pull https://git.openjdk.org/babylon.git pull/1165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1165`

View PR using the GUI difftool: \
`$ git pr show -t 1165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1165.diff">https://git.openjdk.org/babylon/pull/1165.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1165#issuecomment-5472033865)
</details>
