### PR TITLE
8391519: Try-with-resources lowering loses CodeContext mapping for a dependent resource

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5722,11 +5722,6 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// @jls 14.20.3.1 Basic try-with-resources
         Op.Result normalizeBasicTryWithResources(Block.Builder b) {
             assert resourcesBodies.size() == 1;
-            // due to the default behavior of child code context creation when creating
-            // bodies and transforming bodies, b.context(), which contains the mappings
-            // for resource values, differs from the code context for b.parentBody().entryBlock().context()
-            // which does not contain the mappings. In this case we need to explicitly
-            // pass the b's code context when creating the body builder
             Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID));
             Block.Builder entryBlock = normalizedBody.entryBlock();
             Body resourceBody = resourcesBodies.getFirst();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5722,7 +5722,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// @jls 14.20.3.1 Basic try-with-resources
         Op.Result normalizeBasicTryWithResources(Block.Builder b) {
             assert resourcesBodies.size() == 1;
-            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID));
+            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID), b.context(), b.transformer());
             Block.Builder entryBlock = normalizedBody.entryBlock();
             Body resourceBody = resourcesBodies.getFirst();
             CodeType resourceType = resourceBody.bodySignature().returnType();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5722,6 +5722,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         /// @jls 14.20.3.1 Basic try-with-resources
         Op.Result normalizeBasicTryWithResources(Block.Builder b) {
             assert resourcesBodies.size() == 1;
+            // due to the default behavior of child code context creation when creating
+            // bodies and transforming bodies, b.context(), which contains the mappings
+            // for resource values, differs from the code context for b.parentBody().entryBlock().context()
+            // which does not contain the mappings. In this case we need to explicitly
+            // pass the b's code context when creating the body builder
             Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID), b.context(), b.transformer());
             Block.Builder entryBlock = normalizedBody.entryBlock();
             Body resourceBody = resourcesBodies.getFirst();

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -5684,7 +5684,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
         TryOp normalizeExtendedTryWithResources(Body.Builder anc, List<Value> res) {
             Body resource = resourcesBodies.get(res.size());
             Body.Builder resourceBody = Body.Builder.of(anc, CoreType.functionType(resource.yieldType()));
-            resourceBody.entryBlock().transformBody(resource, res);
+            resourceBody.entryBlock().transformBody(resource, res, resourceBody.entryBlock().context(), resourceBody.entryBlock().transformer());
             Body.Builder basicBody = Body.Builder.of(anc, CoreType.functionType(VOID, List.of(resource.yieldType())));
             Block.Builder bodyBlock = basicBody.entryBlock();
             res.add(bodyBlock.parameters().getFirst());
@@ -5692,7 +5692,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 bodyBlock.add(normalizeExtendedTryWithResources(basicBody, res));
                 bodyBlock.add(core_yield());
             } else {
-                bodyBlock.transformBody(body, res);
+                bodyBlock.transformBody(body, res, bodyBlock.context(), bodyBlock.transformer());
             }
             return try_(List.of(resourceBody), basicBody, List.of(), null);
         }
@@ -5727,12 +5727,12 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             // for resource values, differs from the code context for b.parentBody().entryBlock().context()
             // which does not contain the mappings. In this case we need to explicitly
             // pass the b's code context when creating the body builder
-            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID), b.context(), b.transformer());
+            Body.Builder normalizedBody = Body.Builder.of(b.parentBody(), CoreType.functionType(VOID));
             Block.Builder entryBlock = normalizedBody.entryBlock();
             Body resourceBody = resourcesBodies.getFirst();
             CodeType resourceType = resourceBody.bodySignature().returnType();
             Block.Builder afterAcquire = entryBlock.block(resourceType);
-            entryBlock.transformBody(resourceBody, List.of(), (block, op) -> {
+            entryBlock.transformBody(resourceBody, List.of(), entryBlock.context(), (block, op) -> {
                 if (op instanceof CoreOp.YieldOp yop && op.ancestorBody() == resourceBody) {
                     block.add(branch(afterAcquire.reference(block.context().getValue(yop.yieldValue()))));
                 } else {
@@ -5751,7 +5751,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             Value primaryExceptionVar = afterAcquire.add(var(afterAcquire.add(constant(type(Throwable.class), null))));
             // @@@ following builder code may be refactored into a reflected template method transformation
             afterAcquire.add(try_(entryBlock.parentBody(), tryEntry -> {
-                tryEntry.transformBody(body, List.of(resourceArgument));
+                tryEntry.transformBody(body, List.of(resourceArgument), tryEntry.context(), tryEntry.transformer());
             }).catch_(type(Throwable.class), catchB -> {
                 Block.Parameter thrown = catchB.parameters().getFirst();
                 catchB.add(varStore(primaryExceptionVar, thrown));

--- a/test/jdk/jdk/incubator/code/TestTryWithResources.java
+++ b/test/jdk/jdk/incubator/code/TestTryWithResources.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTryWithResources {
 
-    record Resource(Consumer<String> log, String suffix, boolean throwOnClose, boolean throwOnCreate) implements Closeable {
+    record Resource(Consumer<String> log, String suffix, boolean throwOnClose, boolean throwOnCreate, Resource res) implements Closeable {
 
         Resource {
             log.accept("open" + suffix);
@@ -77,12 +77,12 @@ public class TestTryWithResources {
     public static void tryWithResources(Consumer<String> log, boolean throwInBody, boolean throwOnClose1,
                                         boolean throwOnClose2, boolean throwOnClose3, boolean throwOnCreate1,
                                         boolean throwOnCreate2, boolean throwOnCreate3) throws IOException {
-        var r2 = new Resource(log, "2", throwOnClose2, throwOnCreate2);
+        var r2 = new Resource(log, "2", throwOnClose2, throwOnCreate2, null);
         try {
-            try (var _ = new Resource(log, "1", throwOnClose1, throwOnCreate1)) {
+            try (var _ = new Resource(log, "1", throwOnClose1, throwOnCreate1, null)) {
                 log.accept("outerBody");
-                try (var _ = r2;
-                     var _ = new Resource(log, "3", throwOnClose3, throwOnCreate3)) {
+                try (var r1 = r2;
+                     var _ = new Resource(log, "3", throwOnClose3, throwOnCreate3, r1)) {
                     log.accept("innerBody");
                     if (throwInBody) {
                         log.accept("throwBody");
@@ -140,5 +140,4 @@ public class TestTryWithResources {
             assertIterableEquals(expected, actual);
         }
     }
-
 }

--- a/test/jdk/jdk/incubator/code/TestTryWithResources.java
+++ b/test/jdk/jdk/incubator/code/TestTryWithResources.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTryWithResources {
 
-    record Resource(Consumer<String> log, String suffix, boolean throwOnClose, boolean throwOnCreate, Resource res) implements Closeable {
+    record Resource(Consumer<String> log, String suffix, boolean throwOnClose, boolean throwOnCreate, Resource... res) implements Closeable {
 
         Resource {
             log.accept("open" + suffix);
@@ -77,12 +77,12 @@ public class TestTryWithResources {
     public static void tryWithResources(Consumer<String> log, boolean throwInBody, boolean throwOnClose1,
                                         boolean throwOnClose2, boolean throwOnClose3, boolean throwOnCreate1,
                                         boolean throwOnCreate2, boolean throwOnCreate3) throws IOException {
-        var r2 = new Resource(log, "2", throwOnClose2, throwOnCreate2, null);
+        var r2 = new Resource(log, "2", throwOnClose2, throwOnCreate2);
         try {
-            try (var _ = new Resource(log, "1", throwOnClose1, throwOnCreate1, null)) {
+            try (var r1 = new Resource(log, "1", throwOnClose1, throwOnCreate1, r2)) {
                 log.accept("outerBody");
-                try (var r1 = r2;
-                     var _ = new Resource(log, "3", throwOnClose3, throwOnCreate3, r1)) {
+                try (var r = r2;
+                     var _ = new Resource(log, "3", throwOnClose3, throwOnCreate3, r, r1)) {
                     log.accept("innerBody");
                     if (throwInBody) {
                         log.accept("throwBody");


### PR DESCRIPTION
Consider the following code snippet:
```
@Reflect
static int readFirst(byte[] input) throws IOException {
    try (var stream = new ByteArrayInputStream(input);
         var data = new DataInputStream(stream)) {
        return data.read();
    }
}
```
While lowering a code model created from this method, `BytecodeGenerator` throws the following exception:
```
java.lang.IllegalArgumentException:
    No mapping for input value: %param...
    at jdk.incubator.code.CodeContext.getValue(CodeContext.java:128)
    ...
    at JavaOp$TryOp.lambda$normalizeBasicTryWithResources$0(JavaOp.java:5734)
    at BytecodeGenerator.generate(BytecodeGenerator.java:86)
```
The issue is that, when `TryOp.normalizeBasicTryWithResources` creates `normalizedBody`, it does not preserve the active `b.context()` mapping established while converting the extended try-with-resources form into nested basic forms. Consequently, when the second resource initializer is copied, its load of the first resource cannot be mapped.

This proposal modifies `TryOp.normalizeBasicTryWithResources` to preserve the active `b.context()` while creating `normalizedBody`.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8391519](https://bugs.openjdk.org/browse/JDK-8391519): Try-with-resources lowering loses CodeContext mapping for a dependent resource (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1167/head:pull/1167` \
`$ git checkout pull/1167`

Update a local copy of the PR: \
`$ git checkout pull/1167` \
`$ git pull https://git.openjdk.org/babylon.git pull/1167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1167`

View PR using the GUI difftool: \
`$ git pr show -t 1167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1167.diff">https://git.openjdk.org/babylon/pull/1167.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1167#issuecomment-5495162208)
</details>
