### PR TITLE
Add heap pollution casts in the code model

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -722,7 +722,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
 
         public Value toValue(JCExpression expression, Type targetType) {
-            targetType = types.erasure(targetType);
             result = null; // reset
             Type prevPt = pt;
             try {
@@ -748,10 +747,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
             Type refTarget = targetType.isPrimitive()
                     ? types.erasure(codeTypeToType(sourceValue.type()))
-                    : targetType;
+                    : types.erasure(targetType);
 
             if (sourceType.isReference() && refTarget.isReference() &&
-                    !types.isSubtype(types.erasure(sourceType), types.erasure(refTarget))) {
+                    !types.isSubtype(types.erasure(sourceType), refTarget)) {
                 sourceValue = append(JavaOp.cast(typeToCodeType(refTarget), sourceValue));
             }
             return convert(sourceValue, targetType);

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1274,27 +1274,15 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitTypeCast(JCTree.JCTypeCast tree) {
-            Value v = toValue(tree.expr);
-
-            Type expressionType = tree.expr.type;
-            Type type = tree.type;
-            if (expressionType.isPrimitive() && type.isPrimitive()) {
-                if (expressionType.equals(type)) {
-                    // Redundant cast
-                    result = v;
-                } else {
-                    result = append(JavaOp.conv(typeToCodeType(type), v));
-                }
-            } else if (expressionType.isPrimitive() || type.isPrimitive()) {
-                result = convert(v, tree.type);
-            } else if (!expressionType.hasTag(BOT) &&
-                    types.isAssignable(expressionType, type)) {
-                // Redundant cast
-                result = v;
+            // @@@: what about intersection type target?
+            if (tree.expr.type.hasTag(BOT)) {
+                Value v = toValue(tree.expr);
+                result = append(JavaOp.cast(
+                        typeToCodeType(tree.type),
+                        typeToCodeType(types.erasure(tree.type)),
+                        v));
             } else {
-                // Reference cast
-                JavaType jt = typeToCodeType(types.erasure(type));
-                result = append(JavaOp.cast(typeToCodeType(type), jt, v));
+                result = toValue(tree.expr, tree.type);
             }
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1634,7 +1634,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitSwitchExpression(JCTree.JCSwitchExpression tree) {
-            Value target = toValue(tree.selector);
+            Value target = toValue(tree.selector, tree.selector.type);
 
             Type switchType = adaptBottom(tree.type);
             FunctionType caseBodyType = CoreType.functionType(typeToCodeType(switchType));
@@ -1647,7 +1647,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitSwitch(JCTree.JCSwitch tree) {
-            Value target = toValue(tree.selector);
+            Value target = toValue(tree.selector, tree.selector.type);
 
             FunctionType actionType = CoreType.FUNCTION_TYPE_VOID;
 
@@ -1853,8 +1853,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     pushBody(c.body, caseBodyType);
 
                     if (c.body instanceof JCTree.JCExpression e) {
-                        Type yieldType = adaptBottom(tree.type);
+                        Type yieldType = adaptBottom(e.type);
                         Value bodyVal = toValue(e, yieldType);
+                        bodyVal = coerce(bodyVal, yieldType, tree.type);
                         append(CoreOp.core_yield(bodyVal));
                     } else if (c.body instanceof JCTree.JCStatement s) { // this includes Block
                         // Otherwise there is a yield statement
@@ -1914,8 +1915,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitYield(JCTree.JCYield tree) {
-            Type yieldType = adaptBottom(tree.target.type);
+            Type yieldType = adaptBottom(tree.value.type);
             Value retVal = toValue(tree.value, yieldType);
+            retVal = coerce(retVal, yieldType, tree.target.type);
             result = append(JavaOp.java_yield(retVal));
         }
 
@@ -2211,7 +2213,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
                 pushBody(detail,
                         CoreType.functionType(typeToCodeType(tree.detail.type)));
-                Value detailVal = toValue(detail);
+                Value detailVal = toValue(detail, tree.detail.type);
 
                 append(CoreOp.core_yield(detailVal));
                 bodies.add(stack.body);
@@ -2249,7 +2251,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         public void visitSynchronized(JCTree.JCSynchronized tree) {
             // Push expr
             pushBody(tree.lock, CoreType.functionType(typeToCodeType(tree.lock.type)));
-            Value last = toValue(tree.lock);
+            Value last = toValue(tree.lock, tree.lock.type);
             append(CoreOp.core_yield(last));
             Body.Builder expr = stack.body;
 
@@ -2539,7 +2541,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitThrow(JCTree.JCThrow tree) {
-            Value throwVal = toValue(tree.expr);
+            Value throwVal = toValue(tree.expr, tree.expr.type);
             result = append(JavaOp.throw_(throwVal));
         }
 

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -745,13 +745,19 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
-            Type refTarget = targetType.isPrimitive()
-                    ? types.erasure(codeTypeToType(sourceValue.type()))
-                    : types.erasure(targetType);
+            // primitive target requires care: if target is "int", but source
+            // expression has (after type subst) type "Integer", we should still
+            // emit a synthetic cast to "Integer" (if needed)
+            Type refTarget = targetType.isPrimitive() ?
+                    codeTypeToType(sourceValue.type()) :
+                    targetType;
 
             if (sourceType.isReference() && refTarget.isReference() &&
-                    !types.isSubtype(types.erasure(sourceType), refTarget)) {
-                sourceValue = append(JavaOp.cast(typeToCodeType(refTarget), sourceValue));
+                    !types.isSubtype(types.erasure(sourceType), types.erasure(refTarget))) {
+                // the generated synthetic cast uses a raw type as type operand,
+                // but preserves full static type info in the result type
+                sourceValue = append(JavaOp.cast(typeToCodeType(refTarget),
+                        typeToCodeType(types.erasure(refTarget)), sourceValue));
             }
             return convert(sourceValue, targetType);
         }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -65,6 +65,7 @@ import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCConstantCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCDefaultCaseLabel;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCExpressionStatement;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCFunctionalExpression;
 import com.sun.tools.javac.tree.JCTree.JCFunctionalExpression.CodeReflectionInfo;
@@ -721,6 +722,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
 
         public Value toValue(JCExpression expression, Type targetType) {
+            targetType = types.erasure(targetType);
             result = null; // reset
             Type prevPt = pt;
             try {
@@ -744,9 +746,13 @@ public class ReflectMethods extends TreeTranslatorPrev {
         }
 
         Value coerce(Value sourceValue, Type sourceType, Type targetType) {
-            if (sourceType.isReference() && targetType.isReference() &&
-                    !types.isSubtype(types.erasure(sourceType), types.erasure(targetType))) {
-                return append(JavaOp.cast(typeToCodeType(targetType), sourceValue));
+            Type refTarget = targetType.isPrimitive()
+                    ? types.erasure(codeTypeToType(sourceValue.type()))
+                    : targetType;
+
+            if (sourceType.isReference() && refTarget.isReference() &&
+                    !types.isSubtype(types.erasure(sourceType), types.erasure(refTarget))) {
+                sourceValue = append(JavaOp.cast(typeToCodeType(refTarget), sourceValue));
             }
             return convert(sourceValue, targetType);
         }
@@ -1048,7 +1054,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         if (sym.isStatic()) {
                             result = append(JavaOp.fieldLoad(resultType, fr));
                         } else {
-                            result = append(JavaOp.fieldLoad(resultType, fr, thisValue()));
+                            result = coerce(
+                                    append(JavaOp.fieldLoad(resultType, fr, thisValue())),
+                                    sym.erasure(types),
+                                    pt);
                         }
                     }
                 }
@@ -1081,7 +1090,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             Type qualifierTarget = qualifierTarget(tree);
             // @@@: might cause redundant load if accessed symbol is static but the qualifier is not a type
-            Value receiver = toValue(tree.selected);
+            Value receiver = toValue(tree.selected, qualifierTarget);
 
             if (tree.name.equals(names._class)) {
                 result = append(CoreOp.constant(JavaType.J_L_CLASS, typeToCodeType(tree.selected.type)));
@@ -1104,7 +1113,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                             if (sym.isStatic()) {
                                 result = append(JavaOp.fieldLoad(resultType, fr));
                             } else {
-                                result = append(JavaOp.fieldLoad(resultType, fr, receiver));
+                                result = coerce(
+                                        append(JavaOp.fieldLoad(resultType, fr, receiver)),
+                                        sym.erasure(types),
+                                        pt);
                             }
                         }
                     }
@@ -1155,7 +1167,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     JavaType resultType = typeToCodeType(tree.type);
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             resultType, mr, args);
-                    Value res = append(iop);
+                    Value res = coerce(
+                            append(iop),
+                            sym.erasure(types).getReturnType(),
+                            pt);
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;
                     }
@@ -1203,7 +1218,10 @@ public class ReflectMethods extends TreeTranslatorPrev {
                     JavaType resultType = typeToCodeType(tree.type);
                     JavaOp.InvokeOp iop = JavaOp.invoke(ik, tree.varargsElement != null,
                             resultType, mr, args);
-                    Value res = append(iop);
+                    Value res = coerce(
+                            append(iop),
+                            sym.erasure(types).getReturnType(),
+                            pt);
                     if (sym.type.getReturnType().getTag() != TypeTag.VOID) {
                         result = res;
                     }
@@ -1246,7 +1264,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
             Type selectedType = types.skipTypeVars(tree.selected.type, true);
             return selectedType.isCompound() ?
                     tree.sym.owner.type :
-                    Type.noType;
+                    tree.selected.type;
         }
 
         @Override
@@ -1406,6 +1424,12 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
             // Create the match operation
             return append(JavaOp.match(target, patternBody, matchBody));
+        }
+
+        @Override
+        public void visitExec(JCExpressionStatement tree) {
+            toValue(tree.expr); // no target
+            result = null;
         }
 
         @Override
@@ -2162,14 +2186,6 @@ public class ReflectMethods extends TreeTranslatorPrev {
             popBody();
 
             result = append(JavaOp.conditionalExpression(typeToCodeType(condType), predicateBody, trueBody, falseBody));
-        }
-
-        private Type condType(JCExpression tree, Type type) {
-            if (type.hasTag(BOT)) {
-                return adaptBottom(tree.type);
-            } else {
-                return type;
-            }
         }
 
         private Type adaptBottom(Type type) {

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -101,7 +101,7 @@ public class DenotableTypesTest {
     @Reflect
     @IR("""
             func @"test5" ()java.type:"void" -> {
-                %0 : java.type:"java.util.List<? extends java.lang.Number>" = constant @null;
+                %0 : java.type:"java.util.List" = constant @null;
                 %1 : Var<java.type:"java.util.List<? extends java.lang.Number>"> = var %0 @"l";
                 %2 : java.type:"java.util.List<? extends java.lang.Number>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
@@ -117,7 +117,7 @@ public class DenotableTypesTest {
     @Reflect
     @IR("""
             func @"test6" ()java.type:"void" -> {
-                %0 : java.type:"java.util.List<? super java.lang.Number>" = constant @null;
+                %0 : java.type:"java.util.List" = constant @null;
                 %1 : Var<java.type:"java.util.List<? super java.lang.Number>"> = var %0 @"l";
                 %2 : java.type:"java.util.List<? super java.lang.Number>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
@@ -135,7 +135,7 @@ public class DenotableTypesTest {
     @Reflect
     @IR("""
             func @"test7" ()java.type:"void" -> {
-                %0 : java.type:"&DenotableTypesTest::test7():void::<X>" = constant @null;
+                %0 : java.type:"java.lang.Object" = constant @null;
                 %1 : Var<java.type:"&DenotableTypesTest::test7():void::<X>"> = var %0 @"x";
                 %2 : java.type:"&DenotableTypesTest::test7():void::<X>" = var.load %1;
                 %3 : java.type:"java.lang.Runnable" = cast %2 @java.type:"java.lang.Runnable";
@@ -159,10 +159,12 @@ public class DenotableTypesTest {
                 %2 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %2 %3 @java.ref:"java.util.List::get(int):java.lang.Object";
-                %5 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
-                %6 : java.type:"int" = constant @1;
-                %7 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %5 %6 @java.ref:"java.util.List::get(int):java.lang.Object";
-                invoke %4 %7 @java.ref:"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder):void";
+                %5 : java.type:"DenotableTypesTest$Adder" = cast %4 @java.type:"DenotableTypesTest$Adder";
+                %6 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
+                %7 : java.type:"int" = constant @1;
+                %8 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %6 %7 @java.ref:"java.util.List::get(int):java.lang.Object";
+                %9 : java.type:"DenotableTypesTest$Adder" = cast %8 @java.type:"DenotableTypesTest$Adder";
+                invoke %5 %9 @java.ref:"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder):void";
                 return;
             };
             """)
@@ -181,8 +183,10 @@ public class DenotableTypesTest {
                 %2 : java.type:"java.util.List<? extends DenotableTypesTest$Box<java.lang.Integer>>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"DenotableTypesTest$Box<java.lang.Integer>" = invoke %2 %3 @java.ref:"java.util.List::get(int):java.lang.Object";
-                %5 : java.type:"java.lang.Integer" = field.load %4 @java.ref:"DenotableTypesTest$Box::x:java.lang.Object";
-                %6 : Var<java.type:"java.lang.Integer"> = var %5 @"i";
+                %5 : java.type:"DenotableTypesTest$Box" = cast %4 @java.type:"DenotableTypesTest$Box";
+                %6 : java.type:"java.lang.Integer" = field.load %5 @java.ref:"DenotableTypesTest$Box::x:java.lang.Object";
+                %7 : java.type:"java.lang.Integer" = cast %6 @java.type:"java.lang.Integer";
+                %8 : Var<java.type:"java.lang.Integer"> = var %7 @"i";
                 return;
             };
             """)
@@ -429,7 +433,8 @@ public class DenotableTypesTest {
                 %1 : Var<java.type:"DenotableTypesTest$Box<? extends java.lang.Number>"> = var %0 @"box";
                 %2 : java.type:"DenotableTypesTest$Box<? extends java.lang.Number>" = var.load %1;
                 %3 : java.type:"java.lang.Number" = field.load %2 @java.ref:"DenotableTypesTest$Box::x:java.lang.Object";
-                return %3;
+                %4 : java.type:"java.lang.Number" = cast %3 @java.type:"java.lang.Number";
+                return %4;
             };
             """)
     static Number test20(Box<? extends Number> box) {

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -101,7 +101,7 @@ public class DenotableTypesTest {
     @Reflect
     @IR("""
             func @"test5" ()java.type:"void" -> {
-                %0 : java.type:"java.util.List" = constant @null;
+                %0 : java.type:"java.util.List<? extends java.lang.Number>" = constant @null;
                 %1 : Var<java.type:"java.util.List<? extends java.lang.Number>"> = var %0 @"l";
                 %2 : java.type:"java.util.List<? extends java.lang.Number>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
@@ -117,7 +117,7 @@ public class DenotableTypesTest {
     @Reflect
     @IR("""
             func @"test6" ()java.type:"void" -> {
-                %0 : java.type:"java.util.List" = constant @null;
+                %0 : java.type:"java.util.List<? super java.lang.Number>" = constant @null;
                 %1 : Var<java.type:"java.util.List<? super java.lang.Number>"> = var %0 @"l";
                 %2 : java.type:"java.util.List<? super java.lang.Number>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
@@ -135,7 +135,7 @@ public class DenotableTypesTest {
     @Reflect
     @IR("""
             func @"test7" ()java.type:"void" -> {
-                %0 : java.type:"java.lang.Object" = constant @null;
+                %0 : java.type:"&DenotableTypesTest::test7():void::<X>" = constant @null;
                 %1 : Var<java.type:"&DenotableTypesTest::test7():void::<X>"> = var %0 @"x";
                 %2 : java.type:"&DenotableTypesTest::test7():void::<X>" = var.load %1;
                 %3 : java.type:"java.lang.Runnable" = cast %2 @java.type:"java.lang.Runnable";

--- a/test/langtools/tools/javac/reflect/DenotableTypesTest.java
+++ b/test/langtools/tools/javac/reflect/DenotableTypesTest.java
@@ -159,11 +159,11 @@ public class DenotableTypesTest {
                 %2 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %2 %3 @java.ref:"java.util.List::get(int):java.lang.Object";
-                %5 : java.type:"DenotableTypesTest$Adder" = cast %4 @java.type:"DenotableTypesTest$Adder";
+                %5 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = cast %4 @java.type:"DenotableTypesTest$Adder";
                 %6 : java.type:"java.util.List<? extends DenotableTypesTest$Adder<java.lang.Integer>>" = var.load %1;
                 %7 : java.type:"int" = constant @1;
                 %8 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = invoke %6 %7 @java.ref:"java.util.List::get(int):java.lang.Object";
-                %9 : java.type:"DenotableTypesTest$Adder" = cast %8 @java.type:"DenotableTypesTest$Adder";
+                %9 : java.type:"DenotableTypesTest$Adder<java.lang.Integer>" = cast %8 @java.type:"DenotableTypesTest$Adder";
                 invoke %5 %9 @java.ref:"DenotableTypesTest$Adder::add(DenotableTypesTest$Adder):void";
                 return;
             };
@@ -183,7 +183,7 @@ public class DenotableTypesTest {
                 %2 : java.type:"java.util.List<? extends DenotableTypesTest$Box<java.lang.Integer>>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"DenotableTypesTest$Box<java.lang.Integer>" = invoke %2 %3 @java.ref:"java.util.List::get(int):java.lang.Object";
-                %5 : java.type:"DenotableTypesTest$Box" = cast %4 @java.type:"DenotableTypesTest$Box";
+                %5 : java.type:"DenotableTypesTest$Box<java.lang.Integer>" = cast %4 @java.type:"DenotableTypesTest$Box";
                 %6 : java.type:"java.lang.Integer" = field.load %5 @java.ref:"DenotableTypesTest$Box::x:java.lang.Object";
                 %7 : java.type:"java.lang.Integer" = cast %6 @java.type:"java.lang.Integer";
                 %8 : Var<java.type:"java.lang.Integer"> = var %7 @"i";

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -58,115 +58,115 @@ public class ErasedAccessTest {
         }
     }
 
-    static class UnboundedString extends Unbounded<String> {
+    static class UnboundedInteger extends Unbounded<Integer> {
 
         @IR("""
-                func @"testInstanceof" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.String";
+                func @"testInstanceof" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Integer";
                     %5 : Var<java.type:"boolean"> = var %4 @"f_s_s";
-                    %6 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %8 : java.type:"boolean" = instanceof %7 @java.type:"java.lang.String";
+                    %6 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %7 : java.type:"java.lang.Integer" = field.load %6 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %8 : java.type:"boolean" = instanceof %7 @java.type:"java.lang.Integer";
                     %9 : Var<java.type:"boolean"> = var %8 @"f_q_s";
-                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.String";
+                    %10 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.Integer";
                     %12 : Var<java.type:"boolean"> = var %11 @"m_s_s";
-                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %15 : java.type:"boolean" = instanceof %14 @java.type:"java.lang.String";
+                    %13 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %14 : java.type:"java.lang.Integer" = invoke %13 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %15 : java.type:"boolean" = instanceof %14 @java.type:"java.lang.Integer";
                     %16 : Var<java.type:"boolean"> = var %15 @"m_q_s";
                     return;
                 };
                 """)
         @Reflect
-        void testInstanceof(UnboundedString test) {
+        void testInstanceof(UnboundedInteger test) {
             // simple field name
-            boolean f_s_s = x instanceof String;
+            boolean f_s_s = x instanceof Integer;
 
             // qualified field name
-            boolean f_q_s = test.x instanceof String;
+            boolean f_q_s = test.x instanceof Integer;
 
             // simple method name
-            boolean m_s_s = getX() instanceof String;
+            boolean m_s_s = getX() instanceof Integer;
 
             // qualified method name
-            boolean m_q_s = test.getX() instanceof String;
+            boolean m_q_s = test.getX() instanceof Integer;
         }
 
         @IR("""
-                func @"testInstanceofCond" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString", %2 : java.type:"boolean")java.type:"void" -> {
-                    %3 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                func @"testInstanceofCond" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
                     %4 : Var<java.type:"boolean"> = var %2 @"cond";
-                    %5 : java.type:"java.lang.String" = java.cexpression
+                    %5 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %6 : java.type:"boolean" = var.load %4;
                             yield %6;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
                             yield %8;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %9 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
                             yield %10;
                         };
                     %11 : java.type:"boolean" = instanceof %5 @java.type:"java.lang.Object";
                     %12 : Var<java.type:"boolean"> = var %11 @"f_s_o";
-                    %13 : java.type:"java.lang.String" = java.cexpression
+                    %13 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %14 : java.type:"boolean" = var.load %4;
                             yield %14;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %15 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %16 : java.type:"java.lang.String" = field.load %15 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %15 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %16 : java.type:"java.lang.Integer" = field.load %15 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %17 : java.type:"java.lang.Integer" = cast %16 @java.type:"java.lang.Integer";
                             yield %17;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %18 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %19 : java.type:"java.lang.String" = field.load %18 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %18 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %19 : java.type:"java.lang.Integer" = field.load %18 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %20 : java.type:"java.lang.Integer" = cast %19 @java.type:"java.lang.Integer";
                             yield %20;
                         };
                     %21 : java.type:"boolean" = instanceof %13 @java.type:"java.lang.Object";
                     %22 : Var<java.type:"boolean"> = var %21 @"f_q_o";
-                    %23 : java.type:"java.lang.String" = java.cexpression
+                    %23 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %24 : java.type:"boolean" = var.load %4;
                             yield %24;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %25 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %26 : java.type:"java.lang.Integer" = cast %25 @java.type:"java.lang.Integer";
                             yield %26;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %27 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %28 : java.type:"java.lang.String" = cast %27 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %27 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %28 : java.type:"java.lang.Integer" = cast %27 @java.type:"java.lang.Integer";
                             yield %28;
                         };
                     %29 : java.type:"boolean" = instanceof %23 @java.type:"java.lang.Object";
                     %30 : Var<java.type:"boolean"> = var %29 @"m_s_o";
-                    %31 : java.type:"java.lang.String" = java.cexpression
+                    %31 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %32 : java.type:"boolean" = var.load %4;
                             yield %32;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %33 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %33 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %34 : java.type:"java.lang.Integer" = invoke %33 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %35 : java.type:"java.lang.Integer" = cast %34 @java.type:"java.lang.Integer";
                             yield %35;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %36 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %37 : java.type:"java.lang.String" = invoke %36 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %38 : java.type:"java.lang.String" = cast %37 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %36 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %37 : java.type:"java.lang.Integer" = invoke %36 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %38 : java.type:"java.lang.Integer" = cast %37 @java.type:"java.lang.Integer";
                             yield %38;
                         };
                     %39 : java.type:"boolean" = instanceof %31 @java.type:"java.lang.Object";
@@ -175,7 +175,7 @@ public class ErasedAccessTest {
                 };
                 """)
         @Reflect
-        void testInstanceofCond(UnboundedString test, boolean cond) {
+        void testInstanceofCond(UnboundedInteger test, boolean cond) {
             // simple field name
             boolean f_s_o = (cond ? x : x) instanceof Object;
 
@@ -190,16 +190,16 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testExec" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %4 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                func @"testExec" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %4 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %5 : java.type:"java.lang.Integer" = invoke %4 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
                     return;
                 };
                 """)
         @Reflect
-        void testExec(UnboundedString test) {
+        void testExec(UnboundedInteger test) {
             // simple method name
             getX();
 
@@ -208,27 +208,27 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testChainedCall" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
-                    %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
-                    %6 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
-                    %9 : java.type:"int" = invoke %8 @java.ref:"java.lang.String::hashCode():int";
-                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
-                    %12 : java.type:"int" = invoke %11 @java.ref:"java.lang.String::hashCode():int";
-                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %15 : java.type:"java.lang.String" = cast %14 @java.type:"java.lang.String";
-                    %16 : java.type:"int" = invoke %15 @java.ref:"java.lang.String::hashCode():int";
+                func @"testChainedCall" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %4 : java.type:"java.lang.Integer" = cast %3 @java.type:"java.lang.Integer";
+                    %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.Integer::hashCode():int";
+                    %6 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %7 : java.type:"java.lang.Integer" = field.load %6 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
+                    %9 : java.type:"int" = invoke %8 @java.ref:"java.lang.Integer::hashCode():int";
+                    %10 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %11 : java.type:"java.lang.Integer" = cast %10 @java.type:"java.lang.Integer";
+                    %12 : java.type:"int" = invoke %11 @java.ref:"java.lang.Integer::hashCode():int";
+                    %13 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %14 : java.type:"java.lang.Integer" = invoke %13 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %15 : java.type:"java.lang.Integer" = cast %14 @java.type:"java.lang.Integer";
+                    %16 : java.type:"int" = invoke %15 @java.ref:"java.lang.Integer::hashCode():int";
                     return;
                 };
                 """)
         @Reflect
-        void testChainedCall(UnboundedString test) {
+        void testChainedCall(UnboundedInteger test) {
             // simple field name
             x.hashCode();
 
@@ -243,82 +243,82 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testChainedCallCond" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString", %2 : java.type:"boolean")java.type:"void" -> {
-                    %3 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                func @"testChainedCallCond" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
                     %4 : Var<java.type:"boolean"> = var %2 @"cond";
-                    %5 : java.type:"java.lang.String" = java.cexpression
+                    %5 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %6 : java.type:"boolean" = var.load %4;
                             yield %6;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
                             yield %8;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %9 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
                             yield %10;
                         };
-                    %11 : java.type:"int" = invoke %5 @java.ref:"java.lang.String::hashCode():int";
-                    %12 : java.type:"java.lang.String" = java.cexpression
+                    %11 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::hashCode():int";
+                    %12 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %13 : java.type:"boolean" = var.load %4;
                             yield %13;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %14 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %14 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %15 : java.type:"java.lang.Integer" = field.load %14 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %16 : java.type:"java.lang.Integer" = cast %15 @java.type:"java.lang.Integer";
                             yield %16;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %17 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %18 : java.type:"java.lang.String" = field.load %17 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                            %19 : java.type:"java.lang.String" = cast %18 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %17 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %18 : java.type:"java.lang.Integer" = field.load %17 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %19 : java.type:"java.lang.Integer" = cast %18 @java.type:"java.lang.Integer";
                             yield %19;
                         };
-                    %20 : java.type:"int" = invoke %12 @java.ref:"java.lang.String::hashCode():int";
-                    %21 : java.type:"java.lang.String" = java.cexpression
+                    %20 : java.type:"int" = invoke %12 @java.ref:"java.lang.Integer::hashCode():int";
+                    %21 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %22 : java.type:"boolean" = var.load %4;
                             yield %22;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %23 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %24 : java.type:"java.lang.String" = cast %23 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %23 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %24 : java.type:"java.lang.Integer" = cast %23 @java.type:"java.lang.Integer";
                             yield %24;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %25 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %26 : java.type:"java.lang.Integer" = cast %25 @java.type:"java.lang.Integer";
                             yield %26;
                         };
-                    %27 : java.type:"int" = invoke %21 @java.ref:"java.lang.String::hashCode():int";
-                    %28 : java.type:"java.lang.String" = java.cexpression
+                    %27 : java.type:"int" = invoke %21 @java.ref:"java.lang.Integer::hashCode():int";
+                    %28 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %29 : java.type:"boolean" = var.load %4;
                             yield %29;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %30 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %31 : java.type:"java.lang.String" = invoke %30 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %32 : java.type:"java.lang.String" = cast %31 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %30 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %31 : java.type:"java.lang.Integer" = invoke %30 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %32 : java.type:"java.lang.Integer" = cast %31 @java.type:"java.lang.Integer";
                             yield %32;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %33 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
-                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %33 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %34 : java.type:"java.lang.Integer" = invoke %33 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %35 : java.type:"java.lang.Integer" = cast %34 @java.type:"java.lang.Integer";
                             yield %35;
                         };
-                    %36 : java.type:"int" = invoke %28 @java.ref:"java.lang.String::hashCode():int";
+                    %36 : java.type:"int" = invoke %28 @java.ref:"java.lang.Integer::hashCode():int";
                     return;
                 };
                 """)
         @Reflect
-        void testChainedCallCond(UnboundedString test, boolean cond) {
+        void testChainedCallCond(UnboundedInteger test, boolean cond) {
             // simple field name
             (cond ? x : x).hashCode();
 
@@ -333,166 +333,166 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testAssign" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                func @"testAssign" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
                     %3 : Var<java.type:"java.lang.Object"> = var @"o";
-                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
-                    %5 : Var<java.type:"java.lang.String"> = var @"s";
-                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %4 : Var<java.type:"java.lang.Number"> = var @"n";
+                    %5 : Var<java.type:"java.lang.Integer"> = var @"i";
+                    %6 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
                     var.store %3 %6;
-                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %8 : java.type:"java.lang.CharSequence" = cast %7 @java.type:"java.lang.CharSequence";
+                    %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %8 : java.type:"java.lang.Number" = cast %7 @java.type:"java.lang.Number";
                     var.store %4 %8;
-                    %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                    %9 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
                     var.store %5 %10;
-                    %11 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %12 : java.type:"java.lang.String" = field.load %11 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %11 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %12 : java.type:"java.lang.Integer" = field.load %11 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
                     var.store %3 %12;
-                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %14 : java.type:"java.lang.String" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %15 : java.type:"java.lang.CharSequence" = cast %14 @java.type:"java.lang.CharSequence";
+                    %13 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %14 : java.type:"java.lang.Integer" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %15 : java.type:"java.lang.Number" = cast %14 @java.type:"java.lang.Number";
                     var.store %4 %15;
-                    %16 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %17 : java.type:"java.lang.String" = field.load %16 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %18 : java.type:"java.lang.String" = cast %17 @java.type:"java.lang.String";
+                    %16 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %17 : java.type:"java.lang.Integer" = field.load %16 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %18 : java.type:"java.lang.Integer" = cast %17 @java.type:"java.lang.Integer";
                     var.store %5 %18;
-                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %19 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
                     var.store %3 %19;
-                    %20 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %21 : java.type:"java.lang.CharSequence" = cast %20 @java.type:"java.lang.CharSequence";
+                    %20 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %21 : java.type:"java.lang.Number" = cast %20 @java.type:"java.lang.Number";
                     var.store %4 %21;
-                    %22 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %23 : java.type:"java.lang.String" = cast %22 @java.type:"java.lang.String";
+                    %22 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %23 : java.type:"java.lang.Integer" = cast %22 @java.type:"java.lang.Integer";
                     var.store %5 %23;
-                    %24 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %25 : java.type:"java.lang.String" = invoke %24 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %24 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %25 : java.type:"java.lang.Integer" = invoke %24 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
                     var.store %3 %25;
-                    %26 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %27 : java.type:"java.lang.String" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %28 : java.type:"java.lang.CharSequence" = cast %27 @java.type:"java.lang.CharSequence";
+                    %26 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %27 : java.type:"java.lang.Integer" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %28 : java.type:"java.lang.Number" = cast %27 @java.type:"java.lang.Number";
                     var.store %4 %28;
-                    %29 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %30 : java.type:"java.lang.String" = invoke %29 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %31 : java.type:"java.lang.String" = cast %30 @java.type:"java.lang.String";
+                    %29 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %30 : java.type:"java.lang.Integer" = invoke %29 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %31 : java.type:"java.lang.Integer" = cast %30 @java.type:"java.lang.Integer";
                     var.store %5 %31;
                     return;
                 };
                 """)
         @Reflect
-        void testAssign(UnboundedString test) {
-            Object o; CharSequence cs; String s;
+        void testAssign(UnboundedInteger test) {
+            Object o; Number n; Integer i;
 
             // simple field name
             o = x;
-            cs = x;
-            s = x;
+            n = x;
+            i = x;
 
             // qualified field name
             o = test.x;
-            cs = test.x;
-            s = test.x;
+            n = test.x;
+            i = test.x;
 
             // simple method name
             o = getX();
-            cs = getX();
-            s = getX();
+            n = getX();
+            i = getX();
 
             // qualified method name
             o = test.getX();
-            cs = test.getX();
-            s = test.getX();
+            n = test.getX();
+            i = test.getX();
         }
 
         @IR("""
-                func @"testArrayInit" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                func @"testArrayInit" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
                     %3 : Var<java.type:"java.lang.Object[]"> = var @"o";
-                    %4 : Var<java.type:"java.lang.CharSequence[]"> = var @"cs";
-                    %5 : Var<java.type:"java.lang.String[]"> = var @"s";
+                    %4 : Var<java.type:"java.lang.Number[]"> = var @"n";
+                    %5 : Var<java.type:"java.lang.Integer[]"> = var @"i";
                     %6 : java.type:"int" = constant @1;
                     %7 : java.type:"java.lang.Object[]" = new %6 @java.ref:"java.lang.Object[]::(int)";
-                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %8 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
                     %9 : java.type:"int" = constant @0;
                     array.store %7 %9 %8;
                     var.store %3 %7;
                     %10 : java.type:"int" = constant @1;
-                    %11 : java.type:"java.lang.CharSequence[]" = new %10 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %12 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %13 : java.type:"java.lang.CharSequence" = cast %12 @java.type:"java.lang.CharSequence";
+                    %11 : java.type:"java.lang.Number[]" = new %10 @java.ref:"java.lang.Number[]::(int)";
+                    %12 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %13 : java.type:"java.lang.Number" = cast %12 @java.type:"java.lang.Number";
                     %14 : java.type:"int" = constant @0;
                     array.store %11 %14 %13;
                     var.store %4 %11;
                     %15 : java.type:"int" = constant @1;
-                    %16 : java.type:"java.lang.String[]" = new %15 @java.ref:"java.lang.String[]::(int)";
-                    %17 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %18 : java.type:"java.lang.String" = cast %17 @java.type:"java.lang.String";
+                    %16 : java.type:"java.lang.Integer[]" = new %15 @java.ref:"java.lang.Integer[]::(int)";
+                    %17 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %18 : java.type:"java.lang.Integer" = cast %17 @java.type:"java.lang.Integer";
                     %19 : java.type:"int" = constant @0;
                     array.store %16 %19 %18;
                     var.store %5 %16;
                     %20 : java.type:"int" = constant @1;
                     %21 : java.type:"java.lang.Object[]" = new %20 @java.ref:"java.lang.Object[]::(int)";
-                    %22 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %23 : java.type:"java.lang.String" = field.load %22 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %22 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %23 : java.type:"java.lang.Integer" = field.load %22 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
                     %24 : java.type:"int" = constant @0;
                     array.store %21 %24 %23;
                     var.store %3 %21;
                     %25 : java.type:"int" = constant @1;
-                    %26 : java.type:"java.lang.CharSequence[]" = new %25 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %27 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %28 : java.type:"java.lang.String" = field.load %27 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %29 : java.type:"java.lang.CharSequence" = cast %28 @java.type:"java.lang.CharSequence";
+                    %26 : java.type:"java.lang.Number[]" = new %25 @java.ref:"java.lang.Number[]::(int)";
+                    %27 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %28 : java.type:"java.lang.Integer" = field.load %27 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %29 : java.type:"java.lang.Number" = cast %28 @java.type:"java.lang.Number";
                     %30 : java.type:"int" = constant @0;
                     array.store %26 %30 %29;
                     var.store %4 %26;
                     %31 : java.type:"int" = constant @1;
-                    %32 : java.type:"java.lang.String[]" = new %31 @java.ref:"java.lang.String[]::(int)";
-                    %33 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %34 : java.type:"java.lang.String" = field.load %33 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                    %32 : java.type:"java.lang.Integer[]" = new %31 @java.ref:"java.lang.Integer[]::(int)";
+                    %33 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %34 : java.type:"java.lang.Integer" = field.load %33 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %35 : java.type:"java.lang.Integer" = cast %34 @java.type:"java.lang.Integer";
                     %36 : java.type:"int" = constant @0;
                     array.store %32 %36 %35;
                     var.store %5 %32;
                     %37 : java.type:"int" = constant @1;
                     %38 : java.type:"java.lang.Object[]" = new %37 @java.ref:"java.lang.Object[]::(int)";
-                    %39 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %39 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
                     %40 : java.type:"int" = constant @0;
                     array.store %38 %40 %39;
                     var.store %3 %38;
                     %41 : java.type:"int" = constant @1;
-                    %42 : java.type:"java.lang.CharSequence[]" = new %41 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %43 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %44 : java.type:"java.lang.CharSequence" = cast %43 @java.type:"java.lang.CharSequence";
+                    %42 : java.type:"java.lang.Number[]" = new %41 @java.ref:"java.lang.Number[]::(int)";
+                    %43 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %44 : java.type:"java.lang.Number" = cast %43 @java.type:"java.lang.Number";
                     %45 : java.type:"int" = constant @0;
                     array.store %42 %45 %44;
                     var.store %4 %42;
                     %46 : java.type:"int" = constant @1;
-                    %47 : java.type:"java.lang.String[]" = new %46 @java.ref:"java.lang.String[]::(int)";
-                    %48 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %49 : java.type:"java.lang.String" = cast %48 @java.type:"java.lang.String";
+                    %47 : java.type:"java.lang.Integer[]" = new %46 @java.ref:"java.lang.Integer[]::(int)";
+                    %48 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %49 : java.type:"java.lang.Integer" = cast %48 @java.type:"java.lang.Integer";
                     %50 : java.type:"int" = constant @0;
                     array.store %47 %50 %49;
                     var.store %5 %47;
                     %51 : java.type:"int" = constant @1;
                     %52 : java.type:"java.lang.Object[]" = new %51 @java.ref:"java.lang.Object[]::(int)";
-                    %53 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %54 : java.type:"java.lang.String" = invoke %53 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %53 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %54 : java.type:"java.lang.Integer" = invoke %53 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
                     %55 : java.type:"int" = constant @0;
                     array.store %52 %55 %54;
                     var.store %3 %52;
                     %56 : java.type:"int" = constant @1;
-                    %57 : java.type:"java.lang.CharSequence[]" = new %56 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %58 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %59 : java.type:"java.lang.String" = invoke %58 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %60 : java.type:"java.lang.CharSequence" = cast %59 @java.type:"java.lang.CharSequence";
+                    %57 : java.type:"java.lang.Number[]" = new %56 @java.ref:"java.lang.Number[]::(int)";
+                    %58 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %59 : java.type:"java.lang.Integer" = invoke %58 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %60 : java.type:"java.lang.Number" = cast %59 @java.type:"java.lang.Number";
                     %61 : java.type:"int" = constant @0;
                     array.store %57 %61 %60;
                     var.store %4 %57;
                     %62 : java.type:"int" = constant @1;
-                    %63 : java.type:"java.lang.String[]" = new %62 @java.ref:"java.lang.String[]::(int)";
-                    %64 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %65 : java.type:"java.lang.String" = invoke %64 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %66 : java.type:"java.lang.String" = cast %65 @java.type:"java.lang.String";
+                    %63 : java.type:"java.lang.Integer[]" = new %62 @java.ref:"java.lang.Integer[]::(int)";
+                    %64 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %65 : java.type:"java.lang.Integer" = invoke %64 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %66 : java.type:"java.lang.Integer" = cast %65 @java.type:"java.lang.Integer";
                     %67 : java.type:"int" = constant @0;
                     array.store %63 %67 %66;
                     var.store %5 %63;
@@ -500,177 +500,223 @@ public class ErasedAccessTest {
                 };
                 """)
         @Reflect
-        void testArrayInit(UnboundedString test) {
-            Object[] o; CharSequence[] cs; String[] s;
+        void testArrayInit(UnboundedInteger test) {
+            Object[] o; Number[] n; Integer[] i;
 
             // simple field name
             o = new Object[] { x };
-            cs = new CharSequence[] { x };
-            s = new String[] { x };
+            n = new Number[] { x };
+            i = new Integer[] { x };
 
             // qualified field name
             o = new Object[] { test.x };
-            cs = new CharSequence[] { test.x };
-            s = new String[] { test.x };
+            n = new Number[] { test.x };
+            i = new Integer[] { test.x };
 
             // simple method name
             o = new Object[] { getX() };
-            cs = new CharSequence[] { getX() };
-            s = new String[] { getX() };
+            n = new Number[] { getX() };
+            i = new Integer[] { getX() };
 
             // qualified method name
             o = new Object[] { test.getX() };
-            cs = new CharSequence[] { test.getX() };
-            s = new String[] { test.getX() };
+            n = new Number[] { test.getX() };
+            i = new Integer[] { test.getX() };
         }
 
         @IR("""
-                func @"testCast" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                func @"testCast" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
                     %3 : Var<java.type:"java.lang.Object"> = var @"o";
-                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
-                    %5 : Var<java.type:"java.lang.String"> = var @"s";
-                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %4 : Var<java.type:"java.lang.Number"> = var @"n";
+                    %5 : Var<java.type:"java.lang.Integer"> = var @"i";
+                    %6 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
                     var.store %3 %6;
-                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %8 : java.type:"java.lang.CharSequence" = cast %7 @java.type:"java.lang.CharSequence";
+                    %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %8 : java.type:"java.lang.Number" = cast %7 @java.type:"java.lang.Number";
                     var.store %4 %8;
-                    %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                    %9 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
                     var.store %5 %10;
-                    %11 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %12 : java.type:"java.lang.String" = field.load %11 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %11 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %12 : java.type:"java.lang.Integer" = field.load %11 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
                     var.store %3 %12;
-                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %14 : java.type:"java.lang.String" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %15 : java.type:"java.lang.CharSequence" = cast %14 @java.type:"java.lang.CharSequence";
+                    %13 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %14 : java.type:"java.lang.Integer" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %15 : java.type:"java.lang.Number" = cast %14 @java.type:"java.lang.Number";
                     var.store %4 %15;
-                    %16 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %17 : java.type:"java.lang.String" = field.load %16 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %18 : java.type:"java.lang.String" = cast %17 @java.type:"java.lang.String";
+                    %16 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %17 : java.type:"java.lang.Integer" = field.load %16 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %18 : java.type:"java.lang.Integer" = cast %17 @java.type:"java.lang.Integer";
                     var.store %5 %18;
-                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %19 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
                     var.store %3 %19;
-                    %20 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %21 : java.type:"java.lang.CharSequence" = cast %20 @java.type:"java.lang.CharSequence";
+                    %20 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %21 : java.type:"java.lang.Number" = cast %20 @java.type:"java.lang.Number";
                     var.store %4 %21;
-                    %22 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %23 : java.type:"java.lang.String" = cast %22 @java.type:"java.lang.String";
+                    %22 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %23 : java.type:"java.lang.Integer" = cast %22 @java.type:"java.lang.Integer";
                     var.store %5 %23;
-                    %24 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %25 : java.type:"java.lang.String" = invoke %24 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %24 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %25 : java.type:"java.lang.Integer" = invoke %24 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
                     var.store %3 %25;
-                    %26 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %27 : java.type:"java.lang.String" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %28 : java.type:"java.lang.CharSequence" = cast %27 @java.type:"java.lang.CharSequence";
+                    %26 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %27 : java.type:"java.lang.Integer" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %28 : java.type:"java.lang.Number" = cast %27 @java.type:"java.lang.Number";
                     var.store %4 %28;
-                    %29 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %30 : java.type:"java.lang.String" = invoke %29 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %31 : java.type:"java.lang.String" = cast %30 @java.type:"java.lang.String";
+                    %29 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %30 : java.type:"java.lang.Integer" = invoke %29 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %31 : java.type:"java.lang.Integer" = cast %30 @java.type:"java.lang.Integer";
                     var.store %5 %31;
                     return;
                 };
                 """)
         @Reflect
-        void testCast(UnboundedString test) {
-            Object o; CharSequence cs; String s;
+        void testCast(UnboundedInteger test) {
+            Object o; Number n; Integer i;
 
             // simple field name
             o = (Object) x;
-            cs = (CharSequence) x;
-            s = (String) x;
+            n = (Number) x;
+            i = (Integer) x;
 
             // qualified field name
             o = (Object) test.x;
-            cs = (CharSequence) test.x;
-            s = (String) test.x;
+            n = (Number) test.x;
+            i = (Integer) test.x;
 
             // simple method name
             o = (Object) getX();
-            cs = (CharSequence) getX();
-            s = (String) getX();
+            n = (Number) getX();
+            i = (Integer) getX();
 
             // qualified method name
             o = (Object) test.getX();
-            cs = (CharSequence) test.getX();
-            s = (String) test.getX();
+            n = (Number) test.getX();
+            i = (Integer) test.getX();
         }
 
         void o(Object o) { }
-        void cs(CharSequence cs) { }
-        void s(String s) { }
+        void n(Number n) { }
+        void i(Integer i) { }
 
         @IR("""
-                func @"testMethod" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    invoke %0 %3 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
-                    %4 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %5 : java.type:"java.lang.CharSequence" = cast %4 @java.type:"java.lang.CharSequence";
-                    invoke %0 %5 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
-                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %7 : java.type:"java.lang.String" = cast %6 @java.type:"java.lang.String";
-                    invoke %0 %7 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
-                    %8 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %9 : java.type:"java.lang.String" = field.load %8 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    invoke %0 %9 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
-                    %10 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %11 : java.type:"java.lang.String" = field.load %10 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %12 : java.type:"java.lang.CharSequence" = cast %11 @java.type:"java.lang.CharSequence";
-                    invoke %0 %12 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
-                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %14 : java.type:"java.lang.String" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
-                    %15 : java.type:"java.lang.String" = cast %14 @java.type:"java.lang.String";
-                    invoke %0 %15 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
-                    %16 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    invoke %0 %16 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
-                    %17 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %18 : java.type:"java.lang.CharSequence" = cast %17 @java.type:"java.lang.CharSequence";
-                    invoke %0 %18 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
-                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
-                    invoke %0 %20 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
-                    %21 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %22 : java.type:"java.lang.String" = invoke %21 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    invoke %0 %22 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
-                    %23 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %24 : java.type:"java.lang.String" = invoke %23 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %25 : java.type:"java.lang.CharSequence" = cast %24 @java.type:"java.lang.CharSequence";
-                    invoke %0 %25 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
-                    %26 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
-                    %27 : java.type:"java.lang.String" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
-                    %28 : java.type:"java.lang.String" = cast %27 @java.type:"java.lang.String";
-                    invoke %0 %28 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
+                func @"testMethod" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    invoke %0 %3 @java.ref:"ErasedAccessTest$UnboundedInteger::o(java.lang.Object):void";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %5 : java.type:"java.lang.Number" = cast %4 @java.type:"java.lang.Number";
+                    invoke %0 %5 @java.ref:"ErasedAccessTest$UnboundedInteger::n(java.lang.Number):void";
+                    %6 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %7 : java.type:"java.lang.Integer" = cast %6 @java.type:"java.lang.Integer";
+                    invoke %0 %7 @java.ref:"ErasedAccessTest$UnboundedInteger::i(java.lang.Integer):void";
+                    %8 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %9 : java.type:"java.lang.Integer" = field.load %8 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    invoke %0 %9 @java.ref:"ErasedAccessTest$UnboundedInteger::o(java.lang.Object):void";
+                    %10 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %11 : java.type:"java.lang.Integer" = field.load %10 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %12 : java.type:"java.lang.Number" = cast %11 @java.type:"java.lang.Number";
+                    invoke %0 %12 @java.ref:"ErasedAccessTest$UnboundedInteger::n(java.lang.Number):void";
+                    %13 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %14 : java.type:"java.lang.Integer" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %15 : java.type:"java.lang.Integer" = cast %14 @java.type:"java.lang.Integer";
+                    invoke %0 %15 @java.ref:"ErasedAccessTest$UnboundedInteger::i(java.lang.Integer):void";
+                    %16 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    invoke %0 %16 @java.ref:"ErasedAccessTest$UnboundedInteger::o(java.lang.Object):void";
+                    %17 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %18 : java.type:"java.lang.Number" = cast %17 @java.type:"java.lang.Number";
+                    invoke %0 %18 @java.ref:"ErasedAccessTest$UnboundedInteger::n(java.lang.Number):void";
+                    %19 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %20 : java.type:"java.lang.Integer" = cast %19 @java.type:"java.lang.Integer";
+                    invoke %0 %20 @java.ref:"ErasedAccessTest$UnboundedInteger::i(java.lang.Integer):void";
+                    %21 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %22 : java.type:"java.lang.Integer" = invoke %21 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    invoke %0 %22 @java.ref:"ErasedAccessTest$UnboundedInteger::o(java.lang.Object):void";
+                    %23 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %24 : java.type:"java.lang.Integer" = invoke %23 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %25 : java.type:"java.lang.Number" = cast %24 @java.type:"java.lang.Number";
+                    invoke %0 %25 @java.ref:"ErasedAccessTest$UnboundedInteger::n(java.lang.Number):void";
+                    %26 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %27 : java.type:"java.lang.Integer" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %28 : java.type:"java.lang.Integer" = cast %27 @java.type:"java.lang.Integer";
+                    invoke %0 %28 @java.ref:"ErasedAccessTest$UnboundedInteger::i(java.lang.Integer):void";
                     return;
                 };
                 """)
         @Reflect
-        void testMethod(UnboundedString test) {
+        void testMethod(UnboundedInteger test) {
             // simple field name
             o(x);
-            cs(x);
-            s(x);
+            n(x);
+            i(x);
 
             // qualified field name
             o(test.x);
-            cs(test.x);
-            s(test.x);
+            n(test.x);
+            i(test.x);
 
             // simple method name
             o(getX());
-            cs(getX());
-            s(getX());
+            n(getX());
+            i(getX());
 
             // qualified method name
             o(test.getX());
-            cs(test.getX());
-            s(test.getX());
+            n(test.getX());
+            i(test.getX());
+        }
+
+        @IR("""
+                func @"testWidening" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %3 : Var<java.type:"long"> = var @"l";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %5 : java.type:"java.lang.Integer" = cast %4 @java.type:"java.lang.Integer";
+                    %6 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::intValue():int";
+                    %7 : java.type:"long" = conv %6;
+                    var.store %3 %7;
+                    %8 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %9 : java.type:"java.lang.Integer" = field.load %8 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
+                    %11 : java.type:"int" = invoke %10 @java.ref:"java.lang.Integer::intValue():int";
+                    %12 : java.type:"long" = conv %11;
+                    var.store %3 %12;
+                    %13 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %14 : java.type:"java.lang.Integer" = cast %13 @java.type:"java.lang.Integer";
+                    %15 : java.type:"int" = invoke %14 @java.ref:"java.lang.Integer::intValue():int";
+                    %16 : java.type:"long" = conv %15;
+                    var.store %3 %16;
+                    %17 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %18 : java.type:"java.lang.Integer" = invoke %17 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %19 : java.type:"java.lang.Integer" = cast %18 @java.type:"java.lang.Integer";
+                    %20 : java.type:"int" = invoke %19 @java.ref:"java.lang.Integer::intValue():int";
+                    %21 : java.type:"long" = conv %20;
+                    var.store %3 %21;
+                    return;
+                };
+                """)
+        @Reflect
+        void testWidening(UnboundedInteger test) {
+            long l;
+
+            // simple field name
+            l = x;
+
+            // qualified field name
+            l = test.x;
+
+            // simple method name
+            l = getX();
+
+            // qualified method name
+            l = test.getX();
         }
     }
 
     // the part below is just copied from the above with minor adaptations in the expected IRs
 
-    static class Bounded<X extends CharSequence> {
+    static class Bounded<X extends Number> {
         X x;
 
         X getX() {
@@ -678,115 +724,115 @@ public class ErasedAccessTest {
         }
     }
 
-    static class BoundedString extends Bounded<String> {
+    static class BoundedInteger extends Bounded<Integer> {
 
         @IR("""
-                func @"testInstanceof" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.String";
+                func @"testInstanceof" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Integer";
                     %5 : Var<java.type:"boolean"> = var %4 @"f_s_s";
-                    %6 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %8 : java.type:"boolean" = instanceof %7 @java.type:"java.lang.String";
+                    %6 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %7 : java.type:"java.lang.Integer" = field.load %6 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %8 : java.type:"boolean" = instanceof %7 @java.type:"java.lang.Integer";
                     %9 : Var<java.type:"boolean"> = var %8 @"f_q_s";
-                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.String";
+                    %10 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.Integer";
                     %12 : Var<java.type:"boolean"> = var %11 @"m_s_s";
-                    %13 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %15 : java.type:"boolean" = instanceof %14 @java.type:"java.lang.String";
+                    %13 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %14 : java.type:"java.lang.Integer" = invoke %13 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %15 : java.type:"boolean" = instanceof %14 @java.type:"java.lang.Integer";
                     %16 : Var<java.type:"boolean"> = var %15 @"m_q_s";
                     return;
                 };
                 """)
         @Reflect
-        void testInstanceof(BoundedString test) {
+        void testInstanceof(BoundedInteger test) {
             // simple field name
-            boolean f_s_s = x instanceof String;
+            boolean f_s_s = x instanceof Integer;
 
             // qualified field name
-            boolean f_q_s = test.x instanceof String;
+            boolean f_q_s = test.x instanceof Integer;
 
             // simple method name
-            boolean m_s_s = getX() instanceof String;
+            boolean m_s_s = getX() instanceof Integer;
 
             // qualified method name
-            boolean m_q_s = test.getX() instanceof String;
+            boolean m_q_s = test.getX() instanceof Integer;
         }
 
         @IR("""
-                func @"testInstanceofCond" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString", %2 : java.type:"boolean")java.type:"void" -> {
-                    %3 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                func @"testInstanceofCond" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
                     %4 : Var<java.type:"boolean"> = var %2 @"cond";
-                    %5 : java.type:"java.lang.String" = java.cexpression
+                    %5 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %6 : java.type:"boolean" = var.load %4;
                             yield %6;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
                             yield %8;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %9 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
                             yield %10;
                         };
                     %11 : java.type:"boolean" = instanceof %5 @java.type:"java.lang.Object";
                     %12 : Var<java.type:"boolean"> = var %11 @"f_s_o";
-                    %13 : java.type:"java.lang.String" = java.cexpression
+                    %13 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %14 : java.type:"boolean" = var.load %4;
                             yield %14;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %15 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %16 : java.type:"java.lang.String" = field.load %15 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %15 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %16 : java.type:"java.lang.Integer" = field.load %15 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %17 : java.type:"java.lang.Integer" = cast %16 @java.type:"java.lang.Integer";
                             yield %17;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %18 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %19 : java.type:"java.lang.String" = field.load %18 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %18 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %19 : java.type:"java.lang.Integer" = field.load %18 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %20 : java.type:"java.lang.Integer" = cast %19 @java.type:"java.lang.Integer";
                             yield %20;
                         };
                     %21 : java.type:"boolean" = instanceof %13 @java.type:"java.lang.Object";
                     %22 : Var<java.type:"boolean"> = var %21 @"f_q_o";
-                    %23 : java.type:"java.lang.String" = java.cexpression
+                    %23 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %24 : java.type:"boolean" = var.load %4;
                             yield %24;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %25 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %26 : java.type:"java.lang.Integer" = cast %25 @java.type:"java.lang.Integer";
                             yield %26;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %27 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %28 : java.type:"java.lang.String" = cast %27 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %27 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %28 : java.type:"java.lang.Integer" = cast %27 @java.type:"java.lang.Integer";
                             yield %28;
                         };
                     %29 : java.type:"boolean" = instanceof %23 @java.type:"java.lang.Object";
                     %30 : Var<java.type:"boolean"> = var %29 @"m_s_o";
-                    %31 : java.type:"java.lang.String" = java.cexpression
+                    %31 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %32 : java.type:"boolean" = var.load %4;
                             yield %32;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %33 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %33 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %34 : java.type:"java.lang.Integer" = invoke %33 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %35 : java.type:"java.lang.Integer" = cast %34 @java.type:"java.lang.Integer";
                             yield %35;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %36 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %37 : java.type:"java.lang.String" = invoke %36 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %38 : java.type:"java.lang.String" = cast %37 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %36 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %37 : java.type:"java.lang.Integer" = invoke %36 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %38 : java.type:"java.lang.Integer" = cast %37 @java.type:"java.lang.Integer";
                             yield %38;
                         };
                     %39 : java.type:"boolean" = instanceof %31 @java.type:"java.lang.Object";
@@ -795,7 +841,7 @@ public class ErasedAccessTest {
                 };
                 """)
         @Reflect
-        void testInstanceofCond(BoundedString test, boolean cond) {
+        void testInstanceofCond(BoundedInteger test, boolean cond) {
             // simple field name
             boolean f_s_o = (cond ? x : x) instanceof Object;
 
@@ -810,16 +856,16 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testExec" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %4 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                func @"testExec" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %4 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %5 : java.type:"java.lang.Integer" = invoke %4 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     return;
                 };
                 """)
         @Reflect
-        void testExec(BoundedString test) {
+        void testExec(BoundedInteger test) {
             // simple method name
             getX();
 
@@ -828,27 +874,27 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testChainedCall" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
-                    %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
-                    %6 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
-                    %9 : java.type:"int" = invoke %8 @java.ref:"java.lang.String::hashCode():int";
-                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
-                    %12 : java.type:"int" = invoke %11 @java.ref:"java.lang.String::hashCode():int";
-                    %13 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %15 : java.type:"java.lang.String" = cast %14 @java.type:"java.lang.String";
-                    %16 : java.type:"int" = invoke %15 @java.ref:"java.lang.String::hashCode():int";
+                func @"testChainedCall" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %4 : java.type:"java.lang.Integer" = cast %3 @java.type:"java.lang.Integer";
+                    %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.Integer::hashCode():int";
+                    %6 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %7 : java.type:"java.lang.Integer" = field.load %6 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
+                    %9 : java.type:"int" = invoke %8 @java.ref:"java.lang.Integer::hashCode():int";
+                    %10 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %11 : java.type:"java.lang.Integer" = cast %10 @java.type:"java.lang.Integer";
+                    %12 : java.type:"int" = invoke %11 @java.ref:"java.lang.Integer::hashCode():int";
+                    %13 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %14 : java.type:"java.lang.Integer" = invoke %13 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %15 : java.type:"java.lang.Integer" = cast %14 @java.type:"java.lang.Integer";
+                    %16 : java.type:"int" = invoke %15 @java.ref:"java.lang.Integer::hashCode():int";
                     return;
                 };
                 """)
         @Reflect
-        void testChainedCall(BoundedString test) {
+        void testChainedCall(BoundedInteger test) {
             // simple field name
             x.hashCode();
 
@@ -863,82 +909,82 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testChainedCallCond" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString", %2 : java.type:"boolean")java.type:"void" -> {
-                    %3 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                func @"testChainedCallCond" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
                     %4 : Var<java.type:"boolean"> = var %2 @"cond";
-                    %5 : java.type:"java.lang.String" = java.cexpression
+                    %5 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %6 : java.type:"boolean" = var.load %4;
                             yield %6;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
                             yield %8;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %9 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
                             yield %10;
                         };
-                    %11 : java.type:"int" = invoke %5 @java.ref:"java.lang.String::hashCode():int";
-                    %12 : java.type:"java.lang.String" = java.cexpression
+                    %11 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::hashCode():int";
+                    %12 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %13 : java.type:"boolean" = var.load %4;
                             yield %13;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %14 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %14 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %15 : java.type:"java.lang.Integer" = field.load %14 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %16 : java.type:"java.lang.Integer" = cast %15 @java.type:"java.lang.Integer";
                             yield %16;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %17 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %18 : java.type:"java.lang.String" = field.load %17 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                            %19 : java.type:"java.lang.String" = cast %18 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %17 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %18 : java.type:"java.lang.Integer" = field.load %17 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %19 : java.type:"java.lang.Integer" = cast %18 @java.type:"java.lang.Integer";
                             yield %19;
                         };
-                    %20 : java.type:"int" = invoke %12 @java.ref:"java.lang.String::hashCode():int";
-                    %21 : java.type:"java.lang.String" = java.cexpression
+                    %20 : java.type:"int" = invoke %12 @java.ref:"java.lang.Integer::hashCode():int";
+                    %21 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %22 : java.type:"boolean" = var.load %4;
                             yield %22;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %23 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %24 : java.type:"java.lang.String" = cast %23 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %23 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %24 : java.type:"java.lang.Integer" = cast %23 @java.type:"java.lang.Integer";
                             yield %24;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %25 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %26 : java.type:"java.lang.Integer" = cast %25 @java.type:"java.lang.Integer";
                             yield %26;
                         };
-                    %27 : java.type:"int" = invoke %21 @java.ref:"java.lang.String::hashCode():int";
-                    %28 : java.type:"java.lang.String" = java.cexpression
+                    %27 : java.type:"int" = invoke %21 @java.ref:"java.lang.Integer::hashCode():int";
+                    %28 : java.type:"java.lang.Integer" = java.cexpression
                         ()java.type:"boolean" -> {
                             %29 : java.type:"boolean" = var.load %4;
                             yield %29;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %30 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %31 : java.type:"java.lang.String" = invoke %30 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %32 : java.type:"java.lang.String" = cast %31 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %30 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %31 : java.type:"java.lang.Integer" = invoke %30 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %32 : java.type:"java.lang.Integer" = cast %31 @java.type:"java.lang.Integer";
                             yield %32;
                         }
-                        ()java.type:"java.lang.String" -> {
-                            %33 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
-                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                        ()java.type:"java.lang.Integer" -> {
+                            %33 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %34 : java.type:"java.lang.Integer" = invoke %33 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %35 : java.type:"java.lang.Integer" = cast %34 @java.type:"java.lang.Integer";
                             yield %35;
                         };
-                    %36 : java.type:"int" = invoke %28 @java.ref:"java.lang.String::hashCode():int";
+                    %36 : java.type:"int" = invoke %28 @java.ref:"java.lang.Integer::hashCode():int";
                     return;
                 };
                 """)
         @Reflect
-        void testChainedCallCond(BoundedString test, boolean cond) {
+        void testChainedCallCond(BoundedInteger test, boolean cond) {
             // simple field name
             (cond ? x : x).hashCode();
 
@@ -953,158 +999,158 @@ public class ErasedAccessTest {
         }
 
         @IR("""
-                func @"testAssign" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                func @"testAssign" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
                     %3 : Var<java.type:"java.lang.Object"> = var @"o";
-                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
-                    %5 : Var<java.type:"java.lang.String"> = var @"s";
-                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %4 : Var<java.type:"java.lang.Number"> = var @"n";
+                    %5 : Var<java.type:"java.lang.Integer"> = var @"i";
+                    %6 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %3 %6;
-                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %4 %7;
-                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %9 : java.type:"java.lang.String" = cast %8 @java.type:"java.lang.String";
+                    %8 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %9 : java.type:"java.lang.Integer" = cast %8 @java.type:"java.lang.Integer";
                     var.store %5 %9;
-                    %10 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %11 : java.type:"java.lang.String" = field.load %10 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %10 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %11 : java.type:"java.lang.Integer" = field.load %10 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %3 %11;
-                    %12 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %13 : java.type:"java.lang.String" = field.load %12 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %12 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %13 : java.type:"java.lang.Integer" = field.load %12 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %4 %13;
-                    %14 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                    %14 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %15 : java.type:"java.lang.Integer" = field.load %14 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %16 : java.type:"java.lang.Integer" = cast %15 @java.type:"java.lang.Integer";
                     var.store %5 %16;
-                    %17 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %17 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %3 %17;
-                    %18 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %18 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %4 %18;
-                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                    %19 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %20 : java.type:"java.lang.Integer" = cast %19 @java.type:"java.lang.Integer";
                     var.store %5 %20;
-                    %21 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %22 : java.type:"java.lang.String" = invoke %21 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %21 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %22 : java.type:"java.lang.Integer" = invoke %21 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %3 %22;
-                    %23 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %24 : java.type:"java.lang.String" = invoke %23 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %23 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %24 : java.type:"java.lang.Integer" = invoke %23 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %4 %24;
-                    %25 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %26 : java.type:"java.lang.String" = invoke %25 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %27 : java.type:"java.lang.String" = cast %26 @java.type:"java.lang.String";
+                    %25 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %26 : java.type:"java.lang.Integer" = invoke %25 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %27 : java.type:"java.lang.Integer" = cast %26 @java.type:"java.lang.Integer";
                     var.store %5 %27;
                     return;
                 };
                 """)
         @Reflect
-        void testAssign(BoundedString test) {
-            Object o; CharSequence cs; String s;
+        void testAssign(BoundedInteger test) {
+            Object o; Number n; Integer i;
 
             // simple field name
             o = x;
-            cs = x;
-            s = x;
+            n = x;
+            i = x;
 
             // qualified field name
             o = test.x;
-            cs = test.x;
-            s = test.x;
+            n = test.x;
+            i = test.x;
 
             // simple method name
             o = getX();
-            cs = getX();
-            s = getX();
+            n = getX();
+            i = getX();
 
             // qualified method name
             o = test.getX();
-            cs = test.getX();
-            s = test.getX();
+            n = test.getX();
+            i = test.getX();
         }
 
         @IR("""
-                func @"testArrayInit" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                func @"testArrayInit" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
                     %3 : Var<java.type:"java.lang.Object[]"> = var @"o";
-                    %4 : Var<java.type:"java.lang.CharSequence[]"> = var @"cs";
-                    %5 : Var<java.type:"java.lang.String[]"> = var @"s";
+                    %4 : Var<java.type:"java.lang.Number[]"> = var @"n";
+                    %5 : Var<java.type:"java.lang.Integer[]"> = var @"i";
                     %6 : java.type:"int" = constant @1;
                     %7 : java.type:"java.lang.Object[]" = new %6 @java.ref:"java.lang.Object[]::(int)";
-                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %8 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     %9 : java.type:"int" = constant @0;
                     array.store %7 %9 %8;
                     var.store %3 %7;
                     %10 : java.type:"int" = constant @1;
-                    %11 : java.type:"java.lang.CharSequence[]" = new %10 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %12 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %11 : java.type:"java.lang.Number[]" = new %10 @java.ref:"java.lang.Number[]::(int)";
+                    %12 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     %13 : java.type:"int" = constant @0;
                     array.store %11 %13 %12;
                     var.store %4 %11;
                     %14 : java.type:"int" = constant @1;
-                    %15 : java.type:"java.lang.String[]" = new %14 @java.ref:"java.lang.String[]::(int)";
-                    %16 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
+                    %15 : java.type:"java.lang.Integer[]" = new %14 @java.ref:"java.lang.Integer[]::(int)";
+                    %16 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %17 : java.type:"java.lang.Integer" = cast %16 @java.type:"java.lang.Integer";
                     %18 : java.type:"int" = constant @0;
                     array.store %15 %18 %17;
                     var.store %5 %15;
                     %19 : java.type:"int" = constant @1;
                     %20 : java.type:"java.lang.Object[]" = new %19 @java.ref:"java.lang.Object[]::(int)";
-                    %21 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %22 : java.type:"java.lang.String" = field.load %21 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %21 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %22 : java.type:"java.lang.Integer" = field.load %21 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     %23 : java.type:"int" = constant @0;
                     array.store %20 %23 %22;
                     var.store %3 %20;
                     %24 : java.type:"int" = constant @1;
-                    %25 : java.type:"java.lang.CharSequence[]" = new %24 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %26 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %27 : java.type:"java.lang.String" = field.load %26 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %25 : java.type:"java.lang.Number[]" = new %24 @java.ref:"java.lang.Number[]::(int)";
+                    %26 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %27 : java.type:"java.lang.Integer" = field.load %26 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     %28 : java.type:"int" = constant @0;
                     array.store %25 %28 %27;
                     var.store %4 %25;
                     %29 : java.type:"int" = constant @1;
-                    %30 : java.type:"java.lang.String[]" = new %29 @java.ref:"java.lang.String[]::(int)";
-                    %31 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %32 : java.type:"java.lang.String" = field.load %31 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %33 : java.type:"java.lang.String" = cast %32 @java.type:"java.lang.String";
+                    %30 : java.type:"java.lang.Integer[]" = new %29 @java.ref:"java.lang.Integer[]::(int)";
+                    %31 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %32 : java.type:"java.lang.Integer" = field.load %31 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %33 : java.type:"java.lang.Integer" = cast %32 @java.type:"java.lang.Integer";
                     %34 : java.type:"int" = constant @0;
                     array.store %30 %34 %33;
                     var.store %5 %30;
                     %35 : java.type:"int" = constant @1;
                     %36 : java.type:"java.lang.Object[]" = new %35 @java.ref:"java.lang.Object[]::(int)";
-                    %37 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %37 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     %38 : java.type:"int" = constant @0;
                     array.store %36 %38 %37;
                     var.store %3 %36;
                     %39 : java.type:"int" = constant @1;
-                    %40 : java.type:"java.lang.CharSequence[]" = new %39 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %41 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %40 : java.type:"java.lang.Number[]" = new %39 @java.ref:"java.lang.Number[]::(int)";
+                    %41 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     %42 : java.type:"int" = constant @0;
                     array.store %40 %42 %41;
                     var.store %4 %40;
                     %43 : java.type:"int" = constant @1;
-                    %44 : java.type:"java.lang.String[]" = new %43 @java.ref:"java.lang.String[]::(int)";
-                    %45 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %46 : java.type:"java.lang.String" = cast %45 @java.type:"java.lang.String";
+                    %44 : java.type:"java.lang.Integer[]" = new %43 @java.ref:"java.lang.Integer[]::(int)";
+                    %45 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %46 : java.type:"java.lang.Integer" = cast %45 @java.type:"java.lang.Integer";
                     %47 : java.type:"int" = constant @0;
                     array.store %44 %47 %46;
                     var.store %5 %44;
                     %48 : java.type:"int" = constant @1;
                     %49 : java.type:"java.lang.Object[]" = new %48 @java.ref:"java.lang.Object[]::(int)";
-                    %50 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %51 : java.type:"java.lang.String" = invoke %50 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %50 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %51 : java.type:"java.lang.Integer" = invoke %50 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     %52 : java.type:"int" = constant @0;
                     array.store %49 %52 %51;
                     var.store %3 %49;
                     %53 : java.type:"int" = constant @1;
-                    %54 : java.type:"java.lang.CharSequence[]" = new %53 @java.ref:"java.lang.CharSequence[]::(int)";
-                    %55 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %56 : java.type:"java.lang.String" = invoke %55 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %54 : java.type:"java.lang.Number[]" = new %53 @java.ref:"java.lang.Number[]::(int)";
+                    %55 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %56 : java.type:"java.lang.Integer" = invoke %55 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     %57 : java.type:"int" = constant @0;
                     array.store %54 %57 %56;
                     var.store %4 %54;
                     %58 : java.type:"int" = constant @1;
-                    %59 : java.type:"java.lang.String[]" = new %58 @java.ref:"java.lang.String[]::(int)";
-                    %60 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %61 : java.type:"java.lang.String" = invoke %60 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %62 : java.type:"java.lang.String" = cast %61 @java.type:"java.lang.String";
+                    %59 : java.type:"java.lang.Integer[]" = new %58 @java.ref:"java.lang.Integer[]::(int)";
+                    %60 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %61 : java.type:"java.lang.Integer" = invoke %60 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %62 : java.type:"java.lang.Integer" = cast %61 @java.type:"java.lang.Integer";
                     %63 : java.type:"int" = constant @0;
                     array.store %59 %63 %62;
                     var.store %5 %59;
@@ -1112,169 +1158,215 @@ public class ErasedAccessTest {
                 };
                 """)
         @Reflect
-        void testArrayInit(BoundedString test) {
-            Object[] o; CharSequence[] cs; String[] s;
+        void testArrayInit(BoundedInteger test) {
+            Object[] o; Number[] n; Integer[] i;
 
             // simple field name
             o = new Object[] { x };
-            cs = new CharSequence[] { x };
-            s = new String[] { x };
+            n = new Number[] { x };
+            i = new Integer[] { x };
 
             // qualified field name
             o = new Object[] { test.x };
-            cs = new CharSequence[] { test.x };
-            s = new String[] { test.x };
+            n = new Number[] { test.x };
+            i = new Integer[] { test.x };
 
             // simple method name
             o = new Object[] { getX() };
-            cs = new CharSequence[] { getX() };
-            s = new String[] { getX() };
+            n = new Number[] { getX() };
+            i = new Integer[] { getX() };
 
             // qualified method name
             o = new Object[] { test.getX() };
-            cs = new CharSequence[] { test.getX() };
-            s = new String[] { test.getX() };
+            n = new Number[] { test.getX() };
+            i = new Integer[] { test.getX() };
         }
 
         @IR("""
-                func @"testCast" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                func @"testCast" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
                     %3 : Var<java.type:"java.lang.Object"> = var @"o";
-                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
-                    %5 : Var<java.type:"java.lang.String"> = var @"s";
-                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %4 : Var<java.type:"java.lang.Number"> = var @"n";
+                    %5 : Var<java.type:"java.lang.Integer"> = var @"i";
+                    %6 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %3 %6;
-                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %4 %7;
-                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %9 : java.type:"java.lang.String" = cast %8 @java.type:"java.lang.String";
+                    %8 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %9 : java.type:"java.lang.Integer" = cast %8 @java.type:"java.lang.Integer";
                     var.store %5 %9;
-                    %10 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %11 : java.type:"java.lang.String" = field.load %10 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %10 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %11 : java.type:"java.lang.Integer" = field.load %10 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %3 %11;
-                    %12 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %13 : java.type:"java.lang.String" = field.load %12 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %12 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %13 : java.type:"java.lang.Integer" = field.load %12 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
                     var.store %4 %13;
-                    %14 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                    %14 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %15 : java.type:"java.lang.Integer" = field.load %14 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %16 : java.type:"java.lang.Integer" = cast %15 @java.type:"java.lang.Integer";
                     var.store %5 %16;
-                    %17 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %17 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %3 %17;
-                    %18 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %18 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %4 %18;
-                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                    %19 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %20 : java.type:"java.lang.Integer" = cast %19 @java.type:"java.lang.Integer";
                     var.store %5 %20;
-                    %21 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %22 : java.type:"java.lang.String" = invoke %21 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %21 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %22 : java.type:"java.lang.Integer" = invoke %21 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %3 %22;
-                    %23 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %24 : java.type:"java.lang.String" = invoke %23 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %23 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %24 : java.type:"java.lang.Integer" = invoke %23 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
                     var.store %4 %24;
-                    %25 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %26 : java.type:"java.lang.String" = invoke %25 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %27 : java.type:"java.lang.String" = cast %26 @java.type:"java.lang.String";
+                    %25 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %26 : java.type:"java.lang.Integer" = invoke %25 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %27 : java.type:"java.lang.Integer" = cast %26 @java.type:"java.lang.Integer";
                     var.store %5 %27;
                     return;
                 };
                 """)
         @Reflect
-        void testCast(BoundedString test) {
-            Object o; CharSequence cs; String s;
+        void testCast(BoundedInteger test) {
+            Object o; Number n; Integer i;
 
             // simple field name
             o = (Object) x;
-            cs = (CharSequence) x;
-            s = (String) x;
+            n = (Number) x;
+            i = (Integer) x;
 
             // qualified field name
             o = (Object) test.x;
-            cs = (CharSequence) test.x;
-            s = (String) test.x;
+            n = (Number) test.x;
+            i = (Integer) test.x;
 
             // simple method name
             o = (Object) getX();
-            cs = (CharSequence) getX();
-            s = (String) getX();
+            n = (Number) getX();
+            i = (Integer) getX();
 
             // qualified method name
             o = (Object) test.getX();
-            cs = (CharSequence) test.getX();
-            s = (String) test.getX();
+            n = (Number) test.getX();
+            i = (Integer) test.getX();
         }
 
         void o(Object o) { }
-        void cs(CharSequence cs) { }
-        void s(String s) { }
+        void n(Number n) { }
+        void i(Integer i) { }
 
         @IR("""
-                func @"testMethod" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
-                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
-                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    invoke %0 %3 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
-                    %4 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    invoke %0 %4 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
-                    %5 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %6 : java.type:"java.lang.String" = cast %5 @java.type:"java.lang.String";
-                    invoke %0 %6 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
-                    %7 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %8 : java.type:"java.lang.String" = field.load %7 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    invoke %0 %8 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
-                    %9 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %10 : java.type:"java.lang.String" = field.load %9 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    invoke %0 %10 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
-                    %11 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %12 : java.type:"java.lang.String" = field.load %11 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
-                    %13 : java.type:"java.lang.String" = cast %12 @java.type:"java.lang.String";
-                    invoke %0 %13 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
-                    %14 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    invoke %0 %14 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
-                    %15 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    invoke %0 %15 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
-                    %16 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
-                    invoke %0 %17 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
-                    %18 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %19 : java.type:"java.lang.String" = invoke %18 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    invoke %0 %19 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
-                    %20 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %21 : java.type:"java.lang.String" = invoke %20 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    invoke %0 %21 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
-                    %22 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
-                    %23 : java.type:"java.lang.String" = invoke %22 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
-                    %24 : java.type:"java.lang.String" = cast %23 @java.type:"java.lang.String";
-                    invoke %0 %24 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
+                func @"testMethod" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    invoke %0 %3 @java.ref:"ErasedAccessTest$BoundedInteger::o(java.lang.Object):void";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    invoke %0 %4 @java.ref:"ErasedAccessTest$BoundedInteger::n(java.lang.Number):void";
+                    %5 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %6 : java.type:"java.lang.Integer" = cast %5 @java.type:"java.lang.Integer";
+                    invoke %0 %6 @java.ref:"ErasedAccessTest$BoundedInteger::i(java.lang.Integer):void";
+                    %7 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %8 : java.type:"java.lang.Integer" = field.load %7 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    invoke %0 %8 @java.ref:"ErasedAccessTest$BoundedInteger::o(java.lang.Object):void";
+                    %9 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %10 : java.type:"java.lang.Integer" = field.load %9 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    invoke %0 %10 @java.ref:"ErasedAccessTest$BoundedInteger::n(java.lang.Number):void";
+                    %11 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %12 : java.type:"java.lang.Integer" = field.load %11 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %13 : java.type:"java.lang.Integer" = cast %12 @java.type:"java.lang.Integer";
+                    invoke %0 %13 @java.ref:"ErasedAccessTest$BoundedInteger::i(java.lang.Integer):void";
+                    %14 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    invoke %0 %14 @java.ref:"ErasedAccessTest$BoundedInteger::o(java.lang.Object):void";
+                    %15 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    invoke %0 %15 @java.ref:"ErasedAccessTest$BoundedInteger::n(java.lang.Number):void";
+                    %16 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %17 : java.type:"java.lang.Integer" = cast %16 @java.type:"java.lang.Integer";
+                    invoke %0 %17 @java.ref:"ErasedAccessTest$BoundedInteger::i(java.lang.Integer):void";
+                    %18 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %19 : java.type:"java.lang.Integer" = invoke %18 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    invoke %0 %19 @java.ref:"ErasedAccessTest$BoundedInteger::o(java.lang.Object):void";
+                    %20 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %21 : java.type:"java.lang.Integer" = invoke %20 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    invoke %0 %21 @java.ref:"ErasedAccessTest$BoundedInteger::n(java.lang.Number):void";
+                    %22 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %23 : java.type:"java.lang.Integer" = invoke %22 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %24 : java.type:"java.lang.Integer" = cast %23 @java.type:"java.lang.Integer";
+                    invoke %0 %24 @java.ref:"ErasedAccessTest$BoundedInteger::i(java.lang.Integer):void";
                     return;
                 };
                 """)
         @Reflect
-        void testMethod(BoundedString test) {
+        void testMethod(BoundedInteger test) {
             // simple field name
             o(x);
-            cs(x);
-            s(x);
+            n(x);
+            i(x);
 
             // qualified field name
             o(test.x);
-            cs(test.x);
-            s(test.x);
+            n(test.x);
+            i(test.x);
 
             // simple method name
             o(getX());
-            cs(getX());
-            s(getX());
+            n(getX());
+            i(getX());
 
             // qualified method name
             o(test.getX());
-            cs(test.getX());
-            s(test.getX());
+            n(test.getX());
+            i(test.getX());
+        }
+
+        @IR("""
+                func @"testWidening" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %3 : Var<java.type:"long"> = var @"l";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %5 : java.type:"java.lang.Integer" = cast %4 @java.type:"java.lang.Integer";
+                    %6 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::intValue():int";
+                    %7 : java.type:"long" = conv %6;
+                    var.store %3 %7;
+                    %8 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %9 : java.type:"java.lang.Integer" = field.load %8 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %10 : java.type:"java.lang.Integer" = cast %9 @java.type:"java.lang.Integer";
+                    %11 : java.type:"int" = invoke %10 @java.ref:"java.lang.Integer::intValue():int";
+                    %12 : java.type:"long" = conv %11;
+                    var.store %3 %12;
+                    %13 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %14 : java.type:"java.lang.Integer" = cast %13 @java.type:"java.lang.Integer";
+                    %15 : java.type:"int" = invoke %14 @java.ref:"java.lang.Integer::intValue():int";
+                    %16 : java.type:"long" = conv %15;
+                    var.store %3 %16;
+                    %17 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %18 : java.type:"java.lang.Integer" = invoke %17 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %19 : java.type:"java.lang.Integer" = cast %18 @java.type:"java.lang.Integer";
+                    %20 : java.type:"int" = invoke %19 @java.ref:"java.lang.Integer::intValue():int";
+                    %21 : java.type:"long" = conv %20;
+                    var.store %3 %21;
+                    return;
+                };
+                """)
+        @Reflect
+        void testWidening(BoundedInteger test) {
+            long l;
+
+            // simple field name
+            l = x;
+
+            // qualified field name
+            l = test.x;
+
+            // simple method name
+            l = getX();
+
+            // qualified method name
+            l = test.getX();
         }
     }
 
 
     static final String TEST_CLASSES_DIR = System.getProperty("test.classes", ".");
-    static final Class<?>[] TEST_CLASSES = new Class<?>[] { UnboundedString.class, BoundedString.class };
+    static final Class<?>[] TEST_CLASSES = new Class<?>[] { UnboundedInteger.class, BoundedInteger.class };
 
     public static void main(String[] args) throws ReflectiveOperationException, IOException {
         for (Class<?> testClass : TEST_CLASSES) {

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -240,6 +240,60 @@ public class ErasedAccessTest {
         return (c ? xs.x : xs.x).hashCode();
     }
 
+    @Reflect
+    @IR("""
+            func @"method_objectAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                return %3;
+            };
+            """)
+    static Object method_objectAssign(Box<String> xs) {
+        return xs.get();
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_CharSequenceAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %4 : java.type:"java.lang.CharSequence" = cast %3 @java.type:"java.lang.CharSequence";
+                return %4;
+            };
+            """)
+    static CharSequence method_CharSequenceAssign(Box<String> xs) {
+        return xs.get();
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_objectAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                return %3;
+            };
+            """)
+    static Object field_objectAssign(Box<String> xs) {
+        return xs.x;
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_CharSequenceAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                %4 : java.type:"java.lang.CharSequence" = cast %3 @java.type:"java.lang.CharSequence";
+                return %4;
+            };
+            """)
+    static CharSequence field_CharSequenceAssign(Box<String> xs) {
+        return xs.x;
+    }
+
     static class Box<X> {
         X x;
         Box(X x) { this.x = x; }

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.code.Op;
+import jdk.incubator.code.Reflect;
+import jdk.incubator.code.dialect.core.CoreOp.FuncOp;
+import jdk.incubator.code.dialect.java.JavaOp;
+import jdk.incubator.code.dialect.java.JavaType;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.instruction.TypeCheckInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.List;
+
+/*
+ * @test
+ * @summary Smoke test for timing of synthetic erasure casts
+ * @modules jdk.incubator.code
+ * @build ErasedAccessTest
+ * @run main ErasedAccessTest
+ * @run main CodeReflectionTester ErasedAccessTest
+ */
+
+public class ErasedAccessTest {
+    @Reflect
+    @IR("""
+            func @"method_typeTest" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Object";
+                return %4;
+            };
+            """)
+    static boolean method_typeTest(Box<String> xs) {
+        return xs.get() instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_typeTestCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        yield %8;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %10 : java.type:"java.lang.String" = invoke %9 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                        yield %11;
+                    };
+                %12 : java.type:"boolean" = instanceof %4 @java.type:"java.lang.Object";
+                return %12;
+            };
+            """)
+    static boolean method_typeTestCond(boolean c, Box<String> xs) {
+        return (c ? xs.get() : xs.get()) instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_chainedCall" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
+                %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                return %5;
+            };
+            """)
+    static int method_chainedCall(Box<String> xs) {
+        return xs.get().hashCode();
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_chainedCallCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        yield %8;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %10 : java.type:"java.lang.String" = invoke %9 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                        yield %11;
+                    };
+                %12 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                return %12;
+            };
+            """)
+    static int method_chainedCallCond(boolean c, Box<String> xs) {
+        return (c ? xs.get() : xs.get()).hashCode();
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_exec" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                return;
+            };
+            """)
+    static void method_exec(Box<String> xs) {
+        xs.get();
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_typeTest" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Object";
+                return %4;
+            };
+            """)
+    static boolean field_typeTest(Box<String> xs) {
+        return xs.x instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_typeTestCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        yield %8;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %10 : java.type:"java.lang.String" = field.load %9 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                        yield %11;
+                    };
+                %12 : java.type:"boolean" = instanceof %4 @java.type:"java.lang.Object";
+                return %12;
+            };
+            """)
+    static boolean field_typeTestCond(boolean c, Box<String> xs) {
+        return (c ? xs.x : xs.x) instanceof Object;
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_chainedCall" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
+                %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                return %5;
+            };
+            """)
+    static int field_chainedCall(Box<String> xs) {
+        return xs.x.hashCode();
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_chainedCallCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
+                %2 : Var<java.type:"boolean"> = var %0 @"c";
+                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
+                %4 : java.type:"java.lang.String" = java.cexpression
+                    ()java.type:"boolean" -> {
+                        %5 : java.type:"boolean" = var.load %2;
+                        yield %5;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                        yield %8;
+                    }
+                    ()java.type:"java.lang.String" -> {
+                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
+                        %10 : java.type:"java.lang.String" = field.load %9 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                        yield %11;
+                    };
+                %12 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                return %12;
+            };
+            """)
+    static int field_chainedCallCond(boolean c, Box<String> xs) {
+        return (c ? xs.x : xs.x).hashCode();
+    }
+
+    static class Box<X> {
+        X x;
+        Box(X x) { this.x = x; }
+        X get() { return x; }
+    }
+
+    static final String TEST_CLASSES_DIR = System.getProperty("test.classes", ".");
+
+    public static void main(String[] args) throws ReflectiveOperationException, IOException {
+        ClassModel mod = ClassFile.of().parse(Path.of(TEST_CLASSES_DIR, "ErasedAccessTest.class"));
+        for (Method m : ErasedAccessTest.class.getDeclaredMethods()) {
+            if (m.isAnnotationPresent(Reflect.class)) {
+                FuncOp model = Op.ofMethod(m).get();
+                System.out.println(model.toText());
+                CodeModel bytecode = mod.methods().stream()
+                        .filter(mm -> mm.methodName().stringValue().equals(m.getName()))
+                        .findAny()
+                        .flatMap(MethodModel::code)
+                        .orElseThrow(() -> new AssertionError("Code model not found for method " + m.getName()));
+                List<ClassDesc> modelCasts = modelCasts(model);
+                List<ClassDesc> bytecodeCasts = bytecodeCasts(bytecode);
+                if (!modelCasts.equals(bytecodeCasts)) {
+                    throw new AssertionError("Casts do not match for method " + m.getName() +
+                            "\nbytecode casts = " + bytecodeCasts +
+                            "\nmodel casts = " + modelCasts);
+                }
+            }
+        }
+    }
+
+    static List<ClassDesc> bytecodeCasts(CodeModel m) {
+        return m.elementStream()
+                .filter(i -> i instanceof TypeCheckInstruction tci && tci.opcode() == Opcode.CHECKCAST)
+                .map(TypeCheckInstruction.class::cast)
+                .map(i -> i.type().asSymbol())
+                .toList();
+    }
+
+    static List<ClassDesc> modelCasts(FuncOp model) {
+        return model.elements()
+                .filter(JavaOp.CastOp.class::isInstance)
+                .map(JavaOp.CastOp.class::cast)
+                .map(c -> ((JavaType) c.targetType()).toNominalDescriptor())
+                .toList();
+    }
+}

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -50,15 +50,19 @@ import java.util.List;
 
 public class ErasedAccessTest {
 
-    static class Unbounded<X> {
+    static class Unbounded<X, T extends Throwable> {
         X x;
+        T t;
 
         X getX() {
             return x;
         }
+        T getT() {
+            return t;
+        }
     }
 
-    static class UnboundedInteger extends Unbounded<Integer> {
+    static class UnboundedInteger extends Unbounded<Integer, WrongThreadException> {
 
         @IR("""
                 func @"testInstanceof" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
@@ -712,6 +716,688 @@ public class ErasedAccessTest {
             // qualified method name
             l = test.getX();
         }
+
+        @IR("""
+                func @"testAssert" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    assert
+                        ()java.type:"boolean" -> {
+                            %3 : java.type:"boolean" = constant @false;
+                            yield %3;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %5 : java.type:"java.lang.Integer" = cast %4 @java.type:"java.lang.Integer";
+                            yield %5;
+                        };
+                    assert
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = constant @false;
+                            yield %6;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %7 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                            %8 : java.type:"java.lang.Integer" = field.load %7 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %9 : java.type:"java.lang.Integer" = cast %8 @java.type:"java.lang.Integer";
+                            yield %9;
+                        };
+                    assert
+                        ()java.type:"boolean" -> {
+                            %10 : java.type:"boolean" = constant @false;
+                            yield %10;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %11 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %12 : java.type:"java.lang.Integer" = cast %11 @java.type:"java.lang.Integer";
+                            yield %12;
+                        };
+                    assert
+                        ()java.type:"boolean" -> {
+                            %13 : java.type:"boolean" = constant @false;
+                            yield %13;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %14 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                            %15 : java.type:"java.lang.Integer" = invoke %14 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %16 : java.type:"java.lang.Integer" = cast %15 @java.type:"java.lang.Integer";
+                            yield %16;
+                        };
+                    return;
+                };
+                """)
+        @Reflect
+        void testAssert(UnboundedInteger test) {
+            // simple field name
+            assert false : x;
+
+            // qualified field name
+            assert false : test.x;
+
+            // simple method name
+            assert false : getX();
+
+            // qualified method name
+            assert false : test.getX();
+        }
+
+        @IR("""
+                func @"testSynchronized" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %4 : java.type:"java.lang.Integer" = cast %3 @java.type:"java.lang.Integer";
+                            yield %4;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %5 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                            %6 : java.type:"java.lang.Integer" = field.load %5 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %7 : java.type:"java.lang.Integer" = cast %6 @java.type:"java.lang.Integer";
+                            yield %7;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %8 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %9 : java.type:"java.lang.Integer" = cast %8 @java.type:"java.lang.Integer";
+                            yield %9;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %10 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                            %11 : java.type:"java.lang.Integer" = invoke %10 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %12 : java.type:"java.lang.Integer" = cast %11 @java.type:"java.lang.Integer";
+                            yield %12;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    return;
+                };
+                """)
+        @Reflect
+        @SuppressWarnings("identity")
+        void testSynchronized(UnboundedInteger test) {
+            // simple field name
+            synchronized (x) { };
+
+            // qualified field name
+            synchronized (test.x) { };
+
+            // simple method name
+            synchronized (getX()) { };
+
+            // qualified method name
+            synchronized (test.getX()) { };
+        }
+
+        @IR("""
+                func @"testYield" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger", %2 : java.type:"int")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %4 : Var<java.type:"int"> = var %2 @"s";
+                    %5 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %6 : Var<java.type:"java.lang.Number"> = var @"n";
+                    %7 : Var<java.type:"java.lang.Integer"> = var @"i";
+                    %8 : java.type:"int" = var.load %4;
+                    %9 : java.type:"java.lang.Object" = java.switch.expression %8
+                        (%10 : java.type:"int")java.type:"boolean" -> {
+                            %11 : java.type:"int" = constant @0;
+                            %12 : java.type:"boolean" = eq %10 %11;
+                            yield %12;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %13 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %14 : java.type:"java.lang.Integer" = cast %13 @java.type:"java.lang.Integer";
+                            yield %14;
+                        }
+                        ()java.type:"boolean" -> {
+                            %15 : java.type:"boolean" = constant @true;
+                            yield %15;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %16 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %17 : java.type:"java.lang.Integer" = cast %16 @java.type:"java.lang.Integer";
+                            yield %17;
+                        };
+                    var.store %5 %9;
+                    %18 : java.type:"int" = var.load %4;
+                    %19 : java.type:"java.lang.Number" = java.switch.expression %18
+                        (%20 : java.type:"int")java.type:"boolean" -> {
+                            %21 : java.type:"int" = constant @0;
+                            %22 : java.type:"boolean" = eq %20 %21;
+                            yield %22;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %23 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %24 : java.type:"java.lang.Integer" = cast %23 @java.type:"java.lang.Integer";
+                            yield %24;
+                        }
+                        ()java.type:"boolean" -> {
+                            %25 : java.type:"boolean" = constant @true;
+                            yield %25;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %26 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %27 : java.type:"java.lang.Integer" = cast %26 @java.type:"java.lang.Integer";
+                            yield %27;
+                        };
+                    var.store %6 %19;
+                    %28 : java.type:"int" = var.load %4;
+                    %29 : java.type:"java.lang.Integer" = java.switch.expression %28
+                        (%30 : java.type:"int")java.type:"boolean" -> {
+                            %31 : java.type:"int" = constant @0;
+                            %32 : java.type:"boolean" = eq %30 %31;
+                            yield %32;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %33 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %34 : java.type:"java.lang.Integer" = cast %33 @java.type:"java.lang.Integer";
+                            yield %34;
+                        }
+                        ()java.type:"boolean" -> {
+                            %35 : java.type:"boolean" = constant @true;
+                            yield %35;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %36 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %37 : java.type:"java.lang.Integer" = cast %36 @java.type:"java.lang.Integer";
+                            yield %37;
+                        };
+                    var.store %7 %29;
+                    %38 : java.type:"int" = var.load %4;
+                    %39 : java.type:"java.lang.Object" = java.switch.expression %38
+                        (%40 : java.type:"int")java.type:"boolean" -> {
+                            %41 : java.type:"int" = constant @0;
+                            %42 : java.type:"boolean" = eq %40 %41;
+                            yield %42;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %43 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %44 : java.type:"java.lang.Integer" = field.load %43 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %45 : java.type:"java.lang.Integer" = cast %44 @java.type:"java.lang.Integer";
+                            yield %45;
+                        }
+                        ()java.type:"boolean" -> {
+                            %46 : java.type:"boolean" = constant @true;
+                            yield %46;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %47 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %48 : java.type:"java.lang.Integer" = field.load %47 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %49 : java.type:"java.lang.Integer" = cast %48 @java.type:"java.lang.Integer";
+                            yield %49;
+                        };
+                    var.store %5 %39;
+                    %50 : java.type:"int" = var.load %4;
+                    %51 : java.type:"java.lang.Number" = java.switch.expression %50
+                        (%52 : java.type:"int")java.type:"boolean" -> {
+                            %53 : java.type:"int" = constant @0;
+                            %54 : java.type:"boolean" = eq %52 %53;
+                            yield %54;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %55 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %56 : java.type:"java.lang.Integer" = field.load %55 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %57 : java.type:"java.lang.Integer" = cast %56 @java.type:"java.lang.Integer";
+                            yield %57;
+                        }
+                        ()java.type:"boolean" -> {
+                            %58 : java.type:"boolean" = constant @true;
+                            yield %58;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %59 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %60 : java.type:"java.lang.Integer" = field.load %59 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %61 : java.type:"java.lang.Integer" = cast %60 @java.type:"java.lang.Integer";
+                            yield %61;
+                        };
+                    var.store %6 %51;
+                    %62 : java.type:"int" = var.load %4;
+                    %63 : java.type:"java.lang.Integer" = java.switch.expression %62
+                        (%64 : java.type:"int")java.type:"boolean" -> {
+                            %65 : java.type:"int" = constant @0;
+                            %66 : java.type:"boolean" = eq %64 %65;
+                            yield %66;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %67 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %68 : java.type:"java.lang.Integer" = field.load %67 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %69 : java.type:"java.lang.Integer" = cast %68 @java.type:"java.lang.Integer";
+                            yield %69;
+                        }
+                        ()java.type:"boolean" -> {
+                            %70 : java.type:"boolean" = constant @true;
+                            yield %70;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %71 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %72 : java.type:"java.lang.Integer" = field.load %71 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                            %73 : java.type:"java.lang.Integer" = cast %72 @java.type:"java.lang.Integer";
+                            yield %73;
+                        };
+                    var.store %7 %63;
+                    %74 : java.type:"int" = var.load %4;
+                    %75 : java.type:"java.lang.Object" = java.switch.expression %74
+                        (%76 : java.type:"int")java.type:"boolean" -> {
+                            %77 : java.type:"int" = constant @0;
+                            %78 : java.type:"boolean" = eq %76 %77;
+                            yield %78;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %79 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %80 : java.type:"java.lang.Integer" = cast %79 @java.type:"java.lang.Integer";
+                            yield %80;
+                        }
+                        ()java.type:"boolean" -> {
+                            %81 : java.type:"boolean" = constant @true;
+                            yield %81;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %82 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %83 : java.type:"java.lang.Integer" = cast %82 @java.type:"java.lang.Integer";
+                            yield %83;
+                        };
+                    var.store %5 %75;
+                    %84 : java.type:"int" = var.load %4;
+                    %85 : java.type:"java.lang.Number" = java.switch.expression %84
+                        (%86 : java.type:"int")java.type:"boolean" -> {
+                            %87 : java.type:"int" = constant @0;
+                            %88 : java.type:"boolean" = eq %86 %87;
+                            yield %88;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %89 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %90 : java.type:"java.lang.Integer" = cast %89 @java.type:"java.lang.Integer";
+                            yield %90;
+                        }
+                        ()java.type:"boolean" -> {
+                            %91 : java.type:"boolean" = constant @true;
+                            yield %91;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %92 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %93 : java.type:"java.lang.Integer" = cast %92 @java.type:"java.lang.Integer";
+                            yield %93;
+                        };
+                    var.store %6 %85;
+                    %94 : java.type:"int" = var.load %4;
+                    %95 : java.type:"java.lang.Integer" = java.switch.expression %94
+                        (%96 : java.type:"int")java.type:"boolean" -> {
+                            %97 : java.type:"int" = constant @0;
+                            %98 : java.type:"boolean" = eq %96 %97;
+                            yield %98;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %99 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %100 : java.type:"java.lang.Integer" = cast %99 @java.type:"java.lang.Integer";
+                            yield %100;
+                        }
+                        ()java.type:"boolean" -> {
+                            %101 : java.type:"boolean" = constant @true;
+                            yield %101;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %102 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %103 : java.type:"java.lang.Integer" = cast %102 @java.type:"java.lang.Integer";
+                            yield %103;
+                        };
+                    var.store %7 %95;
+                    %104 : java.type:"int" = var.load %4;
+                    %105 : java.type:"java.lang.Object" = java.switch.expression %104
+                        (%106 : java.type:"int")java.type:"boolean" -> {
+                            %107 : java.type:"int" = constant @0;
+                            %108 : java.type:"boolean" = eq %106 %107;
+                            yield %108;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %109 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %110 : java.type:"java.lang.Integer" = invoke %109 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %111 : java.type:"java.lang.Integer" = cast %110 @java.type:"java.lang.Integer";
+                            yield %111;
+                        }
+                        ()java.type:"boolean" -> {
+                            %112 : java.type:"boolean" = constant @true;
+                            yield %112;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %113 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %114 : java.type:"java.lang.Integer" = invoke %113 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %115 : java.type:"java.lang.Integer" = cast %114 @java.type:"java.lang.Integer";
+                            yield %115;
+                        };
+                    var.store %5 %105;
+                    %116 : java.type:"int" = var.load %4;
+                    %117 : java.type:"java.lang.Number" = java.switch.expression %116
+                        (%118 : java.type:"int")java.type:"boolean" -> {
+                            %119 : java.type:"int" = constant @0;
+                            %120 : java.type:"boolean" = eq %118 %119;
+                            yield %120;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %121 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %122 : java.type:"java.lang.Integer" = invoke %121 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %123 : java.type:"java.lang.Integer" = cast %122 @java.type:"java.lang.Integer";
+                            yield %123;
+                        }
+                        ()java.type:"boolean" -> {
+                            %124 : java.type:"boolean" = constant @true;
+                            yield %124;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %125 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %126 : java.type:"java.lang.Integer" = invoke %125 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %127 : java.type:"java.lang.Integer" = cast %126 @java.type:"java.lang.Integer";
+                            yield %127;
+                        };
+                    var.store %6 %117;
+                    %128 : java.type:"int" = var.load %4;
+                    %129 : java.type:"java.lang.Integer" = java.switch.expression %128
+                        (%130 : java.type:"int")java.type:"boolean" -> {
+                            %131 : java.type:"int" = constant @0;
+                            %132 : java.type:"boolean" = eq %130 %131;
+                            yield %132;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %133 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %134 : java.type:"java.lang.Integer" = invoke %133 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %135 : java.type:"java.lang.Integer" = cast %134 @java.type:"java.lang.Integer";
+                            yield %135;
+                        }
+                        ()java.type:"boolean" -> {
+                            %136 : java.type:"boolean" = constant @true;
+                            yield %136;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %137 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %138 : java.type:"java.lang.Integer" = invoke %137 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                            %139 : java.type:"java.lang.Integer" = cast %138 @java.type:"java.lang.Integer";
+                            yield %139;
+                        };
+                    var.store %7 %129;
+                    return;
+                };
+                """)
+        @Reflect
+        void testYield(UnboundedInteger test, int s) {
+            Object o; Number n; Integer i;
+
+            // simple field name
+            o = switch (s) {
+                case 0 -> x;
+                default -> x;
+            };
+
+            n = switch (s) {
+                case 0 -> x;
+                default -> x;
+            };
+
+            i = switch (s) {
+                case 0 -> x;
+                default -> x;
+            };
+
+            // qualified field name
+            o = switch (s) {
+                case 0 -> test.x;
+                default -> test.x;
+            };
+
+            n = switch (s) {
+                case 0 -> test.x;
+                default -> test.x;
+            };
+
+            i = switch (s) {
+                case 0 -> test.x;
+                default -> test.x;
+            };
+
+            // simple method name
+            o = switch (s) {
+                case 0 -> getX();
+                default -> getX();
+            };
+
+            n = switch (s) {
+                case 0 -> getX();
+                default -> getX();
+            };
+
+            i = switch (s) {
+                case 0 -> getX();
+                default -> getX();
+            };
+
+            // qualified method name
+            o = switch (s) {
+                case 0 -> test.getX();
+                default -> test.getX();
+            };
+
+            n = switch (s) {
+                case 0 -> test.getX();
+                default -> test.getX();
+            };
+
+            i = switch (s) {
+                case 0 -> test.getX();
+                default -> test.getX();
+            };
+        }
+
+        @IR("""
+                func @"testThrows" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %4 : Var<java.type:"boolean"> = var %2 @"cond";
+                    java.if
+                        ()java.type:"boolean" -> {
+                            %5 : java.type:"boolean" = var.load %4;
+                            yield %5;
+                        }
+                        ()java.type:"void" -> {
+                            %6 : java.type:"java.lang.WrongThreadException" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::t:java.lang.Throwable";
+                            %7 : java.type:"java.lang.WrongThreadException" = cast %6 @java.type:"java.lang.WrongThreadException";
+                            throw %7;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.if
+                        ()java.type:"boolean" -> {
+                            %8 : java.type:"boolean" = var.load %4;
+                            yield %8;
+                        }
+                        ()java.type:"void" -> {
+                            %9 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %10 : java.type:"java.lang.WrongThreadException" = field.load %9 @java.ref:"ErasedAccessTest$UnboundedInteger::t:java.lang.Throwable";
+                            %11 : java.type:"java.lang.WrongThreadException" = cast %10 @java.type:"java.lang.WrongThreadException";
+                            throw %11;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.if
+                        ()java.type:"boolean" -> {
+                            %12 : java.type:"boolean" = var.load %4;
+                            yield %12;
+                        }
+                        ()java.type:"void" -> {
+                            %13 : java.type:"java.lang.WrongThreadException" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getT():java.lang.Throwable";
+                            %14 : java.type:"java.lang.WrongThreadException" = cast %13 @java.type:"java.lang.WrongThreadException";
+                            throw %14;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.if
+                        ()java.type:"boolean" -> {
+                            %15 : java.type:"boolean" = var.load %4;
+                            yield %15;
+                        }
+                        ()java.type:"void" -> {
+                            %16 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %3;
+                            %17 : java.type:"java.lang.WrongThreadException" = invoke %16 @java.ref:"ErasedAccessTest$UnboundedInteger::getT():java.lang.Throwable";
+                            %18 : java.type:"java.lang.WrongThreadException" = cast %17 @java.type:"java.lang.WrongThreadException";
+                            throw %18;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    return;
+                };
+                """)
+        @Reflect
+        void testThrows(UnboundedInteger test, boolean cond) {
+            // simple field name
+            if (cond) {
+                throw t;
+            }
+
+            // qualified field name
+            if (cond) {
+                throw test.t;
+            }
+
+            // simple method name
+            if (cond) {
+                throw getT();
+            }
+
+            // qualified method name
+            if (cond) {
+                throw test.getT();
+            }
+        }
+
+        @IR("""
+                func @"testSwitchSelector" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %5 : java.type:"java.lang.Integer" = cast %4 @java.type:"java.lang.Integer";
+                    java.switch.statement %5
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = constant @true;
+                            yield %6;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
+                    %9 : java.type:"java.lang.Object" = java.switch.expression %8
+                        ()java.type:"boolean" -> {
+                            %10 : java.type:"boolean" = constant @true;
+                            yield %10;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %11 : java.type:"java.lang.Object" = constant @null;
+                            yield %11;
+                        };
+                    var.store %3 %9;
+                    %12 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %13 : java.type:"java.lang.Integer" = field.load %12 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %14 : java.type:"java.lang.Integer" = cast %13 @java.type:"java.lang.Integer";
+                    java.switch.statement %14
+                        ()java.type:"boolean" -> {
+                            %15 : java.type:"boolean" = constant @true;
+                            yield %15;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %16 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %17 : java.type:"java.lang.Integer" = field.load %16 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %18 : java.type:"java.lang.Integer" = cast %17 @java.type:"java.lang.Integer";
+                    %19 : java.type:"java.lang.Object" = java.switch.expression %18
+                        ()java.type:"boolean" -> {
+                            %20 : java.type:"boolean" = constant @true;
+                            yield %20;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %21 : java.type:"java.lang.Object" = constant @null;
+                            yield %21;
+                        };
+                    var.store %3 %19;
+                    %22 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %23 : java.type:"java.lang.Integer" = cast %22 @java.type:"java.lang.Integer";
+                    java.switch.statement %23
+                        ()java.type:"boolean" -> {
+                            %24 : java.type:"boolean" = constant @true;
+                            yield %24;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %25 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %26 : java.type:"java.lang.Integer" = cast %25 @java.type:"java.lang.Integer";
+                    %27 : java.type:"java.lang.Object" = java.switch.expression %26
+                        ()java.type:"boolean" -> {
+                            %28 : java.type:"boolean" = constant @true;
+                            yield %28;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %29 : java.type:"java.lang.Object" = constant @null;
+                            yield %29;
+                        };
+                    var.store %3 %27;
+                    %30 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %31 : java.type:"java.lang.Integer" = invoke %30 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %32 : java.type:"java.lang.Integer" = cast %31 @java.type:"java.lang.Integer";
+                    java.switch.statement %32
+                        ()java.type:"boolean" -> {
+                            %33 : java.type:"boolean" = constant @true;
+                            yield %33;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %34 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %35 : java.type:"java.lang.Integer" = invoke %34 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %36 : java.type:"java.lang.Integer" = cast %35 @java.type:"java.lang.Integer";
+                    %37 : java.type:"java.lang.Object" = java.switch.expression %36
+                        ()java.type:"boolean" -> {
+                            %38 : java.type:"boolean" = constant @true;
+                            yield %38;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %39 : java.type:"java.lang.Object" = constant @null;
+                            yield %39;
+                        };
+                    var.store %3 %37;
+                    return;
+                };
+                """)
+        @Reflect
+        void testSwitchSelector(UnboundedInteger test) {
+            Object o;
+
+            // simple field name
+            switch (x) {default -> { }}
+            o = switch (x) { default -> null; };
+
+            // qualified field name
+            switch (test.x) {default -> { }}
+            o = switch (test.x) { default -> null; };
+
+            // simple method name
+            switch (getX()) {default -> { }}
+            o = switch (getX()) { default -> null; };
+
+            // qualified method name
+            switch (test.getX()) {default -> { }}
+            o = switch (test.getX()) { default -> null; };
+        }
     }
 
     // the part below is just copied from the above with minor adaptations in the expected IRs
@@ -1361,6 +2047,604 @@ public class ErasedAccessTest {
 
             // qualified method name
             l = test.getX();
+        }
+
+        @IR("""
+                func @"testAssert" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    assert
+                        ()java.type:"boolean" -> {
+                            %3 : java.type:"boolean" = constant @false;
+                            yield %3;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %5 : java.type:"java.lang.Integer" = cast %4 @java.type:"java.lang.Integer";
+                            yield %5;
+                        };
+                    assert
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = constant @false;
+                            yield %6;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %7 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                            %8 : java.type:"java.lang.Integer" = field.load %7 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %9 : java.type:"java.lang.Integer" = cast %8 @java.type:"java.lang.Integer";
+                            yield %9;
+                        };
+                    assert
+                        ()java.type:"boolean" -> {
+                            %10 : java.type:"boolean" = constant @false;
+                            yield %10;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %11 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %12 : java.type:"java.lang.Integer" = cast %11 @java.type:"java.lang.Integer";
+                            yield %12;
+                        };
+                    assert
+                        ()java.type:"boolean" -> {
+                            %13 : java.type:"boolean" = constant @false;
+                            yield %13;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %14 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                            %15 : java.type:"java.lang.Integer" = invoke %14 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %16 : java.type:"java.lang.Integer" = cast %15 @java.type:"java.lang.Integer";
+                            yield %16;
+                        };
+                    return;
+                };
+                """)
+        @Reflect
+        void testAssert(BoundedInteger test) {
+            // simple field name
+            assert false : x;
+
+            // qualified field name
+            assert false : test.x;
+
+            // simple method name
+            assert false : getX();
+
+            // qualified method name
+            assert false : test.getX();
+        }
+
+        @IR("""
+                func @"testSynchronized" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %3 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %4 : java.type:"java.lang.Integer" = cast %3 @java.type:"java.lang.Integer";
+                            yield %4;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %5 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                            %6 : java.type:"java.lang.Integer" = field.load %5 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %7 : java.type:"java.lang.Integer" = cast %6 @java.type:"java.lang.Integer";
+                            yield %7;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %8 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %9 : java.type:"java.lang.Integer" = cast %8 @java.type:"java.lang.Integer";
+                            yield %9;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    java.synchronized
+                        ()java.type:"java.lang.Integer" -> {
+                            %10 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                            %11 : java.type:"java.lang.Integer" = invoke %10 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %12 : java.type:"java.lang.Integer" = cast %11 @java.type:"java.lang.Integer";
+                            yield %12;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    return;
+                };
+                """)
+        @Reflect
+        @SuppressWarnings("identity")
+        void testSynchronized(BoundedInteger test) {
+            // simple field name
+            synchronized (x) { };
+
+            // qualified field name
+            synchronized (test.x) { };
+
+            // simple method name
+            synchronized (getX()) { };
+
+            // qualified method name
+            synchronized (test.getX()) { };
+        }
+
+        @IR("""
+                func @"testYield" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger", %2 : java.type:"int")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %4 : Var<java.type:"int"> = var %2 @"s";
+                    %5 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %6 : Var<java.type:"java.lang.Number"> = var @"n";
+                    %7 : Var<java.type:"java.lang.Integer"> = var @"i";
+                    %8 : java.type:"int" = var.load %4;
+                    %9 : java.type:"java.lang.Object" = java.switch.expression %8
+                        (%10 : java.type:"int")java.type:"boolean" -> {
+                            %11 : java.type:"int" = constant @0;
+                            %12 : java.type:"boolean" = eq %10 %11;
+                            yield %12;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %13 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %14 : java.type:"java.lang.Integer" = cast %13 @java.type:"java.lang.Integer";
+                            yield %14;
+                        }
+                        ()java.type:"boolean" -> {
+                            %15 : java.type:"boolean" = constant @true;
+                            yield %15;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %16 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %17 : java.type:"java.lang.Integer" = cast %16 @java.type:"java.lang.Integer";
+                            yield %17;
+                        };
+                    var.store %5 %9;
+                    %18 : java.type:"int" = var.load %4;
+                    %19 : java.type:"java.lang.Number" = java.switch.expression %18
+                        (%20 : java.type:"int")java.type:"boolean" -> {
+                            %21 : java.type:"int" = constant @0;
+                            %22 : java.type:"boolean" = eq %20 %21;
+                            yield %22;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %23 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %24 : java.type:"java.lang.Integer" = cast %23 @java.type:"java.lang.Integer";
+                            yield %24;
+                        }
+                        ()java.type:"boolean" -> {
+                            %25 : java.type:"boolean" = constant @true;
+                            yield %25;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %26 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %27 : java.type:"java.lang.Integer" = cast %26 @java.type:"java.lang.Integer";
+                            yield %27;
+                        };
+                    var.store %6 %19;
+                    %28 : java.type:"int" = var.load %4;
+                    %29 : java.type:"java.lang.Integer" = java.switch.expression %28
+                        (%30 : java.type:"int")java.type:"boolean" -> {
+                            %31 : java.type:"int" = constant @0;
+                            %32 : java.type:"boolean" = eq %30 %31;
+                            yield %32;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %33 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %34 : java.type:"java.lang.Integer" = cast %33 @java.type:"java.lang.Integer";
+                            yield %34;
+                        }
+                        ()java.type:"boolean" -> {
+                            %35 : java.type:"boolean" = constant @true;
+                            yield %35;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %36 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %37 : java.type:"java.lang.Integer" = cast %36 @java.type:"java.lang.Integer";
+                            yield %37;
+                        };
+                    var.store %7 %29;
+                    %38 : java.type:"int" = var.load %4;
+                    %39 : java.type:"java.lang.Object" = java.switch.expression %38
+                        (%40 : java.type:"int")java.type:"boolean" -> {
+                            %41 : java.type:"int" = constant @0;
+                            %42 : java.type:"boolean" = eq %40 %41;
+                            yield %42;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %43 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %44 : java.type:"java.lang.Integer" = field.load %43 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %45 : java.type:"java.lang.Integer" = cast %44 @java.type:"java.lang.Integer";
+                            yield %45;
+                        }
+                        ()java.type:"boolean" -> {
+                            %46 : java.type:"boolean" = constant @true;
+                            yield %46;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %47 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %48 : java.type:"java.lang.Integer" = field.load %47 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %49 : java.type:"java.lang.Integer" = cast %48 @java.type:"java.lang.Integer";
+                            yield %49;
+                        };
+                    var.store %5 %39;
+                    %50 : java.type:"int" = var.load %4;
+                    %51 : java.type:"java.lang.Number" = java.switch.expression %50
+                        (%52 : java.type:"int")java.type:"boolean" -> {
+                            %53 : java.type:"int" = constant @0;
+                            %54 : java.type:"boolean" = eq %52 %53;
+                            yield %54;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %55 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %56 : java.type:"java.lang.Integer" = field.load %55 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %57 : java.type:"java.lang.Integer" = cast %56 @java.type:"java.lang.Integer";
+                            yield %57;
+                        }
+                        ()java.type:"boolean" -> {
+                            %58 : java.type:"boolean" = constant @true;
+                            yield %58;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %59 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %60 : java.type:"java.lang.Integer" = field.load %59 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %61 : java.type:"java.lang.Integer" = cast %60 @java.type:"java.lang.Integer";
+                            yield %61;
+                        };
+                    var.store %6 %51;
+                    %62 : java.type:"int" = var.load %4;
+                    %63 : java.type:"java.lang.Integer" = java.switch.expression %62
+                        (%64 : java.type:"int")java.type:"boolean" -> {
+                            %65 : java.type:"int" = constant @0;
+                            %66 : java.type:"boolean" = eq %64 %65;
+                            yield %66;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %67 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %68 : java.type:"java.lang.Integer" = field.load %67 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %69 : java.type:"java.lang.Integer" = cast %68 @java.type:"java.lang.Integer";
+                            yield %69;
+                        }
+                        ()java.type:"boolean" -> {
+                            %70 : java.type:"boolean" = constant @true;
+                            yield %70;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %71 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %72 : java.type:"java.lang.Integer" = field.load %71 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                            %73 : java.type:"java.lang.Integer" = cast %72 @java.type:"java.lang.Integer";
+                            yield %73;
+                        };
+                    var.store %7 %63;
+                    %74 : java.type:"int" = var.load %4;
+                    %75 : java.type:"java.lang.Object" = java.switch.expression %74
+                        (%76 : java.type:"int")java.type:"boolean" -> {
+                            %77 : java.type:"int" = constant @0;
+                            %78 : java.type:"boolean" = eq %76 %77;
+                            yield %78;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %79 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %80 : java.type:"java.lang.Integer" = cast %79 @java.type:"java.lang.Integer";
+                            yield %80;
+                        }
+                        ()java.type:"boolean" -> {
+                            %81 : java.type:"boolean" = constant @true;
+                            yield %81;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %82 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %83 : java.type:"java.lang.Integer" = cast %82 @java.type:"java.lang.Integer";
+                            yield %83;
+                        };
+                    var.store %5 %75;
+                    %84 : java.type:"int" = var.load %4;
+                    %85 : java.type:"java.lang.Number" = java.switch.expression %84
+                        (%86 : java.type:"int")java.type:"boolean" -> {
+                            %87 : java.type:"int" = constant @0;
+                            %88 : java.type:"boolean" = eq %86 %87;
+                            yield %88;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %89 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %90 : java.type:"java.lang.Integer" = cast %89 @java.type:"java.lang.Integer";
+                            yield %90;
+                        }
+                        ()java.type:"boolean" -> {
+                            %91 : java.type:"boolean" = constant @true;
+                            yield %91;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %92 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %93 : java.type:"java.lang.Integer" = cast %92 @java.type:"java.lang.Integer";
+                            yield %93;
+                        };
+                    var.store %6 %85;
+                    %94 : java.type:"int" = var.load %4;
+                    %95 : java.type:"java.lang.Integer" = java.switch.expression %94
+                        (%96 : java.type:"int")java.type:"boolean" -> {
+                            %97 : java.type:"int" = constant @0;
+                            %98 : java.type:"boolean" = eq %96 %97;
+                            yield %98;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %99 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %100 : java.type:"java.lang.Integer" = cast %99 @java.type:"java.lang.Integer";
+                            yield %100;
+                        }
+                        ()java.type:"boolean" -> {
+                            %101 : java.type:"boolean" = constant @true;
+                            yield %101;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %102 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %103 : java.type:"java.lang.Integer" = cast %102 @java.type:"java.lang.Integer";
+                            yield %103;
+                        };
+                    var.store %7 %95;
+                    %104 : java.type:"int" = var.load %4;
+                    %105 : java.type:"java.lang.Object" = java.switch.expression %104
+                        (%106 : java.type:"int")java.type:"boolean" -> {
+                            %107 : java.type:"int" = constant @0;
+                            %108 : java.type:"boolean" = eq %106 %107;
+                            yield %108;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %109 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %110 : java.type:"java.lang.Integer" = invoke %109 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %111 : java.type:"java.lang.Integer" = cast %110 @java.type:"java.lang.Integer";
+                            yield %111;
+                        }
+                        ()java.type:"boolean" -> {
+                            %112 : java.type:"boolean" = constant @true;
+                            yield %112;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %113 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %114 : java.type:"java.lang.Integer" = invoke %113 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %115 : java.type:"java.lang.Integer" = cast %114 @java.type:"java.lang.Integer";
+                            yield %115;
+                        };
+                    var.store %5 %105;
+                    %116 : java.type:"int" = var.load %4;
+                    %117 : java.type:"java.lang.Number" = java.switch.expression %116
+                        (%118 : java.type:"int")java.type:"boolean" -> {
+                            %119 : java.type:"int" = constant @0;
+                            %120 : java.type:"boolean" = eq %118 %119;
+                            yield %120;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %121 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %122 : java.type:"java.lang.Integer" = invoke %121 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %123 : java.type:"java.lang.Integer" = cast %122 @java.type:"java.lang.Integer";
+                            yield %123;
+                        }
+                        ()java.type:"boolean" -> {
+                            %124 : java.type:"boolean" = constant @true;
+                            yield %124;
+                        }
+                        ()java.type:"java.lang.Number" -> {
+                            %125 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %126 : java.type:"java.lang.Integer" = invoke %125 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %127 : java.type:"java.lang.Integer" = cast %126 @java.type:"java.lang.Integer";
+                            yield %127;
+                        };
+                    var.store %6 %117;
+                    %128 : java.type:"int" = var.load %4;
+                    %129 : java.type:"java.lang.Integer" = java.switch.expression %128
+                        (%130 : java.type:"int")java.type:"boolean" -> {
+                            %131 : java.type:"int" = constant @0;
+                            %132 : java.type:"boolean" = eq %130 %131;
+                            yield %132;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %133 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %134 : java.type:"java.lang.Integer" = invoke %133 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %135 : java.type:"java.lang.Integer" = cast %134 @java.type:"java.lang.Integer";
+                            yield %135;
+                        }
+                        ()java.type:"boolean" -> {
+                            %136 : java.type:"boolean" = constant @true;
+                            yield %136;
+                        }
+                        ()java.type:"java.lang.Integer" -> {
+                            %137 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %3;
+                            %138 : java.type:"java.lang.Integer" = invoke %137 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                            %139 : java.type:"java.lang.Integer" = cast %138 @java.type:"java.lang.Integer";
+                            yield %139;
+                        };
+                    var.store %7 %129;
+                    return;
+                };
+                """)
+        @Reflect
+        void testYield(BoundedInteger test, int s) {
+            Object o; Number n; Integer i;
+
+            // simple field name
+            o = switch (s) {
+                case 0 -> x;
+                default -> x;
+            };
+
+            n = switch (s) {
+                case 0 -> x;
+                default -> x;
+            };
+
+            i = switch (s) {
+                case 0 -> x;
+                default -> x;
+            };
+
+            // qualified field name
+            o = switch (s) {
+                case 0 -> test.x;
+                default -> test.x;
+            };
+
+            n = switch (s) {
+                case 0 -> test.x;
+                default -> test.x;
+            };
+
+            i = switch (s) {
+                case 0 -> test.x;
+                default -> test.x;
+            };
+
+            // simple method name
+            o = switch (s) {
+                case 0 -> getX();
+                default -> getX();
+            };
+
+            n = switch (s) {
+                case 0 -> getX();
+                default -> getX();
+            };
+
+            i = switch (s) {
+                case 0 -> getX();
+                default -> getX();
+            };
+
+            // qualified method name
+            o = switch (s) {
+                case 0 -> test.getX();
+                default -> test.getX();
+            };
+
+            n = switch (s) {
+                case 0 -> test.getX();
+                default -> test.getX();
+            };
+
+            i = switch (s) {
+                case 0 -> test.getX();
+                default -> test.getX();
+            };
+        }
+
+        @IR("""
+                func @"testSwitchSelector" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %5 : java.type:"java.lang.Integer" = cast %4 @java.type:"java.lang.Integer";
+                    java.switch.statement %5
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = constant @true;
+                            yield %6;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %7 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %8 : java.type:"java.lang.Integer" = cast %7 @java.type:"java.lang.Integer";
+                    %9 : java.type:"java.lang.Object" = java.switch.expression %8
+                        ()java.type:"boolean" -> {
+                            %10 : java.type:"boolean" = constant @true;
+                            yield %10;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %11 : java.type:"java.lang.Object" = constant @null;
+                            yield %11;
+                        };
+                    var.store %3 %9;
+                    %12 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %13 : java.type:"java.lang.Integer" = field.load %12 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %14 : java.type:"java.lang.Integer" = cast %13 @java.type:"java.lang.Integer";
+                    java.switch.statement %14
+                        ()java.type:"boolean" -> {
+                            %15 : java.type:"boolean" = constant @true;
+                            yield %15;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %16 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %17 : java.type:"java.lang.Integer" = field.load %16 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %18 : java.type:"java.lang.Integer" = cast %17 @java.type:"java.lang.Integer";
+                    %19 : java.type:"java.lang.Object" = java.switch.expression %18
+                        ()java.type:"boolean" -> {
+                            %20 : java.type:"boolean" = constant @true;
+                            yield %20;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %21 : java.type:"java.lang.Object" = constant @null;
+                            yield %21;
+                        };
+                    var.store %3 %19;
+                    %22 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %23 : java.type:"java.lang.Integer" = cast %22 @java.type:"java.lang.Integer";
+                    java.switch.statement %23
+                        ()java.type:"boolean" -> {
+                            %24 : java.type:"boolean" = constant @true;
+                            yield %24;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %25 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %26 : java.type:"java.lang.Integer" = cast %25 @java.type:"java.lang.Integer";
+                    %27 : java.type:"java.lang.Object" = java.switch.expression %26
+                        ()java.type:"boolean" -> {
+                            %28 : java.type:"boolean" = constant @true;
+                            yield %28;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %29 : java.type:"java.lang.Object" = constant @null;
+                            yield %29;
+                        };
+                    var.store %3 %27;
+                    %30 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %31 : java.type:"java.lang.Integer" = invoke %30 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %32 : java.type:"java.lang.Integer" = cast %31 @java.type:"java.lang.Integer";
+                    java.switch.statement %32
+                        ()java.type:"boolean" -> {
+                            %33 : java.type:"boolean" = constant @true;
+                            yield %33;
+                        }
+                        ()java.type:"void" -> {
+                            yield;
+                        };
+                    %34 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %35 : java.type:"java.lang.Integer" = invoke %34 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %36 : java.type:"java.lang.Integer" = cast %35 @java.type:"java.lang.Integer";
+                    %37 : java.type:"java.lang.Object" = java.switch.expression %36
+                        ()java.type:"boolean" -> {
+                            %38 : java.type:"boolean" = constant @true;
+                            yield %38;
+                        }
+                        ()java.type:"java.lang.Object" -> {
+                            %39 : java.type:"java.lang.Object" = constant @null;
+                            yield %39;
+                        };
+                    var.store %3 %37;
+                    return;
+                };
+                """)
+        @Reflect
+        void testSwitchSelector(BoundedInteger test) {
+            Object o;
+
+            // simple field name
+            switch (x) {default -> { }}
+            o = switch (x) { default -> null; };
+
+            // qualified field name
+            switch (test.x) {default -> { }}
+            o = switch (test.x) { default -> null; };
+
+            // simple method name
+            switch (getX()) {default -> { }}
+            o = switch (getX()) { default -> null; };
+
+            // qualified method name
+            switch (test.getX()) {default -> { }}
+            o = switch (test.getX()) { default -> null; };
         }
     }
 

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -49,377 +49,1252 @@ import java.util.List;
  */
 
 public class ErasedAccessTest {
-    @Reflect
-    @IR("""
-            func @"method_typeTest" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Object";
-                return %4;
-            };
-            """)
-    static boolean method_typeTest(Box<String> xs) {
-        return xs.get() instanceof Object;
-    }
 
-    @Reflect
-    @IR("""
-            func @"method_typeTestCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
-                %2 : Var<java.type:"boolean"> = var %0 @"c";
-                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
-                %4 : java.type:"java.lang.String" = java.cexpression
-                    ()java.type:"boolean" -> {
-                        %5 : java.type:"boolean" = var.load %2;
-                        yield %5;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
-                        yield %8;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %10 : java.type:"java.lang.String" = invoke %9 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
-                        yield %11;
-                    };
-                %12 : java.type:"boolean" = instanceof %4 @java.type:"java.lang.Object";
-                return %12;
-            };
-            """)
-    static boolean method_typeTestCond(boolean c, Box<String> xs) {
-        return (c ? xs.get() : xs.get()) instanceof Object;
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_chainedCall" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
-                %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
-                return %5;
-            };
-            """)
-    static int method_chainedCall(Box<String> xs) {
-        return xs.get().hashCode();
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_chainedCallCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
-                %2 : Var<java.type:"boolean"> = var %0 @"c";
-                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
-                %4 : java.type:"java.lang.String" = java.cexpression
-                    ()java.type:"boolean" -> {
-                        %5 : java.type:"boolean" = var.load %2;
-                        yield %5;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %7 : java.type:"java.lang.String" = invoke %6 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
-                        yield %8;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %10 : java.type:"java.lang.String" = invoke %9 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
-                        yield %11;
-                    };
-                %12 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
-                return %12;
-            };
-            """)
-    static int method_chainedCallCond(boolean c, Box<String> xs) {
-        return (c ? xs.get() : xs.get()).hashCode();
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_exec" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                return;
-            };
-            """)
-    static void method_exec(Box<String> xs) {
-        xs.get();
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_typeTest" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.Object";
-                return %4;
-            };
-            """)
-    static boolean field_typeTest(Box<String> xs) {
-        return xs.x instanceof Object;
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_typeTestCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"boolean" -> {
-                %2 : Var<java.type:"boolean"> = var %0 @"c";
-                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
-                %4 : java.type:"java.lang.String" = java.cexpression
-                    ()java.type:"boolean" -> {
-                        %5 : java.type:"boolean" = var.load %2;
-                        yield %5;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
-                        yield %8;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %10 : java.type:"java.lang.String" = field.load %9 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
-                        yield %11;
-                    };
-                %12 : java.type:"boolean" = instanceof %4 @java.type:"java.lang.Object";
-                return %12;
-            };
-            """)
-    static boolean field_typeTestCond(boolean c, Box<String> xs) {
-        return (c ? xs.x : xs.x) instanceof Object;
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_chainedCall" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
-                %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
-                return %5;
-            };
-            """)
-    static int field_chainedCall(Box<String> xs) {
-        return xs.x.hashCode();
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_chainedCallCond" (%0 : java.type:"boolean", %1 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"int" -> {
-                %2 : Var<java.type:"boolean"> = var %0 @"c";
-                %3 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %1 @"xs";
-                %4 : java.type:"java.lang.String" = java.cexpression
-                    ()java.type:"boolean" -> {
-                        %5 : java.type:"boolean" = var.load %2;
-                        yield %5;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %6 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                        %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
-                        yield %8;
-                    }
-                    ()java.type:"java.lang.String" -> {
-                        %9 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %3;
-                        %10 : java.type:"java.lang.String" = field.load %9 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                        %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
-                        yield %11;
-                    };
-                %12 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
-                return %12;
-            };
-            """)
-    static int field_chainedCallCond(boolean c, Box<String> xs) {
-        return (c ? xs.x : xs.x).hashCode();
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_objectAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                return %3;
-            };
-            """)
-    static Object method_objectAssign(Box<String> xs) {
-        return xs.get();
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_CharSequenceAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                %4 : java.type:"java.lang.CharSequence" = cast %3 @java.type:"java.lang.CharSequence";
-                return %4;
-            };
-            """)
-    static CharSequence method_CharSequenceAssign(Box<String> xs) {
-        return xs.get();
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_ObjectArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"int" = constant @1;
-                %3 : java.type:"java.lang.Object[]" = new %2 @java.ref:"java.lang.Object[]::(int)";
-                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                %6 : java.type:"int" = constant @0;
-                array.store %3 %6 %5;
-                %7 : Var<java.type:"java.lang.Object[]"> = var %3 @"csArr";
-                return;
-            };
-            """)
-    static void method_ObjectArrayInit(Box<String> xs) {
-        Object[] csArr = new Object[] { xs.get() };
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_CharSequenceArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"int" = constant @1;
-                %3 : java.type:"java.lang.CharSequence[]" = new %2 @java.ref:"java.lang.CharSequence[]::(int)";
-                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                %6 : java.type:"java.lang.CharSequence" = cast %5 @java.type:"java.lang.CharSequence";
-                %7 : java.type:"int" = constant @0;
-                array.store %3 %7 %6;
-                %8 : Var<java.type:"java.lang.CharSequence[]"> = var %3 @"csArr";
-                return;
-            };
-            """)
-    static void method_CharSequenceArrayInit(Box<String> xs) {
-        CharSequence[] csArr = new CharSequence[] { xs.get() };
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_ObjectArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"int" = constant @1;
-                %3 : java.type:"java.lang.Object[]" = new %2 @java.ref:"java.lang.Object[]::(int)";
-                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %5 : java.type:"java.lang.String" = field.load %4 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                %6 : java.type:"int" = constant @0;
-                array.store %3 %6 %5;
-                %7 : Var<java.type:"java.lang.Object[]"> = var %3 @"csArr";
-                return;
-            };
-            """)
-    static void field_ObjectArrayInit(Box<String> xs) {
-        Object[] csArr = new Object[] { xs.x };
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_CharSequenceArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"int" = constant @1;
-                %3 : java.type:"java.lang.CharSequence[]" = new %2 @java.ref:"java.lang.CharSequence[]::(int)";
-                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %5 : java.type:"java.lang.String" = field.load %4 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                %6 : java.type:"java.lang.CharSequence" = cast %5 @java.type:"java.lang.CharSequence";
-                %7 : java.type:"int" = constant @0;
-                array.store %3 %7 %6;
-                %8 : Var<java.type:"java.lang.CharSequence[]"> = var %3 @"csArr";
-                return;
-            };
-            """)
-    static void field_CharSequenceArrayInit(Box<String> xs) {
-        CharSequence[] csArr = new CharSequence[] { xs.x };
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_ObjectCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                return %3;
-            };
-            """)
-    static Object method_ObjectCast(Box<String> xs) {
-        return (Object)xs.get();
-    }
-
-    @Reflect
-    @IR("""
-            func @"method_CharSequenceCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
-                %4 : java.type:"java.lang.CharSequence" = cast %3 @java.type:"java.lang.CharSequence";
-                return %4;
-            };
-            """)
-    static CharSequence method_CharSequenceCast(Box<String> xs) {
-        return (CharSequence)xs.get();
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_ObjectCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                return %3;
-            };
-            """)
-    static Object field_ObjectCast(Box<String> xs) {
-        return (Object)xs.x;
-    }
-
-    @Reflect
-    @IR("""
-            func @"field_CharSequenceCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
-                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
-                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
-                %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
-                %4 : java.type:"java.lang.CharSequence" = cast %3 @java.type:"java.lang.CharSequence";
-                return %4;
-            };
-            """)
-    static CharSequence field_CharSequenceCast(Box<String> xs) {
-        return (CharSequence)xs.x;
-    }
-
-    static class Box<X> {
+    static class Unbounded<X> {
         X x;
-        Box(X x) { this.x = x; }
-        X get() { return x; }
+
+        X getX() {
+            return x;
+        }
     }
+
+    static class UnboundedString extends Unbounded<String> {
+
+        @IR("""
+                func @"testInstanceof" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.String";
+                    %5 : Var<java.type:"boolean"> = var %4 @"f_s_s";
+                    %6 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %8 : java.type:"boolean" = instanceof %7 @java.type:"java.lang.String";
+                    %9 : Var<java.type:"boolean"> = var %8 @"f_q_s";
+                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.String";
+                    %12 : Var<java.type:"boolean"> = var %11 @"m_s_s";
+                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %15 : java.type:"boolean" = instanceof %14 @java.type:"java.lang.String";
+                    %16 : Var<java.type:"boolean"> = var %15 @"m_q_s";
+                    return;
+                };
+                """)
+        @Reflect
+        void testInstanceof(UnboundedString test) {
+            // simple field name
+            boolean f_s_s = x instanceof String;
+
+            // qualified field name
+            boolean f_q_s = test.x instanceof String;
+
+            // simple method name
+            boolean m_s_s = getX() instanceof String;
+
+            // qualified method name
+            boolean m_q_s = test.getX() instanceof String;
+        }
+
+        @IR("""
+                func @"testInstanceofCond" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %4 : Var<java.type:"boolean"> = var %2 @"cond";
+                    %5 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = var.load %4;
+                            yield %6;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                            yield %8;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                            yield %10;
+                        };
+                    %11 : java.type:"boolean" = instanceof %5 @java.type:"java.lang.Object";
+                    %12 : Var<java.type:"boolean"> = var %11 @"f_s_o";
+                    %13 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %14 : java.type:"boolean" = var.load %4;
+                            yield %14;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %15 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %16 : java.type:"java.lang.String" = field.load %15 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
+                            yield %17;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %18 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %19 : java.type:"java.lang.String" = field.load %18 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                            yield %20;
+                        };
+                    %21 : java.type:"boolean" = instanceof %13 @java.type:"java.lang.Object";
+                    %22 : Var<java.type:"boolean"> = var %21 @"f_q_o";
+                    %23 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %24 : java.type:"boolean" = var.load %4;
+                            yield %24;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                            yield %26;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %27 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %28 : java.type:"java.lang.String" = cast %27 @java.type:"java.lang.String";
+                            yield %28;
+                        };
+                    %29 : java.type:"boolean" = instanceof %23 @java.type:"java.lang.Object";
+                    %30 : Var<java.type:"boolean"> = var %29 @"m_s_o";
+                    %31 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %32 : java.type:"boolean" = var.load %4;
+                            yield %32;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %33 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                            yield %35;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %36 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %37 : java.type:"java.lang.String" = invoke %36 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %38 : java.type:"java.lang.String" = cast %37 @java.type:"java.lang.String";
+                            yield %38;
+                        };
+                    %39 : java.type:"boolean" = instanceof %31 @java.type:"java.lang.Object";
+                    %40 : Var<java.type:"boolean"> = var %39 @"m_q_o";
+                    return;
+                };
+                """)
+        @Reflect
+        void testInstanceofCond(UnboundedString test, boolean cond) {
+            // simple field name
+            boolean f_s_o = (cond ? x : x) instanceof Object;
+
+            // qualified field name
+            boolean f_q_o = (cond ? test.x : test.x) instanceof Object;
+
+            // simple method name
+            boolean m_s_o = (cond ? getX() : getX()) instanceof Object;
+
+            // qualified method name
+            boolean m_q_o = (cond ? test.getX() : test.getX()) instanceof Object;
+        }
+
+        @IR("""
+                func @"testExec" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %4 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    return;
+                };
+                """)
+        @Reflect
+        void testExec(UnboundedString test) {
+            // simple method name
+            getX();
+
+            // qualified method name
+            test.getX();
+        }
+
+        @IR("""
+                func @"testChainedCall" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
+                    %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                    %6 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                    %9 : java.type:"int" = invoke %8 @java.ref:"java.lang.String::hashCode():int";
+                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                    %12 : java.type:"int" = invoke %11 @java.ref:"java.lang.String::hashCode():int";
+                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %15 : java.type:"java.lang.String" = cast %14 @java.type:"java.lang.String";
+                    %16 : java.type:"int" = invoke %15 @java.ref:"java.lang.String::hashCode():int";
+                    return;
+                };
+                """)
+        @Reflect
+        void testChainedCall(UnboundedString test) {
+            // simple field name
+            x.hashCode();
+
+            // qualified field name
+            test.x.hashCode();
+
+            // simple method name
+            getX().hashCode();
+
+            // qualified method name
+            test.getX().hashCode();
+        }
+
+        @IR("""
+                func @"testChainedCallCond" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %4 : Var<java.type:"boolean"> = var %2 @"cond";
+                    %5 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = var.load %4;
+                            yield %6;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                            yield %8;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                            yield %10;
+                        };
+                    %11 : java.type:"int" = invoke %5 @java.ref:"java.lang.String::hashCode():int";
+                    %12 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %13 : java.type:"boolean" = var.load %4;
+                            yield %13;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %14 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                            yield %16;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %17 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %18 : java.type:"java.lang.String" = field.load %17 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                            %19 : java.type:"java.lang.String" = cast %18 @java.type:"java.lang.String";
+                            yield %19;
+                        };
+                    %20 : java.type:"int" = invoke %12 @java.ref:"java.lang.String::hashCode():int";
+                    %21 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %22 : java.type:"boolean" = var.load %4;
+                            yield %22;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %23 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %24 : java.type:"java.lang.String" = cast %23 @java.type:"java.lang.String";
+                            yield %24;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                            yield %26;
+                        };
+                    %27 : java.type:"int" = invoke %21 @java.ref:"java.lang.String::hashCode():int";
+                    %28 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %29 : java.type:"boolean" = var.load %4;
+                            yield %29;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %30 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %31 : java.type:"java.lang.String" = invoke %30 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %32 : java.type:"java.lang.String" = cast %31 @java.type:"java.lang.String";
+                            yield %32;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %33 : java.type:"ErasedAccessTest$UnboundedString" = var.load %3;
+                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                            yield %35;
+                        };
+                    %36 : java.type:"int" = invoke %28 @java.ref:"java.lang.String::hashCode():int";
+                    return;
+                };
+                """)
+        @Reflect
+        void testChainedCallCond(UnboundedString test, boolean cond) {
+            // simple field name
+            (cond ? x : x).hashCode();
+
+            // qualified field name
+            (cond ? test.x : test.x).hashCode();
+
+            // simple method name
+            (cond ? getX() : getX()).hashCode();
+
+            // qualified method name
+            (cond ? test.getX() : test.getX()).hashCode();
+        }
+
+        @IR("""
+                func @"testAssign" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
+                    %5 : Var<java.type:"java.lang.String"> = var @"s";
+                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    var.store %3 %6;
+                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %8 : java.type:"java.lang.CharSequence" = cast %7 @java.type:"java.lang.CharSequence";
+                    var.store %4 %8;
+                    %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                    var.store %5 %10;
+                    %11 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %12 : java.type:"java.lang.String" = field.load %11 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    var.store %3 %12;
+                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %14 : java.type:"java.lang.String" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %15 : java.type:"java.lang.CharSequence" = cast %14 @java.type:"java.lang.CharSequence";
+                    var.store %4 %15;
+                    %16 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %17 : java.type:"java.lang.String" = field.load %16 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %18 : java.type:"java.lang.String" = cast %17 @java.type:"java.lang.String";
+                    var.store %5 %18;
+                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    var.store %3 %19;
+                    %20 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %21 : java.type:"java.lang.CharSequence" = cast %20 @java.type:"java.lang.CharSequence";
+                    var.store %4 %21;
+                    %22 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %23 : java.type:"java.lang.String" = cast %22 @java.type:"java.lang.String";
+                    var.store %5 %23;
+                    %24 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %25 : java.type:"java.lang.String" = invoke %24 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    var.store %3 %25;
+                    %26 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %27 : java.type:"java.lang.String" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %28 : java.type:"java.lang.CharSequence" = cast %27 @java.type:"java.lang.CharSequence";
+                    var.store %4 %28;
+                    %29 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %30 : java.type:"java.lang.String" = invoke %29 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %31 : java.type:"java.lang.String" = cast %30 @java.type:"java.lang.String";
+                    var.store %5 %31;
+                    return;
+                };
+                """)
+        @Reflect
+        void testAssign(UnboundedString test) {
+            Object o; CharSequence cs; String s;
+
+            // simple field name
+            o = x;
+            cs = x;
+            s = x;
+
+            // qualified field name
+            o = test.x;
+            cs = test.x;
+            s = test.x;
+
+            // simple method name
+            o = getX();
+            cs = getX();
+            s = getX();
+
+            // qualified method name
+            o = test.getX();
+            cs = test.getX();
+            s = test.getX();
+        }
+
+        @IR("""
+                func @"testArrayInit" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object[]"> = var @"o";
+                    %4 : Var<java.type:"java.lang.CharSequence[]"> = var @"cs";
+                    %5 : Var<java.type:"java.lang.String[]"> = var @"s";
+                    %6 : java.type:"int" = constant @1;
+                    %7 : java.type:"java.lang.Object[]" = new %6 @java.ref:"java.lang.Object[]::(int)";
+                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %9 : java.type:"int" = constant @0;
+                    array.store %7 %9 %8;
+                    var.store %3 %7;
+                    %10 : java.type:"int" = constant @1;
+                    %11 : java.type:"java.lang.CharSequence[]" = new %10 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %12 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %13 : java.type:"java.lang.CharSequence" = cast %12 @java.type:"java.lang.CharSequence";
+                    %14 : java.type:"int" = constant @0;
+                    array.store %11 %14 %13;
+                    var.store %4 %11;
+                    %15 : java.type:"int" = constant @1;
+                    %16 : java.type:"java.lang.String[]" = new %15 @java.ref:"java.lang.String[]::(int)";
+                    %17 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %18 : java.type:"java.lang.String" = cast %17 @java.type:"java.lang.String";
+                    %19 : java.type:"int" = constant @0;
+                    array.store %16 %19 %18;
+                    var.store %5 %16;
+                    %20 : java.type:"int" = constant @1;
+                    %21 : java.type:"java.lang.Object[]" = new %20 @java.ref:"java.lang.Object[]::(int)";
+                    %22 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %23 : java.type:"java.lang.String" = field.load %22 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %24 : java.type:"int" = constant @0;
+                    array.store %21 %24 %23;
+                    var.store %3 %21;
+                    %25 : java.type:"int" = constant @1;
+                    %26 : java.type:"java.lang.CharSequence[]" = new %25 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %27 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %28 : java.type:"java.lang.String" = field.load %27 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %29 : java.type:"java.lang.CharSequence" = cast %28 @java.type:"java.lang.CharSequence";
+                    %30 : java.type:"int" = constant @0;
+                    array.store %26 %30 %29;
+                    var.store %4 %26;
+                    %31 : java.type:"int" = constant @1;
+                    %32 : java.type:"java.lang.String[]" = new %31 @java.ref:"java.lang.String[]::(int)";
+                    %33 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %34 : java.type:"java.lang.String" = field.load %33 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                    %36 : java.type:"int" = constant @0;
+                    array.store %32 %36 %35;
+                    var.store %5 %32;
+                    %37 : java.type:"int" = constant @1;
+                    %38 : java.type:"java.lang.Object[]" = new %37 @java.ref:"java.lang.Object[]::(int)";
+                    %39 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %40 : java.type:"int" = constant @0;
+                    array.store %38 %40 %39;
+                    var.store %3 %38;
+                    %41 : java.type:"int" = constant @1;
+                    %42 : java.type:"java.lang.CharSequence[]" = new %41 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %43 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %44 : java.type:"java.lang.CharSequence" = cast %43 @java.type:"java.lang.CharSequence";
+                    %45 : java.type:"int" = constant @0;
+                    array.store %42 %45 %44;
+                    var.store %4 %42;
+                    %46 : java.type:"int" = constant @1;
+                    %47 : java.type:"java.lang.String[]" = new %46 @java.ref:"java.lang.String[]::(int)";
+                    %48 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %49 : java.type:"java.lang.String" = cast %48 @java.type:"java.lang.String";
+                    %50 : java.type:"int" = constant @0;
+                    array.store %47 %50 %49;
+                    var.store %5 %47;
+                    %51 : java.type:"int" = constant @1;
+                    %52 : java.type:"java.lang.Object[]" = new %51 @java.ref:"java.lang.Object[]::(int)";
+                    %53 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %54 : java.type:"java.lang.String" = invoke %53 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %55 : java.type:"int" = constant @0;
+                    array.store %52 %55 %54;
+                    var.store %3 %52;
+                    %56 : java.type:"int" = constant @1;
+                    %57 : java.type:"java.lang.CharSequence[]" = new %56 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %58 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %59 : java.type:"java.lang.String" = invoke %58 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %60 : java.type:"java.lang.CharSequence" = cast %59 @java.type:"java.lang.CharSequence";
+                    %61 : java.type:"int" = constant @0;
+                    array.store %57 %61 %60;
+                    var.store %4 %57;
+                    %62 : java.type:"int" = constant @1;
+                    %63 : java.type:"java.lang.String[]" = new %62 @java.ref:"java.lang.String[]::(int)";
+                    %64 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %65 : java.type:"java.lang.String" = invoke %64 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %66 : java.type:"java.lang.String" = cast %65 @java.type:"java.lang.String";
+                    %67 : java.type:"int" = constant @0;
+                    array.store %63 %67 %66;
+                    var.store %5 %63;
+                    return;
+                };
+                """)
+        @Reflect
+        void testArrayInit(UnboundedString test) {
+            Object[] o; CharSequence[] cs; String[] s;
+
+            // simple field name
+            o = new Object[] { x };
+            cs = new CharSequence[] { x };
+            s = new String[] { x };
+
+            // qualified field name
+            o = new Object[] { test.x };
+            cs = new CharSequence[] { test.x };
+            s = new String[] { test.x };
+
+            // simple method name
+            o = new Object[] { getX() };
+            cs = new CharSequence[] { getX() };
+            s = new String[] { getX() };
+
+            // qualified method name
+            o = new Object[] { test.getX() };
+            cs = new CharSequence[] { test.getX() };
+            s = new String[] { test.getX() };
+        }
+
+        @IR("""
+                func @"testCast" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
+                    %5 : Var<java.type:"java.lang.String"> = var @"s";
+                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    var.store %3 %6;
+                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %8 : java.type:"java.lang.CharSequence" = cast %7 @java.type:"java.lang.CharSequence";
+                    var.store %4 %8;
+                    %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                    var.store %5 %10;
+                    %11 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %12 : java.type:"java.lang.String" = field.load %11 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    var.store %3 %12;
+                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %14 : java.type:"java.lang.String" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %15 : java.type:"java.lang.CharSequence" = cast %14 @java.type:"java.lang.CharSequence";
+                    var.store %4 %15;
+                    %16 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %17 : java.type:"java.lang.String" = field.load %16 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %18 : java.type:"java.lang.String" = cast %17 @java.type:"java.lang.String";
+                    var.store %5 %18;
+                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    var.store %3 %19;
+                    %20 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %21 : java.type:"java.lang.CharSequence" = cast %20 @java.type:"java.lang.CharSequence";
+                    var.store %4 %21;
+                    %22 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %23 : java.type:"java.lang.String" = cast %22 @java.type:"java.lang.String";
+                    var.store %5 %23;
+                    %24 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %25 : java.type:"java.lang.String" = invoke %24 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    var.store %3 %25;
+                    %26 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %27 : java.type:"java.lang.String" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %28 : java.type:"java.lang.CharSequence" = cast %27 @java.type:"java.lang.CharSequence";
+                    var.store %4 %28;
+                    %29 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %30 : java.type:"java.lang.String" = invoke %29 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %31 : java.type:"java.lang.String" = cast %30 @java.type:"java.lang.String";
+                    var.store %5 %31;
+                    return;
+                };
+                """)
+        @Reflect
+        void testCast(UnboundedString test) {
+            Object o; CharSequence cs; String s;
+
+            // simple field name
+            o = (Object) x;
+            cs = (CharSequence) x;
+            s = (String) x;
+
+            // qualified field name
+            o = (Object) test.x;
+            cs = (CharSequence) test.x;
+            s = (String) test.x;
+
+            // simple method name
+            o = (Object) getX();
+            cs = (CharSequence) getX();
+            s = (String) getX();
+
+            // qualified method name
+            o = (Object) test.getX();
+            cs = (CharSequence) test.getX();
+            s = (String) test.getX();
+        }
+
+        void o(Object o) { }
+        void cs(CharSequence cs) { }
+        void s(String s) { }
+
+        @IR("""
+                func @"testMethod" (%0 : java.type:"ErasedAccessTest$UnboundedString", %1 : java.type:"ErasedAccessTest$UnboundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    invoke %0 %3 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
+                    %4 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %5 : java.type:"java.lang.CharSequence" = cast %4 @java.type:"java.lang.CharSequence";
+                    invoke %0 %5 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
+                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %7 : java.type:"java.lang.String" = cast %6 @java.type:"java.lang.String";
+                    invoke %0 %7 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
+                    %8 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %9 : java.type:"java.lang.String" = field.load %8 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    invoke %0 %9 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
+                    %10 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %11 : java.type:"java.lang.String" = field.load %10 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %12 : java.type:"java.lang.CharSequence" = cast %11 @java.type:"java.lang.CharSequence";
+                    invoke %0 %12 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
+                    %13 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %14 : java.type:"java.lang.String" = field.load %13 @java.ref:"ErasedAccessTest$UnboundedString::x:java.lang.Object";
+                    %15 : java.type:"java.lang.String" = cast %14 @java.type:"java.lang.String";
+                    invoke %0 %15 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
+                    %16 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    invoke %0 %16 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
+                    %17 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %18 : java.type:"java.lang.CharSequence" = cast %17 @java.type:"java.lang.CharSequence";
+                    invoke %0 %18 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
+                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                    invoke %0 %20 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
+                    %21 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %22 : java.type:"java.lang.String" = invoke %21 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    invoke %0 %22 @java.ref:"ErasedAccessTest$UnboundedString::o(java.lang.Object):void";
+                    %23 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %24 : java.type:"java.lang.String" = invoke %23 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %25 : java.type:"java.lang.CharSequence" = cast %24 @java.type:"java.lang.CharSequence";
+                    invoke %0 %25 @java.ref:"ErasedAccessTest$UnboundedString::cs(java.lang.CharSequence):void";
+                    %26 : java.type:"ErasedAccessTest$UnboundedString" = var.load %2;
+                    %27 : java.type:"java.lang.String" = invoke %26 @java.ref:"ErasedAccessTest$UnboundedString::getX():java.lang.Object";
+                    %28 : java.type:"java.lang.String" = cast %27 @java.type:"java.lang.String";
+                    invoke %0 %28 @java.ref:"ErasedAccessTest$UnboundedString::s(java.lang.String):void";
+                    return;
+                };
+                """)
+        @Reflect
+        void testMethod(UnboundedString test) {
+            // simple field name
+            o(x);
+            cs(x);
+            s(x);
+
+            // qualified field name
+            o(test.x);
+            cs(test.x);
+            s(test.x);
+
+            // simple method name
+            o(getX());
+            cs(getX());
+            s(getX());
+
+            // qualified method name
+            o(test.getX());
+            cs(test.getX());
+            s(test.getX());
+        }
+    }
+
+    // the part below is just copied from the above with minor adaptations in the expected IRs
+
+    static class Bounded<X extends CharSequence> {
+        X x;
+
+        X getX() {
+            return x;
+        }
+    }
+
+    static class BoundedString extends Bounded<String> {
+
+        @IR("""
+                func @"testInstanceof" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %4 : java.type:"boolean" = instanceof %3 @java.type:"java.lang.String";
+                    %5 : Var<java.type:"boolean"> = var %4 @"f_s_s";
+                    %6 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %8 : java.type:"boolean" = instanceof %7 @java.type:"java.lang.String";
+                    %9 : Var<java.type:"boolean"> = var %8 @"f_q_s";
+                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %11 : java.type:"boolean" = instanceof %10 @java.type:"java.lang.String";
+                    %12 : Var<java.type:"boolean"> = var %11 @"m_s_s";
+                    %13 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %15 : java.type:"boolean" = instanceof %14 @java.type:"java.lang.String";
+                    %16 : Var<java.type:"boolean"> = var %15 @"m_q_s";
+                    return;
+                };
+                """)
+        @Reflect
+        void testInstanceof(BoundedString test) {
+            // simple field name
+            boolean f_s_s = x instanceof String;
+
+            // qualified field name
+            boolean f_q_s = test.x instanceof String;
+
+            // simple method name
+            boolean m_s_s = getX() instanceof String;
+
+            // qualified method name
+            boolean m_q_s = test.getX() instanceof String;
+        }
+
+        @IR("""
+                func @"testInstanceofCond" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %4 : Var<java.type:"boolean"> = var %2 @"cond";
+                    %5 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = var.load %4;
+                            yield %6;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                            yield %8;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                            yield %10;
+                        };
+                    %11 : java.type:"boolean" = instanceof %5 @java.type:"java.lang.Object";
+                    %12 : Var<java.type:"boolean"> = var %11 @"f_s_o";
+                    %13 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %14 : java.type:"boolean" = var.load %4;
+                            yield %14;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %15 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %16 : java.type:"java.lang.String" = field.load %15 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
+                            yield %17;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %18 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %19 : java.type:"java.lang.String" = field.load %18 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                            yield %20;
+                        };
+                    %21 : java.type:"boolean" = instanceof %13 @java.type:"java.lang.Object";
+                    %22 : Var<java.type:"boolean"> = var %21 @"f_q_o";
+                    %23 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %24 : java.type:"boolean" = var.load %4;
+                            yield %24;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                            yield %26;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %27 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %28 : java.type:"java.lang.String" = cast %27 @java.type:"java.lang.String";
+                            yield %28;
+                        };
+                    %29 : java.type:"boolean" = instanceof %23 @java.type:"java.lang.Object";
+                    %30 : Var<java.type:"boolean"> = var %29 @"m_s_o";
+                    %31 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %32 : java.type:"boolean" = var.load %4;
+                            yield %32;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %33 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                            yield %35;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %36 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %37 : java.type:"java.lang.String" = invoke %36 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %38 : java.type:"java.lang.String" = cast %37 @java.type:"java.lang.String";
+                            yield %38;
+                        };
+                    %39 : java.type:"boolean" = instanceof %31 @java.type:"java.lang.Object";
+                    %40 : Var<java.type:"boolean"> = var %39 @"m_q_o";
+                    return;
+                };
+                """)
+        @Reflect
+        void testInstanceofCond(BoundedString test, boolean cond) {
+            // simple field name
+            boolean f_s_o = (cond ? x : x) instanceof Object;
+
+            // qualified field name
+            boolean f_q_o = (cond ? test.x : test.x) instanceof Object;
+
+            // simple method name
+            boolean m_s_o = (cond ? getX() : getX()) instanceof Object;
+
+            // qualified method name
+            boolean m_q_o = (cond ? test.getX() : test.getX()) instanceof Object;
+        }
+
+        @IR("""
+                func @"testExec" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %4 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    return;
+                };
+                """)
+        @Reflect
+        void testExec(BoundedString test) {
+            // simple method name
+            getX();
+
+            // qualified method name
+            test.getX();
+        }
+
+        @IR("""
+                func @"testChainedCall" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %4 : java.type:"java.lang.String" = cast %3 @java.type:"java.lang.String";
+                    %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.String::hashCode():int";
+                    %6 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %7 : java.type:"java.lang.String" = field.load %6 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                    %9 : java.type:"int" = invoke %8 @java.ref:"java.lang.String::hashCode():int";
+                    %10 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %11 : java.type:"java.lang.String" = cast %10 @java.type:"java.lang.String";
+                    %12 : java.type:"int" = invoke %11 @java.ref:"java.lang.String::hashCode():int";
+                    %13 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %14 : java.type:"java.lang.String" = invoke %13 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %15 : java.type:"java.lang.String" = cast %14 @java.type:"java.lang.String";
+                    %16 : java.type:"int" = invoke %15 @java.ref:"java.lang.String::hashCode():int";
+                    return;
+                };
+                """)
+        @Reflect
+        void testChainedCall(BoundedString test) {
+            // simple field name
+            x.hashCode();
+
+            // qualified field name
+            test.x.hashCode();
+
+            // simple method name
+            getX().hashCode();
+
+            // qualified method name
+            test.getX().hashCode();
+        }
+
+        @IR("""
+                func @"testChainedCallCond" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString", %2 : java.type:"boolean")java.type:"void" -> {
+                    %3 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %4 : Var<java.type:"boolean"> = var %2 @"cond";
+                    %5 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %6 : java.type:"boolean" = var.load %4;
+                            yield %6;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %8 : java.type:"java.lang.String" = cast %7 @java.type:"java.lang.String";
+                            yield %8;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %9 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                            yield %10;
+                        };
+                    %11 : java.type:"int" = invoke %5 @java.ref:"java.lang.String::hashCode():int";
+                    %12 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %13 : java.type:"boolean" = var.load %4;
+                            yield %13;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %14 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                            yield %16;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %17 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %18 : java.type:"java.lang.String" = field.load %17 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                            %19 : java.type:"java.lang.String" = cast %18 @java.type:"java.lang.String";
+                            yield %19;
+                        };
+                    %20 : java.type:"int" = invoke %12 @java.ref:"java.lang.String::hashCode():int";
+                    %21 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %22 : java.type:"boolean" = var.load %4;
+                            yield %22;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %23 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %24 : java.type:"java.lang.String" = cast %23 @java.type:"java.lang.String";
+                            yield %24;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %25 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %26 : java.type:"java.lang.String" = cast %25 @java.type:"java.lang.String";
+                            yield %26;
+                        };
+                    %27 : java.type:"int" = invoke %21 @java.ref:"java.lang.String::hashCode():int";
+                    %28 : java.type:"java.lang.String" = java.cexpression
+                        ()java.type:"boolean" -> {
+                            %29 : java.type:"boolean" = var.load %4;
+                            yield %29;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %30 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %31 : java.type:"java.lang.String" = invoke %30 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %32 : java.type:"java.lang.String" = cast %31 @java.type:"java.lang.String";
+                            yield %32;
+                        }
+                        ()java.type:"java.lang.String" -> {
+                            %33 : java.type:"ErasedAccessTest$BoundedString" = var.load %3;
+                            %34 : java.type:"java.lang.String" = invoke %33 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                            %35 : java.type:"java.lang.String" = cast %34 @java.type:"java.lang.String";
+                            yield %35;
+                        };
+                    %36 : java.type:"int" = invoke %28 @java.ref:"java.lang.String::hashCode():int";
+                    return;
+                };
+                """)
+        @Reflect
+        void testChainedCallCond(BoundedString test, boolean cond) {
+            // simple field name
+            (cond ? x : x).hashCode();
+
+            // qualified field name
+            (cond ? test.x : test.x).hashCode();
+
+            // simple method name
+            (cond ? getX() : getX()).hashCode();
+
+            // qualified method name
+            (cond ? test.getX() : test.getX()).hashCode();
+        }
+
+        @IR("""
+                func @"testAssign" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
+                    %5 : Var<java.type:"java.lang.String"> = var @"s";
+                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %3 %6;
+                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %4 %7;
+                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %9 : java.type:"java.lang.String" = cast %8 @java.type:"java.lang.String";
+                    var.store %5 %9;
+                    %10 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %11 : java.type:"java.lang.String" = field.load %10 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %3 %11;
+                    %12 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %13 : java.type:"java.lang.String" = field.load %12 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %4 %13;
+                    %14 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                    var.store %5 %16;
+                    %17 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %3 %17;
+                    %18 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %4 %18;
+                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                    var.store %5 %20;
+                    %21 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %22 : java.type:"java.lang.String" = invoke %21 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %3 %22;
+                    %23 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %24 : java.type:"java.lang.String" = invoke %23 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %4 %24;
+                    %25 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %26 : java.type:"java.lang.String" = invoke %25 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %27 : java.type:"java.lang.String" = cast %26 @java.type:"java.lang.String";
+                    var.store %5 %27;
+                    return;
+                };
+                """)
+        @Reflect
+        void testAssign(BoundedString test) {
+            Object o; CharSequence cs; String s;
+
+            // simple field name
+            o = x;
+            cs = x;
+            s = x;
+
+            // qualified field name
+            o = test.x;
+            cs = test.x;
+            s = test.x;
+
+            // simple method name
+            o = getX();
+            cs = getX();
+            s = getX();
+
+            // qualified method name
+            o = test.getX();
+            cs = test.getX();
+            s = test.getX();
+        }
+
+        @IR("""
+                func @"testArrayInit" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object[]"> = var @"o";
+                    %4 : Var<java.type:"java.lang.CharSequence[]"> = var @"cs";
+                    %5 : Var<java.type:"java.lang.String[]"> = var @"s";
+                    %6 : java.type:"int" = constant @1;
+                    %7 : java.type:"java.lang.Object[]" = new %6 @java.ref:"java.lang.Object[]::(int)";
+                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %9 : java.type:"int" = constant @0;
+                    array.store %7 %9 %8;
+                    var.store %3 %7;
+                    %10 : java.type:"int" = constant @1;
+                    %11 : java.type:"java.lang.CharSequence[]" = new %10 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %12 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %13 : java.type:"int" = constant @0;
+                    array.store %11 %13 %12;
+                    var.store %4 %11;
+                    %14 : java.type:"int" = constant @1;
+                    %15 : java.type:"java.lang.String[]" = new %14 @java.ref:"java.lang.String[]::(int)";
+                    %16 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
+                    %18 : java.type:"int" = constant @0;
+                    array.store %15 %18 %17;
+                    var.store %5 %15;
+                    %19 : java.type:"int" = constant @1;
+                    %20 : java.type:"java.lang.Object[]" = new %19 @java.ref:"java.lang.Object[]::(int)";
+                    %21 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %22 : java.type:"java.lang.String" = field.load %21 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %23 : java.type:"int" = constant @0;
+                    array.store %20 %23 %22;
+                    var.store %3 %20;
+                    %24 : java.type:"int" = constant @1;
+                    %25 : java.type:"java.lang.CharSequence[]" = new %24 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %26 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %27 : java.type:"java.lang.String" = field.load %26 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %28 : java.type:"int" = constant @0;
+                    array.store %25 %28 %27;
+                    var.store %4 %25;
+                    %29 : java.type:"int" = constant @1;
+                    %30 : java.type:"java.lang.String[]" = new %29 @java.ref:"java.lang.String[]::(int)";
+                    %31 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %32 : java.type:"java.lang.String" = field.load %31 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %33 : java.type:"java.lang.String" = cast %32 @java.type:"java.lang.String";
+                    %34 : java.type:"int" = constant @0;
+                    array.store %30 %34 %33;
+                    var.store %5 %30;
+                    %35 : java.type:"int" = constant @1;
+                    %36 : java.type:"java.lang.Object[]" = new %35 @java.ref:"java.lang.Object[]::(int)";
+                    %37 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %38 : java.type:"int" = constant @0;
+                    array.store %36 %38 %37;
+                    var.store %3 %36;
+                    %39 : java.type:"int" = constant @1;
+                    %40 : java.type:"java.lang.CharSequence[]" = new %39 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %41 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %42 : java.type:"int" = constant @0;
+                    array.store %40 %42 %41;
+                    var.store %4 %40;
+                    %43 : java.type:"int" = constant @1;
+                    %44 : java.type:"java.lang.String[]" = new %43 @java.ref:"java.lang.String[]::(int)";
+                    %45 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %46 : java.type:"java.lang.String" = cast %45 @java.type:"java.lang.String";
+                    %47 : java.type:"int" = constant @0;
+                    array.store %44 %47 %46;
+                    var.store %5 %44;
+                    %48 : java.type:"int" = constant @1;
+                    %49 : java.type:"java.lang.Object[]" = new %48 @java.ref:"java.lang.Object[]::(int)";
+                    %50 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %51 : java.type:"java.lang.String" = invoke %50 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %52 : java.type:"int" = constant @0;
+                    array.store %49 %52 %51;
+                    var.store %3 %49;
+                    %53 : java.type:"int" = constant @1;
+                    %54 : java.type:"java.lang.CharSequence[]" = new %53 @java.ref:"java.lang.CharSequence[]::(int)";
+                    %55 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %56 : java.type:"java.lang.String" = invoke %55 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %57 : java.type:"int" = constant @0;
+                    array.store %54 %57 %56;
+                    var.store %4 %54;
+                    %58 : java.type:"int" = constant @1;
+                    %59 : java.type:"java.lang.String[]" = new %58 @java.ref:"java.lang.String[]::(int)";
+                    %60 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %61 : java.type:"java.lang.String" = invoke %60 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %62 : java.type:"java.lang.String" = cast %61 @java.type:"java.lang.String";
+                    %63 : java.type:"int" = constant @0;
+                    array.store %59 %63 %62;
+                    var.store %5 %59;
+                    return;
+                };
+                """)
+        @Reflect
+        void testArrayInit(BoundedString test) {
+            Object[] o; CharSequence[] cs; String[] s;
+
+            // simple field name
+            o = new Object[] { x };
+            cs = new CharSequence[] { x };
+            s = new String[] { x };
+
+            // qualified field name
+            o = new Object[] { test.x };
+            cs = new CharSequence[] { test.x };
+            s = new String[] { test.x };
+
+            // simple method name
+            o = new Object[] { getX() };
+            cs = new CharSequence[] { getX() };
+            s = new String[] { getX() };
+
+            // qualified method name
+            o = new Object[] { test.getX() };
+            cs = new CharSequence[] { test.getX() };
+            s = new String[] { test.getX() };
+        }
+
+        @IR("""
+                func @"testCast" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : Var<java.type:"java.lang.CharSequence"> = var @"cs";
+                    %5 : Var<java.type:"java.lang.String"> = var @"s";
+                    %6 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %3 %6;
+                    %7 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %4 %7;
+                    %8 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %9 : java.type:"java.lang.String" = cast %8 @java.type:"java.lang.String";
+                    var.store %5 %9;
+                    %10 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %11 : java.type:"java.lang.String" = field.load %10 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %3 %11;
+                    %12 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %13 : java.type:"java.lang.String" = field.load %12 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    var.store %4 %13;
+                    %14 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %15 : java.type:"java.lang.String" = field.load %14 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %16 : java.type:"java.lang.String" = cast %15 @java.type:"java.lang.String";
+                    var.store %5 %16;
+                    %17 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %3 %17;
+                    %18 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %4 %18;
+                    %19 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %20 : java.type:"java.lang.String" = cast %19 @java.type:"java.lang.String";
+                    var.store %5 %20;
+                    %21 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %22 : java.type:"java.lang.String" = invoke %21 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %3 %22;
+                    %23 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %24 : java.type:"java.lang.String" = invoke %23 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    var.store %4 %24;
+                    %25 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %26 : java.type:"java.lang.String" = invoke %25 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %27 : java.type:"java.lang.String" = cast %26 @java.type:"java.lang.String";
+                    var.store %5 %27;
+                    return;
+                };
+                """)
+        @Reflect
+        void testCast(BoundedString test) {
+            Object o; CharSequence cs; String s;
+
+            // simple field name
+            o = (Object) x;
+            cs = (CharSequence) x;
+            s = (String) x;
+
+            // qualified field name
+            o = (Object) test.x;
+            cs = (CharSequence) test.x;
+            s = (String) test.x;
+
+            // simple method name
+            o = (Object) getX();
+            cs = (CharSequence) getX();
+            s = (String) getX();
+
+            // qualified method name
+            o = (Object) test.getX();
+            cs = (CharSequence) test.getX();
+            s = (String) test.getX();
+        }
+
+        void o(Object o) { }
+        void cs(CharSequence cs) { }
+        void s(String s) { }
+
+        @IR("""
+                func @"testMethod" (%0 : java.type:"ErasedAccessTest$BoundedString", %1 : java.type:"ErasedAccessTest$BoundedString")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedString"> = var %1 @"test";
+                    %3 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    invoke %0 %3 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
+                    %4 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    invoke %0 %4 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
+                    %5 : java.type:"java.lang.String" = field.load %0 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %6 : java.type:"java.lang.String" = cast %5 @java.type:"java.lang.String";
+                    invoke %0 %6 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
+                    %7 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %8 : java.type:"java.lang.String" = field.load %7 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    invoke %0 %8 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
+                    %9 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %10 : java.type:"java.lang.String" = field.load %9 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    invoke %0 %10 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
+                    %11 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %12 : java.type:"java.lang.String" = field.load %11 @java.ref:"ErasedAccessTest$BoundedString::x:java.lang.CharSequence";
+                    %13 : java.type:"java.lang.String" = cast %12 @java.type:"java.lang.String";
+                    invoke %0 %13 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
+                    %14 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    invoke %0 %14 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
+                    %15 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    invoke %0 %15 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
+                    %16 : java.type:"java.lang.String" = invoke %0 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %17 : java.type:"java.lang.String" = cast %16 @java.type:"java.lang.String";
+                    invoke %0 %17 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
+                    %18 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %19 : java.type:"java.lang.String" = invoke %18 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    invoke %0 %19 @java.ref:"ErasedAccessTest$BoundedString::o(java.lang.Object):void";
+                    %20 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %21 : java.type:"java.lang.String" = invoke %20 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    invoke %0 %21 @java.ref:"ErasedAccessTest$BoundedString::cs(java.lang.CharSequence):void";
+                    %22 : java.type:"ErasedAccessTest$BoundedString" = var.load %2;
+                    %23 : java.type:"java.lang.String" = invoke %22 @java.ref:"ErasedAccessTest$BoundedString::getX():java.lang.CharSequence";
+                    %24 : java.type:"java.lang.String" = cast %23 @java.type:"java.lang.String";
+                    invoke %0 %24 @java.ref:"ErasedAccessTest$BoundedString::s(java.lang.String):void";
+                    return;
+                };
+                """)
+        @Reflect
+        void testMethod(BoundedString test) {
+            // simple field name
+            o(x);
+            cs(x);
+            s(x);
+
+            // qualified field name
+            o(test.x);
+            cs(test.x);
+            s(test.x);
+
+            // simple method name
+            o(getX());
+            cs(getX());
+            s(getX());
+
+            // qualified method name
+            o(test.getX());
+            cs(test.getX());
+            s(test.getX());
+        }
+    }
+
 
     static final String TEST_CLASSES_DIR = System.getProperty("test.classes", ".");
+    static final Class<?>[] TEST_CLASSES = new Class<?>[] { UnboundedString.class, BoundedString.class };
 
     public static void main(String[] args) throws ReflectiveOperationException, IOException {
-        ClassModel mod = ClassFile.of().parse(Path.of(TEST_CLASSES_DIR, "ErasedAccessTest.class"));
-        for (Method m : ErasedAccessTest.class.getDeclaredMethods()) {
-            if (m.isAnnotationPresent(Reflect.class)) {
-                FuncOp model = Op.ofMethod(m).get();
-                System.out.println(model.toText());
-                CodeModel bytecode = mod.methods().stream()
-                        .filter(mm -> mm.methodName().stringValue().equals(m.getName()))
-                        .findAny()
-                        .flatMap(MethodModel::code)
-                        .orElseThrow(() -> new AssertionError("Code model not found for method " + m.getName()));
-                List<ClassDesc> modelCasts = modelCasts(model);
-                List<ClassDesc> bytecodeCasts = bytecodeCasts(bytecode);
-                if (!modelCasts.equals(bytecodeCasts)) {
-                    throw new AssertionError("Casts do not match for method " + m.getName() +
-                            "\nbytecode casts = " + bytecodeCasts +
-                            "\nmodel casts = " + modelCasts);
+        for (Class<?> testClass : TEST_CLASSES) {
+            ClassModel mod = ClassFile.of().parse(Path.of(TEST_CLASSES_DIR, testClass.getName() + ".class"));
+            for (Method m : testClass.getDeclaredMethods()) {
+                if (m.isAnnotationPresent(Reflect.class)) {
+                    FuncOp model = Op.ofMethod(m).get();
+                    System.out.println(model.toText());
+                    CodeModel bytecode = mod.methods().stream()
+                            .filter(mm -> mm.methodName().stringValue().equals(m.getName()))
+                            .findAny()
+                            .flatMap(MethodModel::code)
+                            .orElseThrow(() -> new AssertionError("Code model not found for method " + m.getName()));
+                    List<ClassDesc> modelCasts = modelCasts(model);
+                    List<ClassDesc> bytecodeCasts = bytecodeCasts(bytecode);
+                    if (!modelCasts.equals(bytecodeCasts)) {
+                        throw new AssertionError("Casts do not match for method " + m.getName() +
+                                "\nbytecode casts = " + bytecodeCasts +
+                                "\nmodel casts = " + modelCasts);
+                    }
                 }
             }
         }

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -269,20 +269,121 @@ public class ErasedAccessTest {
 
     @Reflect
     @IR("""
-            func @"field_objectAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
+            func @"method_ObjectArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"int" = constant @1;
+                %3 : java.type:"java.lang.Object[]" = new %2 @java.ref:"java.lang.Object[]::(int)";
+                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %6 : java.type:"int" = constant @0;
+                array.store %3 %6 %5;
+                %7 : Var<java.type:"java.lang.Object[]"> = var %3 @"csArr";
+                return;
+            };
+            """)
+    static void method_ObjectArrayInit(Box<String> xs) {
+        Object[] csArr = new Object[] { xs.get() };
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_CharSequenceArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"int" = constant @1;
+                %3 : java.type:"java.lang.CharSequence[]" = new %2 @java.ref:"java.lang.CharSequence[]::(int)";
+                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %6 : java.type:"java.lang.CharSequence" = cast %5 @java.type:"java.lang.CharSequence";
+                %7 : java.type:"int" = constant @0;
+                array.store %3 %7 %6;
+                %8 : Var<java.type:"java.lang.CharSequence[]"> = var %3 @"csArr";
+                return;
+            };
+            """)
+    static void method_CharSequenceArrayInit(Box<String> xs) {
+        CharSequence[] csArr = new CharSequence[] { xs.get() };
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_ObjectArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"int" = constant @1;
+                %3 : java.type:"java.lang.Object[]" = new %2 @java.ref:"java.lang.Object[]::(int)";
+                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %5 : java.type:"java.lang.String" = field.load %4 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                %6 : java.type:"int" = constant @0;
+                array.store %3 %6 %5;
+                %7 : Var<java.type:"java.lang.Object[]"> = var %3 @"csArr";
+                return;
+            };
+            """)
+    static void field_ObjectArrayInit(Box<String> xs) {
+        Object[] csArr = new Object[] { xs.x };
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_CharSequenceArrayInit" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"void" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"int" = constant @1;
+                %3 : java.type:"java.lang.CharSequence[]" = new %2 @java.ref:"java.lang.CharSequence[]::(int)";
+                %4 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %5 : java.type:"java.lang.String" = field.load %4 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
+                %6 : java.type:"java.lang.CharSequence" = cast %5 @java.type:"java.lang.CharSequence";
+                %7 : java.type:"int" = constant @0;
+                array.store %3 %7 %6;
+                %8 : Var<java.type:"java.lang.CharSequence[]"> = var %3 @"csArr";
+                return;
+            };
+            """)
+    static void field_CharSequenceArrayInit(Box<String> xs) {
+        CharSequence[] csArr = new CharSequence[] { xs.x };
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_ObjectCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                return %3;
+            };
+            """)
+    static Object method_ObjectCast(Box<String> xs) {
+        return (Object)xs.get();
+    }
+
+    @Reflect
+    @IR("""
+            func @"method_CharSequenceCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
+                %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
+                %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
+                %3 : java.type:"java.lang.String" = invoke %2 @java.ref:"ErasedAccessTest$Box::get():java.lang.Object";
+                %4 : java.type:"java.lang.CharSequence" = cast %3 @java.type:"java.lang.CharSequence";
+                return %4;
+            };
+            """)
+    static CharSequence method_CharSequenceCast(Box<String> xs) {
+        return (CharSequence)xs.get();
+    }
+
+    @Reflect
+    @IR("""
+            func @"field_ObjectCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.Object" -> {
                 %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
                 %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
                 %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
                 return %3;
             };
             """)
-    static Object field_objectAssign(Box<String> xs) {
-        return xs.x;
+    static Object field_ObjectCast(Box<String> xs) {
+        return (Object)xs.x;
     }
 
     @Reflect
     @IR("""
-            func @"field_CharSequenceAssign" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
+            func @"field_CharSequenceCast" (%0 : java.type:"ErasedAccessTest$Box<java.lang.String>")java.type:"java.lang.CharSequence" -> {
                 %1 : Var<java.type:"ErasedAccessTest$Box<java.lang.String>"> = var %0 @"xs";
                 %2 : java.type:"ErasedAccessTest$Box<java.lang.String>" = var.load %1;
                 %3 : java.type:"java.lang.String" = field.load %2 @java.ref:"ErasedAccessTest$Box::x:java.lang.Object";
@@ -290,8 +391,8 @@ public class ErasedAccessTest {
                 return %4;
             };
             """)
-    static CharSequence field_CharSequenceAssign(Box<String> xs) {
-        return xs.x;
+    static CharSequence field_CharSequenceCast(Box<String> xs) {
+        return (CharSequence)xs.x;
     }
 
     static class Box<X> {

--- a/test/langtools/tools/javac/reflect/FieldAccessTest.java
+++ b/test/langtools/tools/javac/reflect/FieldAccessTest.java
@@ -530,8 +530,9 @@ public class FieldAccessTest {
         @IR("""
                 func @"test1" (%0 : java.type:"FieldAccessTest$ZZ")java.type:"int" -> {
                     %1 : java.type:"FieldAccessTest$Y" = field.load %0 @java.ref:"FieldAccessTest$ZZ::x:FieldAccessTest$X";
-                    %2 : java.type:"int" = field.load %1 @java.ref:"FieldAccessTest$Y::yf:int";
-                    return %2;
+                    %2 : java.type:"FieldAccessTest$Y" = cast %1 @java.type:"FieldAccessTest$Y";
+                    %3 : java.type:"int" = field.load %2 @java.ref:"FieldAccessTest$Y::yf:int";
+                    return %3;
                 };
                 """)
         @Reflect
@@ -544,8 +545,9 @@ public class FieldAccessTest {
                     %1 : Var<java.type:"FieldAccessTest$ZZ"> = var %0 @"zz";
                     %2 : java.type:"FieldAccessTest$ZZ" = var.load %1;
                     %3 : java.type:"FieldAccessTest$Y" = field.load %2 @java.ref:"FieldAccessTest$ZZ::x:FieldAccessTest$X";
-                    %4 : java.type:"int" = field.load %3 @java.ref:"FieldAccessTest$Y::yf:int";
-                    return %4;
+                    %4 : java.type:"FieldAccessTest$Y" = cast %3 @java.type:"FieldAccessTest$Y";
+                    %5 : java.type:"int" = field.load %4 @java.ref:"FieldAccessTest$Y::yf:int";
+                    return %5;
                 };
                 """)
         @Reflect
@@ -756,7 +758,8 @@ public class FieldAccessTest {
                 %2 : Var<java.type:"FieldAccessTest$Box<java.lang.String>"> = var %1 @"b";
                 %3 : java.type:"FieldAccessTest$Box<java.lang.String>" = var.load %2;
                 %4 : java.type:"java.lang.String" = field.load %3 @java.ref:"FieldAccessTest$Box::v:java.lang.Object";
-                %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
+                %5 : java.type:"java.lang.String" = cast %4 @java.type:"java.lang.String";
+                %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
+++ b/test/langtools/tools/javac/reflect/IntersectionTypeTest.java
@@ -73,17 +73,19 @@ class IntersectionTypeTest {
     // #X<&m<IntersectionTypeTest, test2, func<void, IntersectionTypeTest$A>, IntersectionTypeTest$A>
     @Reflect
     @IR("""
-            func @"test2" (%0 : java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>)")java.type:"void" -> {
-                %1 : Var<java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>)"> = var %0 @"x";
-                %2 : java.type:"IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>)" = var.load %1;
+            func @"test2" (%0 : java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>")java.type:"void" -> {
+                %1 : Var<java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>"> = var %0 @"x";
+                %2 : java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>" = var.load %1;
                 %3 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$A::f_A:java.lang.Object";
                 %4 : Var<java.type:"java.lang.Object"> = var %3 @"oA";
-                %5 : java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>)" = var.load %1;
-                %6 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$B::f_B:java.lang.Object";
-                %7 : Var<java.type:"java.lang.Object"> = var %6 @"oB";
-                %8 : java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>)" = var.load %1;
-                %9 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$C::f_C:java.lang.Object";
-                %10 : Var<java.type:"java.lang.Object"> = var %9 @"oC";
+                %5 : java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>" = var.load %1;
+                %6 : java.type:"IntersectionTypeTest$B" = cast %5 @java.type:"IntersectionTypeTest$B";
+                %7 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$B::f_B:java.lang.Object";
+                %8 : Var<java.type:"java.lang.Object"> = var %7 @"oB";
+                %9 : java.type:"&IntersectionTypeTest::test2(IntersectionTypeTest$A):void::<X extends IntersectionTypeTest$A>" = var.load %1;
+                %10 : java.type:"IntersectionTypeTest$C" = cast %9 @java.type:"IntersectionTypeTest$C";
+                %11 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$C::f_C:java.lang.Object";
+                %12 : Var<java.type:"java.lang.Object"> = var %11 @"oC";
                 return;
             };
             """)
@@ -219,11 +221,13 @@ class IntersectionTypeTest {
                 %9 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$A::f_A:java.lang.Object";
                 %10 : Var<java.type:"java.lang.Object"> = var %9 @"oA";
                 %11 : java.type:"IntersectionTypeTest$A" = var.load %7;
-                %12 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$B::f_B:java.lang.Object";
-                %13 : Var<java.type:"java.lang.Object"> = var %12 @"oB";
-                %14 : java.type:"IntersectionTypeTest$A" = var.load %7;
-                %15 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$C::f_C:java.lang.Object";
-                %16 : Var<java.type:"java.lang.Object"> = var %15 @"oC";
+                %12 : java.type:"IntersectionTypeTest$B" = cast %11 @java.type:"IntersectionTypeTest$B";
+                %13 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$B::f_B:java.lang.Object";
+                %14 : Var<java.type:"java.lang.Object"> = var %13 @"oB";
+                %15 : java.type:"IntersectionTypeTest$A" = var.load %7;
+                %16 : java.type:"IntersectionTypeTest$C" = cast %15 @java.type:"IntersectionTypeTest$C";
+                %17 : java.type:"java.lang.Object" = field.load @java.ref:"IntersectionTypeTest$C::f_C:java.lang.Object";
+                %18 : Var<java.type:"java.lang.Object"> = var %17 @"oC";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/LambdaTest.java
+++ b/test/langtools/tools/javac/reflect/LambdaTest.java
@@ -71,7 +71,8 @@ public class LambdaTest {
                 %3 : Var<java.type:"java.util.function.Supplier<java.lang.String>"> = var %1 @"c";
                 %4 : java.type:"java.util.function.Supplier<java.lang.String>" = var.load %3;
                 %5 : java.type:"java.lang.String" = invoke %4 @java.ref:"java.util.function.Supplier::get():java.lang.Object";
-                %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
+                %6 : java.type:"java.lang.String" = cast %5 @java.type:"java.lang.String";
+                %7 : Var<java.type:"java.lang.String"> = var %6 @"s";
                 return;
             };
             """)
@@ -141,14 +142,15 @@ public class LambdaTest {
                     %20 : java.type:"int" = var.load %3;
                     %21 : java.type:"java.util.function.Supplier<java.lang.Integer>" = var.load %19;
                     %22 : java.type:"java.lang.Integer" = invoke %21 @java.ref:"java.util.function.Supplier::get():java.lang.Object";
-                    %23 : java.type:"int" = invoke %22 @java.ref:"java.lang.Integer::intValue():int";
-                    %24 : java.type:"int" = add %20 %23;
-                    %25 : Var<java.type:"int"> = var %24 @"r";
-                    %26 : java.type:"int" = var.load %25;
-                    %27 : java.type:"java.lang.Integer" = invoke %26 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
-                    return %27;
+                    %23 : java.type:"java.lang.Integer" = cast %22 @java.type:"java.lang.Integer";
+                    %24 : java.type:"int" = invoke %23 @java.ref:"java.lang.Integer::intValue():int";
+                    %25 : java.type:"int" = add %20 %24;
+                    %26 : Var<java.type:"int"> = var %25 @"r";
+                    %27 : java.type:"int" = var.load %26;
+                    %28 : java.type:"java.lang.Integer" = invoke %27 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    return %28;
                 };
-                %28 : Var<java.type:"java.util.function.Supplier<java.lang.Integer>"> = var %7 @"sOuter";
+                %29 : Var<java.type:"java.util.function.Supplier<java.lang.Integer>"> = var %7 @"sOuter";
                 return;
             };
             """)

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -331,7 +331,7 @@ public class MethodCallTest {
                 %1 : Var<java.type:"java.lang.Comparable<java.lang.String>[]"> = var %0 @"values";
                 %2 : java.type:"java.lang.Comparable<java.lang.String>[]" = var.load %1;
                 %3 : java.type:"java.lang.Comparable<java.lang.String>[]" = invoke %2 @java.ref:"java.lang.Comparable[]::clone():java.lang.Object";
-                %4 : java.type:"java.lang.Comparable[]" = cast %3 @java.type:"java.lang.Comparable[]";
+                %4 : java.type:"java.lang.Comparable<java.lang.String>[]" = cast %3 @java.type:"java.lang.Comparable[]";
                 return %4;
             };
             """)

--- a/test/langtools/tools/javac/reflect/MethodCallTest.java
+++ b/test/langtools/tools/javac/reflect/MethodCallTest.java
@@ -278,13 +278,15 @@ public class MethodCallTest {
                 %2 : java.type:"java.util.ArrayList<java.lang.String>" = var.load %1;
                 %3 : java.type:"int" = constant @0;
                 %4 : java.type:"java.lang.String" = invoke %2 %3 @java.ref:"java.util.ArrayList::get(int):java.lang.Object";
-                %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
-                %6 : java.type:"java.util.ArrayList<java.lang.String>" = var.load %1;
-                %7 : Var<java.type:"java.util.List<java.lang.String>"> = var %6 @"l";
-                %8 : java.type:"java.util.List<java.lang.String>" = var.load %7;
-                %9 : java.type:"int" = constant @0;
-                %10 : java.type:"java.lang.String" = invoke %8 %9 @java.ref:"java.util.List::get(int):java.lang.Object";
-                var.store %5 %10;
+                %5 : java.type:"java.lang.String" = cast %4 @java.type:"java.lang.String";
+                %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
+                %7 : java.type:"java.util.ArrayList<java.lang.String>" = var.load %1;
+                %8 : Var<java.type:"java.util.List<java.lang.String>"> = var %7 @"l";
+                %9 : java.type:"java.util.List<java.lang.String>" = var.load %8;
+                %10 : java.type:"int" = constant @0;
+                %11 : java.type:"java.lang.String" = invoke %9 %10 @java.ref:"java.util.List::get(int):java.lang.Object";
+                %12 : java.type:"java.lang.String" = cast %11 @java.type:"java.lang.String";
+                var.store %6 %12;
                 return;
             };
             """)
@@ -297,10 +299,11 @@ public class MethodCallTest {
     @Reflect
     @IR("""
             func @"test11" (%0 : java.type:"java.lang.Object[]")java.type:"java.lang.Object[]" -> {
-                  %1 : Var<java.type:"java.lang.Object[]"> = var %0 @"values";
-                  %2 : java.type:"java.lang.Object[]" = var.load %1;
-                  %3 : java.type:"java.lang.Object[]" = invoke %2 @java.ref:"java.lang.Object[]::clone():java.lang.Object";
-                  return %3;
+                %1 : Var<java.type:"java.lang.Object[]"> = var %0 @"values";
+                %2 : java.type:"java.lang.Object[]" = var.load %1;
+                %3 : java.type:"java.lang.Object[]" = invoke %2 @java.ref:"java.lang.Object[]::clone():java.lang.Object";
+                %4 : java.type:"java.lang.Object[]" = cast %3 @java.type:"java.lang.Object[]";
+                return %4;
             };
             """)
     static Object[] test11(Object[] values) {
@@ -310,10 +313,11 @@ public class MethodCallTest {
     @Reflect
     @IR("""
             func @"test12" (%0 : java.type:"int[]")java.type:"int[]" -> {
-                  %1 : Var<java.type:"int[]"> = var %0 @"values";
-                  %2 : java.type:"int[]" = var.load %1;
-                  %3 : java.type:"int[]" = invoke %2 @java.ref:"int[]::clone():java.lang.Object";
-                  return %3;
+                %1 : Var<java.type:"int[]"> = var %0 @"values";
+                %2 : java.type:"int[]" = var.load %1;
+                %3 : java.type:"int[]" = invoke %2 @java.ref:"int[]::clone():java.lang.Object";
+                %4 : java.type:"int[]" = cast %3 @java.type:"int[]";
+                return %4;
             };
             """)
     static int[] test12(int[] values) {
@@ -327,7 +331,8 @@ public class MethodCallTest {
                 %1 : Var<java.type:"java.lang.Comparable<java.lang.String>[]"> = var %0 @"values";
                 %2 : java.type:"java.lang.Comparable<java.lang.String>[]" = var.load %1;
                 %3 : java.type:"java.lang.Comparable<java.lang.String>[]" = invoke %2 @java.ref:"java.lang.Comparable[]::clone():java.lang.Object";
-                return %3;
+                %4 : java.type:"java.lang.Comparable[]" = cast %3 @java.type:"java.lang.Comparable[]";
+                return %4;
             };
             """)
     static Comparable<String>[] test13(Comparable<String>[] values) {

--- a/test/langtools/tools/javac/reflect/MethodReferenceTest.java
+++ b/test/langtools/tools/javac/reflect/MethodReferenceTest.java
@@ -32,7 +32,9 @@ import java.util.function.Supplier;
  * @test
  * @summary Smoke test for code reflection with method reference expressions.
  * @modules jdk.incubator.code
- * @compile MethodReferenceTest.java
+ * @build MethodReferenceTest
+ * @build CodeReflectionTester
+ * @run main CodeReflectionTester MethodReferenceTest
  */
 
 public class MethodReferenceTest {
@@ -111,9 +113,10 @@ public class MethodReferenceTest {
                     %7 : java.type:"MethodReferenceTest::A<java.lang.String>" = var.load %3;
                     %8 : java.type:"java.lang.String" = var.load %6;
                     %9 : java.type:"java.lang.String" = invoke %7 %8 @java.ref:"MethodReferenceTest::A::m(java.lang.Object):java.lang.Object";
-                    return %9;
+                    %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                    return %10;
                 };
-                %10 : Var<java.type:"java.util.function.Function<java.lang.String, java.lang.String>"> = var %4 @"f";
+                %11 : Var<java.type:"java.util.function.Function<java.lang.String, java.lang.String>"> = var %4 @"f";
                 return;
             };
             """)


### PR DESCRIPTION
There are a bunch of cases where javac deliberatly does not enforce synthetic generic casts:

* E instanceof T, javac does not introduce any cast when lowering E
* expression statements, like E;. Again no cast is added when lowering E
* if the result of a member access is assigned to a wider type -- e.g. `List<String>::get` assigned to `Object` or `CharSequence` -- again, no cast is added here.
    
Unfortunately, when generating the code model, in all the cases above we end up with a value that has a sharp type (the type javac saw for E). This means that, when generating bytecode from the model, we'll end up introducing synthetic casts in these locations, which doesn't respect what javac does.

The fundamental issue is that the bytecode generator can't infer the precise location of javac heap pollution casts once the model has been built -- for instance, the bytecode generator has no way to tell when a cast is required, since it cannot perform subtyping tests.

The more robust option is to follow the path we started when we added implicit conversions in the model (boxing, widening), and _also_ model any required synthetic cast required by heap pollution.

For instance this:

```
    @Reflect
    static void assign(List<String> xs) {
        String o =  xs.get(0);
    }
```

Now generates the following model:

```
   func @loc="21:5:Test.java" @func.source=java.ref:"Test::assign(java.util.List<java.lang.String>):void" (%0 : java.type:"java.util.List<java.lang.String>")java.type:"void" -> {
      %1 : Var<java.type:"java.util.List<java.lang.String>"> = var %0 @loc="21:5" @"xs";
      %2 : java.type:"java.util.List<java.lang.String>" = var.load %1 @loc="23:21";
      %3 : java.type:"int" = constant @loc="23:28" @0;
      %4 : java.type:"java.lang.String" = invoke %2 %3 @loc="23:21" @java.ref:"java.util.List::get(int):java.lang.Object";
      %5 : java.type:"java.lang.String" = cast %4 @loc="23:21" @java.type:"java.lang.String";
      %6 : Var<java.type:"java.lang.String"> = var %5 @loc="23:9" @"o";
      return @loc="21:5";
  };
```    

Note the additional cast in `%5`. This cast appear redundant, but this allows the bytecode generator to actually treat all op result types as an optional annotation, and only consider the `cast` ops as semantically relevant.

I've added a test to make sure that the generated casts are compatible with what javac emits. Of course, a full fix of this issue also requires some changes in `BytecodeGenerator`, but we don't need to couple the two fixes -- the model generated by this PR remains valid under the current translation strategy (it might have some redundant casts).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1172/head:pull/1172` \
`$ git checkout pull/1172`

Update a local copy of the PR: \
`$ git checkout pull/1172` \
`$ git pull https://git.openjdk.org/babylon.git pull/1172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1172`

View PR using the GUI difftool: \
`$ git pr show -t 1172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1172.diff">https://git.openjdk.org/babylon/pull/1172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1172#issuecomment-5574450956)
</details>
