### PR TITLE
Add support for intersection type cast

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -1274,15 +1274,32 @@ public class ReflectMethods extends TreeTranslatorPrev {
 
         @Override
         public void visitTypeCast(JCTree.JCTypeCast tree) {
-            // @@@: what about intersection type target?
+            Type castTarget = tree.type;
+            List<Type> additionalTargets = new ArrayList<>();
+            if (tree.type instanceof Type.IntersectionClassType ict) {
+                // TransTypes emits a component casts following source order,
+                // but leaves the first component (the erasure of the intersection) last.
+                Type principalComponent = ict.getExplicitComponents().head;
+                castTarget = ict.getExplicitComponents().tail.head;
+                additionalTargets = ict.getExplicitComponents()
+                        .tail.tail.append(principalComponent);
+            }
             if (tree.expr.type.hasTag(BOT)) {
                 Value v = toValue(tree.expr);
                 result = append(JavaOp.cast(
                         typeToCodeType(tree.type),
-                        typeToCodeType(types.erasure(tree.type)),
+                        typeToCodeType(types.erasure(castTarget)),
                         v));
             } else {
-                result = toValue(tree.expr, tree.type);
+                result = toValue(tree.expr, castTarget);
+            }
+            for (Type t : additionalTargets) {
+                Type ec = types.erasure(t);
+                if (!types.isSameType(ec, types.erasure(pt))) {
+                    // TransTypes skip components that have same erasure
+                    // as the outer target type
+                    result = coerce(result, codeTypeToType(result.type()), ec);
+                }
             }
         }
 

--- a/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
+++ b/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
+++ b/test/langtools/tools/javac/reflect/CastInstanceOfTest.java
@@ -22,6 +22,8 @@
  */
 
 import jdk.incubator.code.Reflect;
+
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
@@ -145,5 +147,21 @@ public class CastInstanceOfTest {
             """)
     void test7(Object o) {
         boolean b = o instanceof java.lang.String;
+    }
+
+    @Reflect
+    @IR("""
+            func @"test8" (%0 : java.type:"CastInstanceOfTest", %1 : java.type:"java.lang.Object")java.type:"void" -> {
+                %2 : Var<java.type:"java.lang.Object"> = var %1 @"o";
+                %3 : java.type:"java.lang.Object" = var.load %2;
+                %4 : java.type:"java.lang.Runnable" = cast %3 @java.type:"java.lang.Runnable";
+                %5 : java.type:"java.io.Serializable" = cast %4 @java.type:"java.io.Serializable";
+                %6 : java.type:"java.lang.Number" = cast %5 @java.type:"java.lang.Number";
+                %7 : Var<java.type:"java.lang.Object"> = var %6 @"o2";
+                return;
+            };
+            """)
+    void test8(Object o) {
+        Object o2 = (Number & Runnable & Serializable)o;
     }
 }

--- a/test/langtools/tools/javac/reflect/ErasedAccessTest.java
+++ b/test/langtools/tools/javac/reflect/ErasedAccessTest.java
@@ -28,6 +28,7 @@ import jdk.incubator.code.dialect.java.JavaOp;
 import jdk.incubator.code.dialect.java.JavaType;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
@@ -598,6 +599,52 @@ public class ErasedAccessTest {
             o = (Object) test.getX();
             n = (Number) test.getX();
             i = (Integer) test.getX();
+        }
+
+        @IR("""
+                func @"testIntersectionCast" (%0 : java.type:"ErasedAccessTest$UnboundedInteger", %1 : java.type:"ErasedAccessTest$UnboundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$UnboundedInteger"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %5 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %4 @java.type:"java.lang.Comparable";
+                    %6 : java.type:"java.io.Serializable" = cast %5 @java.type:"java.io.Serializable";
+                    %7 : java.type:"java.lang.Number" = cast %6 @java.type:"java.lang.Number";
+                    var.store %3 %7;
+                    %8 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %9 : java.type:"java.lang.Integer" = field.load %8 @java.ref:"ErasedAccessTest$UnboundedInteger::x:java.lang.Object";
+                    %10 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %9 @java.type:"java.lang.Comparable";
+                    %11 : java.type:"java.io.Serializable" = cast %10 @java.type:"java.io.Serializable";
+                    %12 : java.type:"java.lang.Number" = cast %11 @java.type:"java.lang.Number";
+                    var.store %3 %12;
+                    %13 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %14 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %13 @java.type:"java.lang.Comparable";
+                    %15 : java.type:"java.io.Serializable" = cast %14 @java.type:"java.io.Serializable";
+                    %16 : java.type:"java.lang.Number" = cast %15 @java.type:"java.lang.Number";
+                    var.store %3 %16;
+                    %17 : java.type:"ErasedAccessTest$UnboundedInteger" = var.load %2;
+                    %18 : java.type:"java.lang.Integer" = invoke %17 @java.ref:"ErasedAccessTest$UnboundedInteger::getX():java.lang.Object";
+                    %19 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %18 @java.type:"java.lang.Comparable";
+                    %20 : java.type:"java.io.Serializable" = cast %19 @java.type:"java.io.Serializable";
+                    %21 : java.type:"java.lang.Number" = cast %20 @java.type:"java.lang.Number";
+                    var.store %3 %21;
+                    return;
+                };
+                """)
+        @Reflect
+        void testIntersectionCast(UnboundedInteger test) {
+            Object o;
+
+            // simple field name
+            o = (Number & Comparable<Integer> & Serializable) x;
+
+            // qualified field name
+            o = (Number & Comparable<Integer> & Serializable) test.x;
+
+            // simple method name
+            o = (Number & Comparable<Integer> & Serializable) getX();
+
+            // qualified method name
+            o = (Number & Comparable<Integer> & Serializable) test.getX();
         }
 
         void o(Object o) { }
@@ -1934,6 +1981,52 @@ public class ErasedAccessTest {
             o = (Object) test.getX();
             n = (Number) test.getX();
             i = (Integer) test.getX();
+        }
+
+        @IR("""
+                func @"testIntersectionCast" (%0 : java.type:"ErasedAccessTest$BoundedInteger", %1 : java.type:"ErasedAccessTest$BoundedInteger")java.type:"void" -> {
+                    %2 : Var<java.type:"ErasedAccessTest$BoundedInteger"> = var %1 @"test";
+                    %3 : Var<java.type:"java.lang.Object"> = var @"o";
+                    %4 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %5 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %4 @java.type:"java.lang.Comparable";
+                    %6 : java.type:"java.io.Serializable" = cast %5 @java.type:"java.io.Serializable";
+                    %7 : java.type:"java.lang.Number" = cast %6 @java.type:"java.lang.Number";
+                    var.store %3 %7;
+                    %8 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %9 : java.type:"java.lang.Integer" = field.load %8 @java.ref:"ErasedAccessTest$BoundedInteger::x:java.lang.Number";
+                    %10 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %9 @java.type:"java.lang.Comparable";
+                    %11 : java.type:"java.io.Serializable" = cast %10 @java.type:"java.io.Serializable";
+                    %12 : java.type:"java.lang.Number" = cast %11 @java.type:"java.lang.Number";
+                    var.store %3 %12;
+                    %13 : java.type:"java.lang.Integer" = invoke %0 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %14 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %13 @java.type:"java.lang.Comparable";
+                    %15 : java.type:"java.io.Serializable" = cast %14 @java.type:"java.io.Serializable";
+                    %16 : java.type:"java.lang.Number" = cast %15 @java.type:"java.lang.Number";
+                    var.store %3 %16;
+                    %17 : java.type:"ErasedAccessTest$BoundedInteger" = var.load %2;
+                    %18 : java.type:"java.lang.Integer" = invoke %17 @java.ref:"ErasedAccessTest$BoundedInteger::getX():java.lang.Number";
+                    %19 : java.type:"java.lang.Comparable<java.lang.Integer>" = cast %18 @java.type:"java.lang.Comparable";
+                    %20 : java.type:"java.io.Serializable" = cast %19 @java.type:"java.io.Serializable";
+                    %21 : java.type:"java.lang.Number" = cast %20 @java.type:"java.lang.Number";
+                    var.store %3 %21;
+                    return;
+                };
+                """)
+        @Reflect
+        void testIntersectionCast(BoundedInteger test) {
+            Object o;
+
+            // simple field name
+            o = (Number & Comparable<Integer> & Serializable) x;
+
+            // qualified field name
+            o = (Number & Comparable<Integer> & Serializable) test.x;
+
+            // simple method name
+            o = (Number & Comparable<Integer> & Serializable) getX();
+
+            // qualified method name
+            o = (Number & Comparable<Integer> & Serializable) test.getX();
         }
 
         void o(Object o) { }


### PR DESCRIPTION
Java 8 added support for casts featuring intersection types.

JLS 5.1.6.3 states:
> If the conversion is to an intersection type T1 & ... & Tn, then for all i (1 ≤ i ≤ n), any run-time check required for a conversion from S to Ti is also required for the conversion to the intersection type.

So, we need `ReflectMethods` to add casts to all the required intersection components. Moreover, following https://github.com/openjdk/babylon/pull/1172 , we need to respect the precise order in which `TransTypes` stages these casts.

`TransTypes` leaves the cast to the first component last. Casts to other components are added in source order. However, `TransTypes` does so by altering the expression of the emitted cast after the fact (since javac AST are mutable). With code models this is not an option, so we have to carefully stack the casts in the right order.

I've added a simple test in `CastInstanceOfTest` and a more complete test under the new `ErasedAccessTest` to make sure the order of generated conversions matches javac's.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [76c70832](https://git.openjdk.org/babylon/pull/1175/files/76c70832665d1b389a2c738384c20768357b1822)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1175/head:pull/1175` \
`$ git checkout pull/1175`

Update a local copy of the PR: \
`$ git checkout pull/1175` \
`$ git pull https://git.openjdk.org/babylon.git pull/1175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1175`

View PR using the GUI difftool: \
`$ git pr show -t 1175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1175.diff">https://git.openjdk.org/babylon/pull/1175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1175#issuecomment-5625664070)
</details>
