### PR TITLE
8391665: Switch lowering fails with missing fall-through target when default precedes another case

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -3534,9 +3534,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
             // Create predicate and action blocks
             List<Block.Builder> blocks = new ArrayList<>(reorderedBodies.size());
-            blocks.add(b);
-            for (int i = 1; i < reorderedBodies.size(); i ++) {
-                blocks.add(b.block());
+            Map<Body, Block.Builder> body2blocks = new IdentityHashMap<>();
+            for (int i = 0; i < reorderedBodies.size(); i ++) {
+                Block.Builder block = i == 0 ? b : b.block();
+                blocks.add(block);
+                body2blocks.put(reorderedBodies.get(i), block);
             }
 
             Block.Builder exit = b.block();
@@ -3548,10 +3550,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             // Set this body's break target to the exit block
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
             // Set action body's continue target to next action block for lowering of SwitchFallThroughOp
-            for (int i = 1; i < reorderedBodies.size() - 2; i += 2) {
-                Body actionBody = reorderedBodies.get(i);
-                Block.Builder nextActionBlock = blocks.get(i + 2);
-                BranchTarget.setBranchTarget(b.context(), actionBody, null, nextActionBlock);
+            // using original source order
+            for (int i = 1; i < bodies().size() - 2; i += 2) {
+                Body actionBody = bodies().get(i);
+                Body nextActionBody = bodies().get(i + 2);
+                BranchTarget.setBranchTarget(b.context(), actionBody, null, body2blocks.get(nextActionBody));
             }
 
             if (defaultCaseIndex == 0) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -3514,34 +3514,28 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                 }
             }
 
-            // Reorder bodies with default case at the end
-            // @@@ Model this as the last case
-            List<Body> reorderedBodies;
-            if (defaultCaseIndex != -1 && defaultCaseIndex != bodies().size() - 2) {
-                reorderedBodies = new ArrayList<>(bodies().size());
-                for (int i = 0; i < bodies().size(); i += 2) {
-                    if (i != defaultCaseIndex) {
-                        reorderedBodies.add(bodies().get(i));
-                        reorderedBodies.add(bodies().get(i + 1));
-                    }
-                }
-                reorderedBodies.add(bodies().get(defaultCaseIndex));
-                reorderedBodies.add(bodies().get(defaultCaseIndex + 1));
-                defaultCaseIndex = bodies().size() - 2;
-            } else {
-                reorderedBodies = bodies();
-            }
-
             // Create predicate and action blocks
-            List<Block.Builder> blocks = new ArrayList<>(reorderedBodies.size());
-            Map<Body, Block.Builder> body2blocks = new IdentityHashMap<>();
-            for (int i = 0; i < reorderedBodies.size(); i ++) {
-                Block.Builder block = i == 0 ? b : b.block();
-                blocks.add(block);
-                body2blocks.put(reorderedBodies.get(i), block);
+            List<Block.Builder> blocks = new ArrayList<>(bodies().size());
+            // Reuse incoming block for the first predicate
+            int reuseIdx = 0;
+            for (int i = 0; i < bodies().size(); i ++) {
+                if (i == defaultCaseIndex) {
+                    // No block needed for default predicate
+                    blocks.add(null);
+                    if (i == 0) {
+                        // The first predicate is default. Reuese incoming block
+                        // for the default action block itself if the switch is
+                        // only-default, or for the next predicate otherwise
+                        reuseIdx = bodies().size() > 2 ? i + 2 : i + 1;
+                    }
+                } else if (i == reuseIdx) {
+                    blocks.add(b);
+                } else {
+                    blocks.add(b.block());
+                }
             }
 
-            Block.Builder exit = b.block();
+            Block.Builder exit = bodies().isEmpty() ? b : b.block();
             if (resultType() != VOID) {
                 Value r = exit.parameter(resultType());
                 exit.context().mapValue(result(), r);
@@ -3550,46 +3544,38 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             // Set this body's break target to the exit block
             BranchTarget.setBranchTarget(b.context(), this, exit, null);
             // Set action body's continue target to next action block for lowering of SwitchFallThroughOp
-            // using original source order
             for (int i = 1; i < bodies().size() - 2; i += 2) {
                 Body actionBody = bodies().get(i);
-                Body nextActionBody = bodies().get(i + 2);
-                BranchTarget.setBranchTarget(b.context(), actionBody, null, body2blocks.get(nextActionBody));
+                Block.Builder nextActionBlock = blocks.get(i + 2);
+                BranchTarget.setBranchTarget(b.context(), actionBody, null, nextActionBlock);
             }
 
-            if (defaultCaseIndex == 0) {
-                // If there is only the default case branch to the action block
-                Block.Builder actionBlock = blocks.get(1);
-                b.add(branch(actionBlock.reference()));
-            }
-            for (int i = 0; i < reorderedBodies.size(); i += 2) {
-                Body predicateBody = reorderedBodies.get(i);
+            for (int i = 0; i < bodies().size(); i += 2) {
+                Body predicateBody = bodies().get(i);
                 Block.Builder predicateBlock = blocks.get(i);
-                Body actionBody = reorderedBodies.get(i + 1);
+                Body actionBody = bodies().get(i + 1);
                 Block.Builder actionBlock = blocks.get(i + 1);
 
                 // Lower predicate body for non-default cases
                 if (i != defaultCaseIndex) {
-                    boolean isLastCaseNoDefault = i == reorderedBodies.size() - 2;
-                    boolean isLastCaseWithDefault = defaultCaseIndex == i + 2;
+                    int nextPredicateIdx = i + 2;
+                    if (nextPredicateIdx == defaultCaseIndex) {
+                        nextPredicateIdx += 2;
+                    }
+
                     Block.Builder noMatchBlock;
-                    if (isLastCaseNoDefault) {
+                    if (nextPredicateIdx < bodies().size()) {
+                        noMatchBlock = blocks.get(nextPredicateIdx);
+                    } else if (defaultCaseIndex != -1) {
+                        noMatchBlock = blocks.get(defaultCaseIndex + 1);
+                    } else if (this instanceof SwitchExpressionOp) {
                         // If switch expression, the last predicate body should be unconditional
                         // and no conditional branch should be required. Rather than verifying
                         // that create a no match block that terminates with unreachable
-                        if (this instanceof SwitchExpressionOp) {
-                            Block.Builder unreachableBlock = b.block();
-                            unreachableBlock.add(unreachable());
-                            noMatchBlock = unreachableBlock;
-                        } else {
-                            noMatchBlock = exit;
-                        }
-                    } else if (isLastCaseWithDefault) {
-                        Block.Builder defaultActionBlock = blocks.get(defaultCaseIndex + 1);
-                        noMatchBlock = defaultActionBlock;
+                        noMatchBlock = b.block();
+                        noMatchBlock.add(unreachable());
                     } else {
-                        Block.Builder nextPredicateBlock = blocks.get(i + 2);
-                        noMatchBlock = nextPredicateBlock;
+                        noMatchBlock = exit;
                     }
 
                     predicateBlock.transformBody(predicateBody, List.of(selectorExpression), loweringTransformer(inherited,

--- a/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchExpressionOp.java
@@ -268,6 +268,24 @@ public class TestSwitchExpressionOp {
     }
 
     @Test
+    void testCaseConstantEnumWithDefaultFallThrough() {
+        CoreOp.FuncOp lmodel = lower("caseConstantEnumWithDefaultFallThrough");
+        for (Day day : Day.values()) {
+            Assertions.assertEquals(caseConstantEnumWithDefaultFallThrough(day), Interpreter.invoke(MethodHandles.lookup(), lmodel, day));
+        }
+    }
+
+    @Reflect
+    private static int caseConstantEnumWithDefaultFallThrough(Day d) {
+        return switch (d) {
+            case MON, FRI, SUN: yield 0;
+            case TUE:
+            default:
+            case WED: yield 1;
+        };
+    }
+
+    @Test
     void testCaseConstantFallThrough() {
         CoreOp.FuncOp lmodel = lower("caseConstantFallThrough");
         char[] args = {'A', 'B', 'C'};

--- a/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
+++ b/test/jdk/jdk/incubator/code/TestSwitchStatementOp.java
@@ -299,6 +299,24 @@ public class TestSwitchStatementOp {
     }
 
     @Test
+    void testCaseConstantEnumWithDefaultFallThrough() {
+        CoreOp.FuncOp lmodel = lower("caseConstantEnumWithDefaultFallThrough");
+        for (Day day : Day.values()) {
+            Assertions.assertEquals(caseConstantEnumWithDefaultFallThrough(day), Interpreter.invoke(MethodHandles.lookup(), lmodel, day));
+        }
+    }
+
+    @Reflect
+    private static int caseConstantEnumWithDefaultFallThrough(Day d) {
+        switch (d) {
+            case MON, FRI, SUN: return 0;
+            case TUE:
+            default:
+            case WED: return 1;
+        }
+    }
+
+    @Test
     void testCaseConstantOtherKindsOfExpr() {
         CoreOp.FuncOp lmodel = lower("caseConstantOtherKindsOfExpr");
         for (int i = 0; i < 14; i++) {

--- a/test/jdk/jdk/incubator/code/lower/TestSynchronized.java
+++ b/test/jdk/jdk/incubator/code/lower/TestSynchronized.java
@@ -159,54 +159,51 @@ public class TestSynchronized {
                 throw %7;
 
               ^block_2:
-                branch ^block_3;
-
-              ^block_3:
                 %8 : java.type:"java.lang.Object" = var.load %2;
-                branch ^block_4(%8);
+                branch ^block_3(%8);
 
-              ^block_4(%9 : java.type:"java.lang.Object"):
+              ^block_3(%9 : java.type:"java.lang.Object"):
                 monitor.enter %9;
                 %10 : java.type:"java.lang.Throwable" = constant @null;
-                %11 : java.type:"void" = exception.region.enter ^block_5 ^block_12(%10);
+                %11 : java.type:"void" = exception.region.enter ^block_4 ^block_11(%10);
 
-              ^block_5:
+              ^block_4:
                 %12 : java.type:"int" = var.load %3;
                 %13 : java.type:"int" = constant @0;
                 %14 : java.type:"boolean" = gt %12 %13;
-                cbranch %14 ^block_6 ^block_8;
+                cbranch %14 ^block_5 ^block_7;
 
-              ^block_6:
+              ^block_5:
                 %15 : java.type:"int" = var.load %3;
                 monitor.exit %9;
-                exception.region.exit %11 ^block_7;
+                exception.region.exit %11 ^block_6;
+
+              ^block_6:
+                branch ^block_10(%15);
 
               ^block_7:
-                branch ^block_11(%15);
+                branch ^block_8;
 
               ^block_8:
-                branch ^block_9;
-
-              ^block_9:
                 %16 : java.type:"int" = constant @0;
                 monitor.exit %9;
-                exception.region.exit %11 ^block_10;
+                exception.region.exit %11 ^block_9;
 
-              ^block_10:
-                branch ^block_11(%16);
+              ^block_9:
+                branch ^block_10(%16);
 
-              ^block_11(%17 : java.type:"int"):
+              ^block_10(%17 : java.type:"int"):
                 return %17;
 
-              ^block_12(%18 : java.type:"java.lang.Throwable"):
+              ^block_11(%18 : java.type:"java.lang.Throwable"):
                 %19 : java.type:"java.lang.Throwable" = constant @null;
-                %20 : java.type:"void" = exception.region.enter ^block_13 ^block_12(%19);
+                %20 : java.type:"void" = exception.region.enter ^block_12 ^block_11(%19);
+
+              ^block_12:
+                monitor.exit %9;
+                exception.region.exit %20 ^block_13;
 
               ^block_13:
-                monitor.exit %9;
-                exception.region.exit %20 ^block_14;
-
-              ^block_14:
                 throw %18;
             };
             """, ssa = false)


### PR DESCRIPTION
Consider the following code snippet:
```
public enum Test {
    ONE, TWO;

    @Reflect
    static int select(Test t) {
        switch (t) {
            case ONE:
                return 1;
            default:
            case TWO:
                return 2;
        }
    }
}
```
While lowering a code model created from the `select` method, `BytecodeGenerator` throws the following exception:
```
IllegalStateException: No branch target for operation: JavaOp$SwitchFallthroughOp
```
The issue appears to be in the lowering logic: it moves the default case to the end but does not preserve its original fall-through target.

The proposal here is to keep blocks arranged in predicate-evaluation order, with the default case at the end, while deriving fall-through targets from the original source order.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [JDK-8391665](https://bugs.openjdk.org/browse/JDK-8391665): Switch lowering fails with missing fall-through target when default precedes another case (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1169/head:pull/1169` \
`$ git checkout pull/1169`

Update a local copy of the PR: \
`$ git checkout pull/1169` \
`$ git pull https://git.openjdk.org/babylon.git pull/1169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1169`

View PR using the GUI difftool: \
`$ git pr show -t 1169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1169.diff">https://git.openjdk.org/babylon/pull/1169.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1169#issuecomment-5516725345)
</details>
