### PR TITLE
Correct source location of switch case variable operations

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1855,7 +1855,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     pushBody(c, caseBodyType);
 
                     for (JCVariableDecl var : assignedIn(prevCaseVars, c.stats)) {
-                        result = append(CoreOp.var(var.name.toString(), typeToCodeType(var.type)));
+                        result = append(CoreOp.var(var.name.toString(), typeToCodeType(var.type)), generateLocation(var, false));
                         stack.localToOp.put(var.sym, result);
                     }
 


### PR DESCRIPTION
This is a follow up to https://github.com/openjdk/babylon/pull/1164.

This change corrects the source locations of uninitialized `VarOp`s created at the beginning of a case body for variables declared at the top level of preceding case statement groups. Each location is now derived from the corresponding original `JCVariableDecl`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1168/head:pull/1168` \
`$ git checkout pull/1168`

Update a local copy of the PR: \
`$ git checkout pull/1168` \
`$ git pull https://git.openjdk.org/babylon.git pull/1168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1168`

View PR using the GUI difftool: \
`$ git pr show -t 1168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1168.diff">https://git.openjdk.org/babylon/pull/1168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1168#issuecomment-5495666809)
</details>
