### PR TITLE
Fix lowering of reference to primitive pattern

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -6441,32 +6441,26 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
             static Block.Builder lowerTypePattern(Block.Reference falseRef, Block.Builder currentBlock,
                                                   List<Value> bindings,
                                                   TypePatternOp tpOp, Value target) {
-                CodeType targetType = tpOp.targetType();
-
-                // Check if instance of target type
-                Op p; // op that perform type check
-                BiFunction<Block.Builder, Value, Op.Result> c; // logic that append the op performing conversion
                 CodeType s = target.type();
-                CodeType t = targetType;
+                CodeType t = tpOp.targetType();
+                Block.Builder trueBlock = currentBlock;
                 if (t instanceof PrimitiveType pt) {
                     if (s instanceof ClassType cs) {
-                        // unboxing conversions
                         ClassType box;
                         if (cs.unbox().isEmpty()) { // s not a boxed type
                             // e.g. Number -> int, narrowing + unboxing
                             box = pt.box().orElseThrow();
-                            p = instanceOf(box, target);
+                            trueBlock = appendTypeTestOp(instanceOf(box, target), currentBlock, falseRef);
+                            // e.g. Object -> int, on true path we need to cast Object to Integer
+                            target = trueBlock.add(cast(box, target));
                         } else {
                             // e.g. Float -> float, unboxing
                             // e.g. Integer -> long, unboxing + widening
                             box = cs;
-                            p = neq(target, currentBlock.add(constant(s, null)));
+                            Op p = neq(target, currentBlock.add(constant(s, null)));
+                            trueBlock = appendTypeTestOp(p, currentBlock, falseRef);
                         }
-                        c = (b, v) -> {
-                            // e.g. Object -> int, we need to cast target to Integer then invoke Integer#intValue
-                            if (cs.unbox().isEmpty())   v = b.add(cast(box, v));
-                            return b.add(invoke(MethodRef.method(box, t + "Value", t), v));
-                        };
+                        target = trueBlock.add(invoke(MethodRef.method(box, t + "Value", t), target));
                     } else {
                         // primitive to primitive conversion
                         PrimitiveType ps = ((PrimitiveType) s);
@@ -6476,41 +6470,34 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                             // e,g. int -> float, widening with check
                             // e.g. byte -> char, widening and narrowing
                             MethodRef mref = convMethodRef(s, t);
-                            p = invoke(mref, target);
-                        } else {
-                            p = null;
+                            trueBlock = appendTypeTestOp(invoke(mref, target), currentBlock, falseRef);
                         }
-                        c = (b, v) -> b.add(conv(targetType, v));
+                        target = trueBlock.add(conv(t, target));
                     }
                 } else if (s instanceof PrimitiveType ps) {
                     // boxing conversions
                     // e.g. int -> Number, boxing + widening
                     // e.g. byte -> Byte, boxing
-                    p = null;
                     ClassType box = ps.box().orElseThrow();
-                    c = (b, v) -> b.add(invoke(MethodRef.method(box, "valueOf", box, ps), v));
+                    target = currentBlock.add(invoke(MethodRef.method(box, "valueOf", box, ps), target));
                 } else {
                     // reference to reference
                     // e.g. Character -> Character
                     // e.g. Number -> Double, narrowing
                     // e.g. Short -> Object, widening
-                    p = instanceOf(targetType, target);
-                    c = s.equals(t) ? null : (b, v) -> b.add(cast(targetType, v));
-                }
-
-                if (p != null) {
-                    // p != null, we need to perform type check at runtime
-                    Block.Builder nextBlock = currentBlock.block();
-                    currentBlock.add(conditionalBranch(currentBlock.add(p), nextBlock.reference(), falseRef));
-                    currentBlock = nextBlock;
-                }
-                if (c != null) {
-                    target = c.apply(currentBlock, target);
+                    trueBlock = appendTypeTestOp(instanceOf(t, target), currentBlock, falseRef);
+                    if (!s.equals(t))   target = trueBlock.add(cast(t, target));
                 }
 
                 bindings.add(target);
 
-                return currentBlock;
+                return trueBlock;
+            }
+
+            private static Block.Builder appendTypeTestOp(Op p, Block.Builder b, Block.Reference falseBlock) {
+                Block.Builder trueBlock = b.block();
+                b.add(conditionalBranch(b.add(p), trueBlock.reference(), falseBlock));
+                return trueBlock;
             }
 
             private static boolean isWideningAndNarrowingPrimitiveConv(PrimitiveType s, PrimitiveType t) {

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/dialect/java/JavaOp.java
@@ -6445,7 +6445,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
 
                 // Check if instance of target type
                 Op p; // op that perform type check
-                Op c; // op that perform conversion
+                BiFunction<Block.Builder, Value, Op.Result> c; // logic that append the op performing conversion
                 CodeType s = target.type();
                 CodeType t = targetType;
                 if (t instanceof PrimitiveType pt) {
@@ -6462,7 +6462,11 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                             box = cs;
                             p = neq(target, currentBlock.add(constant(s, null)));
                         }
-                        c = invoke(MethodRef.method(box, t + "Value", t), target);
+                        c = (b, v) -> {
+                            // e.g. Object -> int, we need to cast target to Integer then invoke Integer#intValue
+                            if (cs.unbox().isEmpty())   v = b.add(cast(box, v));
+                            return b.add(invoke(MethodRef.method(box, t + "Value", t), v));
+                        };
                     } else {
                         // primitive to primitive conversion
                         PrimitiveType ps = ((PrimitiveType) s);
@@ -6476,7 +6480,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                         } else {
                             p = null;
                         }
-                        c = conv(targetType, target);
+                        c = (b, v) -> b.add(conv(targetType, v));
                     }
                 } else if (s instanceof PrimitiveType ps) {
                     // boxing conversions
@@ -6484,14 +6488,14 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     // e.g. byte -> Byte, boxing
                     p = null;
                     ClassType box = ps.box().orElseThrow();
-                    c = invoke(MethodRef.method(box, "valueOf", box, ps), target);
+                    c = (b, v) -> b.add(invoke(MethodRef.method(box, "valueOf", box, ps), v));
                 } else {
                     // reference to reference
                     // e.g. Character -> Character
                     // e.g. Number -> Double, narrowing
                     // e.g. Short -> Object, widening
                     p = instanceOf(targetType, target);
-                    c = s.equals(t) ? null : cast(targetType, target);
+                    c = s.equals(t) ? null : (b, v) -> b.add(cast(targetType, v));
                 }
 
                 if (p != null) {
@@ -6501,7 +6505,7 @@ public sealed interface JavaOp extends ExternalizedOp.Externalizable {
                     currentBlock = nextBlock;
                 }
                 if (c != null) {
-                    target = currentBlock.add(c);
+                    target = c.apply(currentBlock, target);
                 }
 
                 bindings.add(target);

--- a/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
@@ -275,13 +275,11 @@ public class TestPrimitiveTypePatterns {
         FuncOp lf = f.transform(CodeTransformer.LOWERING_TRANSFORMER);
         System.out.println(lf.toText());
 
-        Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, 1));
-        Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (short) 1));
-        Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (Number) null));
-
         MethodHandle mh = Assertions.assertDoesNotThrow(() -> BytecodeGenerator.generate(MethodHandles.lookup(), lf));
         for (Number n : new Number[]{1, (short) 1, null}) {
-            Assertions.assertEquals(narrowingReferenceUnboxing(n), mh.invoke(n));
+            boolean expected = narrowingReferenceUnboxing(n);
+            Assertions.assertEquals(expected, Interpreter.invoke(MethodHandles.lookup(), lf, n));
+            Assertions.assertEquals(expected, mh.invoke(n));
         }
     }
 

--- a/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
+++ b/test/jdk/jdk/incubator/code/TestPrimitiveTypePatterns.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.runtime.ExactConversionsSupport;
@@ -267,7 +268,7 @@ public class TestPrimitiveTypePatterns {
     }
 
     @Test
-    void testNarrowingReferenceUnboxing() {
+    void testNarrowingReferenceUnboxing() throws Throwable {
         FuncOp f = getFuncOp("narrowingReferenceUnboxing");
         System.out.println(f.toText());
 
@@ -277,6 +278,11 @@ public class TestPrimitiveTypePatterns {
         Assertions.assertEquals(true, Interpreter.invoke(MethodHandles.lookup(), lf, 1));
         Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (short) 1));
         Assertions.assertEquals(false, Interpreter.invoke(MethodHandles.lookup(), lf, (Number) null));
+
+        MethodHandle mh = Assertions.assertDoesNotThrow(() -> BytecodeGenerator.generate(MethodHandles.lookup(), lf));
+        for (Number n : new Number[]{1, (short) 1, null}) {
+            Assertions.assertEquals(narrowingReferenceUnboxing(n), mh.invoke(n));
+        }
     }
 
     @Reflect


### PR DESCRIPTION
The lowering of type pattern from reference type to a primitive type e.g. Object -> int, was missing a cast before on the success path, leading to a verifier error when generate bytecode from the lowered model.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1176/head:pull/1176` \
`$ git checkout pull/1176`

Update a local copy of the PR: \
`$ git checkout pull/1176` \
`$ git pull https://git.openjdk.org/babylon.git pull/1176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1176`

View PR using the GUI difftool: \
`$ git pr show -t 1176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1176.diff">https://git.openjdk.org/babylon/pull/1176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/babylon/pull/1176#issuecomment-5626488948)
</details>
