### PR TITLE
Remove cast insertion in bytecode generator an interpreter

### DIFF
--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/bytecode/BytecodeGenerator.java
@@ -846,11 +846,6 @@ public final class BytecodeGenerator {
                                                       "invokeExact",
                                                       mDesc.insertParameterTypes(0, specialCaller));
                         }
-                        ClassDesc ret = toClassDesc(op.resultType());
-                        if (!ret.isPrimitive() && !ret.equals(mDesc.returnType())) {
-                            // Explicit cast if method return type differs
-                            cob.checkcast(ret);
-                        }
                         push(op.result());
                     }
                     case FuncCallOp op -> {
@@ -1069,11 +1064,6 @@ public final class BytecodeGenerator {
                             fieldType);
         }
         if (!store) {
-            ClassDesc ret = toClassDesc(op.resultType());
-            if (!ret.isPrimitive() && !ret.equals(fieldType)) {
-                // Explicit cast if field type differs
-                cob.checkcast(ret);
-            }
             push(op.result());
         }
     }

--- a/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
+++ b/src/jdk.incubator.code/share/classes/jdk/incubator/code/internal/ReflectMethods.java
@@ -802,7 +802,9 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 }
             } else {
                 // we need to unbox
-                return unbox(exprVal, source, target, types.unboxedType(source));
+                Value unboxed = unbox(exprVal, source, target, types.unboxedType(source));
+                // possible conversion
+                return convert(unboxed, target);
             }
         }
 
@@ -873,13 +875,16 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 case SELECT: {
                     JCFieldAccess assign = (JCFieldAccess) lhs;
 
-                    Value receiver = toValue(assign.selected);
+                    Type qualifierTarget = qualifierTarget(assign);
+                    Value receiver = toValue(assign.selected, qualifierTarget);
 
                     // Scan the rhs, the assign expression result is its input
                     result = toValue(tree.rhs, target);
 
                     Symbol sym = assign.sym;
-                    FieldRef fr = symbolToErasedFieldRef(sym, assign.selected.type);
+                    FieldRef fr = symbolToErasedFieldRef(sym, qualifierTarget.hasTag(NONE) ?
+                            assign.selected.type : qualifierTarget);
+
                     if (sym.isStatic()) {
                         append(JavaOp.fieldStore(fr, result));
                     } else {
@@ -890,7 +895,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 case INDEXED: {
                     JCArrayAccess assign = (JCArrayAccess) lhs;
 
-                    Value array = toValue(assign.indexed);
+                    Value array = toValue(assign.indexed, assign.indexed.type);
                     Value index = toValue(assign.index, syms.intType);
 
                     // Scan the rhs, the assign expression result is its input
@@ -975,13 +980,14 @@ public class ReflectMethods extends TreeTranslatorPrev {
                         case FIELD -> {
                             FieldRef fr = symbolToErasedFieldRef(sym, symbolSiteType(sym));
 
-                            Op.Result lhsOpValue;
+                            Value lhsOpValue;
                             CodeType resultType = typeToCodeType(assign.type);
                             if (sym.isStatic()) {
                                 lhsOpValue = append(JavaOp.fieldLoad(resultType, fr));
                             } else {
                                 lhsOpValue = append(JavaOp.fieldLoad(resultType, fr, thisValue()));
                             }
+                            lhsOpValue = coerce(lhsOpValue, sym.erasure(types), assign.type);
                             // Scan the rhs
                             Value r = scanRhs.apply(lhsOpValue);
 
@@ -997,18 +1003,21 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 case SELECT -> {
                     JCFieldAccess assign = (JCFieldAccess) lhs;
 
-                    Value receiver = toValue(assign.selected);
+                    Type qualifierTarget = qualifierTarget(assign);
+                    Value receiver = toValue(assign.selected, qualifierTarget);
 
                     Symbol sym = assign.sym;
-                    FieldRef fr = symbolToErasedFieldRef(sym, assign.selected.type);
+                    FieldRef fr = symbolToErasedFieldRef(sym, qualifierTarget.hasTag(NONE) ?
+                            assign.selected.type : qualifierTarget);
 
-                    Op.Result lhsOpValue;
+                    Value lhsOpValue;
                     CodeType resultType = typeToCodeType(assign.type);
                     if (sym.isStatic()) {
                         lhsOpValue = append(JavaOp.fieldLoad(resultType, fr));
                     } else {
                         lhsOpValue = append(JavaOp.fieldLoad(resultType, fr, receiver));
                     }
+                    lhsOpValue = coerce(lhsOpValue, sym.erasure(types), assign.type);
                     // Scan the rhs
                     Value r = scanRhs.apply(lhsOpValue);
 
@@ -1021,7 +1030,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
                 case INDEXED -> {
                     JCArrayAccess assign = (JCArrayAccess) lhs;
 
-                    Value array = toValue(assign.indexed);
+                    Value array = toValue(assign.indexed, assign.indexed.type);
                     Value index = toValue(assign.index, syms.intType);
 
                     Op.Result lhsOpValue = append(JavaOp.arrayLoadOp(array, index));
@@ -1137,7 +1146,7 @@ public class ReflectMethods extends TreeTranslatorPrev {
         public void visitIndexed(JCArrayAccess tree) {
             // Visited only for read access
 
-            Value array = toValue(tree.indexed);
+            Value array = toValue(tree.indexed, tree.indexed.type);
 
             Value index = toValue(tree.index, syms.intType);
 
@@ -2006,32 +2015,39 @@ public class ReflectMethods extends TreeTranslatorPrev {
             // Pop expression
             popBody();
 
-            JCVariableDecl var = tree.getVariable();
-            VarType varEType = CoreType.varType(typeToCodeType(var.type));
+            JCVariableDecl loopVariableDecl = tree.getVariable();
+            VarType loopVarType = CoreType.varType(typeToCodeType(loopVariableDecl.type));
 
             // Push init
             // @@@ When lhs assignment is a pattern we embed the pattern match into the init body and
             // return the bound variables
-            Type exprType = types.cvarUpperBound(tree.expr.type);
-            Type elemtype = types.elemtype(exprType); // perhaps expr is an array?
-            if (elemtype == null) {
+            Type iterationType = types.cvarUpperBound(tree.expr.type);
+            boolean isArray = types.isArray(iterationType);
+            Type elementType;
+            if (isArray) {
+                elementType = types.elemtype(iterationType);
+            } else {
                 Type iterableType = types.asSuper(tree.expr.type, syms.iterableType.tsym);
                 com.sun.tools.javac.util.List<Type> iterableParams = iterableType.allparams();
-                elemtype = iterableParams.isEmpty()
+                elementType = iterableParams.isEmpty()
                         ? syms.objectType
                         : types.wildUpperBound(iterableParams.head);
             }
-            pushBody(var, CoreType.functionType(varEType, typeToCodeType(elemtype)));
-            var initVarExpr = convert(stack.block.parameters().get(0), var.type);
-            Op.Result varEResult = append(CoreOp.var(var.name.toString(), initVarExpr));
-            append(CoreOp.core_yield(varEResult));
+            pushBody(loopVariableDecl, CoreType.functionType(loopVarType, typeToCodeType(elementType)));
+
+            Value elementValue = stack.block.parameters().get(0);
+            Type elementProducerType = isArray ? elementType : syms.objectType;
+            // Coerce the element value into a loop value, since Iterator.next's return type is Object
+            Value loopValue = coerce(elementValue, elementProducerType, loopVariableDecl.type);
+            Op.Result loopVar = append(CoreOp.var(loopVariableDecl.name.toString(), loopVarType.valueType(), loopValue));
+            append(CoreOp.core_yield(loopVar));
             Body.Builder init = stack.body;
             // Pop init
             popBody();
 
             // Push body
-            pushBody(tree.body, CoreType.functionType(JavaType.VOID, varEType));
-            stack.localToOp.put(var.sym, stack.block.parameters().get(0));
+            pushBody(tree.body, CoreType.functionType(JavaType.VOID, loopVarType));
+            stack.localToOp.put(loopVariableDecl.sym, stack.block.parameters().get(0));
 
             scan(tree.body);
             appendTerminating(JavaOp::continue_);

--- a/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/BytecodeLift.java
@@ -572,8 +572,10 @@ public final class BytecodeLift {
                                                             bsmDesc.parameterList().stream().map(JavaType::type).toArray(CodeType[]::new));
 
                         Value[] bootstrapArgs = liftBootstrapArgs(bsmDesc, inst.name().toString(), mtd, inst.bootstrapArgs());
+                        Value bootstrapResult = op(JavaOp.invoke(bsmRef, bootstrapArgs));
+                        Value callSite = op(JavaOp.cast(JavaType.type(ConstantDescs.CD_CallSite), bootstrapResult));
                         Value methodHandle = op(JavaOp.invoke(MethodRef.method(CallSite.class, "dynamicInvoker", MethodHandle.class),
-                                                    op(JavaOp.invoke(JavaType.type(ConstantDescs.CD_CallSite), bsmRef, bootstrapArgs))));
+                                                    callSite));
 
                         //invocation
                         List<Value> operands = new ArrayList<>();
@@ -805,12 +807,17 @@ public final class BytecodeLift {
             case DynamicConstantDesc<?> dcd -> {
                 DirectMethodHandleDesc bsm = dcd.bootstrapMethod();
                 MethodTypeDesc bsmDesc = bsm.invocationType();
-                Value[] bootstrapArgs = liftBootstrapArgs(bsmDesc, dcd.constantName(), dcd.constantType(), dcd.bootstrapArgsList());
                 MethodRef bsmRef = MethodRef.method(JavaType.type(bsm.owner()),
                                                     bsm.methodName(),
                                                     JavaType.type(bsmDesc.returnType()),
                                                     bsmDesc.parameterList().stream().map(JavaType::type).toArray(CodeType[]::new));
-                yield op(JavaOp.invoke(bsmRef, bootstrapArgs));
+
+                Value[] bootstrapArgs = liftBootstrapArgs(bsmDesc, dcd.constantName(), dcd.constantType(), dcd.bootstrapArgsList());
+                Op.Result bootstrapResult = op(JavaOp.invoke(bsmRef, bootstrapArgs));
+                JavaType constantType = JavaType.type(dcd.constantType());
+                yield bootstrapResult.type().equals(constantType)
+                        ? bootstrapResult
+                        : op(JavaOp.cast(constantType, bootstrapResult));
             }
             case Boolean b -> op(CoreOp.constant(JavaType.BOOLEAN, b));
             case Byte b -> op(CoreOp.constant(JavaType.BYTE, b));

--- a/test/jdk/jdk/incubator/code/bytecode/lift/TestLiftCustomBytecode.java
+++ b/test/jdk/jdk/incubator/code/bytecode/lift/TestLiftCustomBytecode.java
@@ -103,19 +103,36 @@ public class TestLiftCustomBytecode {
     }
 
     @Test
-    public void testConstantBootstrapsCondy() throws Throwable {
-        byte[] testCondy = ClassFile.of().build(ClassDesc.of("TestCondy"), clb ->
-                clb.withMethodBody("condyMethod", MethodTypeDesc.of(ConstantDescs.CD_Class), ClassFile.ACC_STATIC, cob ->
+    public void testConstantBootstrapsCondyPrimitiveClass() throws Throwable {
+        byte[] testCondy = ClassFile.of().build(ClassDesc.of("TestCondyPrimitiveClass"), clb ->
+                clb.withMethodBody("condyMethodPrimitiveClass", MethodTypeDesc.of(ConstantDescs.CD_Class), ClassFile.ACC_STATIC, cob ->
                         cob.ldc(DynamicConstantDesc.ofNamed(
-                                ConstantDescs.ofConstantBootstrap(ConstantDescs.CD_ConstantBootstraps, "primitiveClass", ConstantDescs.CD_Class),
+                                ConstantDescs.BSM_PRIMITIVE_CLASS,
                                 int.class.descriptorString(),
                                 ConstantDescs.CD_Class))
                            .areturn()));
 
-        CoreOp.FuncOp primitiveInteger = getFuncOp(testCondy, "condyMethod");
+        CoreOp.FuncOp primitiveInteger = getFuncOp(testCondy, "condyMethodPrimitiveClass");
 
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         Assertions.assertEquals(int.class, (Class)Interpreter.invoke(lookup, primitiveInteger));
+    }
+
+    @Test
+    public void testConstantBootstrapsCondyExplicitCast() throws Throwable {
+        byte[] testCondy = ClassFile.of().build(ClassDesc.of("TestCondyExplicitCast"), clb ->
+                clb.withMethodBody("condyMethodExplicitCast", MethodTypeDesc.of(ConstantDescs.CD_String), ClassFile.ACC_STATIC, cob ->
+                        cob.ldc(DynamicConstantDesc.ofNamed(
+                                        ConstantDescs.BSM_EXPLICIT_CAST,
+                                        ConstantDescs.DEFAULT_NAME,
+                                        ConstantDescs.CD_String,
+                                        "CONSTANT"))
+                                .areturn()));
+
+        CoreOp.FuncOp primitiveInteger = getFuncOp(testCondy, "condyMethodExplicitCast");
+        IO.println(primitiveInteger.toText());
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Assertions.assertEquals("CONSTANT", (String)Interpreter.invoke(lookup, primitiveInteger));
     }
 
     @Test

--- a/test/jdk/jdk/incubator/code/lib/JavaLowInterpreter.java
+++ b/test/jdk/jdk/incubator/code/lib/JavaLowInterpreter.java
@@ -264,6 +264,7 @@ public class JavaLowInterpreter extends Interpreter {
                 MethodHandle mh = resolveToMethodHandle(il, o.invokeReference(), o.invokeKind());
 
                 mh = mh.asType(target).asFixedArity();
+//                mh = mh.withVarargs(o.isVarArgs());
                 List<Object> operands = e.valuesOf(o.operands());
                 try {
                     result = mh.invokeWithArguments(operands.toArray());

--- a/test/langtools/tools/javac/reflect/BoxingConversionTest.java
+++ b/test/langtools/tools/javac/reflect/BoxingConversionTest.java
@@ -722,6 +722,21 @@ public class BoxingConversionTest {
 
     @Reflect
     @IR("""
+            func @"test34" (%0 : java.type:"java.lang.Integer")java.type:"void" -> {
+                %1 : Var<java.type:"java.lang.Integer"> = var %0 @"i";
+                %2 : java.type:"java.lang.Integer" = var.load %1;
+                %3 : java.type:"int" = invoke %2 @java.ref:"java.lang.Integer::intValue():int";
+                %4 : java.type:"long" = conv %3;
+                %5 : Var<java.type:"long"> = var %4 @"l";
+                return;
+            };
+            """)
+    static void test34(Integer i) {
+        long l = i;
+    }
+
+    @Reflect
+    @IR("""
             func @"unboxForEachList" (%0 : java.type:"java.util.List<java.lang.Integer>")java.type:"int" -> {
                 %1 : Var<java.type:"java.util.List<java.lang.Integer>"> = var %0 @"li";
                 %2 : java.type:"int" = constant @0;
@@ -732,19 +747,20 @@ public class BoxingConversionTest {
                         yield %4;
                     }
                     (%5 : java.type:"java.lang.Integer")Var<java.type:"int"> -> {
-                        %6 : java.type:"int" = invoke %5 @java.ref:"java.lang.Integer::intValue():int";
-                        %7 : Var<java.type:"int"> = var %6 @"i";
-                        yield %7;
+                        %6 : java.type:"java.lang.Integer" = cast %5 @java.type:"java.lang.Integer";
+                        %7 : java.type:"int" = invoke %6 @java.ref:"java.lang.Integer::intValue():int";
+                        %8 : Var<java.type:"int"> = var %7 @"i";
+                        yield %8;
                     }
-                    (%8 : Var<java.type:"int">)java.type:"void" -> {
-                        %9 : java.type:"int" = var.load %3;
-                        %10 : java.type:"int" = var.load %8;
-                        %11 : java.type:"int" = add %9 %10;
-                        var.store %3 %11;
+                    (%9 : Var<java.type:"int">)java.type:"void" -> {
+                        %10 : java.type:"int" = var.load %3;
+                        %11 : java.type:"int" = var.load %9;
+                        %12 : java.type:"int" = add %10 %11;
+                        var.store %3 %12;
                         java.continue;
                     };
-                %12 : java.type:"int" = var.load %3;
-                return %12;
+                %13 : java.type:"int" = var.load %3;
+                return %13;
             };
             """)
     static int unboxForEachList(List<Integer> li) {

--- a/test/langtools/tools/javac/reflect/FieldAccessTest.java
+++ b/test/langtools/tools/javac/reflect/FieldAccessTest.java
@@ -565,15 +565,16 @@ public class FieldAccessTest {
         @IR("""
                 func @"test1" (%0 : java.type:"FieldAccessTest$WW")java.type:"int" -> {
                     %1 : java.type:"java.lang.Integer" = field.load %0 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
-                    %2 : java.type:"int" = invoke %1 @java.ref:"java.lang.Integer::intValue():int";
-                    %3 : java.type:"int" = constant @1;
-                    %4 : java.type:"int" = add %2 %3;
-                    %5 : java.type:"java.lang.Integer" = invoke %4 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
-                    field.store %0 %5 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
-                    %6 : java.type:"int" = constant @0;
-                    %7 : java.type:"java.lang.Integer" = invoke %6 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
-                    %8 : java.type:"int" = invoke %1 %7 @java.ref:"java.lang.Integer::compareTo(java.lang.Integer):int";
-                    return %8;
+                    %2 : java.type:"java.lang.Integer" = cast %1 @java.type:"java.lang.Integer";
+                    %3 : java.type:"int" = invoke %2 @java.ref:"java.lang.Integer::intValue():int";
+                    %4 : java.type:"int" = constant @1;
+                    %5 : java.type:"int" = add %3 %4;
+                    %6 : java.type:"java.lang.Integer" = invoke %5 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    field.store %0 %6 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
+                    %7 : java.type:"int" = constant @0;
+                    %8 : java.type:"java.lang.Integer" = invoke %7 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    %9 : java.type:"int" = invoke %2 %8 @java.ref:"java.lang.Integer::compareTo(java.lang.Integer):int";
+                    return %9;
                 };
                 """)
         @Reflect
@@ -586,15 +587,16 @@ public class FieldAccessTest {
                     %1 : Var<java.type:"FieldAccessTest$WW"> = var %0 @"w";
                     %2 : java.type:"FieldAccessTest$WW" = var.load %1;
                     %3 : java.type:"java.lang.Integer" = field.load %2 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
-                    %4 : java.type:"int" = invoke %3 @java.ref:"java.lang.Integer::intValue():int";
-                    %5 : java.type:"int" = constant @1;
-                    %6 : java.type:"int" = add %4 %5;
-                    %7 : java.type:"java.lang.Integer" = invoke %6 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
-                    field.store %2 %7 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
-                    %8 : java.type:"int" = constant @0;
-                    %9 : java.type:"java.lang.Integer" = invoke %8 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
-                    %10 : java.type:"int" = invoke %3 %9 @java.ref:"java.lang.Integer::compareTo(java.lang.Integer):int";
-                    return %10;
+                    %4 : java.type:"java.lang.Integer" = cast %3 @java.type:"java.lang.Integer";
+                    %5 : java.type:"int" = invoke %4 @java.ref:"java.lang.Integer::intValue():int";
+                    %6 : java.type:"int" = constant @1;
+                    %7 : java.type:"int" = add %5 %6;
+                    %8 : java.type:"java.lang.Integer" = invoke %7 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    field.store %2 %8 @java.ref:"FieldAccessTest$WW::n:java.lang.Number";
+                    %9 : java.type:"int" = constant @0;
+                    %10 : java.type:"java.lang.Integer" = invoke %9 @java.ref:"java.lang.Integer::valueOf(int):java.lang.Integer";
+                    %11 : java.type:"int" = invoke %4 %10 @java.ref:"java.lang.Integer::compareTo(java.lang.Integer):int";
+                    return %11;
                 };
                 """)
         @Reflect

--- a/test/langtools/tools/javac/reflect/ForLoopTest.java
+++ b/test/langtools/tools/javac/reflect/ForLoopTest.java
@@ -44,23 +44,25 @@ public class ForLoopTest {
                         yield %3;
                     }
                     (%4 : java.type:"java.util.List<java.lang.String>")Var<java.type:"java.util.List<java.lang.String>"> -> {
-                        %5 : Var<java.type:"java.util.List<java.lang.String>"> = var %4 @"l";
-                        yield %5;
+                        %5 : java.type:"java.util.List<java.lang.String>" = cast %4 @java.type:"java.util.List";
+                        %6 : Var<java.type:"java.util.List<java.lang.String>"> = var %5 @"l";
+                        yield %6;
                     }
-                    (%6 : Var<java.type:"java.util.List<java.lang.String>">)java.type:"void" -> {
+                    (%7 : Var<java.type:"java.util.List<java.lang.String>">)java.type:"void" -> {
                         java.enhancedFor
                             ()java.type:"java.util.List<java.lang.String>" -> {
-                                %7 : java.type:"java.util.List<java.lang.String>" = var.load %6;
-                                yield %7;
+                                %8 : java.type:"java.util.List<java.lang.String>" = var.load %7;
+                                yield %8;
                             }
-                            (%8 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
-                                %9 : Var<java.type:"java.lang.String"> = var %8 @"s";
-                                yield %9;
+                            (%9 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
+                                %10 : java.type:"java.lang.String" = cast %9 @java.type:"java.lang.String";
+                                %11 : Var<java.type:"java.lang.String"> = var %10 @"s";
+                                yield %11;
                             }
-                            (%10 : Var<java.type:"java.lang.String">)java.type:"void" -> {
-                                %11 : java.type:"java.io.PrintStream" = field.load @java.ref:"java.lang.System::out:java.io.PrintStream";
-                                %12 : java.type:"java.lang.String" = var.load %10;
-                                invoke %11 %12 @java.ref:"java.io.PrintStream::println(java.lang.String):void";
+                            (%12 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                                %13 : java.type:"java.io.PrintStream" = field.load @java.ref:"java.lang.System::out:java.io.PrintStream";
+                                %14 : java.type:"java.lang.String" = var.load %12;
+                                invoke %13 %14 @java.ref:"java.io.PrintStream::println(java.lang.String):void";
                                 java.continue;
                             };
                         java.continue;
@@ -97,13 +99,14 @@ public class ForLoopTest {
                         yield %13;
                     }
                     (%14 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
-                        %15 : Var<java.type:"java.lang.String"> = var %14 @"s";
-                        yield %15;
+                        %15 : java.type:"java.lang.String" = cast %14 @java.type:"java.lang.String";
+                        %16 : Var<java.type:"java.lang.String"> = var %15 @"s";
+                        yield %16;
                     }
-                    (%16 : Var<java.type:"java.lang.String">)java.type:"void" -> {
-                        %17 : java.type:"java.io.PrintStream" = field.load @java.ref:"java.lang.System::out:java.io.PrintStream";
-                        %18 : java.type:"java.lang.String" = var.load %16;
-                        invoke %17 %18 @java.ref:"java.io.PrintStream::println(java.lang.String):void";
+                    (%17 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                        %18 : java.type:"java.io.PrintStream" = field.load @java.ref:"java.lang.System::out:java.io.PrintStream";
+                        %19 : java.type:"java.lang.String" = var.load %17;
+                        invoke %18 %19 @java.ref:"java.io.PrintStream::println(java.lang.String):void";
                         java.continue;
                     };
                 return;
@@ -125,10 +128,11 @@ public class ForLoopTest {
                         yield %3;
                     }
                     (%4 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
-                        %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
-                        yield %5;
+                        %5 : java.type:"java.lang.String" = cast %4 @java.type:"java.lang.String";
+                        %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
+                        yield %6;
                     }
-                    (%6 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                    (%7 : Var<java.type:"java.lang.String">)java.type:"void" -> {
                         java.continue;
                     };
                 return;
@@ -148,15 +152,16 @@ public class ForLoopTest {
                         yield %3;
                     }
                     (%4 : java.type:"java.lang.String")Var<java.type:"java.lang.String"> -> {
-                        %5 : Var<java.type:"java.lang.String"> = var %4 @"s";
-                        yield %5;
+                        %5 : java.type:"java.lang.String" = cast %4 @java.type:"java.lang.String";
+                        %6 : Var<java.type:"java.lang.String"> = var %5 @"s";
+                        yield %6;
                     }
-                    (%6 : Var<java.type:"java.lang.String">)java.type:"void" -> {
-                        %7 : java.type:"java.lang.String" = var.load %6;
-                        return %7;
+                    (%7 : Var<java.type:"java.lang.String">)java.type:"void" -> {
+                        %8 : java.type:"java.lang.String" = var.load %7;
+                        return %8;
                     };
-                %8 : java.type:"java.lang.String" = constant @"";
-                return %8;
+                %9 : java.type:"java.lang.String" = constant @"";
+                return %9;
             };
             """)
     String test2_2(List<String> l) {


### PR DESCRIPTION
Remove cast insertion in bytecode generator an interpreter.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/babylon.git pull/1177/head:pull/1177` \
`$ git checkout pull/1177`

Update a local copy of the PR: \
`$ git checkout pull/1177` \
`$ git pull https://git.openjdk.org/babylon.git pull/1177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1177`

View PR using the GUI difftool: \
`$ git pr show -t 1177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/babylon/pull/1177.diff">https://git.openjdk.org/babylon/pull/1177.diff</a>

</details>
