### PR TITLE
Sharp IR types lead to spurious synthetic cast failures

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -37,6 +37,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ArrayType;
 import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.IntersectionClassType;
+import com.sun.tools.javac.code.Type.JCNoType;
 import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.code.Type.StructuralTypeMapping;
 import com.sun.tools.javac.code.Type.UnionClassType;
@@ -65,6 +66,7 @@ import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCConstantCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCDefaultCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCExpressionStatement;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCFunctionalExpression;
 import com.sun.tools.javac.tree.JCTree.JCFunctionalExpression.CodeReflectionInfo;
@@ -89,6 +91,8 @@ import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.DefinedBy;
+import com.sun.tools.javac.util.DefinedBy.Api;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Log;
@@ -476,6 +480,18 @@ public class ReflectMethods extends TreeTranslatorPrev {
         private Type pt = Type.noType;
         private final boolean isLambdaReflectable;
         private Type bodyTarget;
+
+        /*
+         * Constant type: special type to be used when field/method access should prefer erased types.
+         * Used to make sure that the types attached to model values is not too sharp when javac,
+         * which could result in too eager synthetic casts.
+         */
+        static final JCNoType erasedType = new JCNoType(){
+            @Override @DefinedBy(Api.LANGUAGE_MODEL)
+            public String toString() {
+                return "erased";
+            }
+        };
 
         BodyScanner(JCMethodDecl tree) {
             this.tree = tree;
@@ -1100,7 +1116,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         } else {
                             FieldRef fr = symbolToErasedFieldRef(sym, qualifierTarget.hasTag(NONE) ?
                                     tree.selected.type : qualifierTarget);
-                            CodeType resultType = typeToCodeType(tree.type);
+                            CodeType resultType = pt == erasedType ?
+                                    typeToCodeType(types.erasure(sym.type)) :
+                                    typeToCodeType(tree.type);
                             if (sym.isStatic()) {
                                 result = append(JavaOp.fieldLoad(resultType, fr));
                             } else {
@@ -1152,7 +1170,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                     MethodRef mr = symbolToErasedMethodRef(sym, symbolSiteType(sym));
 
-                    JavaType resultType = typeToCodeType(tree.type);
+                    JavaType resultType = pt == erasedType ?
+                            typeToCodeType(types.erasure(sym.type.getReturnType())) :
+                            typeToCodeType(tree.type);
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             resultType, mr, args);
                     Value res = append(iop);
@@ -1200,7 +1220,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     // Use the actual type of the expression, tree.type, rather than meth.type.getReturnType()
                     // This ensures invocation expressions to clone on arrays and getClass are modeled
                     // with the correct result type
-                    JavaType resultType = typeToCodeType(tree.type);
+                    JavaType resultType = pt == erasedType ?
+                            typeToCodeType(types.erasure(sym.type.getReturnType())) :
+                            typeToCodeType(tree.type);
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             resultType, mr, args);
                     Value res = append(iop);
@@ -1277,7 +1299,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitTypeTest(JCTree.JCInstanceOf tree) {
-            Value target = toValue(tree.expr);
+            Value target = toValue(tree.expr, erasedType); // erased target
             JCTree.JCPattern pattern = tree.getPattern();
             if (pattern != null) {
                 result = scanPattern(pattern, target);
@@ -1406,6 +1428,12 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             // Create the match operation
             return append(JavaOp.match(target, patternBody, matchBody));
+        }
+
+        @Override
+        public void visitExec(JCExpressionStatement tree) {
+            toValue(tree.expr, erasedType); // erased target
+            result = null;
         }
 
         @Override

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -37,43 +37,43 @@ public class DenotableTypesTest {
     static <X extends Number & Runnable> X m1(X x) { return null; }
     @Reflect
     @IR("""
-            func @"test1" ()java.type:"void" -> {
+            func @"test1" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Number" = constant @null;
                 %1 : java.type:"java.lang.Number" = invoke %0 @java.ref:"DenotableTypesTest::m1(java.lang.Number):java.lang.Number";
-                return;
+                return %1;
             };
             """)
-    static void test1() {
-        m1(null);
+    static Object test1() {
+        return m1(null);
     }
 
     @Reflect
     @IR("""
-            func @"test2" ()java.type:"void" -> {
-                %0 : java.type:"int" = constant @1;
-                %1 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
-                %2 : java.type:"double" = constant @3.0d;
-                %3 : java.type:"java.lang.Double" = invoke %2 @java.ref:"java.lang.Double::valueOf(double):java.lang.Double";
-                %4 : java.type:"java.util.List<? extends java.lang.Number>" = invoke %1 %3 @java.ref:"java.util.List::of(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+            func @"test2" (%0 : java.type:"DenotableTypesTest")java.type:"java.lang.Object" -> {
+                %1 : java.type:"int" = constant @1;
+                %2 : java.type:"java.lang.Integer" = invoke %1 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                %3 : java.type:"double" = constant @3.0d;
+                %4 : java.type:"java.lang.Double" = invoke %3 @java.ref:"java.lang.Double::valueOf(double):java.lang.Double";
+                %5 : java.type:"java.util.List<? extends java.lang.Number>" = invoke %2 %4 @java.ref:"java.util.List::of(java.lang.Object, java.lang.Object):java.util.List";
+                return %5;
             };
             """)
-    static void test2() {
-        List.of(1, 3d); // infinite type! (List<Object & Serializable & Comparable<...>>)
+    Object test2() {
+        return List.of(1, 3d); // infinite type! (List<Object & Serializable & Comparable<...>>)
     }
 
     static <X extends Throwable> X m2(X x) throws X { return null; }
 
     @Reflect
     @IR("""
-            func @"test3" ()java.type:"void" -> {
+            func @"test3" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.RuntimeException" = constant @null;
                 %1 : java.type:"java.lang.RuntimeException" = invoke %0 @java.ref:"DenotableTypesTest::m2(java.lang.Throwable):java.lang.Throwable";
-                return;
+                return %1;
             };
             """)
-    static void test3() { // @@@ cast?
-        m2(null);
+    static Object test3() { // @@@ cast?
+        return m2(null);
     }
 
     interface A { }
@@ -85,52 +85,52 @@ public class DenotableTypesTest {
 
     @Reflect
     @IR("""
-            func @"test4" ()java.type:"void" -> {
+            func @"test4" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
                 %3 : java.type:"DenotableTypesTest$D" = cast %2 @java.type:"DenotableTypesTest$D";
                 %4 : java.type:"DenotableTypesTest$A" = invoke %1 %3 @java.ref:"DenotableTypesTest::pick(java.lang.Object, java.lang.Object):java.lang.Object";
-                return;
+                return %4;
             };
             """)
-    static void test4() { // @@@ cast?
-        pick((C)null, (D)null);
+    static Object test4() { // @@@ cast?
+        return pick((C)null, (D)null);
     }
 
     @Reflect
     @IR("""
-            func @"test5" ()java.type:"void" -> {
+            func @"test5" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.util.List<? extends java.lang.Number>" = constant @null;
                 %1 : Var<java.type:"java.util.List<? extends java.lang.Number>"> = var %0 @"l";
                 %2 : java.type:"java.util.List<? extends java.lang.Number>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"java.lang.Number" = invoke %2 %3 @java.ref:"java.util.List::get(int):java.lang.Object";
-                return;
+                return %4;
             };
             """)
-    static void test5() { // @@@ cast?
+    static Object test5() { // @@@ cast?
         List<? extends Number> l = null;
-        l.get(0);
+        return l.get(0);
     }
 
     @Reflect
     @IR("""
-            func @"test6" ()java.type:"void" -> {
+            func @"test6" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.util.List<? super java.lang.Number>" = constant @null;
                 %1 : Var<java.type:"java.util.List<? super java.lang.Number>"> = var %0 @"l";
                 %2 : java.type:"java.util.List<? super java.lang.Number>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"java.lang.Object" = invoke %2 %3 @java.ref:"java.util.List::get(int):java.lang.Object";
-                return;
+                return %4;
             };
             """)
-    static void test6() {
+    static Object test6() {
         List<? super Number> l = null;
-        l.get(0);
+        return l.get(0);
     }
 
-    static void consume(Runnable r) { }
+    static Object consume(Runnable r) { return null; }
 
     @Reflect
     @IR("""
@@ -139,35 +139,42 @@ public class DenotableTypesTest {
                 %1 : Var<java.type:"&DenotableTypesTest::test7():void::<X>"> = var %0 @"x";
                 %2 : java.type:"&DenotableTypesTest::test7():void::<X>" = var.load %1;
                 %3 : java.type:"java.lang.Runnable" = cast %2 @java.type:"java.lang.Runnable";
-                invoke %3 @java.ref:"DenotableTypesTest::consume(java.lang.Runnable):void";
+                %4 : java.type:"java.lang.Object" = invoke %3 @java.ref:"DenotableTypesTest::consume(java.lang.Runnable):java.lang.Object";
                 return;
             };
             """)
     static <X extends Object & Runnable> void test7() {
+        // @@@: FIXME, we can't update this because we have a JavaType grammar ambiguity
         X x = null;
         consume(x);
     }
 
     interface Adder<X> {
-        void add(Adder<X> adder);
+        Object add(Adder<X> adder);
     }
 
     @Reflect
     @IR("""
-            func @"test8" (%0 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>")java.type:"void" -> {
+            func @"test8" (%0 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>")java.type:"java.lang.Object" -> {
                 %1 : Var<java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>"> = var %0 @"list";
                 %2 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %2 %3 @java.ref:"java.util.List::get(int):java.lang.Object";
-                %5 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
-                %6 : java.type:"int" = constant @1;
-                %7 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %5 %6 @java.ref:"java.util.List::get(int):java.lang.Object";
-                invoke %4 %7 @java.ref:"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder):void";
-                return;
+                %5 : Var<java.type:"DenotableTypesTest$Adder<java.lang.Integer>"> = var %4 @"x";
+                %6 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
+                %7 : java.type:"int" = constant @1;
+                %8 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %6 %7 @java.ref:"java.util.List::get(int):java.lang.Object";
+                %9 : Var<java.type:"DenotableTypesTest$Adder<java.lang.Integer>"> = var %8 @"y";
+                %10 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = var.load %5;
+                %11 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = var.load %9;
+                %12 : java.type:"java.lang.Object" = invoke %10 %11 @java.ref:"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder):java.lang.Object";
+                return %12;
             };
             """)
-    static void test8(List<? extends Adder<Integer>> list) {
-        list.get(0).add(list.get(1));
+    static Object test8(List<? extends Adder<Integer>> list) {
+        var x = list.get(0);
+        var y = list.get(1);
+        return x.add(y);
     }
 
     static class Box<X> {
@@ -191,42 +198,42 @@ public class DenotableTypesTest {
     }
 
     interface E {
-        void m();
+        Object m();
     }
 
     static class XA extends Exception implements E {
-        public void m() { }
+        public Object m() { return null; }
     }
 
     static class XB extends Exception implements E {
-        public void m() { }
+        public Object m() { return null; }
     }
 
-    static void g() throws XA, XB { }
+    static Object g() throws XA, XB { return null; }
 
     @Reflect
     @IR("""
-            func @"test10" ()java.type:"void" -> {
+            func @"test10" ()java.type:"java.lang.Object" -> {
                 java.try @Tuple<Tuple<java.type:"DenotableTypesTest$XA", java.type:"DenotableTypesTest$XB">>
                     ()java.type:"void" -> {
-                        invoke @java.ref:"DenotableTypesTest::g():void";
-                        yield;
+                        %0 : java.type:"java.lang.Object" = invoke @java.ref:"DenotableTypesTest::g():java.lang.Object";
+                        return %0;
                     }
-                    (%0 : java.type:"java.lang.Exception")java.type:"void" -> {
-                        %1 : Var<java.type:"java.lang.Exception"> = var %0 @"x";
-                        %2 : java.type:"java.lang.Exception" = var.load %1;
-                        %3 : java.type:"DenotableTypesTest$E" = cast %2 @java.type:"DenotableTypesTest$E";
-                        invoke %3 @java.ref:"DenotableTypesTest$E::m():void";
-                        yield;
+                    (%1 : java.type:"java.lang.Exception")java.type:"void" -> {
+                        %2 : Var<java.type:"java.lang.Exception"> = var %1 @"x";
+                        %3 : java.type:"java.lang.Exception" = var.load %2;
+                        %4 : java.type:"DenotableTypesTest$E" = cast %3 @java.type:"DenotableTypesTest$E";
+                        %5 : java.type:"java.lang.Object" = invoke %4 @java.ref:"DenotableTypesTest$E::m():java.lang.Object";
+                        return %5;
                     };
-                return;
+                unreachable;
             };
             """)
-    static void test10() {
+    static Object test10() {
         try {
-            g();
+            return g();
         } catch (XA | XB x) {
-            x.m();
+            return x.m();
         }
     }
 
@@ -238,47 +245,47 @@ public class DenotableTypesTest {
 
     @Reflect
     @IR("""
-            func @"test11" ()java.type:"void" -> {
+            func @"test11" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
                 %3 : java.type:"DenotableTypesTest$D" = cast %2 @java.type:"DenotableTypesTest$D";
                 %4 : java.type:"java.util.List<? extends DenotableTypesTest$A>" = invoke %1 %3 @java.ref:"DenotableTypesTest::pickInv(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %4;
             };
             """)
-    static void test11() {
-        pickInv((C)null, (D)null);
+    static Object test11() {
+        return pickInv((C)null, (D)null);
     }
 
     @Reflect
     @IR("""
-            func @"test12" ()java.type:"void" -> {
+            func @"test12" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
                 %3 : java.type:"DenotableTypesTest$D" = cast %2 @java.type:"DenotableTypesTest$D";
                 %4 : java.type:"java.util.List<? extends DenotableTypesTest$A>" = invoke %1 %3 @java.ref:"DenotableTypesTest::pickExt(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %4;
             };
             """)
-    static void test12() {
-        pickExt((C)null, (D)null);
+    static Object test12() {
+        return pickExt((C)null, (D)null);
     }
 
     @Reflect
     @IR("""
-            func @"test13" ()java.type:"void" -> {
+            func @"test13" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
                 %3 : java.type:"DenotableTypesTest$D" = cast %2 @java.type:"DenotableTypesTest$D";
                 %4 : java.type:"java.util.List<?>" = invoke %1 %3 @java.ref:"DenotableTypesTest::pickSup(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %4;
             };
             """)
-    static void test13() {
-        pickSup((C)null, (D)null);
+    static Object test13() {
+        return pickSup((C)null, (D)null);
     }
 
     static <Z> List<Z[]> pickInvArr(Z z1, Z z2) { return null; }
@@ -289,47 +296,47 @@ public class DenotableTypesTest {
 
     @Reflect
     @IR("""
-            func @"test14" ()java.type:"void" -> {
+            func @"test14" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
                 %3 : java.type:"DenotableTypesTest$D" = cast %2 @java.type:"DenotableTypesTest$D";
                 %4 : java.type:"java.util.List<? extends DenotableTypesTest$A[]>" = invoke %1 %3 @java.ref:"DenotableTypesTest::pickInvArr(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %4;
             };
             """)
-    static void test14() {
-        pickInvArr((C)null, (D)null);
+    static Object test14() {
+        return pickInvArr((C)null, (D)null);
     }
 
     @Reflect
     @IR("""
-            func @"test15" ()java.type:"void" -> {
+            func @"test15" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
                 %3 : java.type:"DenotableTypesTest$D" = cast %2 @java.type:"DenotableTypesTest$D";
                 %4 : java.type:"java.util.List<? extends DenotableTypesTest$A[]>" = invoke %1 %3 @java.ref:"DenotableTypesTest::pickExtArr(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %4;
             };
             """)
-    static void test15() {
-        pickExtArr((C)null, (D)null);
+    static Object test15() {
+        return pickExtArr((C)null, (D)null);
     }
 
     @Reflect
     @IR("""
-            func @"test16" ()java.type:"void" -> {
+            func @"test16" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
                 %3 : java.type:"DenotableTypesTest$D" = cast %2 @java.type:"DenotableTypesTest$D";
                 %4 : java.type:"java.util.List<?>" = invoke %1 %3 @java.ref:"DenotableTypesTest::pickSupArr(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %4;
             };
             """)
-    static void test16() {
-        pickSupArr((C)null, (D)null);
+    static Object test16() {
+        return pickSupArr((C)null, (D)null);
     }
 
     interface F<X> { }
@@ -344,7 +351,7 @@ public class DenotableTypesTest {
 
     @Reflect
     @IR("""
-            func @"test17" ()java.type:"void" -> {
+            func @"test17" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
@@ -360,18 +367,18 @@ public class DenotableTypesTest {
                 %12 : java.type:"DenotableTypesTest$H<? extends DenotableTypesTest$A>" = var.load %5;
                 %13 : java.type:"DenotableTypesTest$I<? extends DenotableTypesTest$A>" = var.load %11;
                 %14 : java.type:"java.util.List<? extends DenotableTypesTest$F<? extends DenotableTypesTest$A>>" = invoke %12 %13 @java.ref:"DenotableTypesTest::pickInv(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %14;
             };
             """)
-    static void test17() {
+    static Object test17() {
         var fst = pickH((C)null, (D)null);
         var snd = pickI((C)null, (D)null);
-        pickInv(fst, snd);
+        return pickInv(fst, snd);
     }
 
     @Reflect
     @IR("""
-            func @"test18" ()java.type:"void" -> {
+            func @"test18" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
@@ -387,18 +394,18 @@ public class DenotableTypesTest {
                 %12 : java.type:"DenotableTypesTest$H<? extends DenotableTypesTest$A>" = var.load %5;
                 %13 : java.type:"DenotableTypesTest$I<? extends DenotableTypesTest$A>" = var.load %11;
                 %14 : java.type:"java.util.List<? extends DenotableTypesTest$F<? extends DenotableTypesTest$A>>" = invoke %12 %13 @java.ref:"DenotableTypesTest::pickExt(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %14;
             };
             """)
-    static void test18() {
+    static Object test18() {
         var fst = pickH((C)null, (D)null);
         var snd = pickI((C)null, (D)null);
-        pickExt(fst, snd);
+        return pickExt(fst, snd);
     }
 
     @Reflect
     @IR("""
-            func @"test19" ()java.type:"void" -> {
+            func @"test19" ()java.type:"java.lang.Object" -> {
                 %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : java.type:"DenotableTypesTest$C" = cast %0 @java.type:"DenotableTypesTest$C";
                 %2 : java.type:"java.lang.Object" = constant @null;
@@ -414,13 +421,13 @@ public class DenotableTypesTest {
                 %12 : java.type:"DenotableTypesTest$H<? extends DenotableTypesTest$A>" = var.load %5;
                 %13 : java.type:"DenotableTypesTest$I<? extends DenotableTypesTest$A>" = var.load %11;
                 %14 : java.type:"java.util.List<?>" = invoke %12 %13 @java.ref:"DenotableTypesTest::pickSup(java.lang.Object, java.lang.Object):java.util.List";
-                return;
+                return %14;
             };
             """)
-    static void test19() {
+    static Object test19() {
         var fst = pickH((C)null, (D)null);
         var snd = pickI((C)null, (D)null);
-        pickSup(fst, snd);
+        return pickSup(fst, snd);
     }
 
     @Reflect

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Reflect;
+import jdk.incubator.code.bytecode.BytecodeGenerator;
+import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+
+/*
+ * @test
+ * @summary Smoke test for timing of synthetic erasure casts
+ * @modules jdk.incubator.code
+ * @build ErasedAccessTest
+ * @run main ErasedAccessTest
+ * @run main CodeReflectionTester ErasedAccessTest
+ */
+
+public class ErasedAccessTest {
+    @Reflect
+    @IR("""
+            func @"method_typeTest" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Object";
+                return %4;
+            };
+            """)
+    static boolean method_typeTest(Box<String> xs) {
+        return xs.get() instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_typeTestCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        yield %7;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %9 : java.type:"java.lang.String" = invoke %8 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        yield %9;
+                    };
+                %10 : java.type:"boolean" = instanceof %4 @java.type:"java.lang.Object";
+                return %10;
+            };
+            """)
+    static boolean method_typeTestCond(boolean c, Box<String> xs) {
+        return (c ? xs.get() : xs.get()) instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_chainedCall" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %4 : java.type:"int" = invoke %3 @java.ref:"java.lang.String::hashCode():int";
+                return %4;
+            };
+            """)
+    static int method_chainedCall(Box<String> xs) {
+        return xs.get().hashCode();
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_chainedCallCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        yield %7;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %9 : java.type:"java.lang.String" = invoke %8 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        yield %9;
+                    };
+                %10 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                return %10;
+            };
+            """)
+    static int method_chainedCallCond(boolean c, Box<String> xs) {
+        return (c ? xs.get() : xs.get()).hashCode();
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_exec" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.Object" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                return;
+            };
+            """)
+    static void method_exec(Box<String> xs) {
+        xs.get();
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_typeTest" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.Object" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Object";
+                return %4;
+            };
+            """)
+    static boolean field_typeTest(Box<String> xs) {
+        return xs.x instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_typeTestCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        yield %7;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %9 : java.type:"java.lang.String" = field.load %8 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        yield %9;
+                    };
+                %10 : java.type:"boolean" = instanceof %4 @java.type:"java.lang.Object";
+                return %10;
+            };
+            """)
+    static boolean field_typeTestCond(boolean c, Box<String> xs) {
+        return (c ? xs.x : xs.x) instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_chainedCall" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                %4 : java.type:"int" = invoke %3 @java.ref:"java.lang.String::hashCode():int";
+                return %4;
+            };
+            """)
+    static int field_chainedCall(Box<String> xs) {
+        return xs.x.hashCode();
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_chainedCallCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        yield %7;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %8 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %9 : java.type:"java.lang.String" = field.load %8 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        yield %9;
+                    };
+                %10 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                return %10;
+            };
+            """)
+    static int field_chainedCallCond(boolean c, Box<String> xs) {
+        return (c ? xs.x : xs.x).hashCode();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static Box<String> pollutedBox() {
+        return (Box<String>)new Box(1);
+    }
+
+    static class Box<X> {
+        X x;
+        Box(X x) { this.x = x; }
+        X get() { return x; }
+    }
+
+    public static void main(String[] args) throws ReflectiveOperationException {
+        for (Method m : ErasedAccessTest.class.getDeclaredMethods()) {
+            if (m.isAnnotationPresent(Reflect.class)) {
+                FuncOp model = Op.ofMethod(m).get();
+                System.out.println(model.toText());
+                boolean reflectionResult = invokeReflection(m);
+                boolean modelResult = invokeModel(model);
+                if (reflectionResult != modelResult) {
+                    if (reflectionResult) {
+                        throw new AssertionError("Unexpected ClassCastException when executing model");
+                    } else {
+                        throw new AssertionError("Missing ClassCastException when executing model");
+                    }
+                }
+            }
+        }
+    }
+
+    static boolean invokeReflection(Method m) {
+        Object[] invokeArgs = m.getParameterTypes().length == 1 ?
+                new Object[] { pollutedBox() } :
+                new Object[] { true, pollutedBox() };
+        try {
+            m.invoke(null, invokeArgs);
+            return true;
+        } catch (ReflectiveOperationException e) {
+            if (!(e.getCause() instanceof ClassCastException)) {
+                throw new AssertionError("unexpected exception", e);
+            }
+            return false;
+        }
+    }
+
+    static boolean invokeModel(FuncOp funcOp) {
+        MethodHandle handle = BytecodeGenerator.generate(MethodHandles.lookup(),
+                funcOp);
+        Object[] invokeArgs = funcOp.parameters().size() == 1 ?
+                new Object[] { pollutedBox() } :
+                new Object[] { true, pollutedBox() };
+        try {
+            handle.invokeWithArguments(invokeArgs);
+            return true;
+        } catch (ClassCastException e) {
+            return false;
+        } catch (Throwable ex) {
+            throw new AssertionError("unexpected exception", ex);
+        }
+    }
+}


### PR DESCRIPTION
There are a couple of places where javac deliberatly does not enforce synthetic generic casts:

* `E instanceof T`, javac does not introduce any cast when lowering `E`
* expression statements, like `E;`. Again no cast is added when lowering `E`

Unfortunately, when generating the code model, in both cases we will end up with a value that has a sharp type (the type javac saw for `E`). This means that, when generating bytecode from the model, we'll end up introducing synthetic casts in these locations, which doesn't respect what javac does.

To address this, I've added a synthetic target type in `ReflectMethods` called `erasedType`. This is used in the above two locations as a signal that we're expecting something less sharp. This information in consumed in all places where we perform a field/method access, and, if present, causes the type of the generated IR to be erased.

I've added a test which makes sure that when executing models we get CCE (or not) in the same way as for javac-generated code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1171/head:pull/1171` \
`$ git checkout pull/1171`

Update a local copy of the PR: \
`$ git checkout pull/1171` \
`$ git pull https://git.openjdk.org/babylon.git pull/1171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1171`

View PR using the GUI difftool: \
`$ git pr show -t 1171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1171.diff">https://git.openjdk.org/babylon/pull/1171.diff</a>

</details>
